### PR TITLE
ci: enforce workflow hygiene invariants

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -15,3 +15,9 @@ paths:
   .github/workflows/release.yml:
     ignore:
       - 'unexpected key "queue" for "concurrency" section'
+  .github/workflows/image-refresh.yml:
+    ignore:
+      - 'unexpected key "queue" for "concurrency" section'
+  .github/workflows/nightly-failure-alert.yml:
+    ignore:
+      - 'unexpected key "queue" for "concurrency" section'

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -21,3 +21,9 @@ paths:
   .github/workflows/nightly-failure-alert.yml:
     ignore:
       - 'unexpected key "queue" for "concurrency" section'
+  .github/workflows/smoke.yml:
+    ignore:
+      - 'unexpected key "queue" for "concurrency" section'
+  .github/workflows/ui-tests.yml:
+    ignore:
+      - 'unexpected key "queue" for "concurrency" section'

--- a/.github/workflows/agent-config.yml
+++ b/.github/workflows/agent-config.yml
@@ -45,6 +45,10 @@ permissions:
   packages: read
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   agent-config:
     name: Agent config (role registry + skill/workflow parity)

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -86,6 +86,10 @@ permissions:
   contents: read
   packages: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ inputs.pfsense_ce_version }}
+  cancel-in-progress: false
+
 jobs:
   # ── 0. Map the target CE version to its FreeBSD base + PHP runtime ────────
   # The branch .pkg MUST be built against the FreeBSD ABI + PHP runtime of the

--- a/.github/workflows/build-pkg-linux.yml
+++ b/.github/workflows/build-pkg-linux.yml
@@ -117,6 +117,10 @@ permissions:
   packages: read
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ inputs.artifact_name }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   build:
     name: build pfBlockerNG .pkg (portable, Linux)
@@ -279,7 +283,7 @@ jobs:
 
       - name: Upload package
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v8
         with:
           name: ${{ inputs.artifact_name }}
           path: ${{ steps.build.outputs.pkg_dir }}/*.pkg
@@ -293,7 +297,7 @@ jobs:
         # major) — or by the caller-supplied dep_artifact_name (W1) when the
         # caller's own fan-out is per-version and needs a per-row-unique name.
         if: steps.build.outputs.has_dep_pkgs == '1'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v8
         with:
           name: ${{ steps.build.outputs.dep_artifact_name }}
           path: ${{ steps.build.outputs.dep_pkg_dir }}/*.pkg

--- a/.github/workflows/coderabbit-cli.yml
+++ b/.github/workflows/coderabbit-cli.yml
@@ -16,6 +16,10 @@ permissions:
   contents: read
   pull-requests: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ inputs.pr }}
+  cancel-in-progress: false
+
 jobs:
   cli-review:
     name: CLI review of one PR

--- a/.github/workflows/context-budget.yml
+++ b/.github/workflows/context-budget.yml
@@ -51,6 +51,10 @@ permissions:
   packages: read
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   context-budget:
     name: Context byte budgets + routing headers

--- a/.github/workflows/image-refresh.yml
+++ b/.github/workflows/image-refresh.yml
@@ -102,6 +102,10 @@ permissions:
   packages: read
   contents: read
 
+concurrency:
+  group: image-refresh
+  cancel-in-progress: false
+
 jobs:
   # ── Resolve refresh matrix (CE + Plus) ─────────────────────────────────────
   # Validate the direct_leg input (the reconcile loop's dispatch), or derive the

--- a/.github/workflows/image-refresh.yml
+++ b/.github/workflows/image-refresh.yml
@@ -104,6 +104,7 @@ permissions:
 
 concurrency:
   group: image-refresh
+  queue: max
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/nightly-failure-alert.yml
+++ b/.github/workflows/nightly-failure-alert.yml
@@ -35,6 +35,10 @@ permissions:
   packages: read
   contents: read
 
+concurrency:
+  group: nightly-failure-alert
+  cancel-in-progress: false
+
 jobs:
   recovery:
     name: Close the recovered nightly-red tracking issue

--- a/.github/workflows/nightly-failure-alert.yml
+++ b/.github/workflows/nightly-failure-alert.yml
@@ -37,6 +37,7 @@ permissions:
 
 concurrency:
   group: nightly-failure-alert
+  queue: max
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1299,7 +1299,7 @@ jobs:
         # false already isolates a failed leg, so it simply uploads nothing
         # and attach-pkgs/the publish healthcheck fail closed on the missing
         # asset.
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v8
         with:
           name: pfBlockerNG-relpkg-${{ matrix.variant }}-${{ matrix.pfsense_version }}
           path: ${{ env.PKG_PATH }}
@@ -1311,7 +1311,7 @@ jobs:
         # -- the exact row identity consumers compose. Never uploaded when
         # extra_pkgs is empty (no empty artifacts).
         if: env.HAS_DEP_PKGS == '1'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v8
         with:
           name: pfBlockerNG-relpkg-deppkgs-${{ matrix.variant }}-${{ matrix.pfsense_version }}
           path: ${{ env.DEP_PKG_DIR }}/*.pkg
@@ -1356,7 +1356,7 @@ jobs:
         # py311-charset-normalizer) are deliberate release assets, frozen
         # alongside the branch .pkgs for the pkg-repo publish + EOL/route-only
         # story. The draft healthcheck counts only the effective asset matrix.
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           pattern: pfBlockerNG-relpkg-*
           merge-multiple: true

--- a/.github/workflows/repo-install.yml
+++ b/.github/workflows/repo-install.yml
@@ -39,6 +39,10 @@ permissions:
   contents: read
   packages: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   gate:
     name: Gate (skip nightly if devel unchanged)

--- a/.github/workflows/smoke-single.yml
+++ b/.github/workflows/smoke-single.yml
@@ -277,6 +277,10 @@ permissions:
   contents: read
   packages: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ inputs.image_name }}-${{ inputs.pfsense_version }}-${{ inputs.shard }}-${{ inputs.checkout_ref || github.ref }}
+  cancel-in-progress: false
+
 jobs:
   # Build the branch's .pkg on a PLAIN Linux runner via the portable builder
   # (scripts/build-pkg-portable.py) and publish it as the `pfBlockerNG-pkg`
@@ -846,7 +850,7 @@ jobs:
       # the release gate (#1662).
       - name: Upload shard selection-status marker (leg-level empty-selection gate, issue #1767)
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v8
         with:
           name: smoke-shard-status-${{ inputs.image_name }}-${{ inputs.pfsense_version }}-s${{ inputs.shard }}
           path: smoke-diag/shard-selection-status
@@ -869,7 +873,7 @@ jobs:
 
       - name: Upload smoke diagnostics
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v8
         with:
           # Per-leg-per-shard name (issue #797) — also fixes the pre-existing
           # wart where every leg of a fan-out run uploaded the SAME bare

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -163,6 +163,10 @@ permissions:
   contents: read
   packages: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ inputs.checkout_ref || github.ref }}
+  cancel-in-progress: false
+
 jobs:
   # ── 1. Read CI matrix (every ci:true entry, CE and Plus) ─────────────────────
   #

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -164,7 +164,8 @@ permissions:
   packages: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ inputs.checkout_ref || github.ref }}
+  group: smoke-${{ github.workflow }}-${{ inputs.checkout_ref || github.ref }}
+  queue: max
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/test-version-matrix.yml
+++ b/.github/workflows/test-version-matrix.yml
@@ -12,6 +12,10 @@ permissions:
   packages: read
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test-reader:
     name: Read + print supported-version matrices

--- a/.github/workflows/top1m-healthcheck.yml
+++ b/.github/workflows/top1m-healthcheck.yml
@@ -27,6 +27,10 @@ permissions:
   packages: read
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   # ── 1. Discover every provider from pfb_top1m_providers() ────────────────
   discover:

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -181,6 +181,10 @@ permissions:
   contents: read
   packages: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ inputs.checkout_ref || github.ref }}
+  cancel-in-progress: false
+
 jobs:
   # Build the branch's .pkg on a plain Linux runner (same builder the smoke gate
   # consumes). ONE build PER ci:true leg (version/ABI), not one global build:

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -182,7 +182,8 @@ permissions:
   packages: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ inputs.checkout_ref || github.ref }}
+  group: ui-tests-${{ github.workflow }}-${{ inputs.checkout_ref || github.ref }}
+  queue: max
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/version-tracker.yml
+++ b/.github/workflows/version-tracker.yml
@@ -60,6 +60,10 @@ permissions:
   packages: read
   contents: read
 
+concurrency:
+  group: version-tracker
+  cancel-in-progress: false
+
 jobs:
   # ── 1. Read the curated matrix ───────────────────────────────────────────────
   read-matrix:

--- a/tests/test_issue2231_workflow_hygiene.py
+++ b/tests/test_issue2231_workflow_hygiene.py
@@ -467,6 +467,15 @@ _GH_EXPRESSION = re.compile(r"\$\{\{\s*(.*?)\s*\}\}")
 _UNRESOLVED_EXPRESSION = re.compile(r"<unresolved:(?P<expression>[^>]+)>")
 
 
+def _artifact_action_match(uses: object, where: str) -> re.Match[str] | None:
+    if not isinstance(uses, str):
+        return None
+    match = _ARTIFACT_ACTION.fullmatch(uses)
+    if _ARTIFACT_ACTION_REF.fullmatch(uses) and match is None:
+        raise AssertionError(f"{where}: rule=artifact-major: unclassified action ref {uses!r}")
+    return match
+
+
 def _expression_parts(source: str, separator: str) -> list[str]:
     parts: list[str] = []
     start = 0
@@ -631,6 +640,19 @@ def _selectors_match(name: str, selector: str) -> bool:
 
 def _artifact_chain_offences(sources: dict[str, str]) -> list[str]:
     documents = {name: _workflow_document(source, name) for name, source in sources.items()}
+    for workflow, document in documents.items():
+        jobs = document.get("jobs")
+        if not isinstance(jobs, dict):
+            continue
+        for job_name, job in jobs.items():
+            if not isinstance(job_name, str) or not isinstance(job, dict):
+                continue
+            steps = job.get("steps", [])
+            if not isinstance(steps, list):
+                continue
+            for step_index, step in enumerate(steps):
+                if isinstance(step, dict):
+                    _artifact_action_match(step.get("uses"), f"{workflow}:{job_name}:step-{step_index}")
     offences: set[str] = set()
     download_matches: dict[_DownloadKey, bool] = {}
     download_selectors: dict[_DownloadKey, set[str]] = {}
@@ -707,13 +729,7 @@ def _artifact_chain_offences(sources: dict[str, str]) -> list[str]:
                 for step_index, step in enumerate(steps):
                     if not isinstance(step, dict):
                         continue
-                    uses = step.get("uses")
-                    match = _ARTIFACT_ACTION.fullmatch(uses) if isinstance(uses, str) else None
-                    if isinstance(uses, str) and _ARTIFACT_ACTION_REF.fullmatch(uses) and match is None:
-                        raise AssertionError(
-                            f"{workflow}:{job_name}:step-{step_index}: rule=artifact-major: "
-                            f"unclassified action ref {uses!r}"
-                        )
+                    match = _artifact_action_match(step.get("uses"), f"{workflow}:{job_name}:step-{step_index}")
                     if match is None:
                         continue
                     action_inputs = step.get("with", {})
@@ -1255,6 +1271,8 @@ _DOCKER_GLOBAL_VALUE_OPTIONS = {
     "--tlscert",
     "--tlskey",
     "-H",
+    "-c",
+    "-l",
 }
 
 
@@ -1786,38 +1804,31 @@ def _pin_offences(sources: dict[str, str]) -> list[str]:
             ):
                 identity = True
                 break
+        exact_member = frozenset({(pin.job, pin.output)})
         for job_name in sorted(descendants):
             job = jobs[job_name]
             if not isinstance(job, dict):
                 continue
             job_env = job.get("env", {})
-            aliases: set[str] = set()
-            if isinstance(job_env, dict):
-                aliases.update(
-                    name
-                    for name, value in job_env.items()
-                    if isinstance(name, str)
-                    and isinstance(value, str)
-                    and (pin.job, pin.output)
-                    in {(match.group("job"), match.group("output")) for match in _NEEDS_OUTPUT.finditer(value)}
-                )
             steps = job.get("steps", [])
             if not isinstance(steps, list):
                 continue
             for step in steps:
                 if not isinstance(step, dict):
                     continue
-                step_aliases = set(aliases)
+                effective_env: dict[object, object] = {}
+                if isinstance(job_env, dict):
+                    effective_env.update(job_env)
                 env = step.get("env", {})
                 if isinstance(env, dict):
-                    step_aliases.update(
-                        name
-                        for name, value in env.items()
-                        if isinstance(name, str)
-                        and isinstance(value, str)
-                        and (pin.job, pin.output)
-                        in {(match.group("job"), match.group("output")) for match in _NEEDS_OUTPUT.finditer(value)}
-                    )
+                    effective_env.update(env)
+                step_aliases = {
+                    name
+                    for name, value in effective_env.items()
+                    if isinstance(name, str)
+                    and isinstance(value, str)
+                    and _pin_expression_members(value) == exact_member
+                }
                 run = step.get("run")
                 if not isinstance(run, str):
                     continue
@@ -1883,7 +1894,16 @@ def _pin_offences(sources: dict[str, str]) -> list[str]:
                             or argument.startswith(f"${name}:")
                             or argument.startswith(f"${{{name}}}:")
                         }
-                        if used_git & live_vars:
+                        used_git_live = {
+                            name
+                            for argument in words[2:]
+                            for name in live_vars
+                            if argument == f"${name}"
+                            or argument == f"${{{name}}}"
+                            or argument.startswith(f"${name}:")
+                            or argument.startswith(f"${{{name}}}:")
+                        }
+                        if used_git_live and step_aliases:
                             offences.append(
                                 f"{pin.workflow}:{job_name}: rule=pin-consumer: live git ls-remote "
                                 f"replaces {pin.job}.{pin.output} at identity sink git {words[1]}"

--- a/tests/test_issue2231_workflow_hygiene.py
+++ b/tests/test_issue2231_workflow_hygiene.py
@@ -798,7 +798,7 @@ def _artifact_chain_offences(sources: dict[str, str]) -> list[str]:
             root_produced, _ = scan_instance(workflow, {}, (), (), "workflow_run" not in triggers)
             name = document.get("name")
             if isinstance(name, str):
-                direct_names[name] = root_produced
+                direct_names[name] = tuple(dict.fromkeys((*direct_names.get(name, ()), *root_produced)))
     for workflow in workflow_run_roots:
         names = _trigger_config(documents[workflow], "workflow_run").get("workflows", [])
         assert isinstance(names, list), f"{workflow}: rule=artifact-major: workflow_run.workflows must be a list"
@@ -956,60 +956,102 @@ on: workflow_dispatch
 jobs:
   upload:
     steps:
-      - uses: actions/upload-artifact@v8
+      - uses: "actions/upload-artifact@v8"
         with: {name: expected}
 """,
         "callback.yaml": """\
 on:
   workflow_run:
-    workflows: [Root]
+    workflows: [Root, Missing]
 jobs:
   consume:
     steps:
-      - uses: actions/download-artifact@v8
+      - uses: "actions/download-artifact@v8"
         with: {name: typo}
 """,
     }
     assert _artifact_chain_offences(sources) == [
-        "callback.yaml:consume:step-0: rule=artifact-major: no producer matches ['typo']"
+        "callback.yaml: rule=artifact-major: workflow_run names missing producers ['Missing']",
+        "callback.yaml:consume:step-0: rule=artifact-major: no producer matches ['typo']",
     ]
 
 
-def test_artifact_scanner_resolves_workflow_run_display_name_through_local_reusable_producer() -> None:
-    sources = {
-        "producer.yml": """\
+def test_artifact_scanner_fails_closed_on_broken_job_and_reusable_graphs() -> None:
+    with pytest.raises(AssertionError, match=r"missing-needs.yml: rule=artifact-major: cyclic or missing needs"):
+        _artifact_chain_offences(
+            {
+                "missing-needs.yml": """\
+on: workflow_dispatch
+jobs:
+  consume:
+    needs: absent
+    steps: []
+"""
+            }
+        )
+    with pytest.raises(AssertionError, match=r"local workflow 'missing.yml' does not exist"):
+        _artifact_chain_offences(
+            {
+                "missing-local.yml": """\
+on: workflow_dispatch
+jobs:
+  call:
+    uses: ./.github/workflows/missing.yml
+"""
+            }
+        )
+    with pytest.raises(AssertionError, match=r"recursive reusable workflow"):
+        _artifact_chain_offences(
+            {
+                "a.yml": """\
+on: workflow_dispatch
+jobs:
+  call:
+    uses: ./.github/workflows/b.yml
+""",
+                "b.yml": """\
 on: workflow_call
+jobs:
+  call:
+    uses: ./.github/workflows/a.yml
+""",
+            }
+        )
+
+
+def test_artifact_scanner_accumulates_duplicate_workflow_display_names() -> None:
+    sources = {
+        "one.yml": """\
+name: Producer
+on: workflow_dispatch
 jobs:
   upload:
     steps:
       - uses: actions/upload-artifact@v7
-        with: {name: "diagnostics-${{ inputs.kind }}"}
+        with: {name: pkg}
 """,
-        "root.yaml": """\
-name: Root display name
-"on": workflow_dispatch
+        "two.yml": """\
+name: Producer
+on: workflow_dispatch
 jobs:
-  make:
-    uses: ./.github/workflows/producer.yml
-    with: {kind: "${{ matrix.kind }}"}
+  upload:
+    steps:
+      - uses: actions/upload-artifact@v8
+        with: {name: pkg}
 """,
         "callback.yml": """\
 on:
   workflow_run:
-    workflows: ["Root display name"]
+    workflows: [Producer]
 jobs:
   consume:
     steps:
       - uses: actions/download-artifact@v8
-        with: {pattern: "diagnostics-pfsense-ce-*"}
+        with: {name: pkg}
 """,
     }
     offences = _artifact_chain_offences(sources)
-    assert any(
-        "callback.yml:consume:step-0: rule=artifact-major: download v8 mismatches producers "
-        "[('producer.yml', 'upload', 7)]" in item
-        for item in offences
-    )
+    assert offences, "duplicate workflow display names must retain every producer"
 
 
 # --------------------------------------------------------------------------- #
@@ -1173,13 +1215,23 @@ def _docker_argv(words: list[str]) -> list[str] | None:
     while index < len(words) and re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*=.*", words[index]):
         index += 1
     while index < len(words) and words[index] in {"command", "exec", "sudo"}:
+        wrapper = words[index]
         index += 1
+        if wrapper == "sudo":
+            while index < len(words) and words[index].startswith("-"):
+                option = words[index]
+                index += 1
+                if option in {"-C", "-g", "-h", "-p", "-u"} and index < len(words):
+                    index += 1
     if index < len(words) and words[index] == "env":
         index += 1
         while index < len(words) and (
             words[index].startswith("-") or re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*=.*", words[index])
         ):
+            option = words[index]
             index += 1
+            if option in {"-C", "--chdir", "-S", "--split-string", "-u", "--unset"} and index < len(words):
+                index += 1
     docker = words[index] if index < len(words) else ""
     if (
         index + 1 >= len(words)
@@ -1225,7 +1277,6 @@ def _python_docker_runs(source: str, where: str) -> list[tuple[int, list[str]]]:
         tree = ast.parse(source, filename=where)
     except SyntaxError as exc:
         raise AssertionError(f"{where}:{exc.lineno}: rule=docker-init: invalid Python: {exc.msg}") from exc
-    invocations: list[tuple[int, list[str]]] = []
     imported_calls = {
         alias.asname or alias.name
         for node in tree.body
@@ -1233,6 +1284,21 @@ def _python_docker_runs(source: str, where: str) -> list[tuple[int, list[str]]]:
         for alias in node.names
         if alias.name in {"call", "check_call", "check_output", "Popen", "run"}
     }
+    subprocess_modules = {
+        alias.asname or alias.name
+        for node in tree.body
+        if isinstance(node, ast.Import)
+        for alias in node.names
+        if alias.name == "subprocess"
+    }
+    bound_argv = {
+        target.id: node.value
+        for node in tree.body
+        if isinstance(node, ast.Assign) and isinstance(node.value, (ast.List, ast.Tuple))
+        for target in node.targets
+        if isinstance(target, ast.Name)
+    }
+    invocations: list[tuple[int, list[str]]] = []
     for node in ast.walk(tree):
         if not isinstance(node, ast.Call) or not node.args:
             continue
@@ -1240,7 +1306,7 @@ def _python_docker_runs(source: str, where: str) -> list[tuple[int, list[str]]]:
         is_subprocess = (
             isinstance(function, ast.Attribute)
             and isinstance(function.value, ast.Name)
-            and function.value.id == "subprocess"
+            and function.value.id in subprocess_modules
             and function.attr in {"call", "check_call", "check_output", "Popen", "run"}
         )
         is_os_system = (
@@ -1253,6 +1319,8 @@ def _python_docker_runs(source: str, where: str) -> list[tuple[int, list[str]]]:
         if not (is_subprocess or is_imported_subprocess or is_os_system):
             continue
         argument = node.args[0]
+        if isinstance(argument, ast.Name) and argument.id in bound_argv:
+            argument = bound_argv[argument.id]
         words: list[str] | None = None
         if isinstance(argument, (ast.List, ast.Tuple)):
             words = [
@@ -1354,20 +1422,26 @@ def test_docker_scanner_rejects_wrappers_dynamic_argv_and_late_init() -> None:
     sources = {
         "scripts/wrappers.sh": """\
 sudo docker run alpine
+sudo -u root docker run alpine
 docker run alpine --init
 DOCKER=docker
 "$DOCKER" run --rm alpine
+env -u HOME docker run alpine
 """,
         "tests/smoke/imported.py": """\
+import subprocess as sp
 from subprocess import run
 
 opts = ["--rm", "alpine"]
+command = ["docker", "run", "alpine"]
 run(["docker", "run", "alpine"])
 run(["docker", "run", *opts])
+run(command)
+sp.run(command)
 """,
     }
     offences = _docker_run_offences(sources)
-    assert len(offences) == 5, offences
+    assert len(offences) == 9, offences
     assert all("rule=docker-init" in offence for offence in offences)
 
 

--- a/tests/test_issue2231_workflow_hygiene.py
+++ b/tests/test_issue2231_workflow_hygiene.py
@@ -641,19 +641,6 @@ def _selectors_match(name: str, selector: str) -> bool:
 
 def _artifact_chain_offences(sources: dict[str, str]) -> list[str]:
     documents = {name: _workflow_document(source, name) for name, source in sources.items()}
-    for workflow, document in documents.items():
-        jobs = document.get("jobs")
-        if not isinstance(jobs, dict):
-            continue
-        for job_name, job in jobs.items():
-            if not isinstance(job_name, str) or not isinstance(job, dict):
-                continue
-            steps = job.get("steps", [])
-            if not isinstance(steps, list):
-                continue
-            for step_index, step in enumerate(steps):
-                if isinstance(step, dict):
-                    _artifact_action_match(step.get("uses"), f"{workflow}:{job_name}:step-{step_index}")
     offences: set[str] = set()
     download_matches: dict[_DownloadKey, bool] = {}
     download_selectors: dict[_DownloadKey, set[str]] = {}

--- a/tests/test_issue2231_workflow_hygiene.py
+++ b/tests/test_issue2231_workflow_hygiene.py
@@ -2036,12 +2036,10 @@ def _pin_offences(sources: dict[str, str]) -> list[str]:
                                 _pin_expression_members(argument),
                             )
                         )
-                    has_prepared_argument = any(
-                        reference == argument
-                        or provenance in {"exact", "prepared"}
-                        or bool(argument_members)
-                        and argument_members <= workflow_pins
-                        for _, argument, _, provenance, argument_members in flag_arguments
+                    has_exact_sha_argument = any(
+                        flag.endswith("-sha")
+                        and (reference == argument or argument_members == exact_member or provenance == "exact")
+                        for flag, argument, _, provenance, argument_members in flag_arguments
                     )
                     for flag, argument, argument_var, provenance, argument_members in flag_arguments:
                         if provenance == "derived":
@@ -2061,7 +2059,7 @@ def _pin_offences(sources: dict[str, str]) -> list[str]:
                                 f"{pin.workflow}:{job_name}: rule=pin-consumer: alias overwrites "
                                 f"{pin.job}.{pin.output} at identity sink {flag}"
                             )
-                        elif not has_prepared_argument:
+                        elif not (flag.endswith("-ref") and has_exact_sha_argument):
                             offences.append(
                                 f"{pin.workflow}:{job_name}: rule=pin-consumer: identity flag {flag} uses "
                                 f"a derived, untrusted, or unknown value instead of {pin.job}.{pin.output}"

--- a/tests/test_issue2231_workflow_hygiene.py
+++ b/tests/test_issue2231_workflow_hygiene.py
@@ -452,6 +452,7 @@ class _ArtifactJob(NamedTuple):
 
 _ARTIFACT_ACTION = re.compile(r"^actions/(?P<kind>upload|download)-artifact@v(?P<major>[0-9]+)$")
 _GH_EXPRESSION = re.compile(r"\$\{\{\s*(.*?)\s*\}\}")
+_UNRESOLVED_EXPRESSION = re.compile(r"<unresolved:(?P<expression>[^>]+)>")
 
 
 def _expression_parts(source: str, separator: str) -> list[str]:
@@ -575,6 +576,37 @@ def _workflow_call_path(value: object) -> str | None:
     return match.group("name") if match else None
 
 
+def _glob_patterns_overlap(left: str, right: str) -> bool:
+    pending = {(0, 0)}
+    seen: set[tuple[int, int]] = set()
+    while pending:
+        left_index, right_index = pending.pop()
+        if (left_index, right_index) in seen:
+            continue
+        seen.add((left_index, right_index))
+        if left_index == len(left) and right_index == len(right):
+            return True
+        if left_index < len(left) and left[left_index] == "*":
+            pending.add((left_index + 1, right_index))
+        if right_index < len(right) and right[right_index] == "*":
+            pending.add((left_index, right_index + 1))
+        if left_index == len(left) or right_index == len(right):
+            continue
+        left_token = left[left_index]
+        right_token = right[right_index]
+        if left_token == "*" and right_token == "*":
+            continue
+        if left_token not in "*?" and right_token not in "*?" and left_token != right_token:
+            continue
+        pending.add(
+            (
+                left_index if left_token == "*" else left_index + 1,
+                right_index if right_token == "*" else right_index + 1,
+            )
+        )
+    return False
+
+
 def _selectors_match(name: str, selector: str) -> bool:
     import fnmatch
 
@@ -582,9 +614,7 @@ def _selectors_match(name: str, selector: str) -> bool:
         return True
     dynamic_name = _GH_EXPRESSION.sub("*", name)
     dynamic_selector = _GH_EXPRESSION.sub("*", selector)
-    name_sample = dynamic_name.replace("*", "x").replace("?", "x")
-    selector_sample = dynamic_selector.replace("*", "x").replace("?", "x")
-    return fnmatch.fnmatchcase(name_sample, dynamic_selector) or fnmatch.fnmatchcase(selector_sample, dynamic_name)
+    return _glob_patterns_overlap(dynamic_name, dynamic_selector)
 
 
 def _artifact_chain_offences(sources: dict[str, str]) -> list[str]:
@@ -672,6 +702,19 @@ def _artifact_chain_offences(sources: dict[str, str]) -> list[str]:
                     selector_value = action_inputs.get("name", action_inputs.get("pattern", "*"))
                     selectors = _scalar_values(selector_value, context)
                     assert selectors, f"{workflow}:{job_name}: rule=artifact-major: empty artifact selector"
+                    unresolved = sorted(
+                        {
+                            match.group("expression")
+                            for selector in selectors
+                            for match in _UNRESOLVED_EXPRESSION.finditer(selector)
+                        }
+                    )
+                    if unresolved:
+                        offences.add(
+                            f"{workflow}:{job_name}:step-{step_index}: rule=artifact-major: "
+                            f"unresolved artifact selector {unresolved!r}"
+                        )
+                        continue
                     major = int(match.group("major"))
                     if match.group("kind") == "upload":
                         produced.extend(_Artifact(workflow, job_name, selector, major) for selector in selectors)
@@ -881,10 +924,51 @@ jobs:
     assert any(
         "root.yaml:ambiguous:step-0: rule=artifact-major: ambiguous producers for 'pkg'" in item for item in offences
     )
-    assert any("root.yaml:wrong-output:step-0: rule=artifact-major: no producer matches" in item for item in offences)
+    assert any(
+        "root.yaml:wrong-output:step-0: rule=artifact-major: "
+        "unresolved artifact selector ['needs.make.outputs.missing']" in item
+        for item in offences
+    )
     assert any(
         "root.yaml:pattern:step-0: rule=artifact-major: download v7 mismatches producers" in item
         and "('producer.yml', 'duplicate', 8)" in item
+        for item in offences
+    )
+
+
+def test_artifact_scanner_resolves_workflow_run_display_name_through_local_reusable_producer() -> None:
+    sources = {
+        "producer.yml": """\
+on: workflow_call
+jobs:
+  upload:
+    steps:
+      - uses: actions/upload-artifact@v7
+        with: {name: "diagnostics-${{ inputs.kind }}"}
+""",
+        "root.yaml": """\
+name: Root display name
+"on": workflow_dispatch
+jobs:
+  make:
+    uses: ./.github/workflows/producer.yml
+    with: {kind: "${{ matrix.kind }}"}
+""",
+        "callback.yml": """\
+on:
+  workflow_run:
+    workflows: ["Root display name"]
+jobs:
+  consume:
+    steps:
+      - uses: actions/download-artifact@v8
+        with: {pattern: "diagnostics-pfsense-ce-*"}
+""",
+    }
+    offences = _artifact_chain_offences(sources)
+    assert any(
+        "callback.yml:consume:step-0: rule=artifact-major: download v8 mismatches producers "
+        "[('producer.yml', 'upload', 7)]" in item
         for item in offences
     )
 

--- a/tests/test_issue2231_workflow_hygiene.py
+++ b/tests/test_issue2231_workflow_hygiene.py
@@ -1934,7 +1934,7 @@ def _pin_offences(sources: dict[str, str]) -> list[str]:
                 step_aliases = {
                     name
                     for name in pin_aliases
-                    if isinstance(value := effective_env[name], str) and _pin_expression_members(value) == exact_member
+                    if _pin_expression_members(cast(str, effective_env[name])) == exact_member
                 }
                 invalid_aliases = pin_aliases - step_aliases
                 run = step.get("run")
@@ -1979,6 +1979,9 @@ def _pin_offences(sources: dict[str, str]) -> list[str]:
                         if argument.startswith("$") and not argument.startswith("${"):
                             argument_var = argument[1:]
                         used = {name for name in step_aliases if argument_var == name}
+                        used_invalid = {name for name in invalid_aliases if argument_var == name}
+                        if used_invalid:
+                            invalid_alias_sinks.update((job_name, name, word) for name in used_invalid)
                         if argument_var in live_vars:
                             offences.append(
                                 f"{pin.workflow}:{job_name}: rule=pin-consumer: live git ls-remote "
@@ -2024,7 +2027,7 @@ def _pin_offences(sources: dict[str, str]) -> list[str]:
                             or argument.startswith(f"${{{name}}}:")
                         }
                         if used_git_invalid:
-                            invalid_alias_sinks.update((job_name, name, command) for name in used_git_invalid)
+                            invalid_alias_sinks.update((job_name, name, f"git {command}") for name in used_git_invalid)
                         direct_live = any(re.search(r"\$\(\s*git\s+ls-remote\b", argument) for argument in arguments)
                         if (used_git_live or direct_live) and step_aliases:
                             offences.append(
@@ -2041,8 +2044,8 @@ def _pin_offences(sources: dict[str, str]) -> list[str]:
         if identity:
             offences.extend(
                 f"{pin.workflow}:{job_name}: rule=pin-consumer: derived or untrusted env alias "
-                f"{name} references {pin.job}.{pin.output} at identity sink git {command}"
-                for job_name, name, command in invalid_alias_sinks
+                f"{name} references {pin.job}.{pin.output} at identity sink {sink}"
+                for job_name, name, sink in invalid_alias_sinks
             )
         else:
             offences.append(

--- a/tests/test_issue2231_workflow_hygiene.py
+++ b/tests/test_issue2231_workflow_hygiene.py
@@ -1860,6 +1860,57 @@ def _ref_binding(path: tuple[str, ...]) -> bool:
     }
 
 
+_SHELL_VARIABLE = re.compile(r"\$(?:\{(?P<braced>[A-Za-z_][A-Za-z0-9_]*)(?:[^}]*)\}|(?P<plain>[A-Za-z_][A-Za-z0-9_]*))")
+_SHELL_EXACT_VARIABLE = re.compile(r"\$(?:\{(?P<braced>[A-Za-z_][A-Za-z0-9_]*)\}|(?P<plain>[A-Za-z_][A-Za-z0-9_]*))")
+
+
+def _shell_assignment(words: list[str]) -> tuple[str, str] | None:
+    index = 1 if words and words[0] in {"export", "readonly"} else 0
+    if index >= len(words):
+        return None
+    assignment = re.fullmatch(r"(?P<name>[A-Za-z_][A-Za-z0-9_]*)=(?P<value>.*)", words[index])
+    if assignment is None:
+        return None
+    value = " ".join([assignment.group("value"), *words[index + 1 :]])
+    return assignment.group("name"), value
+
+
+def _shell_alias_provenance(value: str, aliases: Mapping[str, str]) -> str | None:
+    if re.search(r"\$\(\s*git\s+ls-remote\b", value):
+        return "live"
+    variables = [match.group("braced") or match.group("plain") for match in _SHELL_VARIABLE.finditer(value)]
+    inherited = [aliases[name] for name in variables if name in aliases]
+    if not inherited:
+        return None
+    if "live" in inherited:
+        return "live"
+    exact = _SHELL_EXACT_VARIABLE.fullmatch(value)
+    if exact is not None and aliases[exact.group("braced") or exact.group("plain")] == "exact":
+        return "exact"
+    return "derived"
+
+
+def _pin_flag_arguments(words: list[str], base: str) -> list[tuple[str, str]]:
+    arguments: list[tuple[str, str]] = []
+    for index, word in enumerate(words):
+        match = re.fullmatch(
+            r"(?P<flag>--[A-Za-z0-9][A-Za-z0-9_-]*-(?:ref|sha))(?:=(?P<argument>.*))?",
+            word,
+        )
+        if match is None:
+            continue
+        flag = match.group("flag")
+        if base and not flag.removeprefix("--").startswith(base):
+            continue
+        argument = match.group("argument")
+        if argument is None:
+            if index + 1 >= len(words):
+                continue
+            argument = words[index + 1]
+        arguments.append((flag, argument))
+    return arguments
+
+
 def _pin_offences(sources: dict[str, str]) -> list[str]:
     documents = {workflow: _workflow_document(source, workflow) for workflow, source in sources.items()}
     pins, offences = _sha_inventory(documents)
@@ -1888,6 +1939,7 @@ def _pin_offences(sources: dict[str, str]) -> list[str]:
         workflow_pins = {(candidate.job, candidate.output) for candidate in pins if candidate.workflow == pin.workflow}
         identity = False
         invalid_alias_sinks: set[tuple[str, str, str]] = set()
+        derived_alias_sinks: set[tuple[str, str, str]] = set()
         invalid_ref_jobs: set[str] = set()
         for job_name, path, value in consumers:
             if not _ref_binding(path):
@@ -1940,7 +1992,8 @@ def _pin_offences(sources: dict[str, str]) -> list[str]:
                 run = step.get("run")
                 if not isinstance(run, str):
                     continue
-                overridden: set[str] = set()
+                aliases = {name: "exact" for name in step_aliases}
+                aliases.update({name: "derived" for name in invalid_aliases})
                 normalized_run = re.sub(
                     r"\$\((.*?)\)",
                     lambda match: "$(" + " ".join(match.group(1).split()) + ")",
@@ -1948,104 +2001,82 @@ def _pin_offences(sources: dict[str, str]) -> list[str]:
                     flags=re.DOTALL,
                 )
                 commands = _shell_commands(normalized_run)
-                live_vars: set[str] = set()
-                for words in commands:
-                    assignment = re.match(
-                        r'(?:(?:export|readonly)\s+)?(?P<name>[A-Za-z_][A-Za-z0-9_]*)\s*=\s*["\']?'
-                        r"\$\(\s*git\s+ls-remote\b",
-                        " ".join(words),
-                    )
-                    if assignment is not None:
-                        live_vars.add(assignment.group("name"))
                 base = _pin_base(pin.output)
                 for words in commands:
-                    overridden.update(
-                        assignment.group("name")
-                        for word in words
-                        if (assignment := re.fullmatch(r"(?P<name>[A-Za-z_][A-Za-z0-9_]*)=.*", word))
-                        and assignment.group("name") in step_aliases
-                    )
-                    for index, word in enumerate(words[:-1]):
-                        flag = word.removeprefix("--")
-                        relevant_flag = (
-                            word.startswith("--")
-                            and (flag.endswith("-ref") or flag.endswith("-sha"))
-                            and (not base or flag.startswith(base))
+                    assignment = _shell_assignment(words)
+                    if assignment is not None:
+                        name, value = assignment
+                        provenance = _shell_alias_provenance(value, aliases)
+                        if provenance is not None or name in aliases:
+                            aliases[name] = provenance or "overwritten"
+
+                    for flag, argument in _pin_flag_arguments(words, base):
+                        argument_match = _SHELL_EXACT_VARIABLE.fullmatch(argument)
+                        argument_var = (
+                            argument_match.group("braced") or argument_match.group("plain")
+                            if argument_match is not None
+                            else None
                         )
-                        if not relevant_flag:
-                            continue
-                        argument = words[index + 1]
-                        argument_var = argument.removeprefix("${").removesuffix("}")
-                        if argument.startswith("$") and not argument.startswith("${"):
-                            argument_var = argument[1:]
-                        used = {name for name in step_aliases if argument_var == name}
-                        used_invalid = {name for name in invalid_aliases if argument_var == name}
-                        if used_invalid:
-                            invalid_alias_sinks.update((job_name, name, word) for name in used_invalid)
-                        if argument_var in live_vars:
+                        provenance = aliases.get(argument_var or "")
+                        if provenance == "derived":
+                            sinks = invalid_alias_sinks if argument_var in invalid_aliases else derived_alias_sinks
+                            sinks.add((job_name, cast(str, argument_var), flag))
+                        elif provenance == "live":
                             offences.append(
                                 f"{pin.workflow}:{job_name}: rule=pin-consumer: live git ls-remote "
-                                f"replaces {pin.job}.{pin.output} at identity sink {word}"
+                                f"replaces {pin.job}.{pin.output} at identity sink {flag}"
                             )
-                        elif reference == argument:
+                        elif reference == argument or provenance == "exact":
                             identity = True
-                        elif used - overridden:
-                            identity = True
-                        elif used & overridden:
+                        elif provenance == "overwritten":
                             offences.append(
                                 f"{pin.workflow}:{job_name}: rule=pin-consumer: alias overwrites "
-                                f"{pin.job}.{pin.output} at identity sink {word}"
+                                f"{pin.job}.{pin.output} at identity sink {flag}"
                             )
+
                     identity_command = _git_identity_command(words)
-                    if identity_command is not None:
-                        command, arguments = identity_command
-                        used_git = {
-                            name
-                            for argument in arguments
-                            for name in step_aliases
-                            if argument == f"${name}"
-                            or argument == f"${{{name}}}"
-                            or argument.startswith(f"${name}:")
-                            or argument.startswith(f"${{{name}}}:")
-                        }
-                        used_git_live = {
-                            name
-                            for argument in arguments
-                            for name in live_vars
-                            if argument == f"${name}"
-                            or argument == f"${{{name}}}"
-                            or argument.startswith(f"${name}:")
-                            or argument.startswith(f"${{{name}}}:")
-                        }
-                        used_git_invalid = {
-                            name
-                            for argument in arguments
-                            for name in invalid_aliases
-                            if argument == f"${name}"
-                            or argument == f"${{{name}}}"
-                            or argument.startswith(f"${name}:")
-                            or argument.startswith(f"${{{name}}}:")
-                        }
-                        if used_git_invalid:
-                            invalid_alias_sinks.update((job_name, name, f"git {command}") for name in used_git_invalid)
-                        direct_live = any(re.search(r"\$\(\s*git\s+ls-remote\b", argument) for argument in arguments)
-                        if (used_git_live or direct_live) and step_aliases:
-                            offences.append(
-                                f"{pin.workflow}:{job_name}: rule=pin-consumer: live git ls-remote "
-                                f"replaces {pin.job}.{pin.output} at identity sink git {command}"
-                            )
-                        elif used_git & overridden:
-                            offences.append(
-                                f"{pin.workflow}:{job_name}: rule=pin-consumer: alias overwrites "
-                                f"{pin.job}.{pin.output} at identity sink git {command}"
-                            )
-                        elif used_git:
-                            identity = True
+                    if identity_command is None:
+                        continue
+                    command, arguments = identity_command
+                    used_git = {
+                        name
+                        for argument in arguments
+                        for name in aliases
+                        if argument == f"${name}"
+                        or argument == f"${{{name}}}"
+                        or argument.startswith(f"${name}:")
+                        or argument.startswith(f"${{{name}}}:")
+                    }
+                    exact_git = {name for name in used_git if aliases[name] == "exact"}
+                    live_git = {name for name in used_git if aliases[name] == "live"}
+                    derived_git = {name for name in used_git if aliases[name] == "derived"}
+                    overwritten_git = {name for name in used_git if aliases[name] == "overwritten"}
+                    for name in derived_git:
+                        sinks = invalid_alias_sinks if name in invalid_aliases else derived_alias_sinks
+                        sinks.add((job_name, name, f"git {command}"))
+                    direct_live = any(re.search(r"\$\(\s*git\s+ls-remote\b", argument) for argument in arguments)
+                    if (live_git or direct_live) and step_aliases:
+                        offences.append(
+                            f"{pin.workflow}:{job_name}: rule=pin-consumer: live git ls-remote "
+                            f"replaces {pin.job}.{pin.output} at identity sink git {command}"
+                        )
+                    elif overwritten_git:
+                        offences.append(
+                            f"{pin.workflow}:{job_name}: rule=pin-consumer: alias overwrites "
+                            f"{pin.job}.{pin.output} at identity sink git {command}"
+                        )
+                    elif exact_git:
+                        identity = True
         if identity:
             offences.extend(
                 f"{pin.workflow}:{job_name}: rule=pin-consumer: derived or untrusted env alias "
                 f"{name} references {pin.job}.{pin.output} at identity sink {sink}"
                 for job_name, name, sink in invalid_alias_sinks
+            )
+            offences.extend(
+                f"{pin.workflow}:{job_name}: rule=pin-consumer: derived shell alias {name} references "
+                f"{pin.job}.{pin.output} at identity sink {sink}"
+                for job_name, name, sink in derived_alias_sinks
             )
         else:
             offences.append(

--- a/tests/test_issue2231_workflow_hygiene.py
+++ b/tests/test_issue2231_workflow_hygiene.py
@@ -439,6 +439,7 @@ def test_lossless_operational_workflows_keep_every_pending_event(workflow: str) 
     concurrency = _workflow_document(_workflow_sources()[workflow], workflow)["concurrency"]
     assert isinstance(concurrency, dict)
     assert concurrency.get("queue") == "max"
+    assert concurrency.get("cancel-in-progress") is False
 
 
 # --------------------------------------------------------------------------- #
@@ -822,16 +823,16 @@ def _artifact_chain_offences(sources: dict[str, str]) -> list[str]:
         triggers = _trigger_names(document)
         if "workflow_run" in triggers:
             workflow_run_roots.append(workflow)
-        if triggers & (_EXTERNAL_TRIGGERS | {"pull_request"}):
+        if triggers != {"workflow_run"}:
             root_produced, _ = scan_instance(
                 workflow,
                 {},
                 (),
                 (("<direct>", workflow),),
-                "workflow_run" not in triggers,
+                "workflow_run" not in triggers and triggers != {"workflow_call"},
             )
             name = document.get("name")
-            if isinstance(name, str):
+            if isinstance(name, str) and triggers != {"workflow_call"}:
                 direct_names[name] = tuple(dict.fromkeys((*direct_names.get(name, ()), *root_produced)))
     for workflow in workflow_run_roots:
         names = _trigger_config(documents[workflow], "workflow_run").get("workflows", [])
@@ -1086,8 +1087,11 @@ jobs:
         with: {name: pkg}
 """,
     }
-    offences = _artifact_chain_offences(sources)
-    assert offences, "duplicate workflow display names must retain every producer"
+    assert _artifact_chain_offences(sources) == [
+        "callback.yml:consume:step-0: rule=artifact-major: ambiguous producers for 'pkg': "
+        "[('one.yml', 'upload'), ('two.yml', 'upload')]",
+        "callback.yml:consume:step-0: rule=artifact-major: download v8 mismatches producers [('one.yml', 'upload', 7)]",
+    ]
 
 
 # --------------------------------------------------------------------------- #
@@ -1420,7 +1424,7 @@ def _docker_has_init_before_image(argv: list[str]) -> bool:
         word = argv[index]
         if word == "--init":
             return True
-        if not word.startswith("-"):
+        if word == "--" or not word.startswith("-"):
             return False
         index += 2 if word in _DOCKER_VALUE_OPTIONS and "=" not in word else 1
     return False
@@ -1445,23 +1449,69 @@ def _python_docker_runs(source: str, where: str) -> list[tuple[int, list[str]]]:
         for alias in node.names
         if alias.name == "subprocess"
     }
-    bound_argv: dict[str, list[tuple[int, ast.expr]]] = {}
+    scope_types = (ast.Module, ast.FunctionDef, ast.AsyncFunctionDef)
+    parents = {child: parent for parent in ast.walk(tree) for child in ast.iter_child_nodes(parent)}
+
+    def scope_chain(node: ast.AST) -> list[ast.AST]:
+        scopes: list[ast.AST] = []
+        current = node
+        while not isinstance(current, ast.Module):
+            current = parents[current]
+            if isinstance(current, scope_types):
+                scopes.append(current)
+        if not scopes or not isinstance(scopes[-1], ast.Module):
+            scopes.append(tree)
+        return scopes
+
+    bound_argv: dict[ast.AST, dict[str, list[tuple[int, ast.expr]]]] = {}
+    functions: dict[ast.AST, dict[str, ast.FunctionDef | ast.AsyncFunctionDef]] = {}
     for node in ast.walk(tree):
-        if not isinstance(node, ast.Assign) or not isinstance(node.value, (ast.List, ast.Tuple)):
-            continue
-        for target in node.targets:
-            if isinstance(target, ast.Name):
-                bound_argv.setdefault(target.id, []).append((node.lineno, node.value))
-    returned_argv = {
-        node.name: statement.value
-        for node in tree.body
-        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
-        for statement in node.body
-        if isinstance(statement, ast.Return) and isinstance(statement.value, (ast.List, ast.Tuple))
-    }
+        scope = scope_chain(node)[0] if not isinstance(node, ast.Module) else tree
+        if isinstance(node, ast.Assign) and isinstance(node.value, (ast.List, ast.Tuple)):
+            for target in node.targets:
+                if isinstance(target, ast.Name):
+                    bound_argv.setdefault(scope, {}).setdefault(target.id, []).append((node.lineno, node.value))
+        elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            parent_scope = scope_chain(node)[0]
+            functions.setdefault(parent_scope, {})[node.name] = node
+
+    def resolve_factory(argument: ast.expr, seen: frozenset[int] = frozenset()) -> ast.expr:
+        if not (
+            isinstance(argument, ast.Call)
+            and isinstance(argument.func, ast.Name)
+            and not argument.args
+            and not argument.keywords
+        ):
+            return argument
+        for scope in scope_chain(argument):
+            function = functions.get(scope, {}).get(argument.func.id)
+            if function is None:
+                continue
+            if id(function) in seen:
+                return argument
+            returns = [
+                statement.value
+                for statement in function.body
+                if isinstance(statement, ast.Return) and statement.value is not None
+            ]
+            return resolve_factory(returns[0], seen | {id(function)}) if len(returns) == 1 else argument
+        return argument
+
+    def resolve_argument(argument: ast.expr, call: ast.Call) -> ast.expr:
+        if isinstance(argument, ast.Name):
+            for scope in scope_chain(call):
+                bindings = bound_argv.get(scope, {}).get(argument.id)
+                if bindings is None:
+                    continue
+                candidates = [(line, value) for line, value in bindings if line < call.lineno]
+                return max(candidates, key=lambda candidate: candidate[0])[1] if candidates else argument
+        if isinstance(argument, ast.Call):
+            return resolve_factory(argument)
+        return argument
+
     invocations: list[tuple[int, list[str]]] = []
     for node in ast.walk(tree):
-        if not isinstance(node, ast.Call) or not node.args:
+        if not isinstance(node, ast.Call):
             continue
         function = node.func
         is_subprocess = (
@@ -1479,18 +1529,17 @@ def _python_docker_runs(source: str, where: str) -> list[tuple[int, list[str]]]:
         is_imported_subprocess = isinstance(function, ast.Name) and function.id in imported_calls
         if not (is_subprocess or is_imported_subprocess or is_os_system):
             continue
-        argument = node.args[0]
-        if isinstance(argument, ast.Name) and argument.id in bound_argv:
-            candidates = [(line, candidate) for line, candidate in bound_argv[argument.id] if line < node.lineno]
-            if candidates:
-                argument = max(candidates, key=lambda candidate: candidate[0])[1]
-        elif (
-            isinstance(argument, ast.Call)
-            and isinstance(argument.func, ast.Name)
-            and not argument.args
-            and argument.func.id in returned_argv
-        ):
-            argument = returned_argv[argument.func.id]
+        keyword_arguments = [keyword.value for keyword in node.keywords if keyword.arg == "args"]
+        assert len(keyword_arguments) <= 1 and not (node.args and keyword_arguments), (
+            f"{where}:{node.lineno}: rule=docker-init: subprocess argv must have one source"
+        )
+        if node.args:
+            argument = node.args[0]
+        elif keyword_arguments and not is_os_system:
+            argument = keyword_arguments[0]
+        else:
+            continue
+        argument = resolve_argument(argument, node)
         words: list[str] | None = None
         if isinstance(argument, (ast.List, ast.Tuple)):
             words = [
@@ -1625,9 +1674,17 @@ run(command)
 sp.run(command)
 """,
     }
-    offences = _docker_run_offences(sources)
-    assert len(offences) == 9, offences
-    assert all("rule=docker-init" in offence for offence in offences)
+    assert _docker_run_offences(sources) == [
+        "scripts/wrappers.sh:1: rule=docker-init: docker run must include exact token --init",
+        "scripts/wrappers.sh:2: rule=docker-init: docker run must include exact token --init",
+        "scripts/wrappers.sh:3: rule=docker-init: docker run must include exact token --init",
+        "scripts/wrappers.sh:5: rule=docker-init: docker run must include exact token --init",
+        "scripts/wrappers.sh:6: rule=docker-init: docker run must include exact token --init",
+        "tests/smoke/imported.py:6: rule=docker-init: docker run must include exact token --init",
+        "tests/smoke/imported.py:7: rule=docker-init: docker run must include exact token --init",
+        "tests/smoke/imported.py:8: rule=docker-init: docker run must include exact token --init",
+        "tests/smoke/imported.py:9: rule=docker-init: docker run must include exact token --init",
+    ]
 
 
 # --------------------------------------------------------------------------- #
@@ -1754,6 +1811,33 @@ def _pin_expression_members(value: str) -> frozenset[tuple[str, str]]:
     return frozenset(members)
 
 
+_GIT_IDENTITY_COMMANDS = {"show", "checkout", "switch", "reset"}
+_GIT_GLOBAL_VALUE_OPTIONS = {
+    "-C",
+    "-c",
+    "--config-env",
+    "--exec-path",
+    "--git-dir",
+    "--namespace",
+    "--super-prefix",
+    "--work-tree",
+}
+
+
+def _git_identity_command(words: list[str]) -> tuple[str, list[str]] | None:
+    if not words or words[0] != "git":
+        return None
+    index = 1
+    while index < len(words) and words[index].startswith("-"):
+        option = words[index]
+        index += 1
+        if option in _GIT_GLOBAL_VALUE_OPTIONS and "=" not in option and index < len(words):
+            index += 1
+    if index >= len(words) or words[index] not in _GIT_IDENTITY_COMMANDS:
+        return None
+    return words[index], words[index + 1 :]
+
+
 def _ref_binding(path: tuple[str, ...]) -> bool:
     if not path or "env" in path or "outputs" in path:
         return False
@@ -1844,8 +1928,14 @@ def _pin_offences(sources: dict[str, str]) -> list[str]:
                         run,
                     )
                 )
+                normalized_run = re.sub(
+                    r"\$\((.*?)\)",
+                    lambda match: "$(" + " ".join(match.group(1).split()) + ")",
+                    run,
+                    flags=re.DOTALL,
+                )
                 base = _pin_base(pin.output)
-                for words in _shell_commands(run):
+                for words in _shell_commands(normalized_run):
                     for index, word in enumerate(words[:-1]):
                         flag = word.removeprefix("--")
                         relevant_flag = (
@@ -1874,20 +1964,12 @@ def _pin_offences(sources: dict[str, str]) -> list[str]:
                                 f"{pin.workflow}:{job_name}: rule=pin-consumer: alias overwrites "
                                 f"{pin.job}.{pin.output} at identity sink {word}"
                             )
-                    if (
-                        len(words) > 1
-                        and words[0] == "git"
-                        and words[1]
-                        in {
-                            "show",
-                            "checkout",
-                            "switch",
-                            "reset",
-                        }
-                    ):
+                    identity_command = _git_identity_command(words)
+                    if identity_command is not None:
+                        command, arguments = identity_command
                         used_git = {
                             name
-                            for argument in words[2:]
+                            for argument in arguments
                             for name in step_aliases
                             if argument == f"${name}"
                             or argument == f"${{{name}}}"
@@ -1896,22 +1978,23 @@ def _pin_offences(sources: dict[str, str]) -> list[str]:
                         }
                         used_git_live = {
                             name
-                            for argument in words[2:]
+                            for argument in arguments
                             for name in live_vars
                             if argument == f"${name}"
                             or argument == f"${{{name}}}"
                             or argument.startswith(f"${name}:")
                             or argument.startswith(f"${{{name}}}:")
                         }
-                        if used_git_live and step_aliases:
+                        direct_live = any(re.search(r"\$\(\s*git\s+ls-remote\b", argument) for argument in arguments)
+                        if (used_git_live or direct_live) and step_aliases:
                             offences.append(
                                 f"{pin.workflow}:{job_name}: rule=pin-consumer: live git ls-remote "
-                                f"replaces {pin.job}.{pin.output} at identity sink git {words[1]}"
+                                f"replaces {pin.job}.{pin.output} at identity sink git {command}"
                             )
                         elif used_git & overridden:
                             offences.append(
                                 f"{pin.workflow}:{job_name}: rule=pin-consumer: alias overwrites "
-                                f"{pin.job}.{pin.output} at identity sink git {words[1]}"
+                                f"{pin.job}.{pin.output} at identity sink git {command}"
                             )
                         elif used_git:
                             identity = True

--- a/tests/test_issue2231_workflow_hygiene.py
+++ b/tests/test_issue2231_workflow_hygiene.py
@@ -333,6 +333,7 @@ _EXTERNAL_TRIGGERS = {"workflow_dispatch", "push", "schedule", "release"}
 def _workflow_sources() -> dict[str, str]:
     directory = ROOT / ".github/workflows"
     paths = {path.name: path for pattern in ("*.yml", "*.yaml") for path in directory.glob(pattern)}
+    assert paths, f"no workflow files discovered under {directory}"
     return {name: paths[name].read_text(encoding="utf-8") for name in sorted(paths)}
 
 
@@ -457,7 +458,11 @@ class _ArtifactJob(NamedTuple):
     outputs: Mapping[str, frozenset[str]]
 
 
-_ARTIFACT_ACTION = re.compile(r"^actions/(?P<kind>upload|download)-artifact@v(?P<major>[0-9]+)$")
+_DownloadKey = tuple[str, str, int, int, tuple[tuple[str, str], ...], tuple[str, ...]]
+
+
+_ARTIFACT_ACTION_REF = re.compile(r"^actions/(?P<kind>upload|download)-artifact@.+$")
+_ARTIFACT_ACTION = re.compile(r"^actions/(?P<kind>upload|download)-artifact@v(?P<major>[0-9]+)(?:\.[0-9]+){0,2}$")
 _GH_EXPRESSION = re.compile(r"\$\{\{\s*(.*?)\s*\}\}")
 _UNRESOLVED_EXPRESSION = re.compile(r"<unresolved:(?P<expression>[^>]+)>")
 
@@ -627,19 +632,21 @@ def _selectors_match(name: str, selector: str) -> bool:
 def _artifact_chain_offences(sources: dict[str, str]) -> list[str]:
     documents = {name: _workflow_document(source, name) for name, source in sources.items()}
     offences: set[str] = set()
-    download_matches: dict[tuple[str, str, int, int], bool] = {}
-    download_selectors: dict[tuple[str, str, int, int], set[str]] = {}
-    major_mismatches: dict[tuple[str, str, int, int], set[tuple[str, str, int]]] = {}
-    required_downloads: set[tuple[str, str, int, int]] = set()
+    download_matches: dict[_DownloadKey, bool] = {}
+    download_selectors: dict[_DownloadKey, set[str]] = {}
+    major_mismatches: dict[_DownloadKey, set[tuple[str, str, int]]] = {}
+    required_downloads: set[_DownloadKey] = set()
 
     def scan_instance(
         workflow: str,
         supplied_inputs: Mapping[str, frozenset[str]],
         inherited: tuple[_Artifact, ...],
-        stack: tuple[str, ...],
+        stack: tuple[tuple[str, str], ...],
         require_matches: bool,
     ) -> tuple[tuple[_Artifact, ...], Mapping[str, frozenset[str]]]:
-        assert workflow not in stack, f"{workflow}: rule=artifact-major: recursive reusable workflow"
+        assert workflow not in {caller for caller, _ in stack}, (
+            f"{workflow}: rule=artifact-major: recursive reusable workflow"
+        )
         document = documents[workflow]
         inputs = _default_inputs(document)
         inputs.update(supplied_inputs)
@@ -680,7 +687,7 @@ def _artifact_chain_offences(sources: dict[str, str]) -> list[str]:
                         if isinstance(name, str)
                     }
                     called_produced, called_outputs = scan_instance(
-                        call_path, called_inputs, upstream, (*stack, workflow), require_matches
+                        call_path, called_inputs, upstream, (*stack, (workflow, job_name)), require_matches
                     )
                     lineage = tuple(
                         dict.fromkeys(
@@ -702,6 +709,11 @@ def _artifact_chain_offences(sources: dict[str, str]) -> list[str]:
                         continue
                     uses = step.get("uses")
                     match = _ARTIFACT_ACTION.fullmatch(uses) if isinstance(uses, str) else None
+                    if isinstance(uses, str) and _ARTIFACT_ACTION_REF.fullmatch(uses) and match is None:
+                        raise AssertionError(
+                            f"{workflow}:{job_name}:step-{step_index}: rule=artifact-major: "
+                            f"unclassified action ref {uses!r}"
+                        )
                     if match is None:
                         continue
                     action_inputs = step.get("with", {})
@@ -728,7 +740,7 @@ def _artifact_chain_offences(sources: dict[str, str]) -> list[str]:
                     if match.group("kind") == "upload":
                         produced.extend(_Artifact(workflow, job_name, selector, major) for selector in selectors)
                         continue
-                    key = (workflow, job_name, step_index, major)
+                    key = (workflow, job_name, step_index, major, stack, tuple(sorted(selectors)))
                     download_selectors.setdefault(key, set()).update(selectors)
                     download_matches.setdefault(key, False)
                     if require_matches:
@@ -795,7 +807,13 @@ def _artifact_chain_offences(sources: dict[str, str]) -> list[str]:
         if "workflow_run" in triggers:
             workflow_run_roots.append(workflow)
         if triggers & (_EXTERNAL_TRIGGERS | {"pull_request"}):
-            root_produced, _ = scan_instance(workflow, {}, (), (), "workflow_run" not in triggers)
+            root_produced, _ = scan_instance(
+                workflow,
+                {},
+                (),
+                (("<direct>", workflow),),
+                "workflow_run" not in triggers,
+            )
             name = document.get("name")
             if isinstance(name, str):
                 direct_names[name] = tuple(dict.fromkeys((*direct_names.get(name, ()), *root_produced)))
@@ -808,14 +826,16 @@ def _artifact_chain_offences(sources: dict[str, str]) -> list[str]:
         missing = [name for name in names if isinstance(name, str) and name not in direct_names]
         if missing:
             offences.add(f"{workflow}: rule=artifact-major: workflow_run names missing producers {missing!r}")
-        scan_instance(workflow, {}, inherited, (), True)
-    for (workflow, job, step, major), matched in sorted(download_matches.items()):
-        if not matched and (workflow, job, step, major) in required_downloads:
+        scan_instance(workflow, {}, inherited, (("<workflow_run>", workflow),), True)
+    for key, matched in sorted(download_matches.items()):
+        workflow, job, step, major, _, _ = key
+        if not matched and key in required_downloads:
             offences.add(
                 f"{workflow}:{job}:step-{step}: rule=artifact-major: no producer matches "
-                f"{sorted(download_selectors[(workflow, job, step, major)])!r}"
+                f"{sorted(download_selectors[key])!r}"
             )
-    for (workflow, job, step, major), producers in sorted(major_mismatches.items()):
+    for key, producers in sorted(major_mismatches.items()):
+        workflow, job, step, major, _, _ = key
         offences.add(
             f"{workflow}:{job}:step-{step}: rule=artifact-major: download v{major} "
             f"mismatches producers {sorted(producers)!r}"
@@ -1189,8 +1209,12 @@ def _logical_shell_lines(source: str) -> list[tuple[int, str]]:
 
 def _shell_words(source: str, where: str) -> list[tuple[int, list[str]]]:
     commands: list[tuple[int, list[str]]] = []
+    bindings: dict[str, str] = {}
     for line_no, logical in _logical_shell_lines(source):
-        if "docker" not in logical.lower() or "run" not in logical:
+        bound_reference = any(
+            re.search(rf"\$(?:{re.escape(name)}\b|\{{{re.escape(name)}\}})", logical) for name in bindings
+        )
+        if "docker" not in logical.lower() and not ("run" in logical and bound_reference):
             continue
         lexer = shlex.shlex(logical, posix=True, punctuation_chars=";&|()")
         lexer.whitespace_split = True
@@ -1203,11 +1227,35 @@ def _shell_words(source: str, where: str) -> list[tuple[int, list[str]]]:
         for word in [*words, ";"]:
             if word in _SHELL_OPERATORS:
                 if segment:
-                    commands.append((line_no, segment))
+                    for candidate in segment:
+                        assignment = re.fullmatch(r"([A-Za-z_][A-Za-z0-9_]*)=(.*)", candidate)
+                        if assignment is not None and Path(assignment.group(2)).name == "docker":
+                            bindings[assignment.group(1)] = assignment.group(2)
+                    resolved: list[str] = []
+                    for candidate in segment:
+                        variable = re.fullmatch(
+                            r"\$(?:([A-Za-z_][A-Za-z0-9_]*)|\{([A-Za-z_][A-Za-z0-9_]*)\})",
+                            candidate,
+                        )
+                        name = next((group for group in variable.groups() if group), "") if variable else ""
+                        resolved.append(bindings.get(name, candidate))
+                    commands.append((line_no, resolved))
                     segment = []
             else:
                 segment.append(word)
     return commands
+
+
+_DOCKER_GLOBAL_VALUE_OPTIONS = {
+    "--config",
+    "--context",
+    "--host",
+    "--log-level",
+    "--tlscacert",
+    "--tlscert",
+    "--tlskey",
+    "-H",
+}
 
 
 def _docker_argv(words: list[str]) -> list[str] | None:
@@ -1233,30 +1281,118 @@ def _docker_argv(words: list[str]) -> list[str] | None:
             if option in {"-C", "--chdir", "-S", "--split-string", "-u", "--unset"} and index < len(words):
                 index += 1
     docker = words[index] if index < len(words) else ""
-    if (
-        index + 1 >= len(words)
-        or (Path(docker).name != "docker" and "DOCKER" not in docker)
-        or words[index + 1] != "run"
-    ):
+    if Path(docker).name != "docker" and "DOCKER" not in docker:
         return None
-    return words[index + 2 :]
+    index += 1
+    while index < len(words) and words[index] != "run":
+        option = words[index]
+        if not option.startswith("-"):
+            return None
+        index += 1
+        if option in _DOCKER_GLOBAL_VALUE_OPTIONS and "=" not in option and index < len(words):
+            index += 1
+    if index >= len(words):
+        return None
+    return words[index + 1 :]
 
 
 _DOCKER_VALUE_OPTIONS = {
     "--add-host",
+    "--annotation",
+    "--attach",
+    "--blkio-weight",
+    "--blkio-weight-device",
     "--cap-add",
+    "--cap-drop",
+    "--cgroup-parent",
+    "--cgroupns",
+    "--cidfile",
+    "--cpu-count",
+    "--cpu-percent",
+    "--cpu-period",
+    "--cpu-quota",
+    "--cpu-rt-period",
+    "--cpu-rt-runtime",
+    "--cpu-shares",
+    "--cpus",
+    "--cpuset-cpus",
+    "--cpuset-mems",
     "--device",
+    "--device-cgroup-rule",
+    "--device-read-bps",
+    "--device-read-iops",
+    "--device-write-bps",
+    "--device-write-iops",
+    "--dns",
+    "--dns-option",
+    "--dns-search",
+    "--domainname",
+    "--entrypoint",
     "--env",
+    "--env-file",
+    "--expose",
+    "--gpus",
+    "--group-add",
+    "--health-cmd",
+    "--health-interval",
+    "--health-retries",
+    "--health-start-interval",
+    "--health-start-period",
+    "--health-timeout",
+    "--hostname",
+    "--ip",
+    "--ip6",
+    "--ipc",
+    "--isolation",
+    "--kernel-memory",
     "--label",
+    "--label-file",
+    "--link",
+    "--link-local-ip",
+    "--log-driver",
+    "--log-opt",
+    "--mac-address",
+    "--memory",
+    "--memory-reservation",
+    "--memory-swap",
+    "--memory-swappiness",
+    "--mount",
     "--name",
     "--network",
+    "--network-alias",
+    "--oom-score-adj",
+    "--pid",
+    "--pids-limit",
+    "--platform",
     "--publish",
+    "--pull",
+    "--restart",
+    "--runtime",
+    "--security-opt",
+    "--shm-size",
+    "--stop-signal",
+    "--stop-timeout",
+    "--storage-opt",
     "--sysctl",
     "--tmpfs",
+    "--ulimit",
+    "--user",
+    "--userns",
+    "--uts",
     "--volume",
+    "--volume-driver",
+    "--volumes-from",
+    "--workdir",
+    "-a",
+    "-c",
     "-e",
+    "-h",
+    "-l",
+    "-m",
     "-p",
+    "-u",
     "-v",
+    "-w",
 }
 
 
@@ -1291,12 +1427,19 @@ def _python_docker_runs(source: str, where: str) -> list[tuple[int, list[str]]]:
         for alias in node.names
         if alias.name == "subprocess"
     }
-    bound_argv = {
-        target.id: node.value
+    bound_argv: dict[str, list[tuple[int, ast.expr]]] = {}
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Assign) or not isinstance(node.value, (ast.List, ast.Tuple)):
+            continue
+        for target in node.targets:
+            if isinstance(target, ast.Name):
+                bound_argv.setdefault(target.id, []).append((node.lineno, node.value))
+    returned_argv = {
+        node.name: statement.value
         for node in tree.body
-        if isinstance(node, ast.Assign) and isinstance(node.value, (ast.List, ast.Tuple))
-        for target in node.targets
-        if isinstance(target, ast.Name)
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        for statement in node.body
+        if isinstance(statement, ast.Return) and isinstance(statement.value, (ast.List, ast.Tuple))
     }
     invocations: list[tuple[int, list[str]]] = []
     for node in ast.walk(tree):
@@ -1320,7 +1463,16 @@ def _python_docker_runs(source: str, where: str) -> list[tuple[int, list[str]]]:
             continue
         argument = node.args[0]
         if isinstance(argument, ast.Name) and argument.id in bound_argv:
-            argument = bound_argv[argument.id]
+            candidates = [(line, candidate) for line, candidate in bound_argv[argument.id] if line < node.lineno]
+            if candidates:
+                argument = max(candidates, key=lambda candidate: candidate[0])[1]
+        elif (
+            isinstance(argument, ast.Call)
+            and isinstance(argument.func, ast.Name)
+            and not argument.args
+            and argument.func.id in returned_argv
+        ):
+            argument = returned_argv[argument.func.id]
         words: list[str] | None = None
         if isinstance(argument, (ast.List, ast.Tuple)):
             words = [
@@ -1334,20 +1486,35 @@ def _python_docker_runs(source: str, where: str) -> list[tuple[int, list[str]]]:
     return invocations
 
 
+_PHP_STRING_ASSIGN = re.compile(
+    r"\$(?P<name>[A-Za-z_][A-Za-z0-9_]*)\s*=\s*(?P<quote>['\"])(?P<body>.*?)(?P=quote)\s*;",
+    re.DOTALL,
+)
 _PHP_SHELL_CALL = re.compile(
-    r"\b(?:exec|passthru|shell_exec|system)\s*\(\s*(?P<quote>['\"])(?P<body>.*?)(?P=quote)",
+    r"\b(?:exec|passthru|shell_exec|system)\s*\(\s*"
+    r"(?:(?P<quote>['\"])(?P<body>.*?)(?P=quote)|\$(?P<variable>[A-Za-z_][A-Za-z0-9_]*))",
     re.DOTALL,
 )
 
 
 def _php_docker_runs(source: str, where: str) -> list[tuple[int, list[str]]]:
+    variables: dict[str, str] = {}
+    for match in _PHP_STRING_ASSIGN.finditer(source):
+        line_start = source.rfind("\n", 0, match.start()) + 1
+        if not source[line_start : match.start()].lstrip().startswith(("//", "#", "*")):
+            variables[match.group("name")] = match.group("body")
     invocations: list[tuple[int, list[str]]] = []
     for match in _PHP_SHELL_CALL.finditer(source):
         line_start = source.rfind("\n", 0, match.start()) + 1
         if source[line_start : match.start()].lstrip().startswith(("//", "#", "*")):
             continue
+        body = match.group("body")
+        if body is None:
+            body = variables.get(match.group("variable"))
+        if body is None:
+            continue
         line_no = source.count("\n", 0, match.start()) + 1
-        words = _option_words(match.group("body"), f"{where}:{line_no}", "docker-init")
+        words = _option_words(body, f"{where}:{line_no}", "docker-init")
         if _docker_argv(words) is not None:
             invocations.append((line_no, words))
     return invocations
@@ -1454,7 +1621,6 @@ class _ShaPin(NamedTuple):
     workflow: str
     job: str
     output: str
-    step_id: str
 
 
 _PIN_JOB = re.compile(r"(?:^|-)(?:prepare|read|resolve)(?:-|$)")
@@ -1528,7 +1694,7 @@ def _sha_inventory(
                         f"steps.<real-id>.outputs.{output}"
                     )
                     continue
-                pins.append(_ShaPin(workflow, job_name, output, match.group("step")))
+                pins.append(_ShaPin(workflow, job_name, output))
     return pins, offences
 
 
@@ -1557,8 +1723,21 @@ def _pin_base(output: str) -> str:
     return output.removesuffix("_sha").replace("_", "-")
 
 
+def _pin_expression_members(value: str) -> frozenset[tuple[str, str]]:
+    expression = _GH_EXPRESSION.fullmatch(value.strip())
+    if expression is None:
+        return frozenset()
+    members: set[tuple[str, str]] = set()
+    for alternative in _expression_parts(expression.group(1), "||"):
+        member = _NEEDS_OUTPUT.fullmatch(alternative)
+        if member is None:
+            return frozenset()
+        members.add((member.group("job"), member.group("output")))
+    return frozenset(members)
+
+
 def _ref_binding(path: tuple[str, ...]) -> bool:
-    if not path or "env" in path:
+    if not path or "env" in path or "outputs" in path:
         return False
     return path[-1].lower() in {
         "ref",
@@ -1596,10 +1775,13 @@ def _pin_offences(sources: dict[str, str]) -> list[str]:
             )
             continue
 
-        identity = any(
-            _ref_binding(path) and value.strip().startswith("${{") and value.strip().endswith("}}")
-            for _, path, value in consumers
-        )
+        workflow_pins = {(candidate.job, candidate.output) for candidate in pins if candidate.workflow == pin.workflow}
+        identity = False
+        for _, path, value in consumers:
+            members = _pin_expression_members(value)
+            if _ref_binding(path) and (pin.job, pin.output) in members and members <= workflow_pins:
+                identity = True
+                break
         for job_name in sorted(descendants):
             job = jobs[job_name]
             if not isinstance(job, dict):
@@ -1636,11 +1818,14 @@ def _pin_offences(sources: dict[str, str]) -> list[str]:
                 if not isinstance(run, str):
                     continue
                 overridden = {
-                    name for name in step_aliases if re.search(rf"(?m)^\s*(?:export\s+)?{re.escape(name)}=", run)
+                    name
+                    for name in step_aliases
+                    if re.search(rf"(?m)^\s*(?:(?:export|readonly)\s+)?{re.escape(name)}\s*=", run)
                 }
                 live_vars = set(
                     re.findall(
-                        r"(?m)^\s*(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)=.*\bgit\s+ls-remote\b",
+                        r'(?ms)^\s*(?:(?:export|readonly)\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=\s*["\']?'
+                        r"\$\(\s*git\s+ls-remote\b",
                         run,
                     )
                 )
@@ -1677,17 +1862,35 @@ def _pin_offences(sources: dict[str, str]) -> list[str]:
                     if (
                         len(words) > 1
                         and words[0] == "git"
-                        and words[1] in {"show", "checkout", "switch", "reset"}
-                        and any(
-                            argument == f"${name}"
+                        and words[1]
+                        in {
+                            "show",
+                            "checkout",
+                            "switch",
+                            "reset",
+                        }
+                    ):
+                        used_git = {
+                            name
+                            for argument in words[2:]
+                            for name in step_aliases
+                            if argument == f"${name}"
                             or argument == f"${{{name}}}"
                             or argument.startswith(f"${name}:")
                             or argument.startswith(f"${{{name}}}:")
-                            for argument in words[2:]
-                            for name in step_aliases - overridden
-                        )
-                    ):
-                        identity = True
+                        }
+                        if used_git & live_vars:
+                            offences.append(
+                                f"{pin.workflow}:{job_name}: rule=pin-consumer: live git ls-remote "
+                                f"replaces {pin.job}.{pin.output} at identity sink git {words[1]}"
+                            )
+                        elif used_git & overridden:
+                            offences.append(
+                                f"{pin.workflow}:{job_name}: rule=pin-consumer: alias overwrites "
+                                f"{pin.job}.{pin.output} at identity sink git {words[1]}"
+                            )
+                        elif used_git:
+                            identity = True
         if not identity:
             offences.append(
                 f"{pin.workflow}:{pin.job}.{pin.output}: rule=pin-consumer: pin is not consumed by a ref/identity sink"

--- a/tests/test_issue2231_workflow_hygiene.py
+++ b/tests/test_issue2231_workflow_hygiene.py
@@ -433,6 +433,13 @@ def test_workflow_parser_fails_closed_with_file_and_rule_diagnostics(where: str,
         _workflow_document(source, where)
 
 
+@pytest.mark.parametrize("workflow", ("image-refresh.yml", "nightly-failure-alert.yml"))
+def test_lossless_operational_workflows_keep_every_pending_event(workflow: str) -> None:
+    concurrency = _workflow_document(_workflow_sources()[workflow], workflow)["concurrency"]
+    assert isinstance(concurrency, dict)
+    assert concurrency.get("queue") == "max"
+
+
 # --------------------------------------------------------------------------- #
 # 5. Artifact producer/consumer chains keep one action major.
 # --------------------------------------------------------------------------- #
@@ -623,12 +630,14 @@ def _artifact_chain_offences(sources: dict[str, str]) -> list[str]:
     download_matches: dict[tuple[str, str, int, int], bool] = {}
     download_selectors: dict[tuple[str, str, int, int], set[str]] = {}
     major_mismatches: dict[tuple[str, str, int, int], set[tuple[str, str, int]]] = {}
+    required_downloads: set[tuple[str, str, int, int]] = set()
 
     def scan_instance(
         workflow: str,
         supplied_inputs: Mapping[str, frozenset[str]],
         inherited: tuple[_Artifact, ...],
         stack: tuple[str, ...],
+        require_matches: bool,
     ) -> tuple[tuple[_Artifact, ...], Mapping[str, frozenset[str]]]:
         assert workflow not in stack, f"{workflow}: rule=artifact-major: recursive reusable workflow"
         document = documents[workflow]
@@ -671,7 +680,7 @@ def _artifact_chain_offences(sources: dict[str, str]) -> list[str]:
                         if isinstance(name, str)
                     }
                     called_produced, called_outputs = scan_instance(
-                        call_path, called_inputs, upstream, (*stack, workflow)
+                        call_path, called_inputs, upstream, (*stack, workflow), require_matches
                     )
                     lineage = tuple(
                         dict.fromkeys(
@@ -722,6 +731,8 @@ def _artifact_chain_offences(sources: dict[str, str]) -> list[str]:
                     key = (workflow, job_name, step_index, major)
                     download_selectors.setdefault(key, set()).update(selectors)
                     download_matches.setdefault(key, False)
+                    if require_matches:
+                        required_downloads.add(key)
                     available = (*upstream, *produced)
                     matched = {
                         artifact
@@ -784,7 +795,7 @@ def _artifact_chain_offences(sources: dict[str, str]) -> list[str]:
         if "workflow_run" in triggers:
             workflow_run_roots.append(workflow)
         if triggers & (_EXTERNAL_TRIGGERS | {"pull_request"}):
-            root_produced, _ = scan_instance(workflow, {}, (), ())
+            root_produced, _ = scan_instance(workflow, {}, (), (), "workflow_run" not in triggers)
             name = document.get("name")
             if isinstance(name, str):
                 direct_names[name] = root_produced
@@ -797,9 +808,9 @@ def _artifact_chain_offences(sources: dict[str, str]) -> list[str]:
         missing = [name for name in names if isinstance(name, str) and name not in direct_names]
         if missing:
             offences.add(f"{workflow}: rule=artifact-major: workflow_run names missing producers {missing!r}")
-        scan_instance(workflow, {}, inherited, ())
+        scan_instance(workflow, {}, inherited, (), True)
     for (workflow, job, step, major), matched in sorted(download_matches.items()):
-        if not matched and "workflow_run" not in _trigger_names(documents[workflow]):
+        if not matched and (workflow, job, step, major) in required_downloads:
             offences.add(
                 f"{workflow}:{job}:step-{step}: rule=artifact-major: no producer matches "
                 f"{sorted(download_selectors[(workflow, job, step, major)])!r}"
@@ -899,6 +910,7 @@ jobs:
         with: {name: family-two}
 """,
         "root.yaml": """\
+
 on: workflow_dispatch
 jobs:
   make:
@@ -934,6 +946,33 @@ jobs:
         and "('producer.yml', 'duplicate', 8)" in item
         for item in offences
     )
+
+
+def test_artifact_scanner_rejects_unmatched_workflow_run_selector() -> None:
+    sources = {
+        "root.yml": """\
+name: Root
+on: workflow_dispatch
+jobs:
+  upload:
+    steps:
+      - uses: actions/upload-artifact@v8
+        with: {name: expected}
+""",
+        "callback.yaml": """\
+on:
+  workflow_run:
+    workflows: [Root]
+jobs:
+  consume:
+    steps:
+      - uses: actions/download-artifact@v8
+        with: {name: typo}
+""",
+    }
+    assert _artifact_chain_offences(sources) == [
+        "callback.yaml:consume:step-0: rule=artifact-major: no producer matches ['typo']"
+    ]
 
 
 def test_artifact_scanner_resolves_workflow_run_display_name_through_local_reusable_producer() -> None:
@@ -1109,7 +1148,7 @@ def _logical_shell_lines(source: str) -> list[tuple[int, str]]:
 def _shell_words(source: str, where: str) -> list[tuple[int, list[str]]]:
     commands: list[tuple[int, list[str]]] = []
     for line_no, logical in _logical_shell_lines(source):
-        if "docker" not in logical or "run" not in logical:
+        if "docker" not in logical.lower() or "run" not in logical:
             continue
         lexer = shlex.shlex(logical, posix=True, punctuation_chars=";&|()")
         lexer.whitespace_split = True
@@ -1133,7 +1172,7 @@ def _docker_argv(words: list[str]) -> list[str] | None:
     index = 0
     while index < len(words) and re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*=.*", words[index]):
         index += 1
-    while index < len(words) and words[index] in {"command", "exec"}:
+    while index < len(words) and words[index] in {"command", "exec", "sudo"}:
         index += 1
     if index < len(words) and words[index] == "env":
         index += 1
@@ -1141,9 +1180,44 @@ def _docker_argv(words: list[str]) -> list[str] | None:
             words[index].startswith("-") or re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*=.*", words[index])
         ):
             index += 1
-    if index + 1 >= len(words) or Path(words[index]).name != "docker" or words[index + 1] != "run":
+    docker = words[index] if index < len(words) else ""
+    if (
+        index + 1 >= len(words)
+        or (Path(docker).name != "docker" and "DOCKER" not in docker)
+        or words[index + 1] != "run"
+    ):
         return None
     return words[index + 2 :]
+
+
+_DOCKER_VALUE_OPTIONS = {
+    "--add-host",
+    "--cap-add",
+    "--device",
+    "--env",
+    "--label",
+    "--name",
+    "--network",
+    "--publish",
+    "--sysctl",
+    "--tmpfs",
+    "--volume",
+    "-e",
+    "-p",
+    "-v",
+}
+
+
+def _docker_has_init_before_image(argv: list[str]) -> bool:
+    index = 0
+    while index < len(argv):
+        word = argv[index]
+        if word == "--init":
+            return True
+        if not word.startswith("-"):
+            return False
+        index += 2 if word in _DOCKER_VALUE_OPTIONS and "=" not in word else 1
+    return False
 
 
 def _python_docker_runs(source: str, where: str) -> list[tuple[int, list[str]]]:
@@ -1152,6 +1226,13 @@ def _python_docker_runs(source: str, where: str) -> list[tuple[int, list[str]]]:
     except SyntaxError as exc:
         raise AssertionError(f"{where}:{exc.lineno}: rule=docker-init: invalid Python: {exc.msg}") from exc
     invocations: list[tuple[int, list[str]]] = []
+    imported_calls = {
+        alias.asname or alias.name
+        for node in tree.body
+        if isinstance(node, ast.ImportFrom) and node.module == "subprocess"
+        for alias in node.names
+        if alias.name in {"call", "check_call", "check_output", "Popen", "run"}
+    }
     for node in ast.walk(tree):
         if not isinstance(node, ast.Call) or not node.args:
             continue
@@ -1168,14 +1249,16 @@ def _python_docker_runs(source: str, where: str) -> list[tuple[int, list[str]]]:
             and function.value.id == "os"
             and function.attr == "system"
         )
-        if not (is_subprocess or is_os_system):
+        is_imported_subprocess = isinstance(function, ast.Name) and function.id in imported_calls
+        if not (is_subprocess or is_imported_subprocess or is_os_system):
             continue
         argument = node.args[0]
         words: list[str] | None = None
-        if isinstance(argument, (ast.List, ast.Tuple)) and all(
-            isinstance(item, ast.Constant) and isinstance(item.value, str) for item in argument.elts
-        ):
-            words = [cast(str, item.value) for item in argument.elts if isinstance(item, ast.Constant)]
+        if isinstance(argument, (ast.List, ast.Tuple)):
+            words = [
+                cast(str, item.value) if isinstance(item, ast.Constant) and isinstance(item.value, str) else "<dynamic>"
+                for item in argument.elts
+            ]
         elif isinstance(argument, ast.Constant) and isinstance(argument.value, str):
             words = _option_words(argument.value, f"{where}:{node.lineno}", "docker-init")
         if words is not None and _docker_argv(words) is not None:
@@ -1214,7 +1297,7 @@ def _docker_run_offences(sources: dict[str, str]) -> list[str]:
             invocations = _shell_words(source, where)
         for line_no, words in invocations:
             argv = _docker_argv(words)
-            if argv is not None and "--init" not in argv:
+            if argv is not None and not _docker_has_init_before_image(argv):
                 offences.append(f"{where}:{line_no}: rule=docker-init: docker run must include exact token --init")
     return offences
 
@@ -1265,6 +1348,27 @@ system('docker run --rm');
         "tests/smoke/case.py:5: rule=docker-init: docker run must include exact token --init",
         "scripts/case.php:5: rule=docker-init: docker run must include exact token --init",
     ]
+
+
+def test_docker_scanner_rejects_wrappers_dynamic_argv_and_late_init() -> None:
+    sources = {
+        "scripts/wrappers.sh": """\
+sudo docker run alpine
+docker run alpine --init
+DOCKER=docker
+"$DOCKER" run --rm alpine
+""",
+        "tests/smoke/imported.py": """\
+from subprocess import run
+
+opts = ["--rm", "alpine"]
+run(["docker", "run", "alpine"])
+run(["docker", "run", *opts])
+""",
+    }
+    offences = _docker_run_offences(sources)
+    assert len(offences) == 5, offences
+    assert all("rule=docker-init" in offence for offence in offences)
 
 
 # --------------------------------------------------------------------------- #
@@ -1382,8 +1486,15 @@ def _pin_base(output: str) -> str:
 def _ref_binding(path: tuple[str, ...]) -> bool:
     if not path or "env" in path:
         return False
-    key = path[-1].lower()
-    return key == "ref" or key.endswith("_ref") or key == "sha" or key.endswith("_sha")
+    return path[-1].lower() in {
+        "ref",
+        "sha",
+        "checkout_ref",
+        "source_ref",
+        "ports_ref",
+        "smoke_nightly_expected_source_sha",
+        "smoke_repo_expected_source_sha",
+    }
 
 
 def _pin_offences(sources: dict[str, str]) -> list[str]:
@@ -1411,7 +1522,10 @@ def _pin_offences(sources: dict[str, str]) -> list[str]:
             )
             continue
 
-        identity = any(_ref_binding(path) for _, path, _ in consumers)
+        identity = any(
+            _ref_binding(path) and value.strip().startswith("${{") and value.strip().endswith("}}")
+            for _, path, value in consumers
+        )
         for job_name in sorted(descendants):
             job = jobs[job_name]
             if not isinstance(job, dict):
@@ -1448,13 +1562,14 @@ def _pin_offences(sources: dict[str, str]) -> list[str]:
                 if not isinstance(run, str):
                     continue
                 overridden = {
-                    name
-                    for name in step_aliases
-                    if re.search(
-                        rf"(?m)^\s*(?:export\s+)?{re.escape(name)}=.*\bgit\s+ls-remote\b",
+                    name for name in step_aliases if re.search(rf"(?m)^\s*(?:export\s+)?{re.escape(name)}=", run)
+                }
+                live_vars = set(
+                    re.findall(
+                        r"(?m)^\s*(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)=.*\bgit\s+ls-remote\b",
                         run,
                     )
-                }
+                )
                 base = _pin_base(pin.output)
                 for words in _shell_commands(run):
                     for index, word in enumerate(words[:-1]):
@@ -1467,15 +1582,23 @@ def _pin_offences(sources: dict[str, str]) -> list[str]:
                         if not relevant_flag:
                             continue
                         argument = words[index + 1]
-                        used = {name for name in step_aliases if argument == f"${name}" or argument == f"${{{name}}}"}
-                        if reference in argument:
+                        argument_var = argument.removeprefix("${").removesuffix("}")
+                        if argument.startswith("$") and not argument.startswith("${"):
+                            argument_var = argument[1:]
+                        used = {name for name in step_aliases if argument_var == name}
+                        if argument_var in live_vars:
+                            offences.append(
+                                f"{pin.workflow}:{job_name}: rule=pin-consumer: live git ls-remote "
+                                f"replaces {pin.job}.{pin.output} at identity sink {word}"
+                            )
+                        elif reference == argument:
                             identity = True
                         elif used - overridden:
                             identity = True
                         elif used & overridden:
                             offences.append(
-                                f"{pin.workflow}:{job_name}: rule=pin-consumer: live git ls-remote "
-                                f"replaces {pin.job}.{pin.output} at identity sink {word}"
+                                f"{pin.workflow}:{job_name}: rule=pin-consumer: alias overwrites "
+                                f"{pin.job}.{pin.output} at identity sink {word}"
                             )
                     if (
                         len(words) > 1
@@ -1641,3 +1764,39 @@ jobs:
         "live git ls-remote replaces resolve.ports_sha at identity sink --ports-ref" in item for item in offences
     )
     assert not any("unrelated.yaml" in item for item in offences)
+
+
+def test_pin_scanner_rejects_decorated_refs_alias_overwrites_and_indirect_live_refs() -> None:
+    sources = {
+        "hostile.yml": """\
+on: workflow_dispatch
+jobs:
+  prepare:
+    outputs:
+      ports_sha: ${{ steps.pin.outputs.ports_sha }}
+      source_sha: ${{ steps.pin.outputs.source_sha }}
+    steps:
+      - id: pin
+  build:
+    needs: prepare
+    with:
+      ref: refs/heads/${{ needs.prepare.outputs.source_sha }}-attacker
+      arbitrary_sha: ${{ needs.prepare.outputs.source_sha }}
+    steps:
+      - env:
+          PORTS_SHA: ${{ needs.prepare.outputs.ports_sha }}
+        run: |
+          git show \"$PORTS_SHA:Makefile\"
+          FRESH=\"$(git ls-remote origin main)\"
+          build-leg.sh --ports-ref \"$FRESH\"
+      - env:
+          PORTS_SHA: ${{ needs.prepare.outputs.ports_sha }}
+        run: |
+          PORTS_SHA=main
+          build-leg.sh --ports-ref \"$PORTS_SHA\"
+""",
+    }
+    offences = _pin_offences(sources)
+    assert any("prepare.source_sha: rule=pin-consumer: pin is not consumed" in item for item in offences)
+    assert any("live git ls-remote replaces prepare.ports_sha" in item for item in offences)
+    assert any("overwrites prepare.ports_sha" in item for item in offences)

--- a/tests/test_issue2231_workflow_hygiene.py
+++ b/tests/test_issue2231_workflow_hygiene.py
@@ -1864,15 +1864,26 @@ _SHELL_VARIABLE = re.compile(r"\$(?:\{(?P<braced>[A-Za-z_][A-Za-z0-9_]*)(?:[^}]*
 _SHELL_EXACT_VARIABLE = re.compile(r"\$(?:\{(?P<braced>[A-Za-z_][A-Za-z0-9_]*)\}|(?P<plain>[A-Za-z_][A-Za-z0-9_]*))")
 
 
-def _shell_assignment(words: list[str]) -> tuple[str, str] | None:
-    index = 1 if words and words[0] in {"export", "readonly"} else 0
-    if index >= len(words):
-        return None
-    assignment = re.fullmatch(r"(?P<name>[A-Za-z_][A-Za-z0-9_]*)=(?P<value>.*)", words[index])
-    if assignment is None:
-        return None
-    value = " ".join([assignment.group("value"), *words[index + 1 :]])
-    return assignment.group("name"), value
+def _shell_assignments(words: list[str]) -> list[tuple[str, str]]:
+    declarations = bool(words) and words[0] in {"export", "readonly"}
+    assignments: list[tuple[str, str]] = []
+    index = 1 if declarations else 0
+    while index < len(words):
+        assignment = re.fullmatch(r"(?P<name>[A-Za-z_][A-Za-z0-9_]*)=(?P<value>.*)", words[index])
+        if assignment is None:
+            if not declarations:
+                break
+            index += 1
+            continue
+        value = assignment.group("value")
+        depth = value.count("$(") - value.count(")")
+        while depth > 0 and index + 1 < len(words):
+            index += 1
+            value += f" {words[index]}"
+            depth += words[index].count("$(") - words[index].count(")")
+        assignments.append((assignment.group("name"), value))
+        index += 1
+    return assignments
 
 
 def _shell_alias_provenance(value: str, aliases: Mapping[str, str]) -> str | None:
@@ -2012,9 +2023,7 @@ def _pin_offences(sources: dict[str, str]) -> list[str]:
                 commands = _shell_commands(normalized_run)
                 base = _pin_base(pin.output)
                 for words in commands:
-                    assignment = _shell_assignment(words)
-                    if assignment is not None:
-                        name, value = assignment
+                    for name, value in _shell_assignments(words):
                         provenance = _shell_alias_provenance(value, aliases)
                         if provenance is not None or name in aliases:
                             aliases[name] = provenance or "overwritten"

--- a/tests/test_issue2231_workflow_hygiene.py
+++ b/tests/test_issue2231_workflow_hygiene.py
@@ -1778,8 +1778,12 @@ def _pin_offences(sources: dict[str, str]) -> list[str]:
         workflow_pins = {(candidate.job, candidate.output) for candidate in pins if candidate.workflow == pin.workflow}
         identity = False
         for _, path, value in consumers:
-            members = _pin_expression_members(value)
-            if _ref_binding(path) and (pin.job, pin.output) in members and members <= workflow_pins:
+            expression_members = _pin_expression_members(value)
+            if (
+                _ref_binding(path)
+                and (pin.job, pin.output) in expression_members
+                and expression_members <= workflow_pins
+            ):
                 identity = True
                 break
         for job_name in sorted(descendants):

--- a/tests/test_issue2231_workflow_hygiene.py
+++ b/tests/test_issue2231_workflow_hygiene.py
@@ -1988,11 +1988,20 @@ def _pin_offences(sources: dict[str, str]) -> list[str]:
                     for name in pin_aliases
                     if _pin_expression_members(cast(str, effective_env[name])) == exact_member
                 }
+                prepared_aliases = {
+                    name
+                    for name, value in effective_env.items()
+                    if isinstance(name, str)
+                    and isinstance(value, str)
+                    and bool(_pin_expression_members(value))
+                    and _pin_expression_members(value) <= workflow_pins
+                }
                 invalid_aliases = pin_aliases - step_aliases
                 run = step.get("run")
                 if not isinstance(run, str):
                     continue
-                aliases = {name: "exact" for name in step_aliases}
+                aliases = {name: "prepared" for name in prepared_aliases}
+                aliases.update({name: "exact" for name in step_aliases})
                 aliases.update({name: "derived" for name in invalid_aliases})
                 normalized_run = re.sub(
                     r"\$\((.*?)\)",
@@ -2010,6 +2019,7 @@ def _pin_offences(sources: dict[str, str]) -> list[str]:
                         if provenance is not None or name in aliases:
                             aliases[name] = provenance or "overwritten"
 
+                    flag_arguments: list[tuple[str, str, str | None, str | None, frozenset[tuple[str, str]]]] = []
                     for flag, argument in _pin_flag_arguments(words, base):
                         argument_match = _SHELL_EXACT_VARIABLE.fullmatch(argument)
                         argument_var = (
@@ -2017,7 +2027,23 @@ def _pin_offences(sources: dict[str, str]) -> list[str]:
                             if argument_match is not None
                             else None
                         )
-                        provenance = aliases.get(argument_var or "")
+                        flag_arguments.append(
+                            (
+                                flag,
+                                argument,
+                                argument_var,
+                                aliases.get(argument_var or ""),
+                                _pin_expression_members(argument),
+                            )
+                        )
+                    has_prepared_argument = any(
+                        reference == argument
+                        or provenance in {"exact", "prepared"}
+                        or bool(argument_members)
+                        and argument_members <= workflow_pins
+                        for _, argument, _, provenance, argument_members in flag_arguments
+                    )
+                    for flag, argument, argument_var, provenance, argument_members in flag_arguments:
                         if provenance == "derived":
                             sinks = invalid_alias_sinks if argument_var in invalid_aliases else derived_alias_sinks
                             sinks.add((job_name, cast(str, argument_var), flag))
@@ -2026,12 +2052,19 @@ def _pin_offences(sources: dict[str, str]) -> list[str]:
                                 f"{pin.workflow}:{job_name}: rule=pin-consumer: live git ls-remote "
                                 f"replaces {pin.job}.{pin.output} at identity sink {flag}"
                             )
-                        elif reference == argument or provenance == "exact":
+                        elif reference == argument or argument_members == exact_member or provenance == "exact":
                             identity = True
+                        elif provenance == "prepared" or bool(argument_members) and argument_members <= workflow_pins:
+                            continue
                         elif provenance == "overwritten":
                             offences.append(
                                 f"{pin.workflow}:{job_name}: rule=pin-consumer: alias overwrites "
                                 f"{pin.job}.{pin.output} at identity sink {flag}"
+                            )
+                        elif not has_prepared_argument:
+                            offences.append(
+                                f"{pin.workflow}:{job_name}: rule=pin-consumer: identity flag {flag} uses "
+                                f"a derived, untrusted, or unknown value instead of {pin.job}.{pin.output}"
                             )
 
                     identity_command = _git_identity_command(words)

--- a/tests/test_issue2231_workflow_hygiene.py
+++ b/tests/test_issue2231_workflow_hygiene.py
@@ -16,12 +16,23 @@ disables silently. These gates cover what actionlint cannot:
    proves it usable before the suite runs (issue #2261).
 3. The ``actionlint`` job keeps its embedded ShellCheck pass over ``run:``
    bodies, and no config filters that pass's findings away (issue #2241).
+4. Dispatchable workflows own top-level concurrency; artifact chains keep one
+   upload/download action major; container invocations pass ``--init``; and
+   downstream jobs consume prepared SHA pins (issue #2413).
 """
 
 from __future__ import annotations
 
+import ast
 import re
+import shlex
+import subprocess
+from collections.abc import Mapping
 from pathlib import Path
+from typing import NamedTuple, cast
+
+import pytest
+import yaml
 
 ROOT = Path(__file__).resolve().parents[1]
 
@@ -309,3 +320,1240 @@ def test_pass_silencer_scanner_catches_every_spelling() -> None:
     assert _pass_silencers("# actionlint runs shellcheck --norc; see .shellcheckrc") == []
     assert _pass_silencers("      paths-ignore:\n        - '**.md'") == []
     assert _pass_silencers('> "$RUNNER_TEMP/canary-shellcheck.yml"') == []
+
+
+# --------------------------------------------------------------------------- #
+# 4. Dispatchable workflows own top-level concurrency.
+# --------------------------------------------------------------------------- #
+
+
+_EXTERNAL_TRIGGERS = {"workflow_dispatch", "push", "schedule", "release"}
+
+
+def _workflow_sources() -> dict[str, str]:
+    directory = ROOT / ".github/workflows"
+    paths = {path.name: path for pattern in ("*.yml", "*.yaml") for path in directory.glob(pattern)}
+    return {name: paths[name].read_text(encoding="utf-8") for name in sorted(paths)}
+
+
+def _workflow_document(source: str, where: str) -> dict[object, object]:
+    try:
+        document: object = yaml.safe_load(source)
+    except yaml.YAMLError as exc:
+        raise AssertionError(f"{where}: rule=yaml: invalid workflow YAML: {exc}") from exc
+    assert isinstance(document, dict), f"{where}: rule=yaml: workflow must be a non-empty YAML mapping"
+    return document
+
+
+def _trigger_names(document: dict[object, object]) -> set[str]:
+    triggers = document.get(True, document.get("on"))  # PyYAML 1.1 resolves a plain `on` key to True.
+    if isinstance(triggers, str):
+        return {triggers}
+    if isinstance(triggers, list):
+        return {trigger for trigger in triggers if isinstance(trigger, str)}
+    if isinstance(triggers, dict):
+        return {trigger for trigger in triggers if isinstance(trigger, str)}
+    return set()
+
+
+def _concurrency_scan(sources: dict[str, str]) -> tuple[dict[str, str], list[str]]:
+    classifications: dict[str, str] = {}
+    offences: list[str] = []
+    for where, source in sources.items():
+        document = _workflow_document(source, where)
+        triggers = _trigger_names(document)
+        if triggers & _EXTERNAL_TRIGGERS:
+            classifications[where] = "dispatchable"
+            concurrency = document.get("concurrency")
+            valid = (
+                isinstance(concurrency, dict)
+                and isinstance(concurrency.get("group"), str)
+                and bool(concurrency["group"].strip())
+            )
+            if not valid:
+                offences.append(
+                    f"{where}: rule=concurrency: dispatchable triggers {sorted(triggers & _EXTERNAL_TRIGGERS)!r} "
+                    "require top-level concurrency"
+                )
+        elif triggers == {"workflow_call"}:
+            classifications[where] = "reusable-only"
+        else:
+            classifications[where] = "internal-only"
+    return classifications, offences
+
+
+def test_dispatchable_workflows_have_top_level_concurrency() -> None:
+    sources = _workflow_sources()
+    classifications, offences = _concurrency_scan(sources)
+    assert set(classifications) == set(sources)
+    assert not offences, "workflow concurrency hygiene failed:\n  " + "\n  ".join(offences)
+
+
+def test_concurrency_scanner_handles_yaml_trigger_shapes_and_planted_offences() -> None:
+    sources = {
+        "quoted.yaml": (
+            '"on":\n  "workflow_dispatch":\n'
+            "concurrency:\n  group: >-\n    quoted-${{ github.ref }} # parsed as data\n"
+            "jobs: {}\n"
+        ),
+        "mixed.yml": (
+            "on:\n  workflow_call:\n  schedule:\n    - cron: '0 1 * * *'\n"
+            "concurrency:\n  group: mixed-${{ github.ref }} # inline comment\njobs: {}\n"
+        ),
+        "internal.yml": "on:\n  workflow_run:\n  pull_request:\njobs: {}\n",
+        "missing.yml": "on:\n  push:\njobs: {}\n",
+        "empty.yaml": "on:\n  release:\nconcurrency:\n  group: '' # empty after YAML decoding\njobs: {}\n",
+        "scalar.yml": "on:\n  workflow_dispatch:\nconcurrency: text-decoy\njobs: {}\n",
+        "nested-only.yml": (
+            "# concurrency: comments cannot satisfy the rule\n"
+            "on:\n  push:\njobs:\n  test:\n    concurrency:\n      group: nested\n"
+        ),
+    }
+    classifications, offences = _concurrency_scan(sources)
+    assert classifications == {
+        "quoted.yaml": "dispatchable",
+        "mixed.yml": "dispatchable",
+        "internal.yml": "internal-only",
+        "missing.yml": "dispatchable",
+        "empty.yaml": "dispatchable",
+        "scalar.yml": "dispatchable",
+        "nested-only.yml": "dispatchable",
+    }
+    assert offences == [
+        "missing.yml: rule=concurrency: dispatchable triggers ['push'] require top-level concurrency",
+        "empty.yaml: rule=concurrency: dispatchable triggers ['release'] require top-level concurrency",
+        "scalar.yml: rule=concurrency: dispatchable triggers ['workflow_dispatch'] require top-level concurrency",
+        "nested-only.yml: rule=concurrency: dispatchable triggers ['push'] require top-level concurrency",
+    ]
+
+
+@pytest.mark.parametrize(("where", "source"), (("empty.yaml", ""), ("invalid.yml", "on: [\n")))
+def test_workflow_parser_fails_closed_with_file_and_rule_diagnostics(where: str, source: str) -> None:
+    with pytest.raises(AssertionError, match=rf"^{re.escape(where)}: rule=yaml:"):
+        _workflow_document(source, where)
+
+
+# --------------------------------------------------------------------------- #
+# 5. Artifact producer/consumer chains keep one action major.
+# --------------------------------------------------------------------------- #
+
+
+class _Artifact(NamedTuple):
+    workflow: str
+    job: str
+    name: str
+    major: int
+
+
+class _ArtifactJob(NamedTuple):
+    produced: tuple[_Artifact, ...]
+    outputs: Mapping[str, frozenset[str]]
+
+
+_ARTIFACT_ACTION = re.compile(r"^actions/(?P<kind>upload|download)-artifact@v(?P<major>[0-9]+)$")
+_GH_EXPRESSION = re.compile(r"\$\{\{\s*(.*?)\s*\}\}")
+
+
+def _expression_parts(source: str, separator: str) -> list[str]:
+    parts: list[str] = []
+    start = 0
+    depth = 0
+    quote = ""
+    index = 0
+    while index < len(source):
+        char = source[index]
+        if quote:
+            if char == quote and (index == 0 or source[index - 1] != "\\"):
+                quote = ""
+        elif char in {"'", '"'}:
+            quote = char
+        elif char == "(":
+            depth += 1
+        elif char == ")":
+            depth -= 1
+        elif depth == 0 and source.startswith(separator, index):
+            parts.append(source[start:index].strip())
+            start = index + len(separator)
+            index += len(separator) - 1
+        index += 1
+    parts.append(source[start:].strip())
+    return parts
+
+
+def _expression_values(expression: str, context: Mapping[str, frozenset[str]]) -> frozenset[str]:
+    expression = expression.strip()
+    alternatives = _expression_parts(expression, "||")
+    if len(alternatives) > 1:
+        return frozenset().union(*(_expression_values(part, context) for part in alternatives))
+    conditions = _expression_parts(expression, "&&")
+    if len(conditions) > 1:
+        return _expression_values(conditions[-1], context)
+    if expression.startswith("format(") and expression.endswith(")"):
+        arguments = _expression_parts(expression[7:-1], ",")
+        try:
+            template = ast.literal_eval(arguments[0])
+        except (SyntaxError, ValueError):
+            template = None
+        if isinstance(template, str):
+            values = [_expression_values(argument, context) for argument in arguments[1:]]
+            rendered = {template}
+            for position, candidates in enumerate(values):
+                rendered = {
+                    value.replace(f"{{{position}}}", candidate) for value in rendered for candidate in candidates
+                }
+            return frozenset(rendered)
+    if expression in context:
+        return context[expression]
+    step_output = re.fullmatch(r"steps\.[A-Za-z0-9_-]+\.outputs\.([A-Za-z0-9_-]+)", expression)
+    if step_output is not None and f"inputs.{step_output.group(1)}" in context:
+        return context[f"inputs.{step_output.group(1)}"]
+    if expression.startswith(("needs.", "jobs.")):
+        return frozenset({f"<unresolved:{expression}>"})
+    try:
+        literal = ast.literal_eval(expression)
+    except (SyntaxError, ValueError):
+        literal = None
+    if isinstance(literal, (str, int, bool)):
+        return frozenset({str(literal)})
+    return frozenset({f"${{{{ {expression} }}}}"})
+
+
+def _scalar_values(value: object, context: Mapping[str, frozenset[str]]) -> frozenset[str]:
+    if not isinstance(value, str):
+        return frozenset()
+    matches = list(_GH_EXPRESSION.finditer(value))
+    if not matches:
+        return frozenset({value})
+    if len(matches) == 1 and matches[0].span() == (0, len(value)):
+        return _expression_values(matches[0].group(1), context)
+    rendered = {value}
+    for match in matches:
+        token = match.group(0)
+        rendered = {
+            candidate.replace(token, replacement, 1)
+            for candidate in rendered
+            for replacement in _expression_values(match.group(1), context)
+        }
+    return frozenset(rendered)
+
+
+def _trigger_config(document: Mapping[object, object], trigger: str) -> Mapping[object, object]:
+    triggers = document.get(True, document.get("on"))
+    if not isinstance(triggers, dict):
+        return {}
+    config = triggers.get(trigger)
+    return config if isinstance(config, dict) else {}
+
+
+def _default_inputs(document: Mapping[object, object]) -> dict[str, frozenset[str]]:
+    result: dict[str, frozenset[str]] = {}
+    for trigger in ("workflow_call", "workflow_dispatch"):
+        inputs = _trigger_config(document, trigger).get("inputs", {})
+        if not isinstance(inputs, dict):
+            continue
+        for name, config in inputs.items():
+            if not isinstance(name, str) or name in result:
+                continue
+            default = config.get("default", "") if isinstance(config, dict) else ""
+            result[name] = frozenset({str(default)})
+    return result
+
+
+def _needs(job: Mapping[object, object]) -> tuple[str, ...]:
+    value = job.get("needs", ())
+    if isinstance(value, str):
+        return (value,)
+    if isinstance(value, list):
+        return tuple(item for item in value if isinstance(item, str))
+    return ()
+
+
+def _workflow_call_path(value: object) -> str | None:
+    if not isinstance(value, str):
+        return None
+    match = re.fullmatch(r"\./\.github/workflows/(?P<name>[^/]+\.ya?ml)", value)
+    return match.group("name") if match else None
+
+
+def _selectors_match(name: str, selector: str) -> bool:
+    import fnmatch
+
+    if fnmatch.fnmatchcase(name, selector):
+        return True
+    dynamic_name = _GH_EXPRESSION.sub("*", name)
+    dynamic_selector = _GH_EXPRESSION.sub("*", selector)
+    name_sample = dynamic_name.replace("*", "x").replace("?", "x")
+    selector_sample = dynamic_selector.replace("*", "x").replace("?", "x")
+    return fnmatch.fnmatchcase(name_sample, dynamic_selector) or fnmatch.fnmatchcase(selector_sample, dynamic_name)
+
+
+def _artifact_chain_offences(sources: dict[str, str]) -> list[str]:
+    documents = {name: _workflow_document(source, name) for name, source in sources.items()}
+    offences: set[str] = set()
+    download_matches: dict[tuple[str, str, int, int], bool] = {}
+    download_selectors: dict[tuple[str, str, int, int], set[str]] = {}
+    major_mismatches: dict[tuple[str, str, int, int], set[tuple[str, str, int]]] = {}
+
+    def scan_instance(
+        workflow: str,
+        supplied_inputs: Mapping[str, frozenset[str]],
+        inherited: tuple[_Artifact, ...],
+        stack: tuple[str, ...],
+    ) -> tuple[tuple[_Artifact, ...], Mapping[str, frozenset[str]]]:
+        assert workflow not in stack, f"{workflow}: rule=artifact-major: recursive reusable workflow"
+        document = documents[workflow]
+        inputs = _default_inputs(document)
+        inputs.update(supplied_inputs)
+        base_context = {f"inputs.{name}": values for name, values in inputs.items()}
+        jobs = document.get("jobs")
+        assert isinstance(jobs, dict), f"{workflow}: rule=artifact-major: jobs must be a mapping"
+        states: dict[str, _ArtifactJob] = {}
+        pending = {name for name, job in jobs.items() if isinstance(name, str) and isinstance(job, dict)}
+        while pending:
+            ready = [
+                name
+                for name in sorted(pending)
+                if all(dependency in states for dependency in _needs(cast(Mapping[object, object], jobs[name])))
+            ]
+            assert ready, f"{workflow}: rule=artifact-major: cyclic or missing needs {sorted(pending)!r}"
+            for job_name in ready:
+                job = cast(Mapping[object, object], jobs[job_name])
+                dependencies = _needs(job)
+                upstream = tuple(
+                    [*inherited, *(artifact for dependency in dependencies for artifact in states[dependency].produced)]
+                )
+                context = dict(base_context)
+                for dependency in dependencies:
+                    for output, values in states[dependency].outputs.items():
+                        context[f"needs.{dependency}.outputs.{output}"] = values
+                call_path = _workflow_call_path(job.get("uses"))
+                if call_path is not None:
+                    assert call_path in documents, (
+                        f"{workflow}:{job_name}: rule=artifact-major: local workflow {call_path!r} does not exist"
+                    )
+                    with_values = job.get("with", {})
+                    assert isinstance(with_values, dict), (
+                        f"{workflow}:{job_name}: rule=artifact-major: reusable with: must be a mapping"
+                    )
+                    called_inputs = {
+                        name: _scalar_values(value, context)
+                        for name, value in with_values.items()
+                        if isinstance(name, str)
+                    }
+                    called_produced, called_outputs = scan_instance(
+                        call_path, called_inputs, upstream, (*stack, workflow)
+                    )
+                    lineage = tuple(
+                        dict.fromkeys(
+                            [
+                                *(artifact for dependency in dependencies for artifact in states[dependency].produced),
+                                *called_produced,
+                            ]
+                        )
+                    )
+                    states[job_name] = _ArtifactJob(lineage, called_outputs)
+                    pending.remove(job_name)
+                    continue
+
+                produced: list[_Artifact] = []
+                steps = job.get("steps", [])
+                assert isinstance(steps, list), f"{workflow}:{job_name}: rule=artifact-major: steps must be a list"
+                for step_index, step in enumerate(steps):
+                    if not isinstance(step, dict):
+                        continue
+                    uses = step.get("uses")
+                    match = _ARTIFACT_ACTION.fullmatch(uses) if isinstance(uses, str) else None
+                    if match is None:
+                        continue
+                    action_inputs = step.get("with", {})
+                    assert isinstance(action_inputs, dict), (
+                        f"{workflow}:{job_name}: rule=artifact-major: artifact action with: must be a mapping"
+                    )
+                    selector_value = action_inputs.get("name", action_inputs.get("pattern", "*"))
+                    selectors = _scalar_values(selector_value, context)
+                    assert selectors, f"{workflow}:{job_name}: rule=artifact-major: empty artifact selector"
+                    major = int(match.group("major"))
+                    if match.group("kind") == "upload":
+                        produced.extend(_Artifact(workflow, job_name, selector, major) for selector in selectors)
+                        continue
+                    key = (workflow, job_name, step_index, major)
+                    download_selectors.setdefault(key, set()).update(selectors)
+                    download_matches.setdefault(key, False)
+                    available = (*upstream, *produced)
+                    matched = {
+                        artifact
+                        for selector in selectors
+                        for artifact in available
+                        if _selectors_match(artifact.name, selector)
+                    }
+                    if not matched:
+                        continue
+                    download_matches[key] = True
+                    by_name: dict[str, set[tuple[str, str]]] = {}
+                    for artifact in matched:
+                        by_name.setdefault(artifact.name, set()).add((artifact.workflow, artifact.job))
+                        if artifact.major != major:
+                            major_mismatches.setdefault(key, set()).add(
+                                (artifact.workflow, artifact.job, artifact.major)
+                            )
+                    for name, owners in by_name.items():
+                        if len(owners) > 1:
+                            offences.add(
+                                f"{workflow}:{job_name}:step-{step_index}: rule=artifact-major: "
+                                f"ambiguous producers for {name!r}: {sorted(owners)!r}"
+                            )
+                job_outputs: dict[str, frozenset[str]] = {}
+                configured_outputs = job.get("outputs", {})
+                if isinstance(configured_outputs, dict):
+                    job_outputs = {
+                        name: _scalar_values(value, context)
+                        for name, value in configured_outputs.items()
+                        if isinstance(name, str)
+                    }
+                lineage = tuple(
+                    dict.fromkeys(
+                        [
+                            *(artifact for dependency in dependencies for artifact in states[dependency].produced),
+                            *produced,
+                        ]
+                    )
+                )
+                states[job_name] = _ArtifactJob(lineage, job_outputs)
+                pending.remove(job_name)
+
+        all_produced = tuple(dict.fromkeys(artifact for state in states.values() for artifact in state.produced))
+        output_context = dict(base_context)
+        for job_name, state in states.items():
+            for output, values in state.outputs.items():
+                output_context[f"jobs.{job_name}.outputs.{output}"] = values
+        call_outputs = _trigger_config(document, "workflow_call").get("outputs", {})
+        workflow_outputs: dict[str, frozenset[str]] = {}
+        if isinstance(call_outputs, dict):
+            for name, config in call_outputs.items():
+                if isinstance(name, str) and isinstance(config, dict):
+                    workflow_outputs[name] = _scalar_values(config.get("value"), output_context)
+        return all_produced, workflow_outputs
+
+    direct_names: dict[str, tuple[_Artifact, ...]] = {}
+    workflow_run_roots: list[str] = []
+    for workflow, document in documents.items():
+        triggers = _trigger_names(document)
+        if "workflow_run" in triggers:
+            workflow_run_roots.append(workflow)
+        if triggers & (_EXTERNAL_TRIGGERS | {"pull_request"}):
+            root_produced, _ = scan_instance(workflow, {}, (), ())
+            name = document.get("name")
+            if isinstance(name, str):
+                direct_names[name] = root_produced
+    for workflow in workflow_run_roots:
+        names = _trigger_config(documents[workflow], "workflow_run").get("workflows", [])
+        assert isinstance(names, list), f"{workflow}: rule=artifact-major: workflow_run.workflows must be a list"
+        inherited = tuple(
+            artifact for name in names if isinstance(name, str) for artifact in direct_names.get(name, ())
+        )
+        missing = [name for name in names if isinstance(name, str) and name not in direct_names]
+        if missing:
+            offences.add(f"{workflow}: rule=artifact-major: workflow_run names missing producers {missing!r}")
+        scan_instance(workflow, {}, inherited, ())
+    for (workflow, job, step, major), matched in sorted(download_matches.items()):
+        if not matched and "workflow_run" not in _trigger_names(documents[workflow]):
+            offences.add(
+                f"{workflow}:{job}:step-{step}: rule=artifact-major: no producer matches "
+                f"{sorted(download_selectors[(workflow, job, step, major)])!r}"
+            )
+    for (workflow, job, step, major), producers in sorted(major_mismatches.items()):
+        offences.add(
+            f"{workflow}:{job}:step-{step}: rule=artifact-major: download v{major} "
+            f"mismatches producers {sorted(producers)!r}"
+        )
+    return sorted(offences)
+
+
+def test_artifact_action_majors_match_per_producer_consumer_chain() -> None:
+    offences = _artifact_chain_offences(_workflow_sources())
+    assert not offences, "artifact chain hygiene failed:\n  " + "\n  ".join(offences)
+
+
+def test_artifact_scanner_follows_needs_reusable_inputs_outputs_and_workflow_run() -> None:
+    sources = {
+        "producer.yml": """\
+name: Producer
+on:
+  workflow_call:
+    inputs:
+      artifact: {type: string, default: pkg}
+    outputs:
+      artifact:
+        value: ${{ inputs.artifact }}
+jobs:
+  upload:
+    steps:
+      - uses: actions/upload-artifact@v7
+        with: {name: "${{ inputs.artifact }}"}
+""",
+        "root.yaml": """\
+name: Root
+"on": workflow_dispatch
+jobs:
+  make:
+    uses: ./.github/workflows/producer.yml
+    with: {artifact: pkg}
+  bridge:
+    needs: make
+    steps:
+      - run: "true"
+  consume-output:
+    needs: make
+    steps:
+      - uses: actions/download-artifact@v7
+        with: {name: "${{ needs.make.outputs.artifact }}"}
+  consume:
+    needs: bridge
+    steps:
+      - uses: actions/download-artifact@v7
+        with: {name: pkg}
+      - uses: actions/upload-artifact@v8
+        with: {name: status-v8}
+  consume-v8:
+    needs: consume
+    steps:
+      - uses: actions/download-artifact@v8
+        with: {name: status-v8}
+""",
+        "callback.yml": """\
+on:
+  workflow_run:
+    workflows: [Root]
+jobs:
+  consume:
+    steps:
+      - uses: actions/download-artifact@v7
+        with: {pattern: "p*"}
+""",
+    }
+    assert _artifact_chain_offences(sources) == []
+
+
+def test_artifact_scanner_reports_direct_ambiguous_wrong_output_and_pattern_majors() -> None:
+    sources = {
+        "producer.yml": """\
+on:
+  workflow_call:
+    outputs:
+      artifact: {value: pkg}
+jobs:
+  first:
+    steps:
+      - uses: actions/upload-artifact@v7
+        with: {name: pkg}
+      - uses: actions/upload-artifact@v7
+        with: {name: family-one}
+  duplicate:
+    steps:
+      - uses: actions/upload-artifact@v7
+        with: {name: pkg}
+      - uses: actions/upload-artifact@v8
+        with: {name: family-two}
+""",
+        "root.yaml": """\
+on: workflow_dispatch
+jobs:
+  make:
+    uses: ./.github/workflows/producer.yml
+  ambiguous:
+    needs: make
+    steps:
+      - uses: actions/download-artifact@v7
+        with: {name: pkg}
+  wrong-output:
+    needs: make
+    steps:
+      - uses: actions/download-artifact@v7
+        with: {name: "${{ needs.make.outputs.missing }}"}
+  pattern:
+    needs: make
+    steps:
+      - uses: actions/download-artifact@v7
+        with: {pattern: "family-*"}
+""",
+    }
+    offences = _artifact_chain_offences(sources)
+    assert any(
+        "root.yaml:ambiguous:step-0: rule=artifact-major: ambiguous producers for 'pkg'" in item for item in offences
+    )
+    assert any("root.yaml:wrong-output:step-0: rule=artifact-major: no producer matches" in item for item in offences)
+    assert any(
+        "root.yaml:pattern:step-0: rule=artifact-major: download v7 mismatches producers" in item
+        and "('producer.yml', 'duplicate', 8)" in item
+        for item in offences
+    )
+
+
+# --------------------------------------------------------------------------- #
+# 6. Every container invocation passes --init.
+# --------------------------------------------------------------------------- #
+
+
+def _option_words(options: str, where: str, rule: str) -> list[str]:
+    try:
+        return shlex.split(options, comments=False, posix=True)
+    except ValueError as exc:
+        raise AssertionError(f"{where}: rule={rule}: invalid option quoting: {exc}") from exc
+
+
+def _container_offences(sources: dict[str, str]) -> list[str]:
+    offences: list[str] = []
+    for workflow, source in sources.items():
+        jobs = _workflow_document(source, workflow).get("jobs")
+        assert isinstance(jobs, dict), f"{workflow}: rule=container-init: jobs must be a mapping"
+        for job_name, job in jobs.items():
+            if not isinstance(job_name, str) or not isinstance(job, dict) or "container" not in job:
+                continue
+            container = job["container"]
+            options = container.get("options") if isinstance(container, dict) else None
+            if not isinstance(options, str) or "--init" not in _option_words(
+                options, f"{workflow}:{job_name}", "container-init"
+            ):
+                offences.append(
+                    f"{workflow}:{job_name}: rule=container-init: container.options must include exact token --init"
+                )
+    return offences
+
+
+def test_workflow_container_blocks_pass_init_in_block_local_options() -> None:
+    offences = _container_offences(_workflow_sources())
+    assert not offences, "workflow container hygiene failed:\n  " + "\n  ".join(offences)
+
+
+def test_container_scanner_decodes_only_job_container_options() -> None:
+    source = """\
+on: workflow_dispatch
+jobs:
+  quoted:
+    container:
+      image: example/valid
+      options: '--label "odd=a & b"   --init' # inline comment
+  folded:
+    container:
+      image: example/folded
+      options: >-
+        --rm
+        --init
+  scalar:
+    container: example/scalar
+  null-options:
+    container: {image: example/null, options: null}
+  empty-options:
+    container: {image: example/empty, options: ""}
+  expression-only:
+    container:
+      image: example/expression
+      options: ${{ inputs.options }}
+  comment-only:
+    container:
+      image: example/comment
+      options: --rm # --init
+    steps:
+      - run: echo --init
+  decoy:
+    strategy:
+      matrix:
+        options: [--init]
+    steps:
+      - run: |
+          printf '%s\\n' 'container: {options: --init}'
+"""
+    assert _container_offences({"containers.yaml": source}) == [
+        "containers.yaml:scalar: rule=container-init: container.options must include exact token --init",
+        "containers.yaml:null-options: rule=container-init: container.options must include exact token --init",
+        "containers.yaml:empty-options: rule=container-init: container.options must include exact token --init",
+        "containers.yaml:expression-only: rule=container-init: container.options must include exact token --init",
+        "containers.yaml:comment-only: rule=container-init: container.options must include exact token --init",
+    ]
+
+
+_SHELL_OPERATORS = {";", ";;", "&", "&&", "|", "||", "(", ")"}
+
+
+def _tracked_text_sources() -> dict[str, str]:
+    tracked = subprocess.run(
+        ["git", "ls-files", "scripts", "tests/smoke"],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.splitlines()
+    sources: dict[str, str] = {}
+    for name in tracked:
+        path = ROOT / name
+        if not path.is_file():
+            continue
+        try:
+            sources[name] = path.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            continue
+    return sources
+
+
+def _logical_shell_lines(source: str) -> list[tuple[int, str]]:
+    logical: list[tuple[int, str]] = []
+    start = 1
+    parts: list[str] = []
+    heredoc: str | None = None
+    for line_no, line in enumerate(source.splitlines(), 1):
+        if heredoc is not None:
+            if line.strip() == heredoc:
+                heredoc = None
+            continue
+        if not parts:
+            start = line_no
+        if line.endswith("\\"):
+            parts.append(line[:-1])
+            continue
+        parts.append(line)
+        command = " ".join(parts)
+        logical.append((start, command))
+        match = re.search(r"<<-?\s*(['\"]?)([A-Za-z_][A-Za-z0-9_]*)\1", command)
+        if match is not None:
+            heredoc = match.group(2)
+        parts = []
+    if parts:
+        logical.append((start, " ".join(parts)))
+    return logical
+
+
+def _shell_words(source: str, where: str) -> list[tuple[int, list[str]]]:
+    commands: list[tuple[int, list[str]]] = []
+    for line_no, logical in _logical_shell_lines(source):
+        if "docker" not in logical or "run" not in logical:
+            continue
+        lexer = shlex.shlex(logical, posix=True, punctuation_chars=";&|()")
+        lexer.whitespace_split = True
+        lexer.commenters = "#"
+        try:
+            words = list(lexer)
+        except ValueError as exc:
+            raise AssertionError(f"{where}:{line_no}: rule=docker-init: invalid shell quoting: {exc}") from exc
+        segment: list[str] = []
+        for word in [*words, ";"]:
+            if word in _SHELL_OPERATORS:
+                if segment:
+                    commands.append((line_no, segment))
+                    segment = []
+            else:
+                segment.append(word)
+    return commands
+
+
+def _docker_argv(words: list[str]) -> list[str] | None:
+    index = 0
+    while index < len(words) and re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*=.*", words[index]):
+        index += 1
+    while index < len(words) and words[index] in {"command", "exec"}:
+        index += 1
+    if index < len(words) and words[index] == "env":
+        index += 1
+        while index < len(words) and (
+            words[index].startswith("-") or re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*=.*", words[index])
+        ):
+            index += 1
+    if index + 1 >= len(words) or Path(words[index]).name != "docker" or words[index + 1] != "run":
+        return None
+    return words[index + 2 :]
+
+
+def _python_docker_runs(source: str, where: str) -> list[tuple[int, list[str]]]:
+    try:
+        tree = ast.parse(source, filename=where)
+    except SyntaxError as exc:
+        raise AssertionError(f"{where}:{exc.lineno}: rule=docker-init: invalid Python: {exc.msg}") from exc
+    invocations: list[tuple[int, list[str]]] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call) or not node.args:
+            continue
+        function = node.func
+        is_subprocess = (
+            isinstance(function, ast.Attribute)
+            and isinstance(function.value, ast.Name)
+            and function.value.id == "subprocess"
+            and function.attr in {"call", "check_call", "check_output", "Popen", "run"}
+        )
+        is_os_system = (
+            isinstance(function, ast.Attribute)
+            and isinstance(function.value, ast.Name)
+            and function.value.id == "os"
+            and function.attr == "system"
+        )
+        if not (is_subprocess or is_os_system):
+            continue
+        argument = node.args[0]
+        words: list[str] | None = None
+        if isinstance(argument, (ast.List, ast.Tuple)) and all(
+            isinstance(item, ast.Constant) and isinstance(item.value, str) for item in argument.elts
+        ):
+            words = [cast(str, item.value) for item in argument.elts if isinstance(item, ast.Constant)]
+        elif isinstance(argument, ast.Constant) and isinstance(argument.value, str):
+            words = _option_words(argument.value, f"{where}:{node.lineno}", "docker-init")
+        if words is not None and _docker_argv(words) is not None:
+            invocations.append((node.lineno, words))
+    return invocations
+
+
+_PHP_SHELL_CALL = re.compile(
+    r"\b(?:exec|passthru|shell_exec|system)\s*\(\s*(?P<quote>['\"])(?P<body>.*?)(?P=quote)",
+    re.DOTALL,
+)
+
+
+def _php_docker_runs(source: str, where: str) -> list[tuple[int, list[str]]]:
+    invocations: list[tuple[int, list[str]]] = []
+    for match in _PHP_SHELL_CALL.finditer(source):
+        line_start = source.rfind("\n", 0, match.start()) + 1
+        if source[line_start : match.start()].lstrip().startswith(("//", "#", "*")):
+            continue
+        line_no = source.count("\n", 0, match.start()) + 1
+        words = _option_words(match.group("body"), f"{where}:{line_no}", "docker-init")
+        if _docker_argv(words) is not None:
+            invocations.append((line_no, words))
+    return invocations
+
+
+def _docker_run_offences(sources: dict[str, str]) -> list[str]:
+    offences: list[str] = []
+    for where, source in sources.items():
+        suffix = Path(where).suffix
+        if suffix == ".py":
+            invocations = _python_docker_runs(source, where)
+        elif suffix == ".php":
+            invocations = _php_docker_runs(source, where)
+        else:
+            invocations = _shell_words(source, where)
+        for line_no, words in invocations:
+            argv = _docker_argv(words)
+            if argv is not None and "--init" not in argv:
+                offences.append(f"{where}:{line_no}: rule=docker-init: docker run must include exact token --init")
+    return offences
+
+
+def test_tracked_docker_run_invocations_pass_init() -> None:
+    sources = _tracked_text_sources()
+    assert sources, "no tracked text files found under scripts/ or tests/smoke/"
+    offences = _docker_run_offences(sources)
+    assert not offences, "docker invocation hygiene failed:\n  " + "\n  ".join(offences)
+
+
+def test_docker_scanner_handles_commands_continuations_comments_and_metacharacters() -> None:
+    sources = {
+        "scripts/case.sh": """\
+# docker run --rm -- misleading comment
+echo "docker run --rm"
+exec /usr/bin/docker   run --label 'odd=a&b' '--init'
+"docker" \\
+  "run" --rm # --init in a comment is not an option
+docker run --rm; echo --init
+docker run --rm | cat --init
+printf '%s\\n' docker run --rm
+cat <<'TEXT'
+docker run --rm
+TEXT
+command docker run --rm --init && echo done
+""",
+        "tests/smoke/case.py": """\
+import subprocess
+TEXT = "docker run --rm"
+# subprocess.run(["docker", "run", "--rm"])
+subprocess.run(["docker", "run", "--rm", "--init"], check=True)
+subprocess.run(["/usr/bin/docker", "run", "--rm"], check=True)
+""",
+        "scripts/case.php": """\
+<?php
+$text = 'docker run --rm';
+// system('docker run --rm');
+exec('/usr/bin/docker run --rm --init');
+system('docker run --rm');
+""",
+        "scripts/case.txt": "env MODE=test docker run --rm --init || echo failed\n",
+    }
+    assert _docker_run_offences(sources) == [
+        "scripts/case.sh:4: rule=docker-init: docker run must include exact token --init",
+        "scripts/case.sh:6: rule=docker-init: docker run must include exact token --init",
+        "scripts/case.sh:7: rule=docker-init: docker run must include exact token --init",
+        "tests/smoke/case.py:5: rule=docker-init: docker run must include exact token --init",
+        "scripts/case.php:5: rule=docker-init: docker run must include exact token --init",
+    ]
+
+
+# --------------------------------------------------------------------------- #
+# 7. Prepared SHA pins are the exact values consumed downstream.
+# --------------------------------------------------------------------------- #
+
+
+class _ShaPin(NamedTuple):
+    workflow: str
+    job: str
+    output: str
+    step_id: str
+
+
+_PIN_JOB = re.compile(r"(?:^|-)(?:prepare|read|resolve)(?:-|$)")
+_PIN_OUTPUT = re.compile(r"(?:^|_)sha$")
+_PIN_BRIDGE = re.compile(r"^\$\{\{\s*steps\.(?P<step>[A-Za-z0-9_-]+)\.outputs\.(?P<output>[A-Za-z0-9_-]+)\s*\}\}$")
+_NEEDS_OUTPUT = re.compile(
+    r"(?<![A-Za-z0-9_-])needs\.(?P<job>[A-Za-z0-9_-]+)\.outputs\."
+    r"(?P<output>[A-Za-z0-9_-]+)(?![A-Za-z0-9_-])"
+)
+
+
+def _walk_scalars(node: object, path: tuple[str, ...] = ()) -> list[tuple[tuple[str, ...], str]]:
+    scalars: list[tuple[tuple[str, ...], str]] = []
+    if isinstance(node, dict):
+        for key, value in node.items():
+            if isinstance(key, str):
+                scalars.extend(_walk_scalars(value, (*path, key)))
+    elif isinstance(node, list):
+        for index, value in enumerate(node):
+            scalars.extend(_walk_scalars(value, (*path, str(index))))
+    elif isinstance(node, str):
+        scalars.append((path, node))
+    return scalars
+
+
+def _job_descendants(document: Mapping[object, object], producer: str) -> set[str]:
+    jobs = document.get("jobs")
+    assert isinstance(jobs, dict)
+    descendants: set[str] = set()
+    while True:
+        discovered = {
+            name
+            for name, job in jobs.items()
+            if isinstance(name, str)
+            and isinstance(job, dict)
+            and name not in descendants
+            and any(need == producer or need in descendants for need in _needs(job))
+        }
+        if not discovered:
+            return descendants
+        descendants.update(discovered)
+
+
+def _sha_inventory(
+    documents: Mapping[str, Mapping[object, object]],
+) -> tuple[list[_ShaPin], list[str]]:
+    pins: list[_ShaPin] = []
+    offences: list[str] = []
+    for workflow, document in documents.items():
+        jobs = document.get("jobs")
+        assert isinstance(jobs, dict), f"{workflow}: rule=pin-consumer: jobs must be a mapping"
+        for job_name, job in jobs.items():
+            if not isinstance(job_name, str) or not isinstance(job, dict) or _PIN_JOB.search(job_name) is None:
+                continue
+            outputs = job.get("outputs", {})
+            if not isinstance(outputs, dict):
+                continue
+            steps = job.get("steps", [])
+            step_ids = (
+                {step["id"] for step in steps if isinstance(step, dict) and isinstance(step.get("id"), str)}
+                if isinstance(steps, list)
+                else set()
+            )
+            for output, value in outputs.items():
+                if not isinstance(output, str) or _PIN_OUTPUT.search(output) is None:
+                    continue
+                match = _PIN_BRIDGE.fullmatch(value) if isinstance(value, str) else None
+                if match is None or match.group("output") != output or match.group("step") not in step_ids:
+                    offences.append(
+                        f"{workflow}:{job_name}.{output}: rule=pin-consumer: output must bridge "
+                        f"steps.<real-id>.outputs.{output}"
+                    )
+                    continue
+                pins.append(_ShaPin(workflow, job_name, output, match.group("step")))
+    return pins, offences
+
+
+def _shell_commands(source: str) -> list[list[str]]:
+    commands: list[list[str]] = []
+    for _, logical in _logical_shell_lines(source):
+        lexer = shlex.shlex(logical, posix=True, punctuation_chars=";&|()")
+        lexer.whitespace_split = True
+        lexer.commenters = "#"
+        try:
+            words = list(lexer)
+        except ValueError:
+            continue
+        segment: list[str] = []
+        for word in [*words, ";"]:
+            if word in _SHELL_OPERATORS:
+                if segment:
+                    commands.append(segment)
+                    segment = []
+            else:
+                segment.append(word)
+    return commands
+
+
+def _pin_base(output: str) -> str:
+    return output.removesuffix("_sha").replace("_", "-")
+
+
+def _ref_binding(path: tuple[str, ...]) -> bool:
+    if not path or "env" in path:
+        return False
+    key = path[-1].lower()
+    return key == "ref" or key.endswith("_ref") or key == "sha" or key.endswith("_sha")
+
+
+def _pin_offences(sources: dict[str, str]) -> list[str]:
+    documents = {workflow: _workflow_document(source, workflow) for workflow, source in sources.items()}
+    pins, offences = _sha_inventory(documents)
+    for pin in pins:
+        document = documents[pin.workflow]
+        jobs = document["jobs"]
+        assert isinstance(jobs, dict)
+        descendants = _job_descendants(document, pin.job)
+        reference = f"needs.{pin.job}.outputs.{pin.output}"
+        consumers: list[tuple[str, tuple[str, ...], str]] = []
+        for job_name in sorted(descendants):
+            job = jobs[job_name]
+            if not isinstance(job, dict):
+                continue
+            for path, value in _walk_scalars(job):
+                members = {(match.group("job"), match.group("output")) for match in _NEEDS_OUTPUT.finditer(value)}
+                if (pin.job, pin.output) in members:
+                    consumers.append((job_name, path, value))
+        if not consumers:
+            offences.append(
+                f"{pin.workflow}:{pin.job}.{pin.output}: rule=pin-consumer: "
+                "no dependent consumer references the exact output"
+            )
+            continue
+
+        identity = any(_ref_binding(path) for _, path, _ in consumers)
+        for job_name in sorted(descendants):
+            job = jobs[job_name]
+            if not isinstance(job, dict):
+                continue
+            job_env = job.get("env", {})
+            aliases: set[str] = set()
+            if isinstance(job_env, dict):
+                aliases.update(
+                    name
+                    for name, value in job_env.items()
+                    if isinstance(name, str)
+                    and isinstance(value, str)
+                    and (pin.job, pin.output)
+                    in {(match.group("job"), match.group("output")) for match in _NEEDS_OUTPUT.finditer(value)}
+                )
+            steps = job.get("steps", [])
+            if not isinstance(steps, list):
+                continue
+            for step in steps:
+                if not isinstance(step, dict):
+                    continue
+                step_aliases = set(aliases)
+                env = step.get("env", {})
+                if isinstance(env, dict):
+                    step_aliases.update(
+                        name
+                        for name, value in env.items()
+                        if isinstance(name, str)
+                        and isinstance(value, str)
+                        and (pin.job, pin.output)
+                        in {(match.group("job"), match.group("output")) for match in _NEEDS_OUTPUT.finditer(value)}
+                    )
+                run = step.get("run")
+                if not isinstance(run, str):
+                    continue
+                overridden = {
+                    name
+                    for name in step_aliases
+                    if re.search(
+                        rf"(?m)^\s*(?:export\s+)?{re.escape(name)}=.*\bgit\s+ls-remote\b",
+                        run,
+                    )
+                }
+                base = _pin_base(pin.output)
+                for words in _shell_commands(run):
+                    for index, word in enumerate(words[:-1]):
+                        flag = word.removeprefix("--")
+                        relevant_flag = (
+                            word.startswith("--")
+                            and (flag.endswith("-ref") or flag.endswith("-sha"))
+                            and (not base or flag.startswith(base))
+                        )
+                        if not relevant_flag:
+                            continue
+                        argument = words[index + 1]
+                        used = {name for name in step_aliases if argument == f"${name}" or argument == f"${{{name}}}"}
+                        if reference in argument:
+                            identity = True
+                        elif used - overridden:
+                            identity = True
+                        elif used & overridden:
+                            offences.append(
+                                f"{pin.workflow}:{job_name}: rule=pin-consumer: live git ls-remote "
+                                f"replaces {pin.job}.{pin.output} at identity sink {word}"
+                            )
+                    if (
+                        len(words) > 1
+                        and words[0] == "git"
+                        and words[1] in {"show", "checkout", "switch", "reset"}
+                        and any(
+                            argument == f"${name}"
+                            or argument == f"${{{name}}}"
+                            or argument.startswith(f"${name}:")
+                            or argument.startswith(f"${{{name}}}:")
+                            for argument in words[2:]
+                            for name in step_aliases - overridden
+                        )
+                    ):
+                        identity = True
+        if not identity:
+            offences.append(
+                f"{pin.workflow}:{pin.job}.{pin.output}: rule=pin-consumer: pin is not consumed by a ref/identity sink"
+            )
+    return sorted(set(offences))
+
+
+def test_prepare_read_resolve_sha_pins_feed_exact_downstream_consumers() -> None:
+    offences = _pin_offences(_workflow_sources())
+    assert not offences, "SHA pin hygiene failed:\n  " + "\n  ".join(offences)
+
+
+def test_pin_scanner_supports_fallbacks_aliases_exact_reads_and_both_extensions() -> None:
+    sources = {
+        "first.yml": """\
+on: workflow_dispatch
+jobs:
+  prepare:
+    outputs:
+      ports_sha: ${{ steps.pin.outputs.ports_sha }}
+    steps:
+      - id: pin
+        run: echo "ports_sha=$VALUE" >> "$GITHUB_OUTPUT"
+  build:
+    needs: prepare
+    steps:
+      - env:
+          PORTS_SHA: ${{ needs.prepare.outputs.ports_sha }}
+        run: |
+          git fetch origin main
+          git show "$PORTS_SHA:Makefile"
+          build-leg.sh --ports-ref "$PORTS_SHA"
+""",
+        "second.yaml": """\
+"on": workflow_dispatch
+jobs:
+  resolve:
+    outputs:
+      source_sha: ${{ steps.pin.outputs.source_sha }}
+    steps:
+      - id: pin
+        run: echo "source_sha=$VALUE" >> "$GITHUB_OUTPUT"
+  prepare-release:
+    outputs:
+      sha: ${{ steps.pin.outputs.sha }}
+    steps:
+      - id: pin
+        run: echo "sha=$VALUE" >> "$GITHUB_OUTPUT"
+  consume:
+    needs: [resolve, prepare-release]
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.prepare-release.outputs.sha || needs.resolve.outputs.source_sha }}
+""",
+    }
+    assert _pin_offences(sources) == []
+
+
+def test_pin_scanner_reports_wrong_bridges_boundaries_moving_refs_and_live_reresolution() -> None:
+    sources = {
+        "wrong.yaml": """\
+on: workflow_dispatch
+jobs:
+  prepare:
+    outputs:
+      ports_sha: ${{ steps.pin.outputs.wrong_sha }}
+    steps:
+      - id: pin
+  read-matrix:
+    outputs:
+      matrix_sha: ${{ steps.matrix.outputs.matrix_sha }}
+    steps:
+      - id: matrix
+  build:
+    needs: [prepare, read-matrix]
+    env:
+      WRONG: ${{ needs.read-matrix.outputs.matrix_sha_extra }}
+    steps:
+      - run: echo "$WRONG"
+""",
+        "moving-ref.yml": """\
+on: workflow_dispatch
+jobs:
+  prepare:
+    outputs:
+      ports_sha: ${{ steps.pin.outputs.ports_sha }}
+    steps:
+      - id: pin
+  build:
+    needs: prepare
+    steps:
+      - env:
+          PORTS_SHA: ${{ needs.prepare.outputs.ports_sha }}
+          PORTS_REF: pfblockerng/use-github
+        run: |
+          test "$ACTUAL_PORTS_SHA" = "$PORTS_SHA"
+          build-leg.sh --ports-ref "$PORTS_REF"
+""",
+        "live.yml": """\
+on: workflow_dispatch
+jobs:
+  resolve:
+    outputs:
+      ports_sha: ${{ steps.pin.outputs.ports_sha }}
+    steps:
+      - id: pin
+  consume:
+    needs: resolve
+    steps:
+      - env:
+          PORTS_SHA: ${{ needs.resolve.outputs.ports_sha }}
+        run: |
+          PORTS_SHA="$(git ls-remote origin main)"
+          build-leg.sh --ports-ref "$PORTS_SHA"
+""",
+        "unrelated.yaml": """\
+on: workflow_dispatch
+env:
+  WORKFLOW_SHA: ${{ github.workflow_sha }}
+  HEAD_SHA: mutable
+  DIGEST: sha256:abcdef
+jobs:
+  build:
+    steps:
+      - run: |
+          git fetch origin main
+          git tag --contains HEAD
+          printf '%s\\n' metadata-only-ref
+""",
+    }
+    offences = _pin_offences(sources)
+    assert any(
+        item
+        == ("wrong.yaml:prepare.ports_sha: rule=pin-consumer: output must bridge steps.<real-id>.outputs.ports_sha")
+        for item in offences
+    )
+    assert any(
+        item
+        == ("wrong.yaml:read-matrix.matrix_sha: rule=pin-consumer: no dependent consumer references the exact output")
+        for item in offences
+    )
+    assert any(
+        item == ("moving-ref.yml:prepare.ports_sha: rule=pin-consumer: pin is not consumed by a ref/identity sink")
+        for item in offences
+    )
+    assert any(
+        "live git ls-remote replaces resolve.ports_sha at identity sink --ports-ref" in item for item in offences
+    )
+    assert not any("unrelated.yaml" in item for item in offences)

--- a/tests/test_issue2231_workflow_hygiene.py
+++ b/tests/test_issue2231_workflow_hygiene.py
@@ -1425,20 +1425,8 @@ def _python_docker_runs(source: str, where: str) -> list[tuple[int, list[str]]]:
         tree = ast.parse(source, filename=where)
     except SyntaxError as exc:
         raise AssertionError(f"{where}:{exc.lineno}: rule=docker-init: invalid Python: {exc.msg}") from exc
-    imported_calls = {
-        alias.asname or alias.name
-        for node in tree.body
-        if isinstance(node, ast.ImportFrom) and node.module == "subprocess"
-        for alias in node.names
-        if alias.name in {"call", "check_call", "check_output", "Popen", "run"}
-    }
-    subprocess_modules = {
-        alias.asname or alias.name
-        for node in tree.body
-        if isinstance(node, ast.Import)
-        for alias in node.names
-        if alias.name == "subprocess"
-    }
+    imported_calls: dict[ast.AST, set[str]] = {}
+    subprocess_modules: dict[ast.AST, set[str]] = {}
     scope_types = (ast.Module, ast.FunctionDef, ast.AsyncFunctionDef)
     parents = {child: parent for parent in ast.walk(tree) for child in ast.iter_child_nodes(parent)}
 
@@ -1457,7 +1445,17 @@ def _python_docker_runs(source: str, where: str) -> list[tuple[int, list[str]]]:
     functions: dict[ast.AST, dict[str, ast.FunctionDef | ast.AsyncFunctionDef]] = {}
     for node in ast.walk(tree):
         scope = scope_chain(node)[0] if not isinstance(node, ast.Module) else tree
-        if isinstance(node, ast.Assign) and isinstance(node.value, (ast.List, ast.Tuple)):
+        if isinstance(node, ast.ImportFrom) and node.module == "subprocess":
+            imported_calls.setdefault(scope, set()).update(
+                alias.asname or alias.name
+                for alias in node.names
+                if alias.name in {"call", "check_call", "check_output", "Popen", "run"}
+            )
+        elif isinstance(node, ast.Import):
+            subprocess_modules.setdefault(scope, set()).update(
+                alias.asname or alias.name for alias in node.names if alias.name == "subprocess"
+            )
+        elif isinstance(node, ast.Assign) and isinstance(node.value, (ast.List, ast.Tuple)):
             for target in node.targets:
                 if isinstance(target, ast.Name):
                     bound_argv.setdefault(scope, {}).setdefault(target.id, []).append((node.lineno, node.value))
@@ -1515,7 +1513,7 @@ def _python_docker_runs(source: str, where: str) -> list[tuple[int, list[str]]]:
         is_subprocess = (
             isinstance(function, ast.Attribute)
             and isinstance(function.value, ast.Name)
-            and function.value.id in subprocess_modules
+            and any(function.value.id in subprocess_modules.get(scope, set()) for scope in scope_chain(node))
             and function.attr in {"call", "check_call", "check_output", "Popen", "run"}
         )
         is_os_system = (
@@ -1524,7 +1522,9 @@ def _python_docker_runs(source: str, where: str) -> list[tuple[int, list[str]]]:
             and function.value.id == "os"
             and function.attr == "system"
         )
-        is_imported_subprocess = isinstance(function, ast.Name) and function.id in imported_calls
+        is_imported_subprocess = isinstance(function, ast.Name) and any(
+            function.id in imported_calls.get(scope, set()) for scope in scope_chain(node)
+        )
         if not (is_subprocess or is_imported_subprocess or is_os_system):
             continue
         keyword_arguments = [keyword.value for keyword in node.keywords if keyword.arg == "args"]
@@ -1785,7 +1785,7 @@ def _sha_inventory(
 def _shell_commands(source: str) -> list[list[str]]:
     commands: list[list[str]] = []
     for _, logical in _logical_shell_lines(source):
-        lexer = shlex.shlex(logical, posix=True, punctuation_chars=";&|()")
+        lexer = shlex.shlex(logical, posix=True, punctuation_chars=";&|")
         lexer.whitespace_split = True
         lexer.commenters = "#"
         try:
@@ -1887,6 +1887,7 @@ def _pin_offences(sources: dict[str, str]) -> list[str]:
 
         workflow_pins = {(candidate.job, candidate.output) for candidate in pins if candidate.workflow == pin.workflow}
         identity = False
+        invalid_alias_sinks: set[tuple[str, str, str]] = set()
         invalid_ref_jobs: set[str] = set()
         for job_name, path, value in consumers:
             if not _ref_binding(path):
@@ -1920,32 +1921,44 @@ def _pin_offences(sources: dict[str, str]) -> list[str]:
                 env = step.get("env", {})
                 if isinstance(env, dict):
                     effective_env.update(env)
-                step_aliases = {
+                pin_aliases = {
                     name
                     for name, value in effective_env.items()
                     if isinstance(name, str)
                     and isinstance(value, str)
-                    and _pin_expression_members(value) == exact_member
+                    and any(
+                        (member.group("job"), member.group("output")) == (pin.job, pin.output)
+                        for member in _NEEDS_OUTPUT.finditer(value)
+                    )
                 }
+                step_aliases = {
+                    name
+                    for name in pin_aliases
+                    if isinstance(value := effective_env[name], str) and _pin_expression_members(value) == exact_member
+                }
+                invalid_aliases = pin_aliases - step_aliases
                 run = step.get("run")
                 if not isinstance(run, str):
                     continue
                 overridden: set[str] = set()
-                live_vars = set(
-                    re.findall(
-                        r'(?ms)^\s*(?:(?:export|readonly)\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=\s*["\']?'
-                        r"\$\(\s*git\s+ls-remote\b",
-                        run,
-                    )
-                )
                 normalized_run = re.sub(
                     r"\$\((.*?)\)",
                     lambda match: "$(" + " ".join(match.group(1).split()) + ")",
                     run,
                     flags=re.DOTALL,
                 )
+                commands = _shell_commands(normalized_run)
+                live_vars: set[str] = set()
+                for words in commands:
+                    assignment = re.match(
+                        r'(?:(?:export|readonly)\s+)?(?P<name>[A-Za-z_][A-Za-z0-9_]*)\s*=\s*["\']?'
+                        r"\$\(\s*git\s+ls-remote\b",
+                        " ".join(words),
+                    )
+                    if assignment is not None:
+                        live_vars.add(assignment.group("name"))
                 base = _pin_base(pin.output)
-                for words in _shell_commands(normalized_run):
+                for words in commands:
                     overridden.update(
                         assignment.group("name")
                         for word in words
@@ -2001,6 +2014,17 @@ def _pin_offences(sources: dict[str, str]) -> list[str]:
                             or argument.startswith(f"${name}:")
                             or argument.startswith(f"${{{name}}}:")
                         }
+                        used_git_invalid = {
+                            name
+                            for argument in arguments
+                            for name in invalid_aliases
+                            if argument == f"${name}"
+                            or argument == f"${{{name}}}"
+                            or argument.startswith(f"${name}:")
+                            or argument.startswith(f"${{{name}}}:")
+                        }
+                        if used_git_invalid:
+                            invalid_alias_sinks.update((job_name, name, command) for name in used_git_invalid)
                         direct_live = any(re.search(r"\$\(\s*git\s+ls-remote\b", argument) for argument in arguments)
                         if (used_git_live or direct_live) and step_aliases:
                             offences.append(
@@ -2014,7 +2038,13 @@ def _pin_offences(sources: dict[str, str]) -> list[str]:
                             )
                         elif used_git:
                             identity = True
-        if not identity:
+        if identity:
+            offences.extend(
+                f"{pin.workflow}:{job_name}: rule=pin-consumer: derived or untrusted env alias "
+                f"{name} references {pin.job}.{pin.output} at identity sink git {command}"
+                for job_name, name, command in invalid_alias_sinks
+            )
+        else:
             offences.append(
                 f"{pin.workflow}:{pin.job}.{pin.output}: rule=pin-consumer: pin is not consumed by a ref/identity sink"
             )

--- a/tests/test_issue2231_workflow_hygiene.py
+++ b/tests/test_issue2231_workflow_hygiene.py
@@ -1230,7 +1230,10 @@ def _logical_shell_lines(source: str) -> list[tuple[int, str]]:
 def _shell_words(source: str, where: str) -> list[tuple[int, list[str]]]:
     commands: list[tuple[int, list[str]]] = []
     bindings: dict[str, str] = {}
+    command_v = re.compile(r'(?P<name>[A-Za-z_][A-Za-z0-9_]*)\s*=\s*["\']?\$\(\s*command\s+-v\s+docker\s*\)["\']?')
     for line_no, logical in _logical_shell_lines(source):
+        for match in command_v.finditer(logical):
+            bindings[match.group("name")] = "docker"
         bound_reference = any(
             re.search(rf"\$(?:{re.escape(name)}\b|\{{{re.escape(name)}\}})", logical) for name in bindings
         )
@@ -1490,11 +1493,19 @@ def _python_docker_runs(source: str, where: str) -> list[tuple[int, list[str]]]:
             if id(function) in seen:
                 return argument
             returns = [
-                statement.value
+                statement
                 for statement in function.body
                 if isinstance(statement, ast.Return) and statement.value is not None
             ]
-            return resolve_factory(returns[0], seen | {id(function)}) if len(returns) == 1 else argument
+            if len(returns) != 1:
+                return argument
+            result = cast(ast.expr, returns[0].value)
+            if isinstance(result, ast.Name):
+                bindings = bound_argv.get(function, {}).get(result.id, [])
+                candidates = [(line, value) for line, value in bindings if line < returns[0].lineno]
+                if candidates:
+                    result = max(candidates, key=lambda candidate: candidate[0])[1]
+            return resolve_factory(result, seen | {id(function)})
         return argument
 
     def resolve_argument(argument: ast.expr, call: ast.Call) -> ast.expr:
@@ -1557,6 +1568,12 @@ _PHP_STRING_ASSIGN = re.compile(
     r"\$(?P<name>[A-Za-z_][A-Za-z0-9_]*)\s*=\s*(?P<quote>['\"])(?P<body>.*?)(?P=quote)\s*;",
     re.DOTALL,
 )
+_PHP_CONCAT_ASSIGN = re.compile(
+    r"\$(?P<name>[A-Za-z_][A-Za-z0-9_]*)\s*=\s*"
+    r"(?P<body>(?:'[^']*'|\"[^\"]*\")(?:\s*\.\s*(?:'[^']*'|\"[^\"]*\"))+)\s*;",
+    re.DOTALL,
+)
+_PHP_STRING_LITERAL = re.compile(r"'([^']*)'|\"([^\"]*)\"")
 _PHP_SHELL_CALL = re.compile(
     r"\b(?:exec|passthru|shell_exec|system)\s*\(\s*"
     r"(?:(?P<quote>['\"])(?P<body>.*?)(?P=quote)|\$(?P<variable>[A-Za-z_][A-Za-z0-9_]*))",
@@ -1570,6 +1587,11 @@ def _php_docker_runs(source: str, where: str) -> list[tuple[int, list[str]]]:
         line_start = source.rfind("\n", 0, match.start()) + 1
         if not source[line_start : match.start()].lstrip().startswith(("//", "#", "*")):
             variables[match.group("name")] = match.group("body")
+    for match in _PHP_CONCAT_ASSIGN.finditer(source):
+        variables[match.group("name")] = "".join(
+            next((value for value in literal if value), "")
+            for literal in _PHP_STRING_LITERAL.findall(match.group("body"))
+        )
     invocations: list[tuple[int, list[str]]] = []
     for match in _PHP_SHELL_CALL.finditer(source):
         line_start = source.rfind("\n", 0, match.start()) + 1
@@ -1843,7 +1865,6 @@ def _ref_binding(path: tuple[str, ...]) -> bool:
         return False
     return path[-1].lower() in {
         "ref",
-        "sha",
         "checkout_ref",
         "source_ref",
         "ports_ref",
@@ -1879,15 +1900,21 @@ def _pin_offences(sources: dict[str, str]) -> list[str]:
 
         workflow_pins = {(candidate.job, candidate.output) for candidate in pins if candidate.workflow == pin.workflow}
         identity = False
-        for _, path, value in consumers:
+        invalid_ref_jobs: set[str] = set()
+        for job_name, path, value in consumers:
+            if not _ref_binding(path):
+                continue
             expression_members = _pin_expression_members(value)
-            if (
-                _ref_binding(path)
-                and (pin.job, pin.output) in expression_members
-                and expression_members <= workflow_pins
-            ):
+            if (pin.job, pin.output) in expression_members and expression_members <= workflow_pins:
                 identity = True
-                break
+            else:
+                invalid_ref_jobs.add(job_name)
+        if identity:
+            for job_name in invalid_ref_jobs:
+                offences.append(
+                    f"{pin.workflow}:{job_name}: rule=pin-consumer: derived or untrusted ref sink "
+                    f"references {pin.job}.{pin.output}"
+                )
         exact_member = frozenset({(pin.job, pin.output)})
         for job_name in sorted(descendants):
             job = jobs[job_name]
@@ -1916,11 +1943,7 @@ def _pin_offences(sources: dict[str, str]) -> list[str]:
                 run = step.get("run")
                 if not isinstance(run, str):
                     continue
-                overridden = {
-                    name
-                    for name in step_aliases
-                    if re.search(rf"(?m)^\s*(?:(?:export|readonly)\s+)?{re.escape(name)}\s*=", run)
-                }
+                overridden: set[str] = set()
                 live_vars = set(
                     re.findall(
                         r'(?ms)^\s*(?:(?:export|readonly)\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=\s*["\']?'
@@ -1936,6 +1959,12 @@ def _pin_offences(sources: dict[str, str]) -> list[str]:
                 )
                 base = _pin_base(pin.output)
                 for words in _shell_commands(normalized_run):
+                    overridden.update(
+                        assignment.group("name")
+                        for word in words
+                        if (assignment := re.fullmatch(r"(?P<name>[A-Za-z_][A-Za-z0-9_]*)=.*", word))
+                        and assignment.group("name") in step_aliases
+                    )
                     for index, word in enumerate(words[:-1]):
                         flag = word.removeprefix("--")
                         relevant_flag = (

--- a/tests/test_issue2245_stateless_nightly.py
+++ b/tests/test_issue2245_stateless_nightly.py
@@ -45,6 +45,8 @@ def test_actionlint_exception_is_narrowly_scoped_to_workflows_using_queue_max() 
             ".github/workflows/release.yml": {"ignore": [queue_error]},
             ".github/workflows/image-refresh.yml": {"ignore": [queue_error]},
             ".github/workflows/nightly-failure-alert.yml": {"ignore": [queue_error]},
+            ".github/workflows/smoke.yml": {"ignore": [queue_error]},
+            ".github/workflows/ui-tests.yml": {"ignore": [queue_error]},
         }
     }
 
@@ -491,12 +493,18 @@ def outer():
         return ["docker", "run", "alpine"]
     return inner()
 
+def local():
+    argv = ["docker", "run", "alpine"]
+    return argv
+
 subprocess.run(chain())
 subprocess.run(outer())
+subprocess.run(local())
 """
     assert hygiene._docker_run_offences({"tests/smoke/factories.py": source}) == [
-        "tests/smoke/factories.py:14: rule=docker-init: docker run must include exact token --init",
-        "tests/smoke/factories.py:15: rule=docker-init: docker run must include exact token --init",
+        "tests/smoke/factories.py:18: rule=docker-init: docker run must include exact token --init",
+        "tests/smoke/factories.py:19: rule=docker-init: docker run must include exact token --init",
+        "tests/smoke/factories.py:20: rule=docker-init: docker run must include exact token --init",
     ]
 
 
@@ -648,3 +656,98 @@ jobs:
         "direct-live.yml:build: rule=pin-consumer: live git ls-remote replaces "
         "prepare.ports_sha at identity sink git reset",
     ]
+
+
+def test_workflow_hygiene_rejects_invalid_pin_sink_beside_exact_sink() -> None:
+    source = """\
+on: workflow_dispatch
+jobs:
+  prepare:
+    outputs:
+      source_sha: ${{ steps.pin.outputs.source_sha }}
+    steps:
+      - id: pin
+  build:
+    needs: prepare
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.prepare.outputs.source_sha }}
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.prepare.outputs.source_sha || github.ref }}
+"""
+    assert hygiene._pin_offences({"mixed-sinks.yml": source}) == [
+        "mixed-sinks.yml:build: rule=pin-consumer: derived or untrusted ref sink references prepare.source_sha"
+    ]
+
+
+def test_workflow_hygiene_rejects_unrelated_sha_key_as_identity_sink() -> None:
+    source = """\
+on: workflow_dispatch
+jobs:
+  prepare:
+    outputs:
+      source_sha: ${{ steps.pin.outputs.source_sha }}
+    steps:
+      - id: pin
+  build:
+    needs: prepare
+    steps:
+      - uses: actions/github-script@v8
+        with:
+          script: return 0
+          sha: ${{ needs.prepare.outputs.source_sha }}
+"""
+    assert hygiene._pin_offences({"fake-sha.yml": source}) == [
+        "fake-sha.yml:prepare.source_sha: rule=pin-consumer: pin is not consumed by a ref/identity sink"
+    ]
+
+
+def test_workflow_hygiene_rejects_shell_operator_alias_overwrite() -> None:
+    source = """\
+on: workflow_dispatch
+jobs:
+  prepare:
+    outputs:
+      source_sha: ${{ steps.pin.outputs.source_sha }}
+    steps:
+      - id: pin
+  build:
+    needs: prepare
+    env:
+      SOURCE_SHA: ${{ needs.prepare.outputs.source_sha }}
+    steps:
+      - run: 'true; SOURCE_SHA=main; git checkout "$SOURCE_SHA"'
+"""
+    assert hygiene._pin_offences({"operator-shadow.yml": source}) == [
+        "operator-shadow.yml:build: rule=pin-consumer: alias overwrites "
+        "prepare.source_sha at identity sink git checkout",
+        "operator-shadow.yml:prepare.source_sha: rule=pin-consumer: pin is not consumed by a ref/identity sink",
+    ]
+
+
+def test_workflow_hygiene_resolves_static_shell_and_php_docker_aliases() -> None:
+    sources = {
+        "scripts/command-v.sh": 'runtime="$(command -v docker)"\n"$runtime" run alpine\n',
+        "scripts/concat.php": '<?php\n$cmd = "docker " . "run alpine";\nsystem($cmd);\n',
+    }
+    assert hygiene._docker_run_offences(sources) == [
+        "scripts/command-v.sh:2: rule=docker-init: docker run must include exact token --init",
+        "scripts/concat.php:3: rule=docker-init: docker run must include exact token --init",
+    ]
+
+
+@pytest.mark.parametrize(
+    ("workflow", "prefix"),
+    (("smoke.yml", "smoke-"), ("ui-tests.yml", "ui-tests-")),
+)
+def test_reusable_release_gates_have_distinct_lossless_concurrency(workflow: str, prefix: str) -> None:
+    source = (ROOT / ".github" / "workflows" / workflow).read_text(encoding="utf-8")
+    document = hygiene._workflow_document(source, workflow)
+    concurrency = document["concurrency"]
+    assert isinstance(concurrency, dict)
+    group = concurrency.get("group")
+    assert isinstance(group, str) and group.startswith(prefix)
+    assert concurrency.get("queue") == "max"
+    assert concurrency.get("cancel-in-progress") is False

--- a/tests/test_issue2245_stateless_nightly.py
+++ b/tests/test_issue2245_stateless_nightly.py
@@ -159,9 +159,16 @@ $cmd = "docker run alpine";
 system($cmd);
 """,
     }
-    offences = hygiene._docker_run_offences(sources)
-    assert len(offences) == 8, offences
-    assert not any(f"scripts/global.sh:{line}:" in offence for offence in offences for line in (2, 4, 6))
+    assert hygiene._docker_run_offences(sources) == [
+        "scripts/global.sh:1: rule=docker-init: docker run must include exact token --init",
+        "scripts/global.sh:3: rule=docker-init: docker run must include exact token --init",
+        "scripts/global.sh:5: rule=docker-init: docker run must include exact token --init",
+        "scripts/global.sh:7: rule=docker-init: docker run must include exact token --init",
+        "scripts/global.sh:9: rule=docker-init: docker run must include exact token --init",
+        "tests/smoke/local.py:8: rule=docker-init: docker run must include exact token --init",
+        "tests/smoke/local.py:9: rule=docker-init: docker run must include exact token --init",
+        "scripts/variable.php:3: rule=docker-init: docker run must include exact token --init",
+    ]
 
 
 def test_workflow_hygiene_rejects_derived_fake_multiline_and_readonly_sinks() -> None:
@@ -323,6 +330,26 @@ jobs:
         hygiene._artifact_chain_offences({"reusable.yml": source})
 
 
+def test_workflow_hygiene_checks_uncalled_reusable_artifact_chains() -> None:
+    source = """\
+on: workflow_call
+jobs:
+  upload:
+    steps:
+      - uses: actions/upload-artifact@v7
+        with: {name: pkg}
+  download:
+    needs: upload
+    steps:
+      - uses: actions/download-artifact@v8
+        with: {name: pkg}
+"""
+    assert hygiene._artifact_chain_offences({"reusable.yml": source}) == [
+        "reusable.yml:download:step-0: rule=artifact-major: "
+        "download v8 mismatches producers [('reusable.yml', 'upload', 7)]"
+    ]
+
+
 @pytest.mark.parametrize(
     "value",
     (
@@ -449,6 +476,30 @@ docker -l debug run alpine
     ]
 
 
+def test_workflow_hygiene_resolves_nested_and_chained_python_factories() -> None:
+    source = """\
+import subprocess
+
+def leaf():
+    return ["docker", "run", "alpine"]
+
+def chain():
+    return leaf()
+
+def outer():
+    def inner():
+        return ["docker", "run", "alpine"]
+    return inner()
+
+subprocess.run(chain())
+subprocess.run(outer())
+"""
+    assert hygiene._docker_run_offences({"tests/smoke/factories.py": source}) == [
+        "tests/smoke/factories.py:14: rule=docker-init: docker run must include exact token --init",
+        "tests/smoke/factories.py:15: rule=docker-init: docker run must include exact token --init",
+    ]
+
+
 def test_workflow_hygiene_duplicate_display_name_diagnostics_pin_both_producers() -> None:
     sources = {
         "one.yml": """\
@@ -484,4 +535,116 @@ jobs:
         "callback.yml:consume:step-0: rule=artifact-major: ambiguous producers for 'pkg': "
         "[('one.yml', 'upload'), ('two.yml', 'upload')]",
         "callback.yml:consume:step-0: rule=artifact-major: download v8 mismatches producers [('one.yml', 'upload', 7)]",
+    ]
+
+
+def test_workflow_hygiene_scans_merge_group_artifact_graphs() -> None:
+    source = """\
+on: merge_group
+jobs:
+  upload:
+    steps:
+      - uses: actions/upload-artifact@v7
+        with: {name: pkg}
+  download:
+    needs: upload
+    steps:
+      - uses: actions/download-artifact@v8
+        with: {name: pkg}
+"""
+    assert hygiene._artifact_chain_offences({"merge.yml": source}) == [
+        "merge.yml:download:step-0: rule=artifact-major: download v8 mismatches producers [('merge.yml', 'upload', 7)]"
+    ]
+
+
+def test_workflow_hygiene_rejects_init_after_docker_option_terminator() -> None:
+    assert hygiene._docker_run_offences({"scripts/boundary.sh": "docker run -- --init\n"}) == [
+        "scripts/boundary.sh:1: rule=docker-init: docker run must include exact token --init"
+    ]
+
+
+def test_workflow_hygiene_scans_python_subprocess_args_keywords() -> None:
+    source = """\
+import subprocess
+from subprocess import run
+
+subprocess.run(args=["docker", "run", "alpine"])
+run(args=["docker", "run", "alpine"])
+"""
+    assert hygiene._docker_run_offences({"tests/smoke/keyword.py": source}) == [
+        "tests/smoke/keyword.py:4: rule=docker-init: docker run must include exact token --init",
+        "tests/smoke/keyword.py:5: rule=docker-init: docker run must include exact token --init",
+    ]
+
+
+def test_workflow_hygiene_resolves_python_argv_in_its_lexical_scope() -> None:
+    source = """\
+import subprocess
+argv = ["docker", "run", "alpine"]
+def unrelated():
+    argv = ["printf", "safe"]
+
+def invoke():
+    subprocess.run(argv)
+"""
+    assert hygiene._docker_run_offences({"tests/smoke/lexical.py": source}) == [
+        "tests/smoke/lexical.py:7: rule=docker-init: docker run must include exact token --init"
+    ]
+
+
+def test_workflow_hygiene_parses_git_global_options_before_identity_commands() -> None:
+    source = """\
+on: workflow_dispatch
+jobs:
+  prepare:
+    outputs:
+      ports_sha: ${{ steps.pin.outputs.ports_sha }}
+    steps:
+      - id: pin
+  build:
+    needs: prepare
+    steps:
+      - env:
+          PORTS_SHA: ${{ needs.prepare.outputs.ports_sha }}
+        run: |
+          git show "$PORTS_SHA:Makefile"
+          readonly CHECKOUT_REF=$(git ls-remote origin main)
+          git -C ports checkout "$CHECKOUT_REF"
+          readonly RESET_REF=$(git ls-remote origin main)
+          git -Cports reset "$RESET_REF"
+"""
+    assert hygiene._pin_offences({"git-options.yml": source}) == [
+        "git-options.yml:build: rule=pin-consumer: live git ls-remote replaces "
+        "prepare.ports_sha at identity sink git checkout",
+        "git-options.yml:build: rule=pin-consumer: live git ls-remote replaces "
+        "prepare.ports_sha at identity sink git reset",
+    ]
+
+
+def test_workflow_hygiene_rejects_direct_live_git_identity_substitutions() -> None:
+    source = """\
+on: workflow_dispatch
+jobs:
+  prepare:
+    outputs:
+      ports_sha: ${{ steps.pin.outputs.ports_sha }}
+    steps:
+      - id: pin
+  build:
+    needs: prepare
+    steps:
+      - env:
+          PORTS_SHA: ${{ needs.prepare.outputs.ports_sha }}
+        run: |
+          git show "$PORTS_SHA:Makefile"
+          git checkout "$(git ls-remote origin main)"
+          git -C ports reset "$(
+            git ls-remote origin main
+          )"
+"""
+    assert hygiene._pin_offences({"direct-live.yml": source}) == [
+        "direct-live.yml:build: rule=pin-consumer: live git ls-remote replaces "
+        "prepare.ports_sha at identity sink git checkout",
+        "direct-live.yml:build: rule=pin-consumer: live git ls-remote replaces "
+        "prepare.ports_sha at identity sink git reset",
     ]

--- a/tests/test_issue2245_stateless_nightly.py
+++ b/tests/test_issue2245_stateless_nightly.py
@@ -752,6 +752,31 @@ jobs:
     ]
 
 
+def test_workflow_hygiene_rejects_derived_env_alias_at_flag_identity_sink() -> None:
+    source = """\
+on: workflow_dispatch
+jobs:
+  prepare:
+    outputs:
+      ports_sha: ${{ steps.pin.outputs.ports_sha }}
+    steps:
+      - id: pin
+  build:
+    needs: prepare
+    env:
+      PORTS_SHA: ${{ needs.prepare.outputs.ports_sha || github.ref }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.prepare.outputs.ports_sha }}
+      - run: sh scripts/build-leg.sh --ports-ref "$PORTS_SHA"
+"""
+    assert hygiene._pin_offences({"flag-alias.yml": source}) == [
+        "flag-alias.yml:build: rule=pin-consumer: derived or untrusted env alias PORTS_SHA "
+        "references prepare.ports_sha at identity sink --ports-ref"
+    ]
+
+
 def test_workflow_hygiene_reports_semicolon_live_replacement_beside_exact_sink() -> None:
     source = """\
 on: workflow_dispatch

--- a/tests/test_issue2245_stateless_nightly.py
+++ b/tests/test_issue2245_stateless_nightly.py
@@ -777,6 +777,81 @@ jobs:
     ]
 
 
+def test_workflow_hygiene_rejects_derived_env_alias_at_equals_flag_identity_sink() -> None:
+    source = """\
+"on": workflow_dispatch
+jobs:
+  prepare:
+    outputs:
+      ports_sha: ${{ steps.pin.outputs.ports_sha }}
+    steps:
+      - id: pin
+  build:
+    needs: prepare
+    env:
+      PORTS_SHA: ${{ needs.prepare.outputs.ports_sha || github.ref }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.prepare.outputs.ports_sha }}
+      - run: sh scripts/build-leg.sh --ports-ref=$PORTS_SHA
+"""
+    assert hygiene._pin_offences({"equals-flag-env-alias.yml": source}) == [
+        "equals-flag-env-alias.yml:build: rule=pin-consumer: derived or untrusted env alias PORTS_SHA "
+        "references prepare.ports_sha at identity sink --ports-ref"
+    ]
+
+
+def test_workflow_hygiene_reports_live_alias_at_equals_flag_identity_sink() -> None:
+    source = """\
+"on": workflow_dispatch
+jobs:
+  prepare:
+    outputs:
+      ports_sha: ${{ steps.pin.outputs.ports_sha }}
+    steps:
+      - id: pin
+  build:
+    needs: prepare
+    env:
+      PORTS_SHA: ${{ needs.prepare.outputs.ports_sha }}
+    steps:
+      - run: |
+          git show "$PORTS_SHA:Makefile"
+          FRESH=$(git ls-remote origin main)
+          sh scripts/build-leg.sh --ports-ref=$FRESH
+"""
+    assert hygiene._pin_offences({"equals-flag-live-alias.yml": source}) == [
+        "equals-flag-live-alias.yml:build: rule=pin-consumer: live git ls-remote replaces "
+        "prepare.ports_sha at identity sink --ports-ref"
+    ]
+
+
+def test_workflow_hygiene_rejects_derived_shell_alias_at_flag_identity_sink() -> None:
+    source = """\
+"on": workflow_dispatch
+jobs:
+  prepare:
+    outputs:
+      ports_sha: ${{ steps.pin.outputs.ports_sha }}
+    steps:
+      - id: pin
+  build:
+    needs: prepare
+    env:
+      PORTS_SHA: ${{ needs.prepare.outputs.ports_sha }}
+    steps:
+      - run: |
+          git show "$PORTS_SHA:Makefile"
+          FRESH="${PORTS_SHA}-attacker"
+          sh scripts/build-leg.sh --ports-ref "$FRESH"
+"""
+    assert hygiene._pin_offences({"derived-shell-alias.yml": source}) == [
+        "derived-shell-alias.yml:build: rule=pin-consumer: derived shell alias FRESH references "
+        "prepare.ports_sha at identity sink --ports-ref"
+    ]
+
+
 def test_workflow_hygiene_reports_semicolon_live_replacement_beside_exact_sink() -> None:
     source = """\
 on: workflow_dispatch

--- a/tests/test_issue2245_stateless_nightly.py
+++ b/tests/test_issue2245_stateless_nightly.py
@@ -294,3 +294,194 @@ jobs:
     assert hygiene._pin_offences({"fake-output.yml": source}) == [
         "fake-output.yml:prepare.source_sha: rule=pin-consumer: pin is not consumed by a ref/identity sink"
     ]
+
+
+def test_workflow_hygiene_accepts_semver_refs_in_uncalled_reusable_workflows() -> None:
+    source = """\
+on: workflow_call
+jobs:
+  upload:
+    steps:
+      - uses: actions/upload-artifact@v7.1.2
+        with: {name: pkg}
+"""
+    assert hygiene._artifact_chain_offences({"reusable.yml": source}) == []
+
+
+def test_workflow_hygiene_rejects_main_refs_in_uncalled_reusable_workflows() -> None:
+    source = """\
+on: workflow_call
+jobs:
+  upload:
+    steps:
+      - uses: actions/upload-artifact@main
+        with: {name: pkg}
+"""
+    with pytest.raises(
+        AssertionError, match=r"reusable.yml:upload:step-0: rule=artifact-major: unclassified action ref"
+    ):
+        hygiene._artifact_chain_offences({"reusable.yml": source})
+
+
+@pytest.mark.parametrize(
+    "value",
+    (
+        "refs/heads/${{ needs.prepare.outputs.source_sha }}",
+        "${{ needs.prepare.outputs.source_sha || github.sha }}",
+    ),
+)
+def test_workflow_hygiene_rejects_derived_and_fallback_job_env_aliases(value: str) -> None:
+    source = """\
+on: workflow_dispatch
+jobs:
+  prepare:
+    outputs:
+      source_sha: ${{ steps.pin.outputs.source_sha }}
+    steps:
+      - id: pin
+  build:
+    needs: prepare
+    env:
+      SOURCE_SHA: VALUE
+    steps:
+      - run: git checkout "$SOURCE_SHA"
+""".replace("VALUE", value)
+    assert hygiene._pin_offences({"job-env.yml": source}) == [
+        "job-env.yml:prepare.source_sha: rule=pin-consumer: pin is not consumed by a ref/identity sink"
+    ]
+
+
+def test_workflow_hygiene_step_env_shadow_overrides_exact_job_env_alias() -> None:
+    source = """\
+on: workflow_dispatch
+jobs:
+  prepare:
+    outputs:
+      source_sha: ${{ steps.pin.outputs.source_sha }}
+    steps:
+      - id: pin
+  build:
+    needs: prepare
+    env:
+      SOURCE_SHA: ${{ needs.prepare.outputs.source_sha }}
+    steps:
+      - env:
+          SOURCE_SHA: main
+        run: git checkout "$SOURCE_SHA"
+"""
+    assert hygiene._pin_offences({"shadow.yml": source}) == [
+        "shadow.yml:prepare.source_sha: rule=pin-consumer: pin is not consumed by a ref/identity sink"
+    ]
+
+
+@pytest.mark.parametrize(
+    "identity_command",
+    (
+        'git checkout "$PORTS_SHA"',
+        'git show "$PORTS_SHA:Makefile"',
+        'git switch "$PORTS_SHA"',
+        'git reset "$PORTS_SHA"',
+    ),
+)
+def test_workflow_hygiene_reports_readonly_live_replacement_at_git_identity_sinks(
+    identity_command: str,
+) -> None:
+    source = """\
+on: workflow_dispatch
+jobs:
+  prepare:
+    outputs:
+      ports_sha: ${{ steps.pin.outputs.ports_sha }}
+    steps:
+      - id: pin
+  build:
+    needs: prepare
+    steps:
+      - env:
+          PORTS_SHA: ${{ needs.prepare.outputs.ports_sha }}
+        run: |
+          readonly PORTS_SHA=$(git ls-remote origin main)
+          IDENTITY_COMMAND
+""".replace("IDENTITY_COMMAND", identity_command)
+    offences = hygiene._pin_offences({"readonly.yml": source})
+    command = identity_command.split()[1]
+    assert (
+        "readonly.yml:build: rule=pin-consumer: live git ls-remote replaces "
+        f"prepare.ports_sha at identity sink git {command}"
+    ) in offences
+
+
+def test_workflow_hygiene_reports_readonly_live_identity_aliases() -> None:
+    source = """\
+on: workflow_dispatch
+jobs:
+  prepare:
+    outputs:
+      ports_sha: ${{ steps.pin.outputs.ports_sha }}
+    steps:
+      - id: pin
+  build:
+    needs: prepare
+    steps:
+      - env:
+          PORTS_SHA: ${{ needs.prepare.outputs.ports_sha }}
+        run: |
+          readonly CHECKOUT_REF=$(git ls-remote origin main)
+          git checkout "$CHECKOUT_REF"
+"""
+    offences = hygiene._pin_offences({"readonly-alias.yml": source})
+    assert (
+        "readonly-alias.yml:build: rule=pin-consumer: live git ls-remote replaces "
+        "prepare.ports_sha at identity sink git checkout"
+    ) in offences
+
+
+def test_workflow_hygiene_consumes_docker_global_short_option_values_before_run() -> None:
+    source = """\
+docker -c remote run --init alpine
+docker -c remote run alpine
+docker -l debug run --init alpine
+docker -l debug run alpine
+"""
+    assert hygiene._docker_run_offences({"scripts/global-short.sh": source}) == [
+        "scripts/global-short.sh:2: rule=docker-init: docker run must include exact token --init",
+        "scripts/global-short.sh:4: rule=docker-init: docker run must include exact token --init",
+    ]
+
+
+def test_workflow_hygiene_duplicate_display_name_diagnostics_pin_both_producers() -> None:
+    sources = {
+        "one.yml": """\
+name: Producer
+on: workflow_dispatch
+jobs:
+  upload:
+    steps:
+      - uses: actions/upload-artifact@v7
+        with: {name: pkg}
+""",
+        "two.yml": """\
+name: Producer
+on: workflow_dispatch
+jobs:
+  upload:
+    steps:
+      - uses: actions/upload-artifact@v8
+        with: {name: pkg}
+""",
+        "callback.yml": """\
+on:
+  workflow_run:
+    workflows: [Producer]
+jobs:
+  consume:
+    steps:
+      - uses: actions/download-artifact@v8
+        with: {name: pkg}
+""",
+    }
+    assert hygiene._artifact_chain_offences(sources) == [
+        "callback.yml:consume:step-0: rule=artifact-major: ambiguous producers for 'pkg': "
+        "[('one.yml', 'upload'), ('two.yml', 'upload')]",
+        "callback.yml:consume:step-0: rule=artifact-major: download v8 mismatches producers [('one.yml', 'upload', 7)]",
+    ]

--- a/tests/test_issue2245_stateless_nightly.py
+++ b/tests/test_issue2245_stateless_nightly.py
@@ -2,9 +2,11 @@
 
 from pathlib import Path
 
+import pytest
 import yaml
 
 from scripts import release_version as rv
+from tests import test_issue2231_workflow_hygiene as hygiene
 
 ROOT = Path(__file__).resolve().parent.parent
 WORKFLOW = ROOT / ".github" / "workflows" / "nightly.yml"
@@ -45,3 +47,250 @@ def test_actionlint_exception_is_narrowly_scoped_to_workflows_using_queue_max() 
             ".github/workflows/nightly-failure-alert.yml": {"ignore": [queue_error]},
         }
     }
+
+
+def test_workflow_hygiene_discovery_fails_closed_when_no_files_are_found(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(hygiene, "ROOT", tmp_path)
+    with pytest.raises(AssertionError, match=r"no workflow files discovered under"):
+        hygiene._workflow_sources()
+
+
+def test_workflow_hygiene_tracks_each_reusable_call_instance() -> None:
+    sources = {
+        "consumer.yml": """\
+on: workflow_call
+inputs:
+  selector: {type: string}
+jobs:
+  download:
+    steps:
+      - uses: actions/download-artifact@v8
+        with: {name: "${{ inputs.selector }}"}
+""",
+        "root.yml": """\
+name: Root
+on: workflow_dispatch
+jobs:
+  upload:
+    steps:
+      - uses: actions/upload-artifact@v8
+        with: {name: present}
+  good:
+    needs: upload
+    uses: ./.github/workflows/consumer.yml
+    with: {selector: present}
+  bad:
+    needs: upload
+    uses: ./.github/workflows/consumer.yml
+    with: {selector: missing}
+""",
+    }
+    assert hygiene._artifact_chain_offences(sources) == [
+        "consumer.yml:download:step-0: rule=artifact-major: no producer matches ['missing']"
+    ]
+
+
+def test_workflow_hygiene_parses_semver_and_rejects_unclassified_action_refs() -> None:
+    sources = {
+        "semver.yml": """\
+on: workflow_dispatch
+jobs:
+  upload:
+    steps:
+      - uses: actions/upload-artifact@v7.1.2
+        with: {name: pkg}
+  download:
+    needs: upload
+    steps:
+      - uses: actions/download-artifact@v8.0.0
+        with: {name: pkg}
+""",
+    }
+    assert hygiene._artifact_chain_offences(sources) == [
+        "semver.yml:download:step-0: rule=artifact-major: download v8 mismatches producers "
+        "[('semver.yml', 'upload', 7)]"
+    ]
+    with pytest.raises(
+        AssertionError, match=r"unknown.yml:upload:step-0: rule=artifact-major: unclassified action ref"
+    ):
+        hygiene._artifact_chain_offences(
+            {
+                "unknown.yml": """\
+on: workflow_dispatch
+jobs:
+  upload:
+    steps:
+      - uses: actions/upload-artifact@main
+        with: {name: pkg}
+"""
+            }
+        )
+
+
+def test_workflow_hygiene_handles_docker_globals_local_values_and_image_boundary() -> None:
+    sources = {
+        "scripts/global.sh": """\
+docker --context remote run alpine
+docker run --workdir /tmp --init alpine
+docker run --workdir /tmp alpine
+docker run --user 1000 --init alpine
+docker run --user 1000 alpine
+docker run --mount type=tmpfs,dst=/tmp --init alpine
+docker run --mount type=tmpfs,dst=/tmp alpine
+runtime=docker
+"$runtime" run alpine
+""",
+        "tests/smoke/local.py": """\
+import subprocess
+
+def command():
+    return ["docker", "run", "alpine"]
+
+def invoke():
+    argv = ["docker", "run", "alpine"]
+    subprocess.run(argv)
+    subprocess.run(command())
+""",
+        "scripts/variable.php": """\
+<?php
+$cmd = "docker run alpine";
+system($cmd);
+""",
+    }
+    offences = hygiene._docker_run_offences(sources)
+    assert len(offences) == 8, offences
+    assert not any(f"scripts/global.sh:{line}:" in offence for offence in offences for line in (2, 4, 6))
+
+
+def test_workflow_hygiene_rejects_derived_fake_multiline_and_readonly_sinks() -> None:
+    sources = {
+        "derived.yml": """\
+on: workflow_dispatch
+jobs:
+  prepare:
+    outputs:
+      source_sha: ${{ steps.pin.outputs.source_sha }}
+    steps:
+      - id: pin
+  build:
+    needs: prepare
+    outputs:
+      sha: ${{ needs.prepare.outputs.source_sha }}
+    with:
+      ref: ${{ needs.prepare.outputs.source_sha || github.ref }}
+""",
+        "untrusted.yml": """\
+on: workflow_dispatch
+jobs:
+  prepare:
+    outputs:
+      source_sha: ${{ steps.pin.outputs.source_sha }}
+    steps:
+      - id: pin
+  build:
+    needs: prepare
+    with:
+      ref: ${{ needs.prepare.outputs.source_sha || needs.untrusted.outputs.sha }}
+""",
+        "readonly.yml": """\
+on: workflow_dispatch
+jobs:
+  prepare:
+    outputs:
+      ports_sha: ${{ steps.pin.outputs.ports_sha }}
+    steps:
+      - id: pin
+  build:
+    needs: prepare
+    steps:
+      - env:
+          PORTS_SHA: ${{ needs.prepare.outputs.ports_sha }}
+        run: |
+          readonly PORTS_SHA=$(git ls-remote origin main)
+          git checkout \"$PORTS_SHA\"
+""",
+        "multiline.yml": """\
+on: workflow_dispatch
+jobs:
+  prepare:
+    outputs:
+      ports_sha: ${{ steps.pin.outputs.ports_sha }}
+    steps:
+      - id: pin
+  build:
+    needs: prepare
+    steps:
+      - env:
+          PORTS_SHA: ${{ needs.prepare.outputs.ports_sha }}
+        run: |
+          git show \"$PORTS_SHA:Makefile\"
+          FRESH=\"$(
+            git ls-remote origin main
+          )\"
+          build-leg.sh --ports-ref \"$FRESH\"
+      - env:
+          PORTS_SHA: ${{ needs.prepare.outputs.ports_sha }}
+        run: |
+          readonly PORTS_SHA=$(git ls-remote origin main)
+          git checkout \"$PORTS_SHA\"
+""",
+    }
+    offences = hygiene._pin_offences(sources)
+    assert any("derived.yml:prepare.source_sha: rule=pin-consumer: pin is not consumed" in item for item in offences)
+    assert any("untrusted.yml:prepare.source_sha: rule=pin-consumer: pin is not consumed" in item for item in offences)
+    assert any(
+        "readonly.yml:build: rule=pin-consumer: live git ls-remote replaces prepare.ports_sha" in item
+        for item in offences
+    )
+    assert any(
+        "multiline.yml:build: rule=pin-consumer: live git ls-remote replaces prepare.ports_sha" in item
+        for item in offences
+    )
+
+
+@pytest.mark.parametrize(
+    "sink",
+    (
+        '${{ format("refs/heads/{0}", needs.prepare.outputs.source_sha) }}',
+        "${{ needs.prepare.outputs.source_sha }}${{ '' }}",
+        "${{ needs.prepare.outputs.source_sha || 'main' }}",
+    ),
+)
+def test_workflow_hygiene_rejects_derived_pin_expressions(sink: str) -> None:
+    source = """\
+on: workflow_dispatch
+jobs:
+  prepare:
+    outputs:
+      source_sha: ${{ steps.pin.outputs.source_sha }}
+    steps:
+      - id: pin
+  build:
+    needs: prepare
+    with:
+      ref: PIN_SINK
+""".replace("PIN_SINK", sink)
+    assert hygiene._pin_offences({"derived.yml": source}) == [
+        "derived.yml:prepare.source_sha: rule=pin-consumer: pin is not consumed by a ref/identity sink"
+    ]
+
+
+def test_workflow_hygiene_rejects_job_output_as_fake_identity_sink() -> None:
+    source = """\
+on: workflow_dispatch
+jobs:
+  prepare:
+    outputs:
+      source_sha: ${{ steps.pin.outputs.source_sha }}
+    steps:
+      - id: pin
+  build:
+    needs: prepare
+    outputs:
+      sha: ${{ needs.prepare.outputs.source_sha }}
+"""
+    assert hygiene._pin_offences({"fake-output.yml": source}) == [
+        "fake-output.yml:prepare.source_sha: rule=pin-consumer: pin is not consumed by a ref/identity sink"
+    ]

--- a/tests/test_issue2245_stateless_nightly.py
+++ b/tests/test_issue2245_stateless_nightly.py
@@ -852,6 +852,96 @@ jobs:
     ]
 
 
+def test_workflow_hygiene_rejects_unknown_alias_at_flag_identity_sink() -> None:
+    source = """\
+"on": workflow_dispatch
+jobs:
+  prepare:
+    outputs:
+      ports_sha: ${{ steps.pin.outputs.ports_sha }}
+    steps:
+      - id: pin
+  build:
+    needs: prepare
+    steps:
+      - env:
+          PORTS_SHA: ${{ needs.prepare.outputs.ports_sha }}
+        run: |
+          git show "$PORTS_SHA:Makefile"
+          FRESH=main
+          sh scripts/build-leg.sh --ports-ref "$FRESH"
+"""
+    assert hygiene._pin_offences({"unknown-flag-alias.yml": source}) == [
+        "unknown-flag-alias.yml:build: rule=pin-consumer: identity flag --ports-ref uses "
+        "a derived, untrusted, or unknown value instead of prepare.ports_sha"
+    ]
+
+
+@pytest.mark.parametrize(
+    "identity_invocation",
+    (
+        "sh scripts/build-leg.sh --ports-ref main",
+        "sh scripts/build-leg.sh --ports-ref=main",
+    ),
+)
+def test_workflow_hygiene_rejects_direct_literal_at_flag_identity_sink(
+    identity_invocation: str,
+) -> None:
+    source = """\
+"on": workflow_dispatch
+jobs:
+  prepare:
+    outputs:
+      ports_sha: ${{ steps.pin.outputs.ports_sha }}
+    steps:
+      - id: pin
+  build:
+    needs: prepare
+    steps:
+      - env:
+          PORTS_SHA: ${{ needs.prepare.outputs.ports_sha }}
+        run: |
+          git show "$PORTS_SHA:Makefile"
+          IDENTITY_INVOCATION
+""".replace("IDENTITY_INVOCATION", identity_invocation)
+    assert hygiene._pin_offences({"direct-flag-literal.yml": source}) == [
+        "direct-flag-literal.yml:build: rule=pin-consumer: identity flag --ports-ref uses "
+        "a derived, untrusted, or unknown value instead of prepare.ports_sha"
+    ]
+
+
+def test_workflow_hygiene_scopes_flag_identity_sinks_to_matching_prepared_pins() -> None:
+    sources = {
+        "exact-and-unrelated.yml": """\
+"on": workflow_dispatch
+jobs:
+  prepare:
+    outputs:
+      ports_sha: ${{ steps.pin.outputs.ports_sha }}
+    steps:
+      - id: pin
+  build:
+    needs: prepare
+    steps:
+      - env:
+          PORTS_SHA: ${{ needs.prepare.outputs.ports_sha }}
+        run: |
+          git show "$PORTS_SHA:Makefile"
+          sh scripts/build-leg.sh --ports-ref "$PORTS_SHA"
+          sh scripts/build-leg.sh --ports-sha "${{ needs.prepare.outputs.ports_sha }}"
+          sh scripts/build-leg.sh --cache-ref main
+""",
+        "no-prepared-pin.yml": """\
+"on": workflow_dispatch
+jobs:
+  build:
+    steps:
+      - run: sh scripts/build-leg.sh --ports-ref main
+""",
+    }
+    assert hygiene._pin_offences(sources) == []
+
+
 def test_workflow_hygiene_reports_semicolon_live_replacement_beside_exact_sink() -> None:
     source = """\
 on: workflow_dispatch

--- a/tests/test_issue2245_stateless_nightly.py
+++ b/tests/test_issue2245_stateless_nightly.py
@@ -943,6 +943,65 @@ jobs:
     ]
 
 
+@pytest.mark.parametrize(
+    "declaration",
+    (
+        "export OTHER=1 PORTS_SHA=main",
+        "readonly OTHER=1 PORTS_SHA=main",
+    ),
+)
+def test_workflow_hygiene_tracks_every_exported_pin_alias(declaration: str) -> None:
+    source = """\
+"on": workflow_dispatch
+jobs:
+  prepare:
+    outputs:
+      ports_sha: ${{ steps.pin.outputs.ports_sha }}
+    steps:
+      - id: pin
+  build:
+    needs: prepare
+    env:
+      PORTS_SHA: ${{ needs.prepare.outputs.ports_sha }}
+    steps:
+      - run: |
+          sh scripts/build-leg.sh --ports-ref "$PORTS_SHA"
+          DECLARATION
+          sh scripts/build-leg.sh --ports-ref "$PORTS_SHA"
+""".replace("DECLARATION", declaration)
+    assert hygiene._pin_offences({"multi-assignment.yml": source}) == [
+        "multi-assignment.yml:build: rule=pin-consumer: alias overwrites prepare.ports_sha at identity sink --ports-ref"
+    ]
+
+
+@pytest.mark.parametrize(
+    "declaration",
+    (
+        "export OTHER=1 EXTRA=main",
+        "readonly OTHER=1 EXTRA=main",
+    ),
+)
+def test_workflow_hygiene_keeps_exact_pin_after_unrelated_exported_assignments(declaration: str) -> None:
+    source = """\
+"on": workflow_dispatch
+jobs:
+  prepare:
+    outputs:
+      ports_sha: ${{ steps.pin.outputs.ports_sha }}
+    steps:
+      - id: pin
+  build:
+    needs: prepare
+    env:
+      PORTS_SHA: ${{ needs.prepare.outputs.ports_sha }}
+    steps:
+      - run: |
+          DECLARATION
+          sh scripts/build-leg.sh --ports-ref "$PORTS_SHA"
+""".replace("DECLARATION", declaration)
+    assert hygiene._pin_offences({"unrelated-multi-assignment.yml": source}) == []
+
+
 def test_workflow_hygiene_scopes_flag_identity_sinks_to_matching_prepared_pins() -> None:
     sources = {
         "exact-and-unrelated.yml": """\

--- a/tests/test_issue2245_stateless_nightly.py
+++ b/tests/test_issue2245_stateless_nightly.py
@@ -910,6 +910,39 @@ jobs:
     ]
 
 
+@pytest.mark.parametrize(
+    "identity_invocation",
+    (
+        'sh scripts/build-leg.sh --ports-ref "$PORTS_SHA" --ports-ref main',
+        'sh scripts/build-leg.sh --ports-ref="$PORTS_SHA" --ports-ref=main',
+    ),
+)
+def test_workflow_hygiene_validates_each_identity_flag_argument(
+    identity_invocation: str,
+) -> None:
+    source = """\
+"on": workflow_dispatch
+jobs:
+  prepare:
+    outputs:
+      ports_sha: ${{ steps.pin.outputs.ports_sha }}
+    steps:
+      - id: pin
+  build:
+    needs: prepare
+    env:
+      PORTS_SHA: ${{ needs.prepare.outputs.ports_sha }}
+    steps:
+      - run: |
+          git show "$PORTS_SHA:Makefile"
+          IDENTITY_INVOCATION
+""".replace("IDENTITY_INVOCATION", identity_invocation)
+    assert hygiene._pin_offences({"sibling-identity-flags.yml": source}) == [
+        "sibling-identity-flags.yml:build: rule=pin-consumer: identity flag --ports-ref uses "
+        "a derived, untrusted, or unknown value instead of prepare.ports_sha"
+    ]
+
+
 def test_workflow_hygiene_scopes_flag_identity_sinks_to_matching_prepared_pins() -> None:
     sources = {
         "exact-and-unrelated.yml": """\
@@ -929,6 +962,7 @@ jobs:
           git show "$PORTS_SHA:Makefile"
           sh scripts/build-leg.sh --ports-ref "$PORTS_SHA"
           sh scripts/build-leg.sh --ports-sha "${{ needs.prepare.outputs.ports_sha }}"
+          sh scripts/build-leg.sh --ports-sha "$PORTS_SHA" --ports-ref main
           sh scripts/build-leg.sh --cache-ref main
 """,
         "no-prepared-pin.yml": """\

--- a/tests/test_issue2245_stateless_nightly.py
+++ b/tests/test_issue2245_stateless_nightly.py
@@ -727,6 +727,69 @@ jobs:
     ]
 
 
+def test_workflow_hygiene_rejects_derived_env_alias_beside_exact_checkout() -> None:
+    source = """\
+on: workflow_dispatch
+jobs:
+  prepare:
+    outputs:
+      source_sha: ${{ steps.pin.outputs.source_sha }}
+    steps:
+      - id: pin
+  build:
+    needs: prepare
+    env:
+      SOURCE_SHA: ${{ needs.prepare.outputs.source_sha || github.ref }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.prepare.outputs.source_sha }}
+      - run: git checkout "$SOURCE_SHA"
+"""
+    assert hygiene._pin_offences({"mixed-env.yml": source}) == [
+        "mixed-env.yml:build: rule=pin-consumer: derived or untrusted env alias SOURCE_SHA "
+        "references prepare.source_sha at identity sink git checkout"
+    ]
+
+
+def test_workflow_hygiene_reports_semicolon_live_replacement_beside_exact_sink() -> None:
+    source = """\
+on: workflow_dispatch
+jobs:
+  prepare:
+    outputs:
+      ports_sha: ${{ steps.pin.outputs.ports_sha }}
+    steps:
+      - id: pin
+  build:
+    needs: prepare
+    env:
+      PORTS_SHA: ${{ needs.prepare.outputs.ports_sha }}
+    steps:
+      - run: |
+          git show "$PORTS_SHA:Makefile"
+          true; FRESH=$(git ls-remote origin main)
+          FRESH=${FRESH%%[[:space:]]*}
+          git checkout "$FRESH"
+"""
+    assert hygiene._pin_offences({"valid-live.yml": source}) == [
+        "valid-live.yml:build: rule=pin-consumer: live git ls-remote replaces "
+        "prepare.ports_sha at identity sink git checkout"
+    ]
+
+
+def test_workflow_hygiene_resolves_function_local_subprocess_import() -> None:
+    source = """\
+def invoke():
+    import subprocess
+    subprocess.run(["docker", "run", "alpine"], check=True)
+invoke()
+"""
+    assert hygiene._docker_run_offences({"tests/smoke/nested_import.py": source}) == [
+        "tests/smoke/nested_import.py:3: rule=docker-init: docker run must include exact token --init"
+    ]
+
+
 def test_workflow_hygiene_resolves_static_shell_and_php_docker_aliases() -> None:
     sources = {
         "scripts/command-v.sh": 'runtime="$(command -v docker)"\n"$runtime" run alpine\n',

--- a/tests/test_issue2245_stateless_nightly.py
+++ b/tests/test_issue2245_stateless_nightly.py
@@ -41,5 +41,7 @@ def test_actionlint_exception_is_narrowly_scoped_to_workflows_using_queue_max() 
             ".github/workflows/release-published.yml": {"ignore": [queue_error]},
             ".github/workflows/pkg-republish.yml": {"ignore": [queue_error]},
             ".github/workflows/release.yml": {"ignore": [queue_error]},
+            ".github/workflows/image-refresh.yml": {"ignore": [queue_error]},
+            ".github/workflows/nightly-failure-alert.yml": {"ignore": [queue_error]},
         }
     }

--- a/tests/test_smoke_leg_zero_selection_gate.py
+++ b/tests/test_smoke_leg_zero_selection_gate.py
@@ -106,7 +106,7 @@ def _shard_status_upload_step() -> list[str]:
 
 def test_smoke_single_uploads_shard_selection_status_marker() -> None:
     step_text = "\n".join(_shard_status_upload_step())
-    assert "uses: actions/upload-artifact@v7" in step_text, step_text
+    assert "uses: actions/upload-artifact@v8" in step_text, step_text
     assert re.search(r"if:\s*always\(\)", step_text), f"upload must run unconditionally, got:\n{step_text}"
     name_line = next(line for line in _shard_status_upload_step() if line.strip().startswith("name:"))
     assert "inputs.image_name" in name_line and "inputs.pfsense_version" in name_line and "inputs.shard" in name_line, (


### PR DESCRIPTION
## Summary

- require top-level concurrency on every externally dispatchable workflow, preserving lossless operational queues
- enforce artifact-action major parity through needs, reusable-call instances, and `workflow_run` display-name chains
- enforce exact pre-image `--init` on workflow containers and tracked shell/Python/PHP Docker invocations
- enforce exact prepare/read/resolve SHA consumption without derived refs, shadowed aliases, or live re-resolution

Fixes #2413

## Source-derived coverage matrix

| Rule | Source rows | Result |
|---|---|---|
| External-trigger concurrency | 24 `.yml`/`.yaml` workflow documents; 14 missing blocks fixed, 10 existing blocks preserved | clean; image-refresh and nightly-failure-alert use `queue: max` |
| Artifact majors | 26 action rows and 14 local reusable-call jobs: build-pkg-linux → image/smoke/UI; smoke-single → smoke aggregate/module-durations; release attach/external consumers; independent Nightly chain | affected producer/consumer chains aligned on v8; Nightly remains v7 end-to-end |
| Container init | every workflow job `container` mapping plus every tracked UTF-8 file under `scripts/**` and `tests/smoke/**` | no current production invocation; preventive scanner clean |
| Pinned SHA consumption | Nightly prepare source/ports/tools/matrix; Release prepare/read-matrix source/CI metadata/ports; release-published resolve source | all nine pins reach exact dependent ref/identity sinks; no derived/live replacement |

Concurrency fixes cover `agent-config`, `build-image`, `build-pkg-linux`, `coderabbit-cli`, `context-budget`, `image-refresh`, `nightly-failure-alert`, `repo-install`, `smoke-single`, `smoke`, `test-version-matrix`, `top1m-healthcheck`, `ui-tests`, and `version-tracker`.

## Hostile/planted coverage

The scanners exercise empty/invalid inventories and YAML; quoted and mixed triggers/action refs; inline comments; `.yml`/`.yaml`; missing/cyclic needs and reusable workflows; duplicate display names/artifacts; unresolved outputs; per-call reusable inputs; unmatched `workflow_run` selectors; semver and unclassifiable artifact refs in uncalled reusable-only workflows; dynamic names/globs; block-local container options; Docker continuations, heredocs, wrappers, long and short global/run value options, image boundary, option terminators, module-, function-, and factory-local Python argv/import resolution, PHP/shell variables, and late `--init`; exact SHA fallbacks plus fake outputs, format/decorated expressions, derived/fallback job env, step-env shadowing, untrusted alternatives, exact sinks beside invalid aliases, semicolon-delimited live resolution, multiline live resolution, and `readonly` identity aliases.

## Frozen RED → GREEN

The original scanner blob `5e4d1f944b24636cbfbf139871bf4e3ff948d7c0` was proven against untouched base `8016210c99e602e6718fed068232ae4aef7fbaa2`: `4 failed, 24 passed`; every hostile scanner test passed and failures were solely real base workflow offences. The same blob passed `28 passed` after workflow reconciliation.

The earlier final adversarial oracle blob `ff07e098e05fef314a7a8fc63bd7efd9fe8fbf70` produced `8 failed in 0.07s` against exact pre-fix scanner `3e0ae17f688628e25f11b3c377b48876b2b125dc`, then `32 passed in 0.57s` unchanged on the candidate.

### Final bypass closure

Frozen oracle: `tests/test_issue2245_stateless_nightly.py` blob `e3ff77873ccd69f502c0f68ba60a666b5b8a7f68`.

RED used that exact oracle against the scanner bytes from pre-fix head `942942e50ca8c9f38ac13833dedc4cdebe7a1d4c` via isolated module import:

```text
uv run python -c 'import pytest, subprocess, types; source=subprocess.check_output(["git","show","HEAD:tests/test_issue2231_workflow_hygiene.py"], text=True); pre=types.ModuleType("pre_hygiene"); pre.__file__="tests/test_issue2231_workflow_hygiene.py"; exec(compile(source, pre.__file__, "exec"), pre.__dict__); P=type("P", (), {"pytest_runtest_setup": lambda self, item: setattr(item.module, "hygiene", pre)}); nodes=["tests/test_issue2245_stateless_nightly.py::test_workflow_hygiene_rejects_derived_env_alias_beside_exact_checkout", "tests/test_issue2245_stateless_nightly.py::test_workflow_hygiene_reports_semicolon_live_replacement_beside_exact_sink", "tests/test_issue2245_stateless_nightly.py::test_workflow_hygiene_resolves_function_local_subprocess_import"]; raise SystemExit(pytest.main(["-q", "-n0", *nodes], plugins=[P()]))'
```

```text
3 failed in 0.06s
```

The three REDs were exact checkout beside derived/untrusted `SOURCE_SHA`, exact `git show` beside semicolon-delimited live `FRESH`, and function-local `import subprocess` before `docker run` without `--init`.

GREEN on commit `46eb31b33a9e8665abca4b7ea13d67253d271f98`:

```text
uv run pytest -q tests/test_issue2245_stateless_nightly.py::test_workflow_hygiene_rejects_derived_env_alias_beside_exact_checkout tests/test_issue2245_stateless_nightly.py::test_workflow_hygiene_reports_semicolon_live_replacement_beside_exact_sink tests/test_issue2245_stateless_nightly.py::test_workflow_hygiene_resolves_function_local_subprocess_import
```

```text
3 passed in 0.56s
```

The oracle remained byte-identical at `e3ff77873ccd69f502c0f68ba60a666b5b8a7f68` through GREEN.

### Final bounded alias-sink closure

Alias-sink scanner at that closure: `tests/test_issue2231_workflow_hygiene.py` blob `e5501756118a4611cd42e96f07f98bccd516e6e0`.

Frozen oracle: `tests/test_issue2245_stateless_nightly.py` blob `143a31b187ce8761d509ed74597a8e237e73acbd`.

RED ran the three exact hostile rows against unchanged scanner head `5a59644ec4ea9a037ea81b15e294caa3f6860147`:

```text
uv run pytest -q tests/test_issue2245_stateless_nightly.py::test_workflow_hygiene_rejects_derived_env_alias_at_equals_flag_identity_sink tests/test_issue2245_stateless_nightly.py::test_workflow_hygiene_reports_live_alias_at_equals_flag_identity_sink tests/test_issue2245_stateless_nightly.py::test_workflow_hygiene_rejects_derived_shell_alias_at_flag_identity_sink
pytest: 3 failed in 0.61s
```

All three returned `[]`: derived/untrusted job env at `--ports-ref=$PORTS_SHA`, live `ls-remote` replacement at `--ports-ref=$FRESH`, and quoted parameter concatenation consumed through `--ports-ref "$FRESH"`.

GREEN ran the unchanged oracle after the generic flag/alias fix:

```text
uv run pytest -q tests/test_issue2245_stateless_nightly.py::test_workflow_hygiene_rejects_derived_env_alias_at_equals_flag_identity_sink tests/test_issue2245_stateless_nightly.py::test_workflow_hygiene_reports_live_alias_at_equals_flag_identity_sink tests/test_issue2245_stateless_nightly.py::test_workflow_hygiene_rejects_derived_shell_alias_at_flag_identity_sink
pytest: 3 passed in 0.62s
```

The oracle remained byte-identical at `143a31b187ce8761d509ed74597a8e237e73acbd` through GREEN. The scanner now parses both `--*-ref VALUE` / `--*-sha VALUE` and equals forms, and propagates exact, derived, overwritten, and live provenance through shell-local aliases without flag- or file-specific exemptions.
### Final unknown flag-sink closure

Current final scanner: `tests/test_issue2231_workflow_hygiene.py` blob `ce1d7728de632654f100c9b19903202a68d51ce5`.

Frozen oracle: `tests/test_issue2245_stateless_nightly.py` blob `9d58e41c5000b5b438693c176748b3ab36316189`.

RED ran the exact unknown-alias, split/equals direct-literal, and scope-control rows against unchanged scanner head `322bb4287978f1acbb9bf8e3e5e881c57c8ed58d`:

```text
uv run pytest -q -n0 tests/test_issue2245_stateless_nightly.py::test_workflow_hygiene_rejects_unknown_alias_at_flag_identity_sink tests/test_issue2245_stateless_nightly.py::test_workflow_hygiene_rejects_direct_literal_at_flag_identity_sink tests/test_issue2245_stateless_nightly.py::test_workflow_hygiene_scopes_flag_identity_sinks_to_matching_prepared_pins
pytest: 3 failed, 1 passed in 0.11s
```

The three hostile rows all returned `[]`: `FRESH=main` passed through split `--ports-ref "$FRESH"`, and direct `main` passed through both `--ports-ref main` and `--ports-ref=main`. The passing control proved exact prepared aliases/direct needs outputs remain valid and unrelated flags or workflows without a matching prepared pin remain out of scope.

GREEN on commit `3c1e4f22d9ae076921a421cec9d742e4e6f9d298`:

```text
uv run pytest -q -n0 tests/test_issue2245_stateless_nightly.py::test_workflow_hygiene_rejects_unknown_alias_at_flag_identity_sink tests/test_issue2245_stateless_nightly.py::test_workflow_hygiene_rejects_direct_literal_at_flag_identity_sink tests/test_issue2245_stateless_nightly.py::test_workflow_hygiene_scopes_flag_identity_sinks_to_matching_prepared_pins
pytest: 4 passed in 0.05s
```

The oracle remained byte-identical at `9d58e41c5000b5b438693c176748b3ab36316189` through GREEN. Matching `--*-ref` / `--*-sha` sinks now fail closed for unknown aliases and direct literals in split or equals form while retaining exact prepared aliases/direct outputs and ignoring unrelated flag families or workflows with no matching prepared pin.

## Final sibling-flag closure

Current final scanner: `tests/test_issue2231_workflow_hygiene.py` blob `17660024a15fa3253f752c04a210f673fc6a0593`.

Frozen oracle: `tests/test_issue2245_stateless_nightly.py` blob `14213f1c8beaccdc53078e27d11e5177736af7e3`.

RED ran the split and equals sibling-flag rows plus the exact-SHA/raw-ref control against unchanged scanner head `3c1e4f22d9ae076921a421cec9d742e4e6f9d298`:

```text
uv run pytest -q -n0 tests/test_issue2245_stateless_nightly.py::test_workflow_hygiene_validates_each_identity_flag_argument tests/test_issue2245_stateless_nightly.py::test_workflow_hygiene_scopes_flag_identity_sinks_to_matching_prepared_pins
pytest: 2 failed, 1 passed in 0.08s
```

Both hostile rows returned `[]`: an exact prepared `--ports-ref` masked a second `--ports-ref main` argument in split and equals form. The passing control proved an exact `--ports-sha` may still be paired with raw `--ports-ref` metadata.

GREEN on commit `71f89c4b6c38d75cb41e3d2f90e8e7a4f23920a3`:

```text
uv run pytest -q -n0 tests/test_issue2245_stateless_nightly.py::test_workflow_hygiene_validates_each_identity_flag_argument tests/test_issue2245_stateless_nightly.py::test_workflow_hygiene_scopes_flag_identity_sinks_to_matching_prepared_pins
pytest: 3 passed in 0.08s
```

The oracle remained byte-identical at `14213f1c8beaccdc53078e27d11e5177736af7e3` through GREEN. Each relevant identity argument is now validated independently; a verified same-base `--*-sha` keeps paired `--*-ref` metadata out of identity selection without a file-specific exemption.

## Final multi-assignment closure

Current final scanner: `tests/test_issue2231_workflow_hygiene.py` blob `6af015ff7dee7779597449573debb1618c359e98`.

Frozen oracle: `tests/test_issue2245_stateless_nightly.py` blob `51a1bf6ab83d572226b24d74e99b7792bceb2687`.

RED ran the exact `export OTHER=1 PORTS_SHA=main` and `readonly OTHER=1 PORTS_SHA=main` hostile rows plus unrelated-assignment controls against unchanged pre-fix scanner blob `17660024a15fa3253f752c04a210f673fc6a0593`:

```text
uv run pytest -q -n0 tests/test_issue2245_stateless_nightly.py::test_workflow_hygiene_tracks_every_exported_pin_alias tests/test_issue2245_stateless_nightly.py::test_workflow_hygiene_keeps_exact_pin_after_unrelated_exported_assignments
pytest: 2 failed, 2 passed in 0.11s
```

Both hostile rows returned `[]`: only `OTHER=1` was processed, so the later `PORTS_SHA=main` overwrite escaped the sibling `--ports-ref "$PORTS_SHA"` identity sink. Both controls passed with two unrelated assignments and the exact prepared `PORTS_SHA` unchanged.

GREEN on commit `c11a4b7e7358df8d368cb04f66a15f0bc03d15c3`:

```text
uv run pytest -q -n0 tests/test_issue2245_stateless_nightly.py::test_workflow_hygiene_tracks_every_exported_pin_alias tests/test_issue2245_stateless_nightly.py::test_workflow_hygiene_keeps_exact_pin_after_unrelated_exported_assignments
pytest: 4 passed in 0.07s
```

The oracle remained byte-identical at `51a1bf6ab83d572226b24d74e99b7792bceb2687` through GREEN. The scanner now processes every assignment in `export` and `readonly` commands in command order, preserving exact, derived, overwritten, and live provenance without variable- or file-specific exemptions.

## Focused gates

```text
uv run pytest -q -n0 tests/test_issue2231_workflow_hygiene.py tests/test_issue2245_stateless_nightly.py tests/test_nightly_workflow_contract.py tests/test_smoke_leg_zero_selection_gate.py
pytest: 115 passed in 2.64s
```

```text
uv run ruff check tests/test_issue2231_workflow_hygiene.py tests/test_issue2245_stateless_nightly.py
All checks passed!
uv run ruff format --check tests/test_issue2231_workflow_hygiene.py tests/test_issue2245_stateless_nightly.py
2 files already formatted
```

```text
uv run mypy tests/
Success: no issues found in 355 source files
```

Commit policy hooks passed. The final bounded change touches only `tests/test_issue2231_workflow_hygiene.py` and `tests/test_issue2245_stateless_nightly.py`; no workflow, `src/`, dependency, or documentation file changed.

Final pushed head: `c11a4b7e7358df8d368cb04f66a15f0bc03d15c3`.

Parent validation and landing remain pending at this exact head. This head is not a merge instruction.

## Final exact-byte scanner proof

Current final scanner: `tests/test_issue2231_workflow_hygiene.py` blob `6af015ff7dee7779597449573debb1618c359e98` at head `c11a4b7e7358df8d368cb04f66a15f0bc03d15c3`.

An independent detached-base run copied these exact committed scanner bytes onto untouched `8016210c99e602e6718fed068232ae4aef7fbaa2` and ran:

```text
uv run pytest -n 0 tests/test_issue2231_workflow_hygiene.py -q
pytest: 4 failed, 24 passed
```

Every hostile/synthetic row passed; the four failures were only the enumerated real base workflow offences. The same exact blob on the candidate produced:

```text
pytest: 28 passed
```

🤖 Generated by Oh My Pi and posted on behalf of @andrebrait.
