### PR TITLE
ci: reject uppercase frozen RED hashes

### DIFF
--- a/scripts/check_coverage_pairing.py
+++ b/scripts/check_coverage_pairing.py
@@ -148,7 +148,7 @@ def _has_justification(body: str) -> bool:
 
 
 _FROZEN_RED_HEADER = ("frozen red test", "git hash-object", "red run tail")
-_GIT_HASH = re.compile(r"(?:[0-9a-fA-F]{40}|[0-9a-fA-F]{64})")
+_GIT_HASH = re.compile(r"(?:[0-9a-f]{40}|[0-9a-f]{64})")
 _DELIMITER = re.compile(r":?-{3,}:?")
 
 
@@ -236,7 +236,7 @@ def _parse_frozen_red(body: str) -> tuple[list[tuple[str, str]], list[str]]:
         if not tail:
             errors.append(f"Frozen RED record for {path} has no RED run tail")
             continue
-        records.append((path, digest.lower()))
+        records.append((path, digest))
     if not records and not errors:
         errors.append("Frozen RED table has no evidence rows")
     return records, errors

--- a/tests/test_coverage_pairing_check.py
+++ b/tests/test_coverage_pairing_check.py
@@ -400,6 +400,17 @@ def test_matching_frozen_red_record_passes(tmp_path: Any) -> None:
     assert ccp.main(["--pr-body-file", str(body), _RELEASE_SCRIPT, _RELEASE_TEST]) == 0
 
 
+def test_frozen_red_hash_must_be_lowercase(tmp_path: Any, capsys: Any) -> None:
+    body = tmp_path / "pr-body.md"
+    digest = _working_tree_hash(_RELEASE_TEST)
+    body.write_text(_frozen_red_body(_RELEASE_TEST, digest.upper()), encoding="utf-8")
+
+    assert ccp.main(["--pr-body-file", str(body), _RELEASE_SCRIPT, _RELEASE_TEST]) == 1
+    output = capsys.readouterr().out
+    assert _RELEASE_TEST in output
+    assert "Git object ID" in output
+
+
 def test_frozen_red_record_must_name_a_changed_test_and_carry_a_tail(tmp_path: Any, capsys: Any) -> None:
     body = tmp_path / "pr-body.md"
     body.write_text(


### PR DESCRIPTION
Fixes #2415

## What

Follow-up to merged PR #2707: require the recorded `git hash-object` in Frozen RED evidence to use the lowercase native Git spelling. The checker previously accepted uppercase A–F and normalized the supplied digest before comparison, despite issue #2415 requiring wrong-case evidence to fail.

The fix narrows the existing object-ID regex to lowercase hexadecimal and compares the recorded spelling without normalization. No protocol, path class, dependency, workflow, or `src/**` behavior changes.

## Hypotheses and probes

1. `_GIT_HASH` accepted `[A-F]`, so an uppercase version of the exact committed test hash would parse. Confirmed: the exact PR body and eight-path status stream returned exit 0.
2. Lowercasing the parsed value hid the spelling difference before native `git hash-object` comparison. Confirmed from the parser and by the same executed offence; native Git emitted lowercase while the uppercase row still passed.

## Frozen RED evidence

| Frozen RED test | git hash-object | RED run tail |
| --- | --- | --- |
| `tests/test_coverage_pairing_check.py` | `614e5cc4c393bf12ce707651bd018d40d60a4e01` | `pytest: 1 failed; uppercase recorded hash returned checker rc 0 instead of required rc 1` |

RED before the checker edit:

```text
FAILED test_frozen_red_hash_must_be_lowercase
AssertionError: assert 0 == 1
Captured stdout: Coverage pairing OK: shipped tests and available frozen-RED evidence satisfy all rules.
pytest: 1 failed
```

GREEN with the same frozen test file:

```text
test_frozen_red_hash_must_be_lowercase: 1 passed
focused checker suite: 50 passed
ruff check: All checks passed
ruff format --check: 2 files already formatted
mypy: Success: no issues found in 1 source file
```

`git hash-object tests/test_coverage_pairing_check.py` returned `614e5cc4c393bf12ce707651bd018d40d60a4e01` before and after the production edit.

## Scope

- `scripts/check_coverage_pairing.py`: reject uppercase object IDs and preserve the submitted spelling.
- `tests/test_coverage_pairing_check.py`: planted uppercase-hash offence with path diagnostic.

The original source-derived release-plane matrix, neutral classifications, run-gates/CI wiring, five evidence rows, four review legs, and CodeRabbit review remain in #2707.

🤖 Generated by Oh My Pi and posted on behalf of @andrebrait.
