### PR TITLE
smoke: fix live Pages isolation

### DIFF
--- a/tests/smoke/test_repo_install.py
+++ b/tests/smoke/test_repo_install.py
@@ -1419,6 +1419,54 @@ def _install_trusted_fingerprint(vm: SmokeVM, *, timeout: float = 60.0) -> None:
         raise RuntimeError(f"could not install the trusted fingerprint: {put.stderr!r}")
 
 
+def _raise_live_pages_errors(context: str, errors: list[tuple[str, Exception]]) -> None:
+    if not errors:
+        return
+    details = "; ".join(f"{operation}: {type(error).__name__}: {error}" for operation, error in errors)
+    raise RuntimeError(f"{context}: {details}") from errors[0][1]
+
+
+def _ensure_live_pages_packages_absent(vm: SmokeVM) -> None:
+    package_names = (PKG_NAME,) if PKG_NAME == CANONICAL_PKG_NAME else (PKG_NAME, CANONICAL_PKG_NAME)
+    errors: list[tuple[str, Exception]] = []
+    for package_name in package_names:
+        try:
+            pkg_delete(vm, pkg_name=package_name)
+        except Exception as error:
+            errors.append((f"delete {package_name}", error))
+
+    try:
+        installed = installed_pfblockerng_names(vm)
+        remaining = [package_name for package_name in package_names if package_name in installed]
+        if remaining:
+            raise AssertionError(
+                f"live Pages packages still installed: expected absent {list(package_names)!r}; "
+                f"remaining {remaining!r}; installed {installed!r}"
+            )
+    except Exception as error:
+        errors.append(("verify package absence", error))
+
+    _raise_live_pages_errors("live Pages package cleanup failed", errors)
+
+
+def _cleanup_live_pages(vm: SmokeVM, prior_hosts: str) -> None:
+    errors: list[tuple[str, Exception]] = []
+    try:
+        _ensure_live_pages_packages_absent(vm)
+    except Exception as error:
+        errors.append(("package cleanup", error))
+    try:
+        _ssh_check(vm, "/bin/rm", "-f", REPO_CONF)
+    except Exception as error:
+        errors.append(("remove repo conf", error))
+    try:
+        restore_pages_hosts(vm, prior_hosts)
+    except Exception as error:
+        errors.append(("restore Pages hosts", error))
+
+    _raise_live_pages_errors("live Pages teardown failed", errors)
+
+
 @pytest.mark.timeout(900)  # live deploy/DNS/cert can lag + pkg update + install over the public URL.
 def test_install_from_live_pages_url(repo_vm: SmokeVM) -> None:
     """Install the canonical package from the selected live Pages repository."""
@@ -1449,8 +1497,7 @@ def test_install_from_live_pages_url(repo_vm: SmokeVM) -> None:
     prior_hosts = pin_pages_hosts(repo_vm, host)
     try:
         pfsense_prio = repo_priority(repo_vm, NETGATE_REPO_NAME)
-        pkg_delete(repo_vm, pkg_name=PKG_NAME)
-        pkg_delete(repo_vm, pkg_name=CANONICAL_PKG_NAME)
+        _ensure_live_pages_packages_absent(repo_vm)
         write_live_repo_conf(repo_vm, base_url, varver, priority=pfsense_prio + 100)
 
         # WHEN: pkg update must ACCEPT the live HTTPS catalog (a rejected catalog — bad
@@ -1478,10 +1525,13 @@ def test_install_from_live_pages_url(repo_vm: SmokeVM) -> None:
         assert origin == expected_origin, f"installed from {origin!r}, expected selected repo {expected_origin!r}"
         assert_live_package(repo_vm, CANONICAL_PKG_NAME, expected_version, expected_source_sha, expected_channel)
     finally:
-        pkg_delete(repo_vm, pkg_name=PKG_NAME)
-        pkg_delete(repo_vm, pkg_name=CANONICAL_PKG_NAME)
-        _ssh_check(repo_vm, "/bin/rm", "-f", REPO_CONF)
-        restore_pages_hosts(repo_vm, prior_hosts)
+        body_error = sys.exception()
+        try:
+            _cleanup_live_pages(repo_vm, prior_hosts)
+        except Exception as cleanup_error:
+            if body_error is None:
+                raise
+            body_error.add_note(f"live Pages cleanup also failed: {cleanup_error}")
 
 
 @pytest.mark.timeout(1800)

--- a/tests/smoke/test_repo_install.py
+++ b/tests/smoke/test_repo_install.py
@@ -1449,6 +1449,7 @@ def test_install_from_live_pages_url(repo_vm: SmokeVM) -> None:
     prior_hosts = pin_pages_hosts(repo_vm, host)
     try:
         pfsense_prio = repo_priority(repo_vm, NETGATE_REPO_NAME)
+        pkg_delete(repo_vm, pkg_name=PKG_NAME)
         pkg_delete(repo_vm, pkg_name=CANONICAL_PKG_NAME)
         write_live_repo_conf(repo_vm, base_url, varver, priority=pfsense_prio + 100)
 
@@ -1477,6 +1478,7 @@ def test_install_from_live_pages_url(repo_vm: SmokeVM) -> None:
         assert origin == expected_origin, f"installed from {origin!r}, expected selected repo {expected_origin!r}"
         assert_live_package(repo_vm, CANONICAL_PKG_NAME, expected_version, expected_source_sha, expected_channel)
     finally:
+        pkg_delete(repo_vm, pkg_name=PKG_NAME)
         pkg_delete(repo_vm, pkg_name=CANONICAL_PKG_NAME)
         _ssh_check(repo_vm, "/bin/rm", "-f", REPO_CONF)
         restore_pages_hosts(repo_vm, prior_hosts)
@@ -1493,9 +1495,11 @@ def test_live_nightly_downgrade_requires_selected_semantic_repo(repo_vm: SmokeVM
     ``install.sh --channel <channel>`` must then move the canonical package to the selected
     Stable, Testing, or Edge repository and its lower version.
     """
+    from .test_nightly_install import _live_nightly_url
+
     semantic_url = _live_base_url()
-    nightly_url = os.environ.get(LIVE_NIGHTLY_URL_ENV, "").rstrip("/")
-    if semantic_url is None or not nightly_url:
+    nightly_url = _live_nightly_url()
+    if semantic_url is None or nightly_url is None:
         pytest.skip(f"{LIVE_BASE_URL_ENV} and {LIVE_NIGHTLY_URL_ENV} are required for the live downgrade")
     assert semantic_url is not None
     expected_semantic_source = os.environ.get(LIVE_EXPECTED_SOURCE_SHA_ENV)

--- a/tests/test_issue2149_live_repo_identity.py
+++ b/tests/test_issue2149_live_repo_identity.py
@@ -12,6 +12,63 @@ from tests.smoke import test_repo_install as repo
 from tests.smoke.conftest import SmokeVM
 
 
+def _live_pages_cleanup_case(
+    monkeypatch: MonkeyPatch,
+    events: list[str],
+    *,
+    delete_failure_call: int | None = None,
+    install_failure: Exception | None = None,
+    same_identity: bool = False,
+) -> tuple[SmokeVM, str]:
+    canonical_name = repo.CANONICAL_PKG_NAME
+    branch_name = canonical_name if same_identity else f"{canonical_name}-edge"
+    delete_calls = 0
+
+    class FakeVM:
+        def ssh(self, *args: str, **_kwargs: object) -> subprocess.CompletedProcess[str]:
+            if args == ("/bin/rm", "-f", repo.REPO_CONF):
+                events.append("remove-conf")
+            return subprocess.CompletedProcess([], 0, "", "")
+
+    def fake_delete(_vm: object, *, pkg_name: str, **_kwargs: object) -> None:
+        nonlocal delete_calls
+        delete_calls += 1
+        events.append(f"delete:{pkg_name}")
+        if delete_calls == delete_failure_call:
+            raise RuntimeError(f"delete failed: {pkg_name}")
+
+    def fake_absence(_vm: object, **_kwargs: object) -> list[str]:
+        events.append("verify-absent")
+        return []
+
+    def fake_install(_vm: object, *, pkg_name: str, **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        events.append(f"install:{pkg_name}")
+        if install_failure is not None:
+            raise install_failure
+        return subprocess.CompletedProcess([], 0, "", "")
+
+    monkeypatch.setattr(repo, "PKG_NAME", branch_name)
+    monkeypatch.setattr(repo, "_live_base_url", lambda: "https://example.test/pkg/edge")
+    monkeypatch.setenv(repo.LIVE_EXPECTED_SOURCE_SHA_ENV, "a" * 40)
+    monkeypatch.setenv(repo.LIVE_EXPECTED_VERSION_ENV, "4.0.0.a21")
+    monkeypatch.setenv(repo.LIVE_EXPECTED_CHANNEL_ENV, "edge")
+    monkeypatch.setattr(repo, "_box_real_varver", lambda _vm: "ce-current")
+    monkeypatch.setattr(repo, "poll_catalog_served", lambda *_args: None)
+    monkeypatch.setattr(repo, "pin_pages_hosts", lambda *_args: "prior")
+    monkeypatch.setattr(repo, "restore_pages_hosts", lambda *_args: events.append("restore-hosts"))
+    monkeypatch.setattr(repo, "repo_priority", lambda *_args: 0)
+    monkeypatch.setattr(repo, "pkg_delete", fake_delete)
+    monkeypatch.setattr(repo, "installed_pfblockerng_names", fake_absence)
+    monkeypatch.setattr(repo, "write_live_repo_conf", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(repo, "pkg_update", lambda *_args: None)
+    monkeypatch.setattr(repo, "pkg_installed_version_of", lambda *_args: None)
+    monkeypatch.setattr(repo, "pkg_install_from_repo", fake_install)
+    monkeypatch.setattr(repo, "pkg_repo_origin_of", lambda *_args: repo.channel_repo_name("edge"))
+    monkeypatch.setattr(repo, "assert_live_package", lambda _vm, _name, version, *_args: version)
+
+    return cast(SmokeVM, FakeVM()), branch_name
+
+
 def test_smoke_single_exposes_nightly_provenance_inputs() -> None:
     """Actions callers can supply the provenance required by the live Nightly test."""
     workflow = (Path(__file__).parents[1] / ".github/workflows/smoke-single.yml").read_text()
@@ -234,6 +291,151 @@ def test_live_pages_cleanup_deletes_both_names_after_install_failure(monkeypatch
         repo.CANONICAL_PKG_NAME,
     ]
     assert ("/bin/rm", "-f", repo.REPO_CONF) in ssh_calls
+
+
+@pytest.mark.parametrize("delete_failure_call", [3, 4])
+def test_live_pages_teardown_attempts_every_cleanup_after_delete_exception(
+    monkeypatch: MonkeyPatch,
+    delete_failure_call: int,
+) -> None:
+    """Either teardown delete may fail without skipping the other cleanup operations."""
+    events: list[str] = []
+    vm, branch_name = _live_pages_cleanup_case(
+        monkeypatch,
+        events,
+        delete_failure_call=delete_failure_call,
+    )
+    failed_name = branch_name if delete_failure_call == 3 else repo.CANONICAL_PKG_NAME
+
+    with pytest.raises(RuntimeError) as exc_info:
+        repo.test_install_from_live_pages_url(vm)
+
+    assert str(exc_info.value) == (
+        "live Pages teardown failed: package cleanup: RuntimeError: "
+        f"live Pages package cleanup failed: delete {failed_name}: RuntimeError: delete failed: {failed_name}"
+    )
+    assert events == [
+        f"delete:{branch_name}",
+        f"delete:{repo.CANONICAL_PKG_NAME}",
+        "verify-absent",
+        f"install:{repo.CANONICAL_PKG_NAME}",
+        f"delete:{branch_name}",
+        f"delete:{repo.CANONICAL_PKG_NAME}",
+        "verify-absent",
+        "remove-conf",
+        "restore-hosts",
+    ]
+
+
+def test_live_pages_body_exception_survives_cleanup_failure(monkeypatch: MonkeyPatch) -> None:
+    """A cleanup failure is diagnostic context, never a replacement for the body failure."""
+    events: list[str] = []
+    vm, branch_name = _live_pages_cleanup_case(
+        monkeypatch,
+        events,
+        delete_failure_call=3,
+        install_failure=ValueError("install failed"),
+    )
+
+    with pytest.raises(ValueError) as exc_info:
+        repo.test_install_from_live_pages_url(vm)
+    assert str(exc_info.value) == "install failed"
+
+    assert exc_info.value.__notes__ == [
+        "live Pages cleanup also failed: live Pages teardown failed: package cleanup: RuntimeError: "
+        f"live Pages package cleanup failed: delete {branch_name}: RuntimeError: delete failed: {branch_name}"
+    ]
+    assert events == [
+        f"delete:{branch_name}",
+        f"delete:{repo.CANONICAL_PKG_NAME}",
+        "verify-absent",
+        f"install:{repo.CANONICAL_PKG_NAME}",
+        f"delete:{branch_name}",
+        f"delete:{repo.CANONICAL_PKG_NAME}",
+        "verify-absent",
+        "remove-conf",
+        "restore-hosts",
+    ]
+
+
+def test_live_pages_nonzero_deletes_cannot_hide_remaining_packages(monkeypatch: MonkeyPatch) -> None:
+    """Ignored nonzero delete exits are rejected by the installed-identity oracle."""
+    events: list[str] = []
+    canonical_name = repo.CANONICAL_PKG_NAME
+    branch_name = f"{canonical_name}-edge"
+
+    class FakeVM:
+        def ssh(self, *args: str, **_kwargs: object) -> subprocess.CompletedProcess[str]:
+            if args[:5] == ("env", "ASSUME_ALWAYS_YES=yes", "pkg", "delete", "-y"):
+                events.append(f"delete:{args[5]}")
+                return subprocess.CompletedProcess([], 1, "", "delete failed")
+            if args[:4] == ("pkg", "query", "-g", "%n"):
+                events.append("verify-absent")
+                return subprocess.CompletedProcess([], 0, f"{branch_name}\n{canonical_name}\n", "")
+            if args == ("/bin/rm", "-f", repo.REPO_CONF):
+                events.append("remove-conf")
+            return subprocess.CompletedProcess([], 0, "", "")
+
+    def fail_install(*_args: object, **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        raise RuntimeError("install reached with live package identities still present")
+
+    monkeypatch.setattr(repo, "PKG_NAME", branch_name)
+    monkeypatch.setattr(repo, "_live_base_url", lambda: "https://example.test/pkg/edge")
+    monkeypatch.setenv(repo.LIVE_EXPECTED_SOURCE_SHA_ENV, "a" * 40)
+    monkeypatch.setenv(repo.LIVE_EXPECTED_VERSION_ENV, "4.0.0.a21")
+    monkeypatch.setenv(repo.LIVE_EXPECTED_CHANNEL_ENV, "edge")
+    monkeypatch.setattr(repo, "_box_real_varver", lambda _vm: "ce-current")
+    monkeypatch.setattr(repo, "poll_catalog_served", lambda *_args: None)
+    monkeypatch.setattr(repo, "pin_pages_hosts", lambda *_args: "prior")
+    monkeypatch.setattr(repo, "restore_pages_hosts", lambda *_args: events.append("restore-hosts"))
+    monkeypatch.setattr(repo, "repo_priority", lambda *_args: 0)
+    monkeypatch.setattr(repo, "write_live_repo_conf", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(repo, "pkg_update", lambda *_args: None)
+    monkeypatch.setattr(repo, "pkg_installed_version_of", lambda *_args: None)
+    monkeypatch.setattr(repo, "pkg_install_from_repo", fail_install)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        repo.test_install_from_live_pages_url(cast(SmokeVM, FakeVM()))
+
+    expected_absence_error = (
+        "live Pages package cleanup failed: verify package absence: AssertionError: "
+        f"live Pages packages still installed: expected absent [{branch_name!r}, {canonical_name!r}]; "
+        f"remaining [{branch_name!r}, {canonical_name!r}]; installed [{canonical_name!r}, {branch_name!r}]"
+    )
+    assert str(exc_info.value) == expected_absence_error
+    assert exc_info.value.__notes__ == [
+        "live Pages cleanup also failed: live Pages teardown failed: package cleanup: RuntimeError: "
+        + expected_absence_error
+    ]
+    assert events == [
+        f"delete:{branch_name}",
+        f"delete:{canonical_name}",
+        "verify-absent",
+        f"delete:{branch_name}",
+        f"delete:{canonical_name}",
+        "verify-absent",
+        "remove-conf",
+        "restore-hosts",
+    ]
+
+
+def test_live_pages_identical_package_names_are_deleted_once_per_phase(monkeypatch: MonkeyPatch) -> None:
+    """A canonical branch build deduplicates its identical cleanup identity."""
+    events: list[str] = []
+    vm, branch_name = _live_pages_cleanup_case(monkeypatch, events, same_identity=True)
+
+    repo.test_install_from_live_pages_url(vm)
+
+    assert branch_name == repo.CANONICAL_PKG_NAME
+    assert events == [
+        f"delete:{repo.CANONICAL_PKG_NAME}",
+        "verify-absent",
+        f"install:{repo.CANONICAL_PKG_NAME}",
+        f"delete:{repo.CANONICAL_PKG_NAME}",
+        "verify-absent",
+        "remove-conf",
+        "restore-hosts",
+    ]
 
 
 @pytest.mark.parametrize(

--- a/tests/test_issue2149_live_repo_identity.py
+++ b/tests/test_issue2149_live_repo_identity.py
@@ -88,6 +88,37 @@ def test_live_nightly_requires_expected_identity(monkeypatch: MonkeyPatch, missi
         nightly.test_install_from_live_nightly_url(cast(SmokeVM, object()))
 
 
+def test_live_nightly_url_boolean_one_uses_default(monkeypatch: MonkeyPatch) -> None:
+    """The boolean shorthand selects the deployed Nightly root, never the literal ``1``."""
+    monkeypatch.setenv(nightly.LIVE_NIGHTLY_URL_ENV, "1")
+
+    assert nightly._live_nightly_url() == nightly.DEFAULT_LIVE_NIGHTLY_URL
+
+
+def test_live_nightly_downgrade_expands_boolean_live_urls(monkeypatch: MonkeyPatch, tmp_path: Path) -> None:
+    """Both live boolean shorthands reach the downgrade as their current default URLs."""
+    polled: list[str] = []
+
+    def stop_after_urls(base_url: str, _catalog_path: str) -> None:
+        polled.append(base_url)
+        if len(polled) == 2:
+            raise RuntimeError("stop after URL expansion")
+
+    monkeypatch.setenv(repo.LIVE_BASE_URL_ENV, "true")
+    monkeypatch.setenv(repo.LIVE_NIGHTLY_URL_ENV, "true")
+    monkeypatch.setenv(repo.LIVE_EXPECTED_SOURCE_SHA_ENV, "c" * 40)
+    monkeypatch.setenv(repo.LIVE_EXPECTED_VERSION_ENV, "4.0.0")
+    monkeypatch.setenv(repo.NIGHTLY_EXPECTED_SOURCE_SHA_ENV, "b" * 40)
+    monkeypatch.setenv(repo.NIGHTLY_EXPECTED_VERSION_ENV, "20260810_2")
+    monkeypatch.setattr(repo, "_box_real_varver", lambda _vm: "ce-current")
+    monkeypatch.setattr(repo, "poll_catalog_served", stop_after_urls)
+
+    with pytest.raises(RuntimeError, match="stop after URL expansion"):
+        repo.test_live_nightly_downgrade_requires_selected_semantic_repo(cast(SmokeVM, object()), tmp_path)
+
+    assert polled == [repo.DEFAULT_LIVE_BASE_URL, nightly.DEFAULT_LIVE_NIGHTLY_URL]
+
+
 def test_live_pages_install_targets_canonical_package(monkeypatch: MonkeyPatch) -> None:
     """The deployed channel catalog is queried and installed by its canonical package identity."""
     seen: dict[str, list[str] | str] = {"delete": []}
@@ -101,6 +132,8 @@ def test_live_pages_install_targets_canonical_package(monkeypatch: MonkeyPatch) 
             ssh_calls.append(args)
             return subprocess.CompletedProcess([], 0, "", "")
 
+    suffixed_name = f"{repo.CANONICAL_PKG_NAME}-edge"
+    monkeypatch.setattr(repo, "PKG_NAME", suffixed_name)
     monkeypatch.setattr(repo, "_live_base_url", lambda: "https://example.test/pkg/edge")
     monkeypatch.setenv("SMOKE_REPO_EXPECTED_SOURCE_SHA", expected_source)
     monkeypatch.setenv("SMOKE_REPO_EXPECTED_VERSION", expected_version)
@@ -147,12 +180,59 @@ def test_live_pages_install_targets_canonical_package(monkeypatch: MonkeyPatch) 
     repo.test_install_from_live_pages_url(cast(SmokeVM, FakeVM()))
 
     assert seen == {
-        "delete": [repo.CANONICAL_PKG_NAME, repo.CANONICAL_PKG_NAME],
+        "delete": [
+            suffixed_name,
+            repo.CANONICAL_PKG_NAME,
+            suffixed_name,
+            repo.CANONICAL_PKG_NAME,
+        ],
         "query": repo.CANONICAL_PKG_NAME,
         "install": repo.CANONICAL_PKG_NAME,
         "origin": repo.CANONICAL_PKG_NAME,
     }
     assert assertions == [(repo.CANONICAL_PKG_NAME, expected_version, expected_source, "edge")]
+    assert ("/bin/rm", "-f", repo.REPO_CONF) in ssh_calls
+
+
+def test_live_pages_cleanup_deletes_both_names_after_install_failure(monkeypatch: MonkeyPatch) -> None:
+    """Setup and exceptional cleanup remove both the branch and canonical package identities."""
+    deleted: list[str] = []
+    ssh_calls: list[tuple[str, ...]] = []
+    suffixed_name = f"{repo.CANONICAL_PKG_NAME}-edge"
+
+    class FakeVM:
+        def ssh(self, *args: str, **_kwargs: object) -> subprocess.CompletedProcess[str]:
+            ssh_calls.append(args)
+            return subprocess.CompletedProcess([], 0, "", "")
+
+    def fail_install(*_args: object, **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        raise RuntimeError("install failed")
+
+    monkeypatch.setattr(repo, "PKG_NAME", suffixed_name)
+    monkeypatch.setattr(repo, "_live_base_url", lambda: "https://example.test/pkg/edge")
+    monkeypatch.setenv(repo.LIVE_EXPECTED_SOURCE_SHA_ENV, "a" * 40)
+    monkeypatch.setenv(repo.LIVE_EXPECTED_VERSION_ENV, "4.0.0.a21")
+    monkeypatch.setenv(repo.LIVE_EXPECTED_CHANNEL_ENV, "edge")
+    monkeypatch.setattr(repo, "_box_real_varver", lambda _vm: "ce-current")
+    monkeypatch.setattr(repo, "poll_catalog_served", lambda *_args: None)
+    monkeypatch.setattr(repo, "pin_pages_hosts", lambda *_args: "prior")
+    monkeypatch.setattr(repo, "restore_pages_hosts", lambda *_args: None)
+    monkeypatch.setattr(repo, "repo_priority", lambda *_args: 0)
+    monkeypatch.setattr(repo, "pkg_delete", lambda _vm, *, pkg_name, **_kwargs: deleted.append(pkg_name))
+    monkeypatch.setattr(repo, "write_live_repo_conf", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(repo, "pkg_update", lambda *_args: None)
+    monkeypatch.setattr(repo, "pkg_installed_version_of", lambda *_args: None)
+    monkeypatch.setattr(repo, "pkg_install_from_repo", fail_install)
+
+    with pytest.raises(RuntimeError, match="install failed"):
+        repo.test_install_from_live_pages_url(cast(SmokeVM, FakeVM()))
+
+    assert deleted == [
+        suffixed_name,
+        repo.CANONICAL_PKG_NAME,
+        suffixed_name,
+        repo.CANONICAL_PKG_NAME,
+    ]
     assert ("/bin/rm", "-f", repo.REPO_CONF) in ssh_calls
 
 


### PR DESCRIPTION
## Summary

- route the live Nightly downgrade through `_live_nightly_url()` so boolean shorthands expand consistently
- deduplicate the branch-suffixed/canonical identities, delete them before install and during teardown, and verify both are actually absent with the installed-name oracle
- attempt package cleanup, repo-conf removal, and hosts restoration independently; preserve an original body failure while attaching exact cleanup diagnostics
- cover boolean URLs, successful/exceptional cleanup, delete exceptions, ignored nonzero deletes, remaining packages, and identical package identities with hermetic tests

## Evidence

### Diagnosis

- Boolean-path probe with `SMOKE_REPO_LIVE_URL=true` and `SMOKE_NIGHTLY_LIVE_URL=true` returned semantic `https://pkg.pfblockerng.com/stable`, helper-expanded Nightly `https://pkg.pfblockerng.com/nightly`, and raw Nightly env `true`. This confirms the downgrade bypassed the existing helper.
- The focused pre-fix cleanup test passed only while expecting two canonical-name deletions, confirming the branch-suffixed identity was omitted.
- Hostile cleanup probes confirmed sequential teardown skipped later operations after either delete exception, cleanup exceptions replaced the original install failure, ignored nonzero delete exits reached installation with both identities still present, and identical identities were deleted twice per phase.
- The issue's older Edge-default premise is falsified by current `devel`: `DEFAULT_LIVE_BASE_URL` is the Stable post-publish default. This PR preserves that current helper-derived contract and changes no workflow inputs.

### Initial frozen RED/GREEN

Test file hash before and after the initial implementation edit:

```text
8b121387a297b87fed0874dba98587d206f9f74c
```

```text
uv run pytest tests/test_issue2149_live_repo_identity.py -q
RED:   3 failed, 20 passed in 0.84s
GREEN: 23 passed in 0.61s
```

The failures were the literal Nightly value `true`, missing suffixed-name cleanup on success, and missing suffixed-name cleanup after an injected install exception.

### Hostile cleanup frozen RED/GREEN

Final test file hash on both runs:

```text
afb57378db9972c43cfb4983ca9e8d0ea2869e4b
```

RED used the exact final test file against pre-hardening head `352acef2f3a080763ca65a4c69c6f229da43bfb7`:

```text
uv run pytest tests/test_issue2149_live_repo_identity.py -q
5 failed, 23 passed in 0.69s
```

GREEN on hardened code, unchanged tests:

```text
uv run pytest tests/test_issue2149_live_repo_identity.py -q
28 passed in 0.62s
```

Post-rebase GREEN at head `916dce99deffd06914942552fd159e0ff2e2c766`:

```text
uv run pytest tests/test_issue2149_live_repo_identity.py -q
28 passed in 1.17s
```

Fixes #2394

🤖 Generated by Oh My Pi and posted on behalf of @andrebrait.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for Live Pages and Nightly package installation workflows.
  * Added validation for package identity handling, duplicate names, cleanup after failed installations, and removal failures.
  * Improved verification that packages and repository configuration are fully removed after testing.
  * Added checks for Nightly URL handling, downgrade behavior, host-file restoration, and preservation of the original installation error when cleanup also fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->