### PR TITLE
pfblockerng: close DNSBL regex admission residuals

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfb_dnsbl_regex_rules.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_dnsbl_regex_rules.py
@@ -209,10 +209,6 @@ def _regex_group_metadata(pattern: str) -> tuple[dict[int, int], set[int]]:
     return ends, alternates
 
 
-def _regex_group_ends(pattern: str) -> dict[int, int]:
-    return _regex_group_metadata(pattern)[0]
-
-
 def _regex_group_end(pattern: str, index: int, group_ends: dict[int, int] | None = None) -> int:
     """End offset past the matching ``)`` or the string when the group is unclosed."""
     return (group_ends if group_ends is not None else _regex_group_metadata(pattern)[0]).get(index, len(pattern))
@@ -293,8 +289,8 @@ def _regex_conditional_body(
 def _regex_next_unit(
     pattern: str,
     index: int,
-    group_ends: dict[int, int] | None = None,
-    group_alternates: set[int] | None = None,
+    group_ends: dict[int, int],
+    group_alternates: set[int],
     depth: int = 0,
 ) -> tuple[str, str, int]:
     """Read one unit as ``(atom, quantifier role, next index)``."""
@@ -307,11 +303,6 @@ def _regex_next_unit(
         atom_end = _regex_atom_end(pattern, index)
         quantifier_end, role = _regex_quantifier(pattern, atom_end)
         return pattern[index:atom_end], role, max(quantifier_end, atom_end)
-
-    if group_ends is None or group_alternates is None:
-        metadata_ends, metadata_alternates = _regex_group_metadata(pattern)
-        group_ends = metadata_ends if group_ends is None else group_ends
-        group_alternates = metadata_alternates if group_alternates is None else group_alternates
 
     group_end = _regex_group_end(pattern, index, group_ends)
     closed = pattern[group_end - 1 : group_end] == ")"
@@ -366,6 +357,8 @@ def _regex_next_unit(
         if body and not any(character in body for character in "()|"):
             return body, "run", quantifier_end
     if role != "bridge" and index in group_alternates:
+        if depth >= _REGEX_NESTED_SCAN_MAX:
+            return "", "float", max(quantifier_end, group_end)
         body = body if body is not None else pattern[body_start : group_end - 1]
         if body and not _regex_body_has_run(body, depth + 1):
             return body, role, max(quantifier_end, group_end)

--- a/src/usr/local/pkg/pfblockerng/pfb_dnsbl_regex_rules.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_dnsbl_regex_rules.py
@@ -185,33 +185,35 @@ def _regex_quantifier(pattern: str, index: int) -> tuple[int, str]:
     return end, "run" if unbounded else ("bridge" if optional else "break")
 
 
-def _regex_group_end(pattern: str, index: int) -> int:
-    """End offset past the ``)`` closing the group that opens at ``index`` (the end of the
-    string when it is never closed). Parentheses inside a class or an escape do not count."""
-    depth = 0
+def _regex_group_ends(pattern: str) -> dict[int, int]:
+    """Map every group opener to its closing offset in one pass."""
+    stack: list[int] = []
+    ends: dict[int, int] = {}
+    index = 0
     while index < len(pattern):
         character = pattern[index]
         if character in ("\\", "["):
             index = _regex_atom_end(pattern, index)
             continue
         if character == "(":
-            depth += 1
-        elif character == ")":
-            depth -= 1
-            if depth == 0:
-                return index + 1
+            stack.append(index)
+        elif character == ")" and stack:
+            ends[stack.pop()] = index + 1
         index += 1
-    return len(pattern)
+    end = len(pattern)
+    for opening in stack:
+        ends[opening] = end
+    return ends
+
+
+def _regex_group_end(pattern: str, index: int, group_ends: dict[int, int] | None = None) -> int:
+    """End offset past the matching ``)`` or the string when the group is unclosed."""
+    return (group_ends if group_ends is not None else _regex_group_ends(pattern)).get(index, len(pattern))
 
 
 @lru_cache(maxsize=512)
-def _regex_atoms_overlap(first: str, second: str) -> bool:
-    """True when both atoms can match the same character, i.e. the pair is ambiguous.
-
-    Compiled IGNORECASE (#2099): the DNSBL matcher compiles every admitted pattern
-    case-insensitively (#2079/#2097), so this probe must judge overlap under the
-    same semantics the runtime actually executes, not case-sensitive text overlap.
-    """
+def _regex_atoms_share_character(first: str, second: str) -> bool:
+    """True when both units can match one common character."""
     if first == second:
         return True
     try:
@@ -226,11 +228,26 @@ def _regex_atoms_overlap(first: str, second: str) -> bool:
     return any(left.fullmatch(probe) and right.fullmatch(probe) for probe in _REGEX_OVERLAP_ALPHABET)
 
 
-def _regex_body_alternates(body: str) -> bool:
-    """True when ``body`` carries a top-level unescaped ``|`` -- an alternation whose
-    branches the enclosing group's parentheses scope (one inside a nested group or a
-    character class belongs to that construct instead)."""
+@lru_cache(maxsize=512)
+def _regex_atoms_overlap(first: str, second: str) -> bool:
+    """True when ``first`` can also consume the mandatory text matched by ``second``."""
+    if _regex_atoms_share_character(first, second):
+        return True
+    try:
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            re.compile(first, re.IGNORECASE)
+            re.compile(second, re.IGNORECASE)
+    except re.error:
+        return False
+    return _regex_body_overlaps_atom(first, second)
+
+
+def _regex_top_level_branches(body: str) -> tuple[str, ...]:
+    """Split an alternation body without treating nested or escaped pipes as separators."""
+    branches: list[str] = []
     depth = 0
+    start = 0
     index = 0
     while index < len(body):
         character = body[index]
@@ -242,25 +259,43 @@ def _regex_body_alternates(body: str) -> bool:
         elif character == ")":
             depth = max(depth - 1, 0)
         elif character == "|" and depth == 0:
-            return True
+            branches.append(body[start:index])
+            start = index + 1
         index += 1
-    return False
+    branches.append(body[start:])
+    return tuple(branches)
 
 
-def _regex_next_unit(pattern: str, index: int) -> tuple[str, str, int]:
-    """Read one unit at ``index``, returning ``(atom, role, next index)`` with the roles of
-    ``_regex_quantifier``. A group contributes by what it does to the engine, not by its
-    punctuation: a comment or a lookaround consumes nothing and bridges; a plain
-    ``(...)``/``(?:...)``/``(?P<n>...)`` -- and (issue #2082) a scoped-flags ``(?i:...)`` or
-    atomic ``(?>...)`` group -- is scanned through as if the parentheses were not there; one
-    wrapping a single atom IS that atom when the quantifier sits outside it; a conditional
-    ``(?(...)...)``, an atomic ``(?>...)``, or a bare-alternation group returns its body for
-    the caller's overlap probe; a named backreference is role ``float`` (mandatory,
-    overlap unknowable)."""
+def _regex_body_alternates(body: str) -> bool:
+    """True when ``body`` carries an alternation scoped by its enclosing group."""
+    return len(_regex_top_level_branches(body)) > 1
+
+
+def _regex_conditional_body(
+    pattern: str,
+    index: int,
+    group_ends: dict[int, int] | None = None,
+) -> str | None:
+    """The post-condition body of a closed ``(?(id/name)yes|no)`` group."""
+    if not pattern.startswith("(?(", index):
+        return None
+    group_end = _regex_group_end(pattern, index, group_ends)
+    if pattern[group_end - 1 : group_end] != ")":
+        return None
+    condition_end = pattern.find(")", index + 3, group_end)
+    if condition_end == -1 or condition_end >= group_end - 1:
+        return None
+    return pattern[condition_end + 1 : group_end - 1]
+
+
+def _regex_next_unit(
+    pattern: str,
+    index: int,
+    group_ends: dict[int, int] | None = None,
+    depth: int = 0,
+) -> tuple[str, str, int]:
+    """Read one unit as ``(atom, quantifier role, next index)``."""
     if pattern[index] == ")":
-        # A group's closing punctuation separates nothing by itself -- the atoms inside
-        # already decided whether the chain survives -- and a fixed repeat ON the group
-        # floats with it (issue #2082), so `)` never ends a chain.
         quantifier_end, _ = _regex_quantifier(pattern, index + 1)
         return "", "bridge", max(quantifier_end, index + 1)
     if pattern[index] != "(":
@@ -270,16 +305,13 @@ def _regex_next_unit(pattern: str, index: int) -> tuple[str, str, int]:
         quantifier_end, role = _regex_quantifier(pattern, atom_end)
         return pattern[index:atom_end], role, max(quantifier_end, atom_end)
 
-    group_end = _regex_group_end(pattern, index)
+    group_end = _regex_group_end(pattern, index, group_ends)
     closed = pattern[group_end - 1 : group_end] == ")"
     if pattern.startswith(("(?#", "(?=", "(?!", "(?<=", "(?<!"), index):
-        # Skipping an UNCLOSED construct would blind the scan to everything after it.
         if not closed:
             return "", "break", index + 2
         if pattern.startswith("(?#", index):
-            return "", "bridge", group_end  # a comment is inert text, not a pattern
-        # A lookaround matches no characters, so it cannot join or separate the run around
-        # it -- but the engine still backtracks over its body, which is scanned on its own.
+            return "", "bridge", group_end
         body_start = index + 4 if pattern[index + 2] == "<" else index + 3
         return pattern[body_start : group_end - 1], "nested", group_end
     if pattern.startswith("(?P<", index):
@@ -290,21 +322,14 @@ def _regex_next_unit(pattern: str, index: int) -> tuple[str, str, int]:
     elif pattern.startswith("(?:", index):
         body_start = index + 3
     elif pattern.startswith("(?(", index):
-        # issue #2082: a conditional is a mandatory construct whose POSITION floats, so its
-        # post-condition body (an alternation the overlap probe can compile) is handed to
-        # the caller to judge like a bare atom -- never read as a run boundary outright.
-        condition_end = pattern.find(")", index + 3)
-        if not closed or condition_end == -1 or condition_end >= group_end - 1:
+        body = _regex_conditional_body(pattern, index, group_ends)
+        if body is None:
             return "", "break", group_end
-        body = pattern[condition_end + 1 : group_end - 1]
         quantifier_end, role = _regex_quantifier(pattern, group_end)
         if role == "bridge" or not body:
             return "", "bridge", max(quantifier_end, group_end)
         return body, role, max(quantifier_end, group_end)
     elif pattern.startswith("(?>", index):
-        # Atomicity forbids backtracking INSIDE the body, so it is never entered as a run
-        # source -- but the group's POSITION floats with the run around it (issue #2082),
-        # so its body feeds the caller's overlap probe like a bare atom.
         if not closed:
             return "", "break", group_end
         body = pattern[index + 3 : group_end - 1]
@@ -313,42 +338,73 @@ def _regex_next_unit(pattern: str, index: int) -> tuple[str, str, int]:
             return "", "bridge", max(quantifier_end, group_end)
         return body, role, max(quantifier_end, group_end)
     elif pattern.startswith("(?P=", index):
-        # A backreference's character set is unknowable statically, so it can never be
-        # proven a boundary: mandatory, position floats, overlap assumed (issue #2082).
         return "", "float", group_end
     elif pattern.startswith("(?", index):
         flags_end = index + 2
         while flags_end < len(pattern) and pattern[flags_end] in "aiLmsux-":
             flags_end += 1
         if flags_end > index + 2 and pattern[flags_end : flags_end + 1] == ":":
-            body_start = flags_end + 1  # scoped flags: `(?i:...)` backtracks like `(?:...)`
+            body_start = flags_end + 1
         else:
-            return "", "break", group_end  # global flags and any unknown `(?` construct
+            return "", "break", group_end
     else:
         body_start = index + 1
     quantifier_end, role = _regex_quantifier(pattern, group_end)
     body = pattern[body_start : group_end - 1]
-    # A quantified group repeats its body, so the body IS the run's atom -- one atom
-    # (`(?:[a-z])+` is `[a-z]+`) or a plain sequence (`(ab)+(ab)+(ab)+` repeats too). A body
-    # carrying its own group or alternation belongs to the shapes above instead.
     if role == "run" and body and not any(character in body for character in "()|"):
         return body, "run", quantifier_end
-    # A mandatory group over a quantifier-free alternation (`(a|b)`, `(a|(b))`) is the
-    # conditional separator without the condition (issue #2082): entering it would read `|`
-    # as a boundary, so the body -- which compiles standalone -- is handed to the caller's
-    # overlap probe instead. A body carrying any quantifier keeps the entered scan, so a
-    # run inside a branch is still found rather than hidden behind the probe.
-    if (
-        role != "bridge"
-        and body
-        and _regex_body_alternates(body)
-        and not any(character in body for character in "+*{?")
-    ):
+    if role != "bridge" and body and _regex_body_alternates(body) and not _regex_body_has_run(body, depth + 1):
         return body, role, max(quantifier_end, group_end)
-    # Every other group is entered rather than skipped: parentheses hide a run from the
-    # reader, never from the engine, and its atoms -- not its punctuation -- decide what
-    # happens to the chain (issue #2082: a fixed repeat ON the group floats with it).
     return "", "bridge", body_start
+
+
+def _regex_body_has_run(body: str, depth: int = 0) -> bool:
+    """Whether a body contains a genuine backtracking, unbounded quantifier."""
+    group_ends = _regex_group_ends(body)
+    index = 0
+    while index < len(body):
+        unit_start = index
+        conditional = _regex_conditional_body(body, unit_start, group_ends)
+        if conditional is not None and depth < _REGEX_NESTED_SCAN_MAX:
+            if any(_regex_body_has_run(branch, depth + 1) for branch in _regex_top_level_branches(conditional)):
+                return True
+        atom, role, index = _regex_next_unit(body, index, group_ends, depth)
+        if role == "run":
+            return True
+        if role == "nested" and depth < _REGEX_NESTED_SCAN_MAX and _regex_body_has_run(atom, depth + 1):
+            return True
+    return False
+
+
+def _regex_body_overlaps_atom(anchor: str, body: str, depth: int = 0) -> bool:
+    """Whether one body branch consists only of text consumable by repeated ``anchor``."""
+    if depth > _REGEX_NESTED_SCAN_MAX:
+        return False
+    for branch in _regex_top_level_branches(body):
+        group_ends = _regex_group_ends(branch)
+        index = 0
+        overlaps = True
+        while index < len(branch):
+            unit_start = index
+            atom, role, index = _regex_next_unit(branch, index, group_ends, depth)
+            if role == "nested":
+                overlaps = False
+                break
+            if role in ("bridge", "float"):
+                continue
+            if not atom:
+                overlaps = False
+                break
+            if branch[unit_start] == "(":
+                unit_overlaps = _regex_body_overlaps_atom(anchor, atom, depth + 1)
+            else:
+                unit_overlaps = _regex_atoms_share_character(anchor, atom)
+            if not unit_overlaps:
+                overlaps = False
+                break
+        if overlaps:
+            return True
+    return False
 
 
 def _regex_is_backref(atom: str) -> bool:
@@ -358,21 +414,21 @@ def _regex_is_backref(atom: str) -> bool:
 
 
 def _regex_has_adjacent_unbounded_atoms(pattern: str, depth: int = 0) -> bool:
-    """True when ``pattern`` carries an overlap-connected CHAIN of more than
-    ``_REGEX_ADJACENT_ATOM_MAX`` atoms that each take a backtracking unbounded quantifier,
-    where the chain holds at least one back-to-back pair. A mandatory atom overlapping the
-    chain is no boundary -- its position floats inside the span (issue #2082) -- so it
-    bridges the chain while breaking pair-adjacency; a disjoint one really pins the split
-    and ends the chain. A lookaround's body is scanned as a pattern of its own, bounded by
-    ``_REGEX_NESTED_SCAN_MAX`` so nested lookarounds cannot exhaust the stack. Pure string
-    analysis: nothing here runs the candidate against an input."""
-    anchor = ""  # last quantified atom of the chain ("" = no chain)
+    """True when a pattern carries a dangerous overlap-connected quantifier chain."""
+    anchor = ""
     quantified = 0
     pairs = 0
-    adjacent = False  # whether the chain unit before this one was a quantified atom
+    adjacent = False
+    group_ends = _regex_group_ends(pattern)
     index = 0
     while index < len(pattern):
-        atom, role, index = _regex_next_unit(pattern, index)
+        unit_start = index
+        conditional = _regex_conditional_body(pattern, unit_start, group_ends)
+        if conditional is not None and depth < _REGEX_NESTED_SCAN_MAX:
+            for branch in _regex_top_level_branches(conditional):
+                if _regex_has_adjacent_unbounded_atoms(branch, depth + 1):
+                    return True
+        atom, role, index = _regex_next_unit(pattern, index, group_ends, depth)
         if role == "nested":
             if depth < _REGEX_NESTED_SCAN_MAX and _regex_has_adjacent_unbounded_atoms(atom, depth + 1):
                 return True
@@ -390,8 +446,6 @@ def _regex_has_adjacent_unbounded_atoms(pattern: str, depth: int = 0) -> bool:
             if (pairs and quantified > _REGEX_ADJACENT_ATOM_MAX) or quantified > _REGEX_CHAIN_ATOM_MAX:
                 return True
             continue
-        # A mandatory unit whose set overlaps the chain -- or cannot be proven disjoint
-        # (a backreference) -- floats, so it bridges the chain instead of ending it.
         if role == "float" or (atom and anchor and (_regex_atoms_overlap(anchor, atom) or _regex_is_backref(atom))):
             adjacent = False
             continue

--- a/src/usr/local/pkg/pfblockerng/pfb_dnsbl_regex_rules.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_dnsbl_regex_rules.py
@@ -185,10 +185,11 @@ def _regex_quantifier(pattern: str, index: int) -> tuple[int, str]:
     return end, "run" if unbounded else ("bridge" if optional else "break")
 
 
-def _regex_group_ends(pattern: str) -> dict[int, int]:
-    """Map every group opener to its closing offset in one pass."""
+def _regex_group_metadata(pattern: str) -> tuple[dict[int, int], set[int]]:
+    """Map group ends and the groups owning each top-level alternation in one pass."""
     stack: list[int] = []
     ends: dict[int, int] = {}
+    alternates: set[int] = set()
     index = 0
     while index < len(pattern):
         character = pattern[index]
@@ -199,16 +200,22 @@ def _regex_group_ends(pattern: str) -> dict[int, int]:
             stack.append(index)
         elif character == ")" and stack:
             ends[stack.pop()] = index + 1
+        elif character == "|" and stack:
+            alternates.add(stack[-1])
         index += 1
     end = len(pattern)
     for opening in stack:
         ends[opening] = end
-    return ends
+    return ends, alternates
+
+
+def _regex_group_ends(pattern: str) -> dict[int, int]:
+    return _regex_group_metadata(pattern)[0]
 
 
 def _regex_group_end(pattern: str, index: int, group_ends: dict[int, int] | None = None) -> int:
     """End offset past the matching ``)`` or the string when the group is unclosed."""
-    return (group_ends if group_ends is not None else _regex_group_ends(pattern)).get(index, len(pattern))
+    return (group_ends if group_ends is not None else _regex_group_metadata(pattern)[0]).get(index, len(pattern))
 
 
 @lru_cache(maxsize=512)
@@ -266,11 +273,6 @@ def _regex_top_level_branches(body: str) -> tuple[str, ...]:
     return tuple(branches)
 
 
-def _regex_body_alternates(body: str) -> bool:
-    """True when ``body`` carries an alternation scoped by its enclosing group."""
-    return len(_regex_top_level_branches(body)) > 1
-
-
 def _regex_conditional_body(
     pattern: str,
     index: int,
@@ -292,6 +294,7 @@ def _regex_next_unit(
     pattern: str,
     index: int,
     group_ends: dict[int, int] | None = None,
+    group_alternates: set[int] | None = None,
     depth: int = 0,
 ) -> tuple[str, str, int]:
     """Read one unit as ``(atom, quantifier role, next index)``."""
@@ -304,6 +307,11 @@ def _regex_next_unit(
         atom_end = _regex_atom_end(pattern, index)
         quantifier_end, role = _regex_quantifier(pattern, atom_end)
         return pattern[index:atom_end], role, max(quantifier_end, atom_end)
+
+    if group_ends is None or group_alternates is None:
+        metadata_ends, metadata_alternates = _regex_group_metadata(pattern)
+        group_ends = metadata_ends if group_ends is None else group_ends
+        group_alternates = metadata_alternates if group_alternates is None else group_alternates
 
     group_end = _regex_group_end(pattern, index, group_ends)
     closed = pattern[group_end - 1 : group_end] == ")"
@@ -350,17 +358,23 @@ def _regex_next_unit(
     else:
         body_start = index + 1
     quantifier_end, role = _regex_quantifier(pattern, group_end)
-    body = pattern[body_start : group_end - 1]
-    if role == "run" and body and not any(character in body for character in "()|"):
-        return body, "run", quantifier_end
-    if role != "bridge" and body and _regex_body_alternates(body) and not _regex_body_has_run(body, depth + 1):
-        return body, role, max(quantifier_end, group_end)
+    if not closed:
+        return "", "bridge", body_start
+    body: str | None = None
+    if role == "run":
+        body = pattern[body_start : group_end - 1]
+        if body and not any(character in body for character in "()|"):
+            return body, "run", quantifier_end
+    if role != "bridge" and index in group_alternates:
+        body = body if body is not None else pattern[body_start : group_end - 1]
+        if body and not _regex_body_has_run(body, depth + 1):
+            return body, role, max(quantifier_end, group_end)
     return "", "bridge", body_start
 
 
 def _regex_body_has_run(body: str, depth: int = 0) -> bool:
     """Whether a body contains a genuine backtracking, unbounded quantifier."""
-    group_ends = _regex_group_ends(body)
+    group_ends, group_alternates = _regex_group_metadata(body)
     index = 0
     while index < len(body):
         unit_start = index
@@ -368,7 +382,7 @@ def _regex_body_has_run(body: str, depth: int = 0) -> bool:
         if conditional is not None and depth < _REGEX_NESTED_SCAN_MAX:
             if any(_regex_body_has_run(branch, depth + 1) for branch in _regex_top_level_branches(conditional)):
                 return True
-        atom, role, index = _regex_next_unit(body, index, group_ends, depth)
+        atom, role, index = _regex_next_unit(body, index, group_ends, group_alternates, depth)
         if role == "run":
             return True
         if role == "nested" and depth < _REGEX_NESTED_SCAN_MAX and _regex_body_has_run(atom, depth + 1):
@@ -381,12 +395,12 @@ def _regex_body_overlaps_atom(anchor: str, body: str, depth: int = 0) -> bool:
     if depth > _REGEX_NESTED_SCAN_MAX:
         return False
     for branch in _regex_top_level_branches(body):
-        group_ends = _regex_group_ends(branch)
+        group_ends, group_alternates = _regex_group_metadata(branch)
         index = 0
         overlaps = True
         while index < len(branch):
             unit_start = index
-            atom, role, index = _regex_next_unit(branch, index, group_ends, depth)
+            atom, role, index = _regex_next_unit(branch, index, group_ends, group_alternates, depth)
             if role == "nested":
                 overlaps = False
                 break
@@ -419,7 +433,7 @@ def _regex_has_adjacent_unbounded_atoms(pattern: str, depth: int = 0) -> bool:
     quantified = 0
     pairs = 0
     adjacent = False
-    group_ends = _regex_group_ends(pattern)
+    group_ends, group_alternates = _regex_group_metadata(pattern)
     index = 0
     while index < len(pattern):
         unit_start = index
@@ -428,7 +442,7 @@ def _regex_has_adjacent_unbounded_atoms(pattern: str, depth: int = 0) -> bool:
             for branch in _regex_top_level_branches(conditional):
                 if _regex_has_adjacent_unbounded_atoms(branch, depth + 1):
                     return True
-        atom, role, index = _regex_next_unit(pattern, index, group_ends, depth)
+        atom, role, index = _regex_next_unit(pattern, index, group_ends, group_alternates, depth)
         if role == "nested":
             if depth < _REGEX_NESTED_SCAN_MAX and _regex_has_adjacent_unbounded_atoms(atom, depth + 1):
                 return True

--- a/src/usr/local/pkg/pfblockerng/pfb_dnsbl_regex_rules.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_dnsbl_regex_rules.py
@@ -226,7 +226,7 @@ def _regex_atoms_share_character(first: str, second: str) -> bool:
             warnings.simplefilter("ignore")
             left = re.compile(first, re.IGNORECASE)
             right = re.compile(second, re.IGNORECASE)
-    except re.error:
+    except (re.error, RecursionError):
         return False
     return any(left.fullmatch(probe) and right.fullmatch(probe) for probe in _REGEX_OVERLAP_ALPHABET)
 
@@ -241,7 +241,7 @@ def _regex_atoms_overlap(first: str, second: str) -> bool:
             warnings.simplefilter("ignore")
             re.compile(first, re.IGNORECASE)
             re.compile(second, re.IGNORECASE)
-    except re.error:
+    except (re.error, RecursionError):
         return False
     return _regex_body_overlaps_atom(first, second)
 

--- a/tests/test_adr07_regex_safety.py
+++ b/tests/test_adr07_regex_safety.py
@@ -457,6 +457,105 @@ class TestCatastrophicShapeHeuristic:
         assert _regex_is_catastrophic_shape(r"^(?i:[a-z]+[a-z]+[a-z]+[a-z]+)@x\.com$") is True
         assert _regex_is_catastrophic_shape(r"^(?i:[a-z])+(?i:[a-z])+(?i:[a-z])+@x\.com$") is True
 
+    def test_conditional_branches_are_scanned_as_independent_bodies(self) -> None:
+        for pat in (
+            r"^([a-z])(?(1)[a-z]+[a-z]+[a-z]+[a-z]+|b)@x\.com$",
+            r"^(a)?(?(1)b|[a-z]+[a-z]+[a-z]+[a-z]+)@x\.com$",
+            r"^(?P<flag>a)?(?(flag)(?i:[a-z]+[a-z]+[a-z]+)|b)$",
+            r"^(a)(?(1)(?P<body>[a-z]+[a-z]+[a-z]+)|b)$",
+            r"^(a)(?(1)(?=[a-z])[a-z]+[a-z]+[a-z]+|b)$",
+            r"^(a)(?(1)\([a-z]+[a-z]+[a-z]+\)|b)$",
+            r"^(a)(?(1)[a-z]+[a-z]+(?>ab)[a-z]+[a-z]+|b)$",
+        ):
+            assert _regex_is_catastrophic_shape(pat) is True, pat
+        # Branches are separate patterns: two runs on each side of `|` never join.
+        for pat in (
+            r"^(?P<flag>a)?(?(flag)b|c)$",
+            r"^(a)?(?(1)[a-z]+[a-z]+|[a-z]+[a-z]+)$",
+            r"^(a)(?(1)(?>[a-z]+[a-z]+[a-z]+)|b)$",
+        ):
+            assert _regex_is_catastrophic_shape(pat) is False, pat
+
+    def test_multi_character_opaque_bodies_bridge_only_when_their_language_overlaps(self) -> None:
+        for pat in (
+            r"^[a-z]+[a-z]+(?>ab)[a-z]+[a-z]+@x\.com$",
+            r"^[a-z]+[a-z]+(?>ab)+[a-z]+[a-z]+@x\.com$",
+            r"^[a-z]+[a-z]+(foo|foobar)[a-z]+[a-z]+@x\.com$",
+            r"^[a-z]+[a-z]+(?:foo|foobar)+[a-z]+[a-z]+@x\.com$",
+            r"^[a-z]+[a-z]+(?i:foo|foobar)[a-z]+[a-z]+@x\.com$",
+            r"^[a-z]+[a-z]+(?i:(?>ab))[a-z]+[a-z]+@x\.com$",
+            r"^\w+\w+(?>éé)\w+\w+@x\.com$",
+        ):
+            assert _regex_is_catastrophic_shape(pat) is True, pat
+        for pat in (
+            r"^[a-z]+[a-z]+(?>12)[a-z]+[a-z]+$",
+            r"^[a-z]+[a-z]+(?>a\.)[a-z]+[a-z]+$",
+            r"^[a-z]+[a-z]+(\.|,)[a-z]+[a-z]+$",
+            r"^[a-z]+[a-z]+(?i:12|34)[a-z]+[a-z]+$",
+            r"^[a-z]+[a-z]+(?>\(\[)[a-z]+[a-z]+$",
+            r"^[a-z]+[a-z]+(?>\N{BULLET})[a-z]+[a-z]+$",
+            r"^(?>ab)[a-z]+$",
+        ):
+            assert _regex_is_catastrophic_shape(pat) is False, pat
+
+    def test_alternation_shortcut_distinguishes_quantifiers_from_syntax_markers(self) -> None:
+        for pat in (
+            r"^[a-z]+[a-z]+(a|(?:b))[a-z]+[a-z]+@x\.com$",
+            r"^[a-z]+[a-z]+(a|(?P<g1>b))[a-z]+[a-z]+@x\.com$",
+            r"^[a-z]+[a-z]+(a|(?i:b))[a-z]+[a-z]+@x\.com$",
+            r"^[a-z]+[a-z]+(a|(?>b))[a-z]+[a-z]+@x\.com$",
+            r"^[a-z]+[a-z]+(a|(?=b)a)[a-z]+[a-z]+@x\.com$",
+            r"^[a-z]+[a-z]+(a|(?!x)b)[a-z]+[a-z]+@x\.com$",
+            r"^[a-z]+[a-z]+(a|\+)[a-z]+[a-z]+@x\.com$",
+            r"^[a-z]+[a-z]+(a|\*)[a-z]+[a-z]+@x\.com$",
+            r"^[a-z]+[a-z]+(a|\N{BULLET})[a-z]+[a-z]+@x\.com$",
+            r"^[a-z]+[a-z]+(a|(?:b))+[a-z]+[a-z]+@x\.com$",
+        ):
+            assert _regex_is_catastrophic_shape(pat) is True, pat
+        # Marker characters that are literals do not manufacture an overlapping atom.
+        for pat in (
+            r"^[a-z]+[a-z]+(\+|\*)[a-z]+[a-z]+$",
+            r"^[a-z]+[a-z]+(?:\N{BULLET}|\*)[a-z]+[a-z]+$",
+            r"^(a+|b)$",
+        ):
+            assert _regex_is_catastrophic_shape(pat) is False, pat
+        # A genuine run in a branch is entered and scanned rather than hidden by the shortcut.
+        assert _regex_is_catastrophic_shape(r"^([a-z]+[a-z]+[a-z]+|x)@x\.com$") is True
+
+    def test_conditional_branch_scan_stops_at_the_shared_depth_bound(self) -> None:
+        run = "[a-z]+[a-z]+[a-z]+"
+        prefix = "(?P<flag>a)?"
+        at_bound = "(?(flag)" * pfb_dnsbl_regex_rules._REGEX_NESTED_SCAN_MAX + run
+        past_bound = "(?(flag)" * (pfb_dnsbl_regex_rules._REGEX_NESTED_SCAN_MAX + 1) + run
+        assert (
+            _regex_is_catastrophic_shape(prefix + at_bound + "|b)" * pfb_dnsbl_regex_rules._REGEX_NESTED_SCAN_MAX)
+            is True
+        )
+        assert (
+            _regex_is_catastrophic_shape(
+                prefix + past_bound + "|b)" * (pfb_dnsbl_regex_rules._REGEX_NESTED_SCAN_MAX + 1)
+            )
+            is False
+        )
+        flood = prefix + "(?(flag)" * 2000 + "a" + "|b)" * 2000
+        assert isinstance(_regex_is_catastrophic_shape(flood), bool)
+
+    def test_issue2364_shapes_are_dropped_by_the_feed_loader_with_both_cap_modes(self) -> None:
+        unsafe = (
+            r"^([a-z])(?(1)[a-z]+[a-z]+[a-z]+[a-z]+|b)@x\.com$",
+            r"^[a-z]+[a-z]+(?>ab)[a-z]+[a-z]+@x\.com$",
+            r"^[a-z]+[a-z]+(a|(?:b))+[a-z]+[a-z]+@x\.com$",
+        )
+        safe = r"^[a-z]+\.[a-z]+\.[a-z]+$"
+        for cap in (False, True):
+            db, admitted = _dnsbl_compile_regex_rules(
+                [*(_block_rule(pattern) for pattern in unsafe), _block_rule(safe)],
+                static_cap=cap,
+            )
+            assert admitted == 1, cap
+            assert len(db) == 1, cap
+            assert next(iter(db.values()))["re"].pattern == safe
+
     def test_newline_repeat_is_not_read_as_a_named_unicode_escape(self) -> None:
         # The two spellings are different regexes and each pins one half of the scanner.
         # Lowercase `\n{2,}` is a newline carrying an open-ended REPEAT; reading it as the

--- a/tests/test_issue1718_regex_transport.py
+++ b/tests/test_issue1718_regex_transport.py
@@ -76,6 +76,30 @@ def test_swap_load_matches_initial(tmp_path: Path, monkeypatch: Any) -> None:
         P.deinit(0)
 
 
+def test_issue2364_shape_gate_matches_initial_and_swap_user_loads(tmp_path: Path, monkeypatch: Any) -> None:
+    unsafe = r"^[a-z]+[a-z]+(a|(?:b))+[a-z]+[a-z]+@x\.com$"
+    safe = r"^[a-z]+\.[a-z]+\.[a-z]+$"
+    text = f"{unsafe}#unsafe\n{safe}#safe\n"
+    encoded = base64.b64encode(text.encode("utf-8")).decode("ascii")
+    ini = tmp_path / "pfb_unbound.ini"
+    manifest = tmp_path / "pfb_py_sources.json"
+    _manifest(manifest)
+    ini.write_text(_ini(encoded), encoding="utf-8")
+    monkeypatch.setitem(P.pfb, "pfb_unbound.ini", str(ini))
+    monkeypatch.setitem(P.pfb, "pfb_py_sources", str(manifest))
+    try:
+        _initial_load(tmp_path, monkeypatch, _ini(encoded))
+        assert set(P.regexDB) == {"safe"}
+        assert P.regexDB["safe"]["re"].pattern == safe
+
+        swapped = P._build_swap_snapshot()
+        assert swapped is not None
+        assert set(swapped.regex_db) == {"safe"}
+        assert swapped.regex_db["safe"]["re"].pattern == safe
+    finally:
+        P.deinit(0)
+
+
 def test_present_malformed_or_non_utf8_marker_fails_closed(
     tmp_path: Path, monkeypatch: Any, caplog: pytest.LogCaptureFixture
 ) -> None:

--- a/tests/test_pfb_dnsbl_regex_rules.py
+++ b/tests/test_pfb_dnsbl_regex_rules.py
@@ -250,7 +250,11 @@ def test_shape_gate_stays_total_on_malformed_pattern_fragments() -> None:
 
 def test_group_end_scan_is_linear_and_preserves_regex_escaping(monkeypatch: Any) -> None:
     import pfb_dnsbl_regex_rules
-    from pfb_dnsbl_regex_rules import _regex_group_end, _regex_has_adjacent_unbounded_atoms
+    from pfb_dnsbl_regex_rules import (
+        _regex_group_end,
+        _regex_has_adjacent_unbounded_atoms,
+        _regex_is_catastrophic_shape,
+    )
 
     cases = (
         ("(a(b)c)d", 7),
@@ -295,6 +299,8 @@ def test_group_end_scan_is_linear_and_preserves_regex_escaping(monkeypatch: Any)
     nested_alternation = "(a|" * 800 + "b" + ")" * 800
     assert isinstance(_regex_has_adjacent_unbounded_atoms(nested_alternation), bool)
     assert body_scans <= pfb_dnsbl_regex_rules._REGEX_NESTED_SCAN_MAX
+    anchored_alternation = "[a-z]+[a-z]+" + nested_alternation + "[a-z]+[a-z]+"
+    assert isinstance(_regex_is_catastrophic_shape(anchored_alternation), bool)
 
 
 def test_probe_and_resolver_agree_on_issue2364_admission_rows() -> None:

--- a/tests/test_pfb_dnsbl_regex_rules.py
+++ b/tests/test_pfb_dnsbl_regex_rules.py
@@ -261,21 +261,25 @@ def test_group_end_scan_is_linear_and_preserves_regex_escaping() -> None:
         assert _regex_group_end(pattern, 0) == expected, pattern
 
     class CountingPattern(str):
-        reads = 0
+        indexed = 0
+        copied = 0
 
         def __getitem__(self, key: SupportsIndex | slice) -> str:
-            type(self).reads += 1
+            if isinstance(key, slice):
+                type(self).copied += len(range(*key.indices(len(self))))
+            else:
+                type(self).indexed += 1
             return super().__getitem__(key)
 
-    def scan_reads(size: int) -> int:
-        CountingPattern.reads = 0
-        pattern = CountingPattern("(" * size)
-        assert _regex_has_adjacent_unbounded_atoms(pattern) is False
-        return CountingPattern.reads
+    def scan_work(pattern: str) -> int:
+        CountingPattern.indexed = CountingPattern.copied = 0
+        assert _regex_has_adjacent_unbounded_atoms(CountingPattern(pattern)) is False
+        return CountingPattern.indexed + CountingPattern.copied
 
-    small = scan_reads(400)
-    large = scan_reads(800)
-    assert large <= small * 3, f"2x input caused {large / small:.2f}x indexed reads ({small} -> {large})"
+    for build in (lambda size: "(" * size, lambda size: "(" * size + ")" * size):
+        small = scan_work(build(400))
+        large = scan_work(build(800))
+        assert large <= small * 3, f"2x input caused {large / small:.2f}x string work ({small} -> {large})"
 
 
 def test_probe_and_resolver_agree_on_issue2364_admission_rows() -> None:

--- a/tests/test_pfb_dnsbl_regex_rules.py
+++ b/tests/test_pfb_dnsbl_regex_rules.py
@@ -16,6 +16,7 @@ import os
 import subprocess
 import sys
 from pathlib import Path
+from typing import SupportsIndex
 
 PKG_DIR = Path(__file__).resolve().parent.parent / "src/usr/local/pkg/pfblockerng"
 SCRIPT = PKG_DIR / "pfb_dnsbl_regex_rules.py"
@@ -143,6 +144,11 @@ def test_probe_and_resolver_agree_on_every_admission_verdict() -> None:
         "^" + "a" * 300 + "$",
         "",
         "^$",
+        "^([a-z])(?(1)[a-z]+[a-z]+[a-z]+[a-z]+|b)@x\\.com$",
+        "^[a-z]+[a-z]+(?>ab)[a-z]+[a-z]+@x\\.com$",
+        "^[a-z]+[a-z]+(foo|foobar)[a-z]+[a-z]+@x\\.com$",
+        "^[a-z]+[a-z]+(a|(?:b))+[a-z]+[a-z]+@x\\.com$",
+        "^[a-z]+[a-z]+(?>12)[a-z]+[a-z]+$",
     ]
     # The hand-written rows above only cover rules that exist TODAY, so they cannot
     # catch a FUTURE rule wired into one composition and not the other. Enumerate every
@@ -240,6 +246,64 @@ def test_shape_gate_stays_total_on_malformed_pattern_fragments() -> None:
     assert _regex_is_catastrophic_shape(r"(?#x\w+\w+\w+") is True
     assert _regex_is_catastrophic_shape(r"(?=a\w+\w+\w+") is True
     assert _regex_is_catastrophic_shape(r"(?i:\w+\w+\w+") is True
+
+
+def test_group_end_scan_is_linear_and_preserves_regex_escaping() -> None:
+    from pfb_dnsbl_regex_rules import _regex_group_end, _regex_has_adjacent_unbounded_atoms
+
+    cases = (
+        ("(a(b)c)d", 7),
+        (r"(\))x", 4),
+        ("([)])x", 5),
+        ("(a", 2),
+    )
+    for pattern, expected in cases:
+        assert _regex_group_end(pattern, 0) == expected, pattern
+
+    class CountingPattern(str):
+        reads = 0
+
+        def __getitem__(self, key: SupportsIndex | slice) -> str:
+            type(self).reads += 1
+            return super().__getitem__(key)
+
+    def scan_reads(size: int) -> int:
+        CountingPattern.reads = 0
+        pattern = CountingPattern("(" * size)
+        assert _regex_has_adjacent_unbounded_atoms(pattern) is False
+        return CountingPattern.reads
+
+    small = scan_reads(400)
+    large = scan_reads(800)
+    assert large <= small * 3, f"2x input caused {large / small:.2f}x indexed reads ({small} -> {large})"
+
+
+def test_probe_and_resolver_agree_on_issue2364_admission_rows() -> None:
+    from pfb_dnsbl_regex_rules import _regex_is_catastrophic_shape
+
+    rows = (
+        (r"^([a-z])(?(1)[a-z]+[a-z]+[a-z]+[a-z]+|b)@x\.com$", True),
+        (r"^(a)?(?(1)b|[a-z]+[a-z]+[a-z]+[a-z]+)@x\.com$", True),
+        (r"^[a-z]+[a-z]+(?>ab)[a-z]+[a-z]+@x\.com$", True),
+        (r"^[a-z]+[a-z]+(foo|foobar)[a-z]+[a-z]+@x\.com$", True),
+        (r"^[a-z]+[a-z]+(a|(?:b))+[a-z]+[a-z]+@x\.com$", True),
+        (r"^(a)?(?(1)[a-z]+[a-z]+|[a-z]+[a-z]+)$", False),
+        (r"^[a-z]+[a-z]+(?>12)[a-z]+[a-z]+$", False),
+        (r"^[a-z]+[a-z]+(\+|\*)[a-z]+[a-z]+$", False),
+        (r"^xn--bcher-kva\.[a-z]+$", False),
+    )
+    for pattern, expected in rows:
+        assert _regex_is_catastrophic_shape(pattern) is expected, pattern
+
+    proc = run_probe(("".join(pattern + "\n" for pattern, _ in rows)).encode("utf-8"), "0")
+    assert proc.returncode == 1
+    diagnostics = proc.stderr.decode("utf-8").splitlines()
+    expected_lines = [
+        f"line {line_number}: {pattern!r}: catastrophic-backtracking shape"
+        for line_number, (pattern, rejected) in enumerate(rows, 1)
+        if rejected
+    ]
+    assert diagnostics == expected_lines
 
 
 def test_probe_and_resolver_both_reject_an_overlapping_separator_run() -> None:

--- a/tests/test_pfb_dnsbl_regex_rules.py
+++ b/tests/test_pfb_dnsbl_regex_rules.py
@@ -16,7 +16,7 @@ import os
 import subprocess
 import sys
 from pathlib import Path
-from typing import SupportsIndex
+from typing import Any, SupportsIndex
 
 PKG_DIR = Path(__file__).resolve().parent.parent / "src/usr/local/pkg/pfblockerng"
 SCRIPT = PKG_DIR / "pfb_dnsbl_regex_rules.py"
@@ -248,7 +248,8 @@ def test_shape_gate_stays_total_on_malformed_pattern_fragments() -> None:
     assert _regex_is_catastrophic_shape(r"(?i:\w+\w+\w+") is True
 
 
-def test_group_end_scan_is_linear_and_preserves_regex_escaping() -> None:
+def test_group_end_scan_is_linear_and_preserves_regex_escaping(monkeypatch: Any) -> None:
+    import pfb_dnsbl_regex_rules
     from pfb_dnsbl_regex_rules import _regex_group_end, _regex_has_adjacent_unbounded_atoms
 
     cases = (
@@ -279,7 +280,21 @@ def test_group_end_scan_is_linear_and_preserves_regex_escaping() -> None:
     for build in (lambda size: "(" * size, lambda size: "(" * size + ")" * size):
         small = scan_work(build(400))
         large = scan_work(build(800))
+        assert small > 0 and large > 0
         assert large <= small * 3, f"2x input caused {large / small:.2f}x string work ({small} -> {large})"
+
+    body_scans = 0
+    original_body_scan = pfb_dnsbl_regex_rules._regex_body_has_run
+
+    def counted_body_scan(body: str, depth: int = 0) -> bool:
+        nonlocal body_scans
+        body_scans += 1
+        return original_body_scan(body, depth)
+
+    monkeypatch.setattr("pfb_dnsbl_regex_rules._regex_body_has_run", counted_body_scan)
+    nested_alternation = "(a|" * 800 + "b" + ")" * 800
+    assert isinstance(_regex_has_adjacent_unbounded_atoms(nested_alternation), bool)
+    assert body_scans <= pfb_dnsbl_regex_rules._REGEX_NESTED_SCAN_MAX
 
 
 def test_probe_and_resolver_agree_on_issue2364_admission_rows() -> None:


### PR DESCRIPTION
Fixes #2364.

## Problem

Four residual paths let catastrophic DNSBL regex shapes through the shared admission gate:
conditional branches were not re-entered, opaque multi-character bodies could not satisfy the one-character overlap witness, alternation syntax markers were mistaken for quantifiers, and repeated group-end searches made unclosed-group floods quadratic.

## Fix

- Precompute matching group ends in one pass and reuse them throughout each scan.
- Split conditional yes/no bodies at syntax-aware top-level alternations and scan each branch independently under the existing depth bound.
- Prove multi-character opaque bodies overlap only when one complete branch consists of mandatory text consumable by the current run atom; disjoint mandatory text still ends the chain.
- Walk alternation bodies through `_regex_next_unit()` so only genuine run-role quantifiers disable the opaque-body shortcut.

The change remains in `pfb_dnsbl_regex_rules.py`, the shared resolver/probe seam. ADR-07 runtime warn/evict behavior, PHP/UI, and documentation are unchanged.

## Coverage matrix

| Axis | Evidence |
| --- | --- |
| Conditional yes/no and id/name conditions | Both branches reject internal runs; branches remain independent; valid two-run branches stay admitted |
| Nested conditional constructs | Scoped flags, named groups, atomic groups, lookarounds, escaped literals, exact depth boundary, and a 2,000-level flood |
| Opaque multi-character bodies | `(?>ab)`, `(foo|foobar)`, quantified/scoped forms, Unicode `é`; numeric, dotted, escaped-paren/bracket, and bullet separators remain admitted when disjoint |
| Alternation syntax | Noncapturing/named/scoped/atomic/lookaround branches, escaped `+`/`*`, `\N{BULLET}`, and `(a|(?:b))+`; genuine branch runs still take the entered scan |
| Linear group-end scan | Deterministic indexed + copied-character work scales 2.00x: unclosed 1,600 → 3,200 and balanced 4,794 → 9,594; the pre-fix scanner scaled 81,001 → 322,001 (3.98x) |
| Admission consumers | Feed loader with cap off/on, user initial load, user swap load, save-time probe, resolver predicate, and shared-object identity |
| Hostile controls | Malformed/unclosed fragments stay total; disjoint separators, one-run controls, escaped classes/parens, IDN/punycode, wrong-encoding transport, and oversized/deep rows stay safe |

## Test-first evidence

Tests were authored on untouched `e5f13531aecc56b0537b14cfaa0fd1821a86cc00` production and executed RED: **8 failed**. The same byte-identical tests executed GREEN on the fix: **8 passed**.

Red-time `git hash-object` values, independently reverified:

- `tests/test_adr07_regex_safety.py`: `d354639d9dcc42e9b6a3ea9ded5a3af0243aedee`
- `tests/test_pfb_dnsbl_regex_rules.py` initial cycle: `8a0f016bb3c684cc408945717e17e81afdc772fc`
- `tests/test_pfb_dnsbl_regex_rules.py` slice-copy review cycle: `62c33d0d1299205a4b97f7d4cfc9bb3fcdc49cf2`
- `tests/test_pfb_dnsbl_regex_rules.py` bounded-alternation review cycle: `bfeb4e9a23a66039882ce1cca5f3c039aba857bc`
- `tests/test_pfb_dnsbl_regex_rules.py` anchored-overlap totality cycle: `3537666e7609735a826a6562a9ea26c2cb1cd73e`
- `tests/test_issue1718_regex_transport.py`: `2705b158f06b28fee2afe42f2ce326bd2c8dffa4`

Four mechanism-specific scratch regressions were killed: disabled conditional re-entry, single-character-only overlap, raw marker membership, and per-opener suffix scanning. Naive-overlap and joined-branch mutants also flipped the disjoint controls, proving the negative assertions are non-vacuous.

An independent verifier repeated the initial frozen-base RED/current GREEN, hashes, full diff, hostile matrix, mutations, caller parity, and deterministic scaling. Review then found that the first counter observed index operations but not copied slice widths. The strengthened byte-work counter executed RED on `351c5b844` (1 failed at 3.98x) and GREEN unchanged on the review fix (1 passed at 2.00x). A subsequent correctness review found nested alternation owners bypassing the depth bound; the added 800-level totality/call-count row executed RED on `87b989501` with `RecursionError` and GREEN unchanged after bounding the opaque-body scan. The same predicate returns a bool at 512, 1,200, and 2,000 levels.

## Verification

- Focused regex/admission suites: `77 passed`
- `scripts/agent/run-gates.sh --diff origin/devel` on rebased head:
  - coverage pairing: PASS
  - full pytest: PASS
  - Ruff check/format: PASS
  - mypy `tests/`: PASS
- Differential corpus: 305 valid patterns, 23 intended ADMIT→REJECT flips, zero REJECT→ADMIT relaxations

🤖 Generated by Oh My Pi and posted on behalf of @andrebrait.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of unsafe regular-expression patterns, including nested groups, conditional branches, alternations, and quantified structures.
  * Unsafe patterns are now consistently rejected during feed loading and user data updates, while valid patterns remain accepted.
  * Added safeguards for invalid or deeply nested expressions without executing candidate patterns.

* **Tests**
  * Added comprehensive regression coverage for regex safety, loading workflows, and bounded scanning behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->