### PR TITLE
Docs: reconcile stale ADR-07 regex-cap comments

### DIFF
--- a/docs/misc/architecture-notes.md
+++ b/docs/misc/architecture-notes.md
@@ -34,11 +34,11 @@ anchored patterns folded to dicts), and `$important`/`$badfilter` precedence res
 6-band numeric scale, with a build-emitted `important_rules` flag preserving a byte-identical
 fast path when no ABP precedence feature is loaded. (ADR-62 retired PHP's feed-level detection
 that used to route a whole feed here — see below; which lines reach `parse_abp()` is now a
-per-line decision, not a feed-level one.) At load, untrusted feed + user regex passes the always-on
-shared catastrophic-shape gate; the opt-in "Limit long/complex regex" setting separately caps pattern
-length. An always-on runtime warn/evict timer (warn 10 ms / evict 100 ms thread-CPU; snapshot-iterate,
-evict-after-loop) bounds admitted residuals. Pinned by `tests/test_adr07_*` (decision spec/oracle, parser,
-matcher strata, emit/wire, regex safety, PHP boundary); the regex/ReDoS kill-gate is
+per-line decision, not a feed-level one.) At load, the always-on shared catastrophic-shape gate
+rejects unsafe feed and user regex; the opt-in "Limit long/complex regex" setting separately caps
+pattern length. An always-on runtime guard warns on and evicts slow matches. Pinned by
+`tests/test_adr07_*` (decision spec/oracle, parser, matcher strata, emit/wire, regex safety, PHP boundary);
+the regex/ReDoS kill-gate is
 `legacy/benchmarks/spike_adr07_regex.py` — it exits non-zero on NO-GO (`--report-only` forces exit 0),
 runnable via the manual-only CI `benchmarks` job. See `legacy/ADRs/ADR_07_ABP_DNSBL_Support/`.
 

--- a/docs/misc/architecture-notes.md
+++ b/docs/misc/architecture-notes.md
@@ -34,10 +34,10 @@ anchored patterns folded to dicts), and `$important`/`$badfilter` precedence res
 6-band numeric scale, with a build-emitted `important_rules` flag preserving a byte-identical
 fast path when no ABP precedence feature is loaded. (ADR-62 retired PHP's feed-level detection
 that used to route a whole feed here — see below; which lines reach `parse_abp()` is now a
-per-line decision, not a feed-level one.) Untrusted feed + user regex is guarded by an opt-in
-"Limit long/complex regex" static cap (drops over-long/nested-quantifier patterns at load) plus
-an always-on runtime warn/evict timer (warn 10 ms / evict 100 ms thread-CPU; snapshot-iterate,
-evict-after-loop). Pinned by `tests/test_adr07_*` (decision spec/oracle, parser, reconcile,
+per-line decision, not a feed-level one.) At load, untrusted feed + user regex passes the always-on
+shared catastrophic-shape gate; the opt-in "Limit long/complex regex" setting separately caps pattern
+length. An always-on runtime warn/evict timer (warn 10 ms / evict 100 ms thread-CPU; snapshot-iterate,
+evict-after-loop) bounds admitted residuals. Pinned by `tests/test_adr07_*` (decision spec/oracle, parser,
 matcher strata, emit/wire, regex safety, PHP boundary); the regex/ReDoS kill-gate is
 `legacy/benchmarks/spike_adr07_regex.py` — it exits non-zero on NO-GO (`--report-only` forces exit 0),
 runnable via the manual-only CI `benchmarks` job. See `legacy/ADRs/ADR_07_ABP_DNSBL_Support/`.

--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -1615,11 +1615,7 @@ def init_standard(id: int, env: module_env) -> bool:
     pfb["pfb_py_query"] = "pfb_py_query"
     pfb["pfb_py_query_reply"] = "pfb_py_query.reply"
     pfb["pfb_py_count"] = "pfb_py_count"
-    # ADR-07: the ADMITTED feed+user regex total -- the count
-    # sync_package_pfblockerng()'s DNSBL_Regex alias-update block reads (falling
-    # back to the configured regex-line count when this file is stale/absent). It
-    # is the live size of regexDB + allowRegexDB after the shared catastrophic-shape
-    # gate and opt-in length cap (value changes by design, ADR §2).
+    # ADR-07: admitted feed + user regex count consumed by sync_package_pfblockerng().
     pfb["pfb_py_regex_count"] = "pfb_py_regex_count"
     # ADR-48 (issue #789): the per-entry reject tally artifact (BuildResult.rejects,
     # a JSON array of nonzero-total {feed, group, shape, wire_cap} rows) -- PHP reads
@@ -1989,13 +1985,8 @@ def init_standard(id: int, env: module_env) -> bool:
             # Whitelist/HSTS dicts -- or close their entries when the blacklist gate is off.
             _load_whitelist_and_hsts_dbs(dnsbl_built)
 
-            # ADR-07: emit the ADMITTED regex total for sync_package_pfblockerng()'s
-            # DNSBL_Regex alias-update block. regexDB holds USER + FEED block regex;
-            # allowRegexDB holds FEED @@/re/ allow regex. Their shared catastrophic-
-            # shape gate and opt-in length cap already ran, so the live size is the
-            # admitted count (value changes by design, ADR §2). Emitted whenever the
-            # plugin is enabled so the alias is accurate even with feed regex but no
-            # user regex.
+            # Emit the admitted feed + user regex total for PHP's DNSBL_Regex alias,
+            # even when only feed regex is enabled.
             dnsbl_emit_count(pfb["pfb_py_regex_count"], len(regexDB) + len(allowRegexDB))
 
             # Validate SQLite3 database connections. A False validate (issue #900)
@@ -5156,10 +5147,8 @@ def _dnsbl_compile_regex_rules(
     load) -- it never aborts the build. Names are unique per pattern occurrence so two
     feeds carrying the same pattern both load.
 
-    ADR-07: the shared catastrophic-shape gate rejects structurally unsafe patterns
-    at load unconditionally, independent of ``static_cap``. The opt-in length ceiling
-    (the "Limit long/complex regex" setting, ``static_cap``) separately drops
-    over-length-but-safe patterns. Runtime warn/evict bounds admitted residuals.
+    ADR-07: the always-on shared catastrophic-shape gate rejects unsafe patterns;
+    ``static_cap`` separately enables the opt-in length cap.
     """
     db: dict[str, dict[str, Any]] = {}
     admitted = 0
@@ -5238,8 +5227,6 @@ def build(
     tld_wildcard_exclusion = list(config.get("tld_wildcard_exclusion", []))
     exclusion = {e.strip(".") for e in tld_wildcard_exclusion}
 
-    # ADR-07: the opt-in feed-regex length cap. Structural rejection is the
-    # always-on shared catastrophic-shape gate in _dnsbl_compile_regex_rules().
     static_cap = bool(config.get("regex_cap", False))
 
     psl_rules = config.get("psl_rules", PslRules())

--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -1498,7 +1498,8 @@ def init_standard(id: int, env: module_env) -> bool:
     pfb["allowRegexDB"] = False
     pfb["important_rules"] = False
     # ADR-07 regex-safety defaults: opt-in length cap OFF; shared catastrophic-shape
-    # gate and runtime warn/evict ALWAYS on. The ini MAIN section overrides these.
+    # gate and runtime warn/evict are always active. MAIN ini may override
+    # regex_cap, regex_warn_ms, and regex_evict_ms; it cannot disable the shape gate.
     pfb["regex_cap"] = False
     pfb["regex_warn_ms"] = REGEX_WARN_MS_DEFAULT
     pfb["regex_evict_ms"] = REGEX_EVICT_MS_DEFAULT

--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -689,15 +689,13 @@ def _build_swap_snapshot() -> Snapshot | None:
     stratum into FRESH dicts (mutating NO live dict), and return a new Snapshot -- or
     ``None`` to fail-closed (rebuild_and_swap then keeps the live snapshot).
 
-    Reproduces init's DNSBL load off fresh local dicts so the swapped snapshot is the
-    exact set the manifest + ini + static cap define (decision-identical to a fresh init
-    load):
+    Reproduces init's DNSBL load off fresh local dicts so the swapped snapshot is
+    decision-identical to a fresh init load:
       * dnsbl_build_from_manifest() -> data/zone/feedGroupIndex/white + FEED block-regex
         + @@/re/ allow-regex + the important_rules fast-path flag + the loaded count.
         ``None`` (absent/unparseable manifest, build error) -> the whole swap is a no-op.
       * USER REGEX-ini patterns merged on top (band PRIO_USER_BLOCK, sovereign over feed
-        allows), honouring the opt-in static cap -- so a swap NEVER drops user regex
-        (ADR-07).
+        allows), after the shared catastrophic-shape gate and opt-in length cap.
       * hstsDB reloaded from pfb_py_hsts.txt (watch-out (b): hstsDB is NOT in the
         manifest; omitting it would ship an empty hsts_db and silently flip HSTS NULL-vs-
         VIP behaviour)."""
@@ -713,7 +711,7 @@ def _build_swap_snapshot() -> Snapshot | None:
     allow_regex_db: dict[str, Any] = dict(build_result.allow_regex_db)
 
     # USER regex patterns from MAIN.regex_list merged on top of the feed block-regex,
-    # mirroring init's load (incl. the opt-in static cap).
+    # mirroring init's shared catastrophic-shape gate and opt-in length cap.
     if os.path.isfile(pfb["pfb_unbound.ini"]):
         config = ConfigParser()
         try:
@@ -1499,9 +1497,8 @@ def init_standard(id: int, env: module_env) -> bool:
     # existing early-exit path while important_rules is False (behaviour-preserving).
     pfb["allowRegexDB"] = False
     pfb["important_rules"] = False
-    # ADR-07 regex-safety defaults: cap OFF (nothing dropped at load unless the
-    # user enables "Limit long/complex regex"); runtime warn/evict ALWAYS on at the
-    # measured ceilings. The ini MAIN section overrides these.
+    # ADR-07 regex-safety defaults: opt-in length cap OFF; shared catastrophic-shape
+    # gate and runtime warn/evict ALWAYS on. The ini MAIN section overrides these.
     pfb["regex_cap"] = False
     pfb["regex_warn_ms"] = REGEX_WARN_MS_DEFAULT
     pfb["regex_evict_ms"] = REGEX_EVICT_MS_DEFAULT
@@ -1618,12 +1615,11 @@ def init_standard(id: int, env: module_env) -> bool:
     pfb["pfb_py_query"] = "pfb_py_query"
     pfb["pfb_py_query_reply"] = "pfb_py_query.reply"
     pfb["pfb_py_count"] = "pfb_py_count"
-    # ADR-07: the ADMITTED (cap-filtered) feed+user regex total -- the count
+    # ADR-07: the ADMITTED feed+user regex total -- the count
     # sync_package_pfblockerng()'s DNSBL_Regex alias-update block reads (falling
     # back to the configured regex-line count when this file is stale/absent). It
-    # is the live size of regexDB + allowRegexDB AFTER both the user REGEX-ini
-    # load and the feed-regex merge, so patterns the static cap dropped are
-    # excluded (value changes by design, ADR §2).
+    # is the live size of regexDB + allowRegexDB after the shared catastrophic-shape
+    # gate and opt-in length cap (value changes by design, ADR §2).
     pfb["pfb_py_regex_count"] = "pfb_py_regex_count"
     # ADR-48 (issue #789): the per-entry reject tally artifact (BuildResult.rejects,
     # a JSON array of nonzero-total {feed, group, shape, wire_cap} rows) -- PHP reads
@@ -1805,11 +1801,9 @@ def init_standard(id: int, env: module_env) -> bool:
             if config.has_option("MAIN", "forwarding"):
                 pfb["forwarding"] = config.getboolean("MAIN", "forwarding")
 
-            # ADR-07: regex-safety knobs. ``regex_cap`` is the opt-in "Limit
-            # long/complex regex" static pre-filter (drops over-long/nested-quantifier
-            # patterns at load -- feed AND user). ``regex_warn_ms`` / ``regex_evict_ms``
-            # are the always-on runtime warn/evict ceilings (per-match thread CPU). All
-            # default to OFF / the measured defaults when absent.
+            # ADR-07: ``regex_cap`` is the opt-in length cap for feed and user patterns;
+            # the shared catastrophic-shape gate and runtime warn/evict are always on.
+            # Missing settings use cap OFF and the measured runtime defaults.
             if config.has_option("MAIN", "regex_cap"):
                 pfb["regex_cap"] = config.getboolean("MAIN", "regex_cap")
             if config.has_option("MAIN", "regex_warn_ms"):
@@ -1996,10 +1990,9 @@ def init_standard(id: int, env: module_env) -> bool:
             _load_whitelist_and_hsts_dbs(dnsbl_built)
 
             # ADR-07: emit the ADMITTED regex total for sync_package_pfblockerng()'s
-            # DNSBL_Regex alias-update block. regexDB now holds USER regex (REGEX-ini)
-            # + FEED block regex (merged from build()); allowRegexDB holds FEED @@/re/
-            # allow regex. Both have already had over-cap patterns dropped at load
-            # when the static cap is on, so this live size is the cap-filtered
+            # DNSBL_Regex alias-update block. regexDB holds USER + FEED block regex;
+            # allowRegexDB holds FEED @@/re/ allow regex. Their shared catastrophic-
+            # shape gate and opt-in length cap already ran, so the live size is the
             # admitted count (value changes by design, ADR §2). Emitted whenever the
             # plugin is enabled so the alias is accurate even with feed regex but no
             # user regex.
@@ -4039,8 +4032,8 @@ class Snapshot:
     Immutability note (watch-out): the tuple of fields is frozen, but the
     contained dicts are ordinary dicts. ADR-07's runtime regex eviction still mutates
     ``regex_db`` in place (``_regex_evict_names`` in ``evaluate_domain``); a swap replaces
-    the whole snapshot with a freshly-compiled set, so any evicted-pattern state is
-    rebuilt from the manifest + the static cap (reconciled + documented in ADR.md SS2).
+    the whole snapshot with a freshly-compiled set, rebuilding evicted-pattern state from
+    the manifest through the shared admission gates.
 
     The fields mirror the legacy ``containers`` keys + the ``cfg`` fast-path flag so the
     refactor is byte-for-byte decision-identical (pinned by the retained ADR-06/07
@@ -4960,18 +4953,18 @@ def _dnsbl_normalise_whitelist(
 
 
 # ============================================================================ #
-# ADR-07: regex safety (opt-in static cap + always-on runtime warn/evict)      #
+# ADR-07: regex safety (always-on shape gate and runtime guard + opt-in length cap) #
 # ============================================================================ #
 # `re` does not release the GIL during a match and a Python thread cannot be
 # killed, so a query-time timeout CANNOT interrupt a catastrophic match. Bounded
 # residual instead: a pathological pattern's FIRST match may block one query,
-# then it is EVICTED so it cannot hang again. (1) opt-in static cap drops
-# over-long/nested-quantifier patterns at LOAD; (2) always-on runtime timing
-# evicts a pattern from the live regexDB/allowRegexDB over an EVICT ceiling
-# (snapshot-iterate, evict-after-loop; dict.pop is atomic under the GIL).
-
-# The catastrophic-shape gate, the complexity budget, and REGEX_STATIC_LEN_CAP
-# live in pfb_dnsbl_regex_rules.py (issue #1765), imported above.
+# then it is EVICTED so it cannot hang again. The shared catastrophic-shape gate
+# always rejects unsafe structures at LOAD; the opt-in length cap separately drops
+# over-length patterns. Always-on runtime timing evicts an admitted pattern from
+# the live regexDB/allowRegexDB over an EVICT ceiling (snapshot-iterate,
+# evict-after-loop; dict.pop is atomic under the GIL).
+#
+# The shared gate and REGEX_STATIC_LEN_CAP live in pfb_dnsbl_regex_rules.py.
 
 # Runtime warn/evict ceilings (milliseconds of per-match thread CPU; measured
 # defaults, ADR.md SS2). Overridable via the pfb_unbound.ini MAIN section
@@ -5163,14 +5156,10 @@ def _dnsbl_compile_regex_rules(
     load) -- it never aborts the build. Names are unique per pattern occurrence so two
     feeds carrying the same pattern both load.
 
-    ADR-07: a pattern carrying a catastrophic SHAPE (nested / adjacent / overlapping
-    unbounded quantifier, stacked bounded repeat, or over the complexity budget) is
-    DROPPED at load UNCONDITIONALLY -- independent of ``static_cap`` -- because such a
-    shape drives catastrophic backtracking in the `re` engine. The opt-in length ceiling
-    (the "Limit long/complex regex" setting, ``static_cap``) is the SEPARATE tunable half:
-    when True it ALSO drops over-length-but-safe patterns. All checks are pure static
-    string analysis (no execution); the always-on runtime warn/evict guard lives in the
-    matcher (it is what bounds the residual of anything that slips through).
+    ADR-07: the shared catastrophic-shape gate rejects structurally unsafe patterns
+    at load unconditionally, independent of ``static_cap``. The opt-in length ceiling
+    (the "Limit long/complex regex" setting, ``static_cap``) separately drops
+    over-length-but-safe patterns. Runtime warn/evict bounds admitted residuals.
     """
     db: dict[str, dict[str, Any]] = {}
     admitted = 0
@@ -5249,8 +5238,8 @@ def build(
     tld_wildcard_exclusion = list(config.get("tld_wildcard_exclusion", []))
     exclusion = {e.strip(".") for e in tld_wildcard_exclusion}
 
-    # ADR-07: the opt-in static cap (drop over-long / nested-quantifier feed regex
-    # at load). Read from the manifest config; OFF by default so nothing is dropped.
+    # ADR-07: the opt-in feed-regex length cap. Structural rejection is the
+    # always-on shared catastrophic-shape gate in _dnsbl_compile_regex_rules().
     static_cap = bool(config.get("regex_cap", False))
 
     psl_rules = config.get("psl_rules", PslRules())

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -295,7 +295,7 @@ $pfb['unbound_py_ss']	= '/var/unbound/pfb_py_ss.txt';
 $pfb['unbound_py_hsts']	= '/var/unbound/pfb_py_hsts.txt';	// SHIPPED file re-staged by dnsbl_cache_stage() cp -f; fingerprinted so a package update ships a new list and triggers a zero-downtime reload
 $pfb['unbound_py_psl']	= '/var/unbound/dnsbl_psl';	// SHIPPED PSL authority, staged/fingerprinted exactly like unbound_py_hsts above
 $pfb['unbound_py_count']= '/var/unbound/pfb_py_count';
-$pfb['unbound_py_regex_count']= '/var/unbound/pfb_py_regex_count';	// ADR-07: Python-emitted ADMITTED (cap-filtered) feed+user regex total for the DNSBL_Regex alias
+$pfb['unbound_py_regex_count']= '/var/unbound/pfb_py_regex_count';	// ADR-07: Python-emitted admitted feed+user regex total for the DNSBL_Regex alias
 $pfb['unbound_py_reject_stats']= '/var/unbound/pfb_py_reject_stats.json';	// ADR-48: Python-emitted per-entry reject tally (issue #789), read by pfb_emit_entry_reject_stats()
 $pfb['unbound_py_sources']= '/var/unbound/pfb_py_sources.json';	// ADR-06: per-feed manifest consumed by pfb_unbound.py init
 $pfb['unbound_py_top1m']= '/var/unbound/pfb_py_top1m.txt';	// issue #1542: fixed TOP1M sidecar consumed by pfb_unbound.py
@@ -3341,7 +3341,7 @@ function pfb_global() {
 	$pfb['dnsbl_idn_escalate_suspicious']	= PfbConfig::read('dnsbl/pfb_idn_escalate_suspicious');	// Confusable: escalate suspicious mixed-script to block (opt-in)
 	$pfb['dnsbl_regex']	= pfb_cfg_toggle_read($pfb['dnsblconfig']['pfb_regex'] ?? '');			// DNSBL Resolver python regex
 	$pfb['dnsbl_regex_list']= $pfb['dnsblconfig']['pfb_regex_list'] ?? '';	// DNSBL Resolver python regex list
-	$pfb['dnsbl_regex_cap']	= PfbConfig::read('dnsbl/pfb_regex_cap');			// DNSBL Resolver python opt-in "Limit long/complex regex" static cap
+	$pfb['dnsbl_regex_cap']	= PfbConfig::read('dnsbl/pfb_regex_cap');			// DNSBL Resolver Python opt-in regex length cap
 	$pfb['dnsbl_cname']	= pfb_cfg_toggle_read($pfb['dnsblconfig']['pfb_cname'] ?? '');			// DNSBL Resolver python CNAME Validation
 	$pfb['dnsbl_tld_allow']	= pfb_cfg_toggle_read($pfb['dnsblconfig']['tld_allow'] ?? '');			// DNSBL Resolver TLD Allow option
 	$pfb['dnsbl_psl_include_private'] = PfbConfig::read('dnsbl/pfb_psl_include_private');			// PSL PRIVATE recognition (default On)

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
@@ -2771,13 +2771,9 @@ function sync_package_pfblockerng($cron=''): bool {
 			$pfb['alias_dnsbl_all'][] = 'DNSBL_TLD_Allow';
 			dnsbl_stats_update('update', 'DNSBL_TLD_Allow', $tld_allow_cnt);
 		}
-		// ADR-07: the DNSBL_Regex alias count reflects the admitted feed + user
-		// regex total emitted by Python after the shared catastrophic-shape gate
-		// and opt-in length cap (value changes by design, ADR §2 "Emit + counts").
-		// The Python count file is written at resolver (re)load, so it may be
-		// stale/absent; then fall back to the configured user-regex line count
-		// (today's behaviour) when it is not yet present. Surface the alias when the
-		// user regex feature is on OR Python reports admitted feed regex.
+		// ADR-07: use Python's admitted feed + user regex count after the shared
+		// catastrophic-shape gate and opt-in length cap; otherwise fall back to the
+		// configured user-regex count.
 		$py_regex_cnt = NULL;
 		if (file_exists($pfb['unbound_py_regex_count'])) {
 			$raw_rc = trim((string) @file_get_contents($pfb['unbound_py_regex_count']));

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
@@ -2771,12 +2771,11 @@ function sync_package_pfblockerng($cron=''): bool {
 			$pfb['alias_dnsbl_all'][] = 'DNSBL_TLD_Allow';
 			dnsbl_stats_update('update', 'DNSBL_TLD_Allow', $tld_allow_cnt);
 		}
-		// ADR-07: the DNSBL_Regex alias count now reflects the ADMITTED
-		// (cap-filtered) feed + user regex total emitted by Python (regexDB +
-		// allowRegexDB after the static cap drops over-cap patterns at load) --
-		// value changes by design (ADR §2 "Emit + counts"). The Python count file
-		// is written at resolver (re)load, so it may be stale/absent on the first
-		// run or before a reload; fall back to the configured user-regex line count
+		// ADR-07: the DNSBL_Regex alias count reflects the admitted feed + user
+		// regex total emitted by Python after the shared catastrophic-shape gate
+		// and opt-in length cap (value changes by design, ADR §2 "Emit + counts").
+		// The Python count file is written at resolver (re)load, so it may be
+		// stale/absent; then fall back to the configured user-regex line count
 		// (today's behaviour) when it is not yet present. Surface the alias when the
 		// user regex feature is on OR Python reports admitted feed regex.
 		$py_regex_cnt = NULL;

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -1277,7 +1277,7 @@ function pfb_cfg_registry(): array
 			'no_grandfather' => 'v3.2.16 absent-key fallback equals current default',
 		],
 
-		// Python regex static cap ('on'|''). Default ''.
+		// Python opt-in regex length cap ('on'|''). Default ''.
 		'dnsbl/pfb_regex_cap' => [
 			'default'       => '',
 			'read_adapter'  => 'pfb_cfg_toggle_read',


### PR DESCRIPTION
Fixes #2064.

## Summary

- describe `regex_cap` only as the opt-in regex length cap
- describe structural rejection as the always-on shared catastrophic-shape gate
- align ADR-07 architecture, Python runtime, and PHP-facing comments without changing behavior

## Scope

Comment and documentation reconciliation only. No behavior, identifiers, configuration, defaults, user-facing UI, tests, or generated artifacts changed.

no-test-needed: This PR changes only comments and documentation; existing regex admission contracts already cover the unchanged behavior.

## Verification

- Focused behavior/comment contracts: `46 passed`
- `scripts/check_comment_narration.py --diff origin/devel`: PASS
- Canonical diff gates: pytest, Ruff check/format, mypy, PHP syntax, PHPCS, and markdownlint PASS
- PHPStan rerun: PASS
- Local macOS PHPUnit reached the tracked platform-only baseline failure in #2685 (`DownloadSizeCeilingTest` expects SIGXFSZ 153, macOS returns 1); Linux exact-head CI is authoritative

🤖 Generated by Oh My Pi and posted on behalf of @andrebrait.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified documentation for DNSBL regex safety, reload behavior, regex counts, snapshots, and configuration limits.
  * Updated descriptions of regex-count selection, fallback behavior, and opt-in regex length caps.
  * No functional or user-facing behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->