### PR TITLE
fix(release): make source archives reproducible

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -826,7 +826,7 @@ jobs:
   # (/release-with-changelog), who then publishes it. Nothing here un-drafts.
   release:
     name: Create draft GitHub Release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     # The draft is created only AFTER the tag exists on the verified commit —
     # softprops/action-gh-release CREATES a missing tag itself, which is exactly how a
     # failed run used to strand one, so a skipped tag-release must never reach it.
@@ -1094,16 +1094,20 @@ jobs:
             echo "__RELEASE_BODY__"
           } >> "$GITHUB_OUTPUT"
 
+      - name: Pin source archive Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11.15"
+
       - name: Build source archive
         run: |
+          set -eu
           VERSION="${{ steps.meta.outputs.version }}"
           ARCHIVE="pfBlockerNG-${VERSION}.tar.gz"
+          SOURCE_EPOCH="$(git show -s --format=%ct HEAD)"
 
-          # src/ is the production filesystem overlay; dev tooling is outside it
-          tar -czf "$ARCHIVE" \
-            --exclude="*.pyc" \
-            --exclude="__pycache__" \
-            src/
+          python3 "${GITHUB_WORKSPACE}/pfblockerng-src/scripts/build-source-archive.py" \
+            --source src --output "$ARCHIVE" --epoch "$SOURCE_EPOCH"
           echo "ARCHIVE=${ARCHIVE}" >> "$GITHUB_ENV"
 
       - name: Create tagged release handoff

--- a/scripts/build-source-archive.py
+++ b/scripts/build-source-archive.py
@@ -6,9 +6,13 @@ from __future__ import annotations
 import argparse
 import gzip
 import os
+import stat
 import tarfile
 import tempfile
+from collections.abc import Generator
+from contextlib import contextmanager
 from pathlib import Path
+from typing import BinaryIO
 
 _MAX_GZIP_EPOCH = (1 << 32) - 1
 
@@ -34,56 +38,156 @@ def _excluded(relative: Path) -> bool:
     )
 
 
-def build_archive(source: Path, output: Path, epoch: int) -> None:
-    if source.is_symlink() or not source.is_dir():
-        raise ArchiveError(f"source must be a real directory (not a symlink): {source}")
-    output_location = output.parent.resolve() / output.name
-    if output_location.is_relative_to(source.resolve()):
-        raise ArchiveError(f"output must be outside the source directory: {output}")
-
-    paths = [source]
-    paths.extend(
-        sorted(
-            (path for path in source.rglob("*") if not _excluded(path.relative_to(source))),
-            key=lambda path: path.relative_to(source).as_posix(),
-        )
-    )
-
-    temporary = tempfile.NamedTemporaryFile(mode="wb", prefix=f".{output.name}.", dir=output.parent, delete=False)
-    temporary_path = Path(temporary.name)
+@contextmanager
+def _open_directory(path: str | Path, *, dir_fd: int | None = None) -> Generator[int, None, None]:
+    opened = os.open(path, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW, dir_fd=dir_fd)
     try:
-        with (
-            temporary as raw_archive,
-            gzip.GzipFile(filename="", mode="wb", compresslevel=9, fileobj=raw_archive, mtime=epoch) as compressed,
-            tarfile.open(fileobj=compressed, mode="w|", format=tarfile.USTAR_FORMAT) as archive,
-        ):
-            for path in paths:
-                relative = path.relative_to(source)
-                archive_name = "src" if relative == Path() else f"src/{relative.as_posix()}"
-                info = archive.gettarinfo(str(path), arcname=archive_name)
-                if info is None:
-                    raise ArchiveError(f"unsupported source entry: {path}")
-                info.uid = info.gid = 0
-                info.uname = info.gname = "root"
-                info.mtime = epoch
-                info.pax_headers = {}
-                if info.isdir():
-                    info.mode = 0o755
-                    archive.addfile(info)
-                elif info.isfile():
-                    info.mode = 0o755 if info.mode & 0o111 else 0o644
-                    with path.open("rb") as contents:
-                        archive.addfile(info, contents)
-                elif info.issym():
-                    info.mode = 0o777
-                    archive.addfile(info)
-                else:
-                    raise ArchiveError(f"unsupported source entry: {path}")
-        os.replace(temporary_path, output)
+        yield opened
     finally:
-        temporary_path.unlink(missing_ok=True)
+        os.close(opened)
 
-    print(f"built {output} from {len(paths)} normalized entries at source epoch {epoch}")
+
+def _unchanged(expected: os.stat_result, actual: os.stat_result, path: Path) -> None:
+    fields = ("st_dev", "st_ino", "st_mode", "st_size", "st_mtime_ns", "st_ctime_ns")
+    if any(getattr(expected, field) != getattr(actual, field) for field in fields):
+        raise ArchiveError(f"source entry changed while archiving: {path}")
+
+
+def _output_is_within_source(output_parent: Path, source: Path) -> bool:
+    current = output_parent
+    while True:
+        if os.path.samefile(current, source):
+            return True
+        parent = current.parent
+        if parent == current:
+            return False
+        current = parent
+
+
+def _tar_info(
+    relative: Path,
+    snapshot: os.stat_result,
+    epoch: int,
+    *,
+    entry_type: bytes,
+    linkname: str = "",
+) -> tarfile.TarInfo:
+    archive_name = "src" if relative == Path() else f"src/{relative.as_posix()}"
+    info = tarfile.TarInfo(archive_name)
+    info.type = entry_type
+    info.linkname = linkname
+    info.uid = info.gid = 0
+    info.uname = info.gname = "root"
+    info.mtime = epoch
+    if entry_type == tarfile.DIRTYPE:
+        info.mode = 0o755
+    elif entry_type == tarfile.SYMTYPE:
+        info.mode = 0o777
+    else:
+        info.mode = 0o755 if snapshot.st_mode & 0o111 else 0o644
+        info.size = snapshot.st_size
+    return info
+
+
+def _add_member(
+    archive: tarfile.TarFile,
+    info: tarfile.TarInfo,
+    path: Path,
+    contents: BinaryIO | None = None,
+) -> None:
+    try:
+        archive.addfile(info, contents)
+    except ValueError as error:
+        raise ArchiveError(f"USTAR cannot encode source entry {path}: {error}") from error
+
+
+def _archive_directory(
+    archive: tarfile.TarFile,
+    directory_fd: int,
+    relative: Path,
+    snapshot: os.stat_result,
+    epoch: int,
+    source_path: Path,
+) -> int:
+    directory_path = source_path / relative
+    _add_member(archive, _tar_info(relative, snapshot, epoch, entry_type=tarfile.DIRTYPE), directory_path)
+    count = 1
+    with os.scandir(directory_fd) as entries:
+        names = sorted(entry.name for entry in entries)
+
+    for name in names:
+        child_relative = relative / name
+        if _excluded(child_relative):
+            continue
+        display_path = source_path / child_relative
+        before = os.stat(name, dir_fd=directory_fd, follow_symlinks=False)
+        if stat.S_ISDIR(before.st_mode):
+            with _open_directory(name, dir_fd=directory_fd) as child_fd:
+                opened = os.fstat(child_fd)
+                _unchanged(before, opened, display_path)
+                count += _archive_directory(archive, child_fd, child_relative, opened, epoch, source_path)
+        elif stat.S_ISREG(before.st_mode):
+            file_fd = os.open(name, os.O_RDONLY | os.O_NOFOLLOW, dir_fd=directory_fd)
+            try:
+                opened = os.fstat(file_fd)
+                _unchanged(before, opened, display_path)
+                info = _tar_info(child_relative, opened, epoch, entry_type=tarfile.REGTYPE)
+                with os.fdopen(file_fd, "rb", closefd=False) as contents:
+                    _add_member(archive, info, display_path, contents)
+                _unchanged(opened, os.fstat(file_fd), display_path)
+                count += 1
+            finally:
+                os.close(file_fd)
+        elif stat.S_ISLNK(before.st_mode):
+            linkname = os.readlink(name, dir_fd=directory_fd)
+            _unchanged(before, os.stat(name, dir_fd=directory_fd, follow_symlinks=False), display_path)
+            info = _tar_info(child_relative, before, epoch, entry_type=tarfile.SYMTYPE, linkname=linkname)
+            _add_member(archive, info, display_path)
+            count += 1
+        else:
+            raise ArchiveError(f"unsupported source entry: {display_path}")
+
+    _unchanged(snapshot, os.fstat(directory_fd), directory_path)
+    return count
+
+
+def build_archive(source: Path, output: Path, epoch: int) -> None:
+    source_snapshot = os.stat(source, follow_symlinks=False)
+    if not stat.S_ISDIR(source_snapshot.st_mode):
+        raise ArchiveError(f"source must be a real directory (not a symlink): {source}")
+    output_parent = output.parent.resolve(strict=True)
+    if _output_is_within_source(output_parent, source):
+        raise ArchiveError(f"output must be outside the source directory: {output}")
+    output_location = output_parent / output.name
+    with _open_directory(source) as source_fd:
+        opened_source = os.fstat(source_fd)
+        _unchanged(source_snapshot, opened_source, Path("src"))
+        temporary_path: Path | None = None
+        try:
+            with tempfile.NamedTemporaryFile(
+                mode="wb",
+                prefix=f".{output.name}.",
+                dir=output_parent,
+                delete=False,
+            ) as raw_archive:
+                temporary_path = Path(raw_archive.name)
+                with (
+                    gzip.GzipFile(
+                        filename="",
+                        mode="wb",
+                        compresslevel=9,
+                        fileobj=raw_archive,
+                        mtime=epoch,
+                    ) as compressed,
+                    tarfile.open(fileobj=compressed, mode="w|", format=tarfile.USTAR_FORMAT) as archive,
+                ):
+                    count = _archive_directory(archive, source_fd, Path(), opened_source, epoch, source)
+            os.replace(temporary_path, output_location)
+        finally:
+            if temporary_path is not None:
+                temporary_path.unlink(missing_ok=True)
+
+    print(f"built {output} from {count} normalized entries at source epoch {epoch}")
 
 
 def main() -> int:

--- a/scripts/build-source-archive.py
+++ b/scripts/build-source-archive.py
@@ -5,10 +5,16 @@ from __future__ import annotations
 
 import argparse
 import gzip
+import os
 import tarfile
+import tempfile
 from pathlib import Path
 
 _MAX_GZIP_EPOCH = (1 << 32) - 1
+
+
+class ArchiveError(Exception):
+    """Source archive cannot be built without violating its fixed contract."""
 
 
 def _epoch(value: str) -> int:
@@ -22,16 +28,18 @@ def _epoch(value: str) -> int:
 
 
 def _excluded(relative: Path) -> bool:
-    return (
-        relative.suffix == ".pyc"
-        or relative.name == ".DS_Store"
-        or any(part == "__pycache__" or part.startswith("._") for part in relative.parts)
+    return any(
+        part.endswith(".pyc") or part in {"__pycache__", ".DS_Store"} or part.startswith("._")
+        for part in relative.parts
     )
 
 
 def build_archive(source: Path, output: Path, epoch: int) -> None:
-    if not source.is_dir():
-        raise ValueError(f"source directory does not exist: {source}")
+    if source.is_symlink() or not source.is_dir():
+        raise ArchiveError(f"source must be a real directory (not a symlink): {source}")
+    output_location = output.parent.resolve() / output.name
+    if output_location.is_relative_to(source.resolve()):
+        raise ArchiveError(f"output must be outside the source directory: {output}")
 
     paths = [source]
     paths.extend(
@@ -41,31 +49,39 @@ def build_archive(source: Path, output: Path, epoch: int) -> None:
         )
     )
 
-    with (
-        output.open("wb") as raw_archive,
-        gzip.GzipFile(filename="", mode="wb", compresslevel=9, fileobj=raw_archive, mtime=epoch) as compressed,
-        tarfile.open(fileobj=compressed, mode="w|", format=tarfile.USTAR_FORMAT) as archive,
-    ):
-        for path in paths:
-            relative = path.relative_to(source)
-            archive_name = "src" if relative == Path() else f"src/{relative.as_posix()}"
-            info = archive.gettarinfo(str(path), arcname=archive_name)
-            info.uid = info.gid = 0
-            info.uname = info.gname = "root"
-            info.mtime = epoch
-            info.pax_headers = {}
-            if info.isdir():
-                info.mode = 0o755
-                archive.addfile(info)
-            elif info.isfile():
-                info.mode = 0o755 if info.mode & 0o111 else 0o644
-                with path.open("rb") as contents:
-                    archive.addfile(info, contents)
-            elif info.issym():
-                info.mode = 0o777
-                archive.addfile(info)
-            else:
-                raise ValueError(f"unsupported source entry: {path}")
+    temporary = tempfile.NamedTemporaryFile(mode="wb", prefix=f".{output.name}.", dir=output.parent, delete=False)
+    temporary_path = Path(temporary.name)
+    try:
+        with (
+            temporary as raw_archive,
+            gzip.GzipFile(filename="", mode="wb", compresslevel=9, fileobj=raw_archive, mtime=epoch) as compressed,
+            tarfile.open(fileobj=compressed, mode="w|", format=tarfile.USTAR_FORMAT) as archive,
+        ):
+            for path in paths:
+                relative = path.relative_to(source)
+                archive_name = "src" if relative == Path() else f"src/{relative.as_posix()}"
+                info = archive.gettarinfo(str(path), arcname=archive_name)
+                if info is None:
+                    raise ArchiveError(f"unsupported source entry: {path}")
+                info.uid = info.gid = 0
+                info.uname = info.gname = "root"
+                info.mtime = epoch
+                info.pax_headers = {}
+                if info.isdir():
+                    info.mode = 0o755
+                    archive.addfile(info)
+                elif info.isfile():
+                    info.mode = 0o755 if info.mode & 0o111 else 0o644
+                    with path.open("rb") as contents:
+                        archive.addfile(info, contents)
+                elif info.issym():
+                    info.mode = 0o777
+                    archive.addfile(info)
+                else:
+                    raise ArchiveError(f"unsupported source entry: {path}")
+        os.replace(temporary_path, output)
+    finally:
+        temporary_path.unlink(missing_ok=True)
 
     print(f"built {output} from {len(paths)} normalized entries at source epoch {epoch}")
 
@@ -78,7 +94,7 @@ def main() -> int:
     args = parser.parse_args()
     try:
         build_archive(args.source, args.output, args.epoch)
-    except (OSError, tarfile.TarError, ValueError) as error:
+    except (ArchiveError, OSError, tarfile.TarError) as error:
         parser.error(str(error))
     return 0
 

--- a/scripts/build-source-archive.py
+++ b/scripts/build-source-archive.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Build the deterministic production source archive attached to releases."""
+
+from __future__ import annotations
+
+import argparse
+import gzip
+import tarfile
+from pathlib import Path
+
+_MAX_GZIP_EPOCH = (1 << 32) - 1
+
+
+def _epoch(value: str) -> int:
+    try:
+        epoch = int(value)
+    except ValueError as error:
+        raise argparse.ArgumentTypeError("must be an integer") from error
+    if not 0 <= epoch <= _MAX_GZIP_EPOCH:
+        raise argparse.ArgumentTypeError(f"must be between 0 and {_MAX_GZIP_EPOCH}")
+    return epoch
+
+
+def _excluded(relative: Path) -> bool:
+    return (
+        relative.suffix == ".pyc"
+        or relative.name == ".DS_Store"
+        or any(part == "__pycache__" or part.startswith("._") for part in relative.parts)
+    )
+
+
+def build_archive(source: Path, output: Path, epoch: int) -> None:
+    if not source.is_dir():
+        raise ValueError(f"source directory does not exist: {source}")
+
+    paths = [source]
+    paths.extend(
+        sorted(
+            (path for path in source.rglob("*") if not _excluded(path.relative_to(source))),
+            key=lambda path: path.relative_to(source).as_posix(),
+        )
+    )
+
+    with (
+        output.open("wb") as raw_archive,
+        gzip.GzipFile(filename="", mode="wb", compresslevel=9, fileobj=raw_archive, mtime=epoch) as compressed,
+        tarfile.open(fileobj=compressed, mode="w|", format=tarfile.USTAR_FORMAT) as archive,
+    ):
+        for path in paths:
+            relative = path.relative_to(source)
+            archive_name = "src" if relative == Path() else f"src/{relative.as_posix()}"
+            info = archive.gettarinfo(str(path), arcname=archive_name)
+            info.uid = info.gid = 0
+            info.uname = info.gname = "root"
+            info.mtime = epoch
+            info.pax_headers = {}
+            if info.isdir():
+                info.mode = 0o755
+                archive.addfile(info)
+            elif info.isfile():
+                info.mode = 0o755 if info.mode & 0o111 else 0o644
+                with path.open("rb") as contents:
+                    archive.addfile(info, contents)
+            elif info.issym():
+                info.mode = 0o777
+                archive.addfile(info)
+            else:
+                raise ValueError(f"unsupported source entry: {path}")
+
+    print(f"built {output} from {len(paths)} normalized entries at source epoch {epoch}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--source", required=True, type=Path, help="production src/ directory")
+    parser.add_argument("--output", required=True, type=Path, help="output .tar.gz path")
+    parser.add_argument("--epoch", required=True, type=_epoch, help="source commit timestamp")
+    args = parser.parse_args()
+    try:
+        build_archive(args.source, args.output, args.epoch)
+    except (OSError, tarfile.TarError, ValueError) as error:
+        parser.error(str(error))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/build-source-archive.py
+++ b/scripts/build-source-archive.py
@@ -53,17 +53,6 @@ def _unchanged(expected: os.stat_result, actual: os.stat_result, path: Path) -> 
         raise ArchiveError(f"source entry changed while archiving: {path}")
 
 
-def _output_is_within_source(output_parent: Path, source: Path) -> bool:
-    current = output_parent
-    while True:
-        if os.path.samefile(current, source):
-            return True
-        parent = current.parent
-        if parent == current:
-            return False
-        current = parent
-
-
 def _tar_info(
     relative: Path,
     snapshot: os.stat_result,
@@ -156,7 +145,9 @@ def build_archive(source: Path, output: Path, epoch: int) -> None:
     if not stat.S_ISDIR(source_snapshot.st_mode):
         raise ArchiveError(f"source must be a real directory (not a symlink): {source}")
     output_parent = output.parent.resolve(strict=True)
-    if _output_is_within_source(output_parent, source):
+    if os.path.samefile(output_parent, source) or any(
+        os.path.samefile(parent, source) for parent in output_parent.parents
+    ):
         raise ArchiveError(f"output must be outside the source directory: {output}")
     output_location = output_parent / output.name
     with _open_directory(source) as source_fd:

--- a/scripts/build-source-archive.py
+++ b/scripts/build-source-archive.py
@@ -6,15 +6,17 @@ from __future__ import annotations
 import argparse
 import gzip
 import os
+import secrets
 import stat
 import tarfile
-import tempfile
 from collections.abc import Generator
 from contextlib import contextmanager
 from pathlib import Path
 from typing import BinaryIO
 
 _MAX_GZIP_EPOCH = (1 << 32) - 1
+_DIRECTORY_FLAGS = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+_TEMPORARY_ATTEMPTS = 100
 
 
 class ArchiveError(Exception):
@@ -40,11 +42,55 @@ def _excluded(relative: Path) -> bool:
 
 @contextmanager
 def _open_directory(path: str | Path, *, dir_fd: int | None = None) -> Generator[int, None, None]:
-    opened = os.open(path, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW, dir_fd=dir_fd)
+    opened = os.open(path, _DIRECTORY_FLAGS, dir_fd=dir_fd)
     try:
         yield opened
     finally:
         os.close(opened)
+
+
+def _same_directory(first: os.stat_result, second: os.stat_result) -> bool:
+    return (first.st_dev, first.st_ino) == (second.st_dev, second.st_ino)
+
+
+def _directory_is_within(directory_fd: int, ancestor_fd: int) -> bool:
+    ancestor = os.fstat(ancestor_fd)
+    current_fd = os.dup(directory_fd)
+    try:
+        while True:
+            current = os.fstat(current_fd)
+            if _same_directory(current, ancestor):
+                return True
+            parent_fd = os.open("..", _DIRECTORY_FLAGS, dir_fd=current_fd)
+            parent = os.fstat(parent_fd)
+            if _same_directory(current, parent):
+                os.close(parent_fd)
+                return False
+            os.close(current_fd)
+            current_fd = parent_fd
+    finally:
+        os.close(current_fd)
+
+
+def _create_temporary(directory_fd: int, output_name: str) -> tuple[str, BinaryIO]:
+    for _ in range(_TEMPORARY_ATTEMPTS):
+        name = f".{output_name}.{secrets.token_hex(12)}"
+        try:
+            opened = os.open(
+                name,
+                os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW,
+                0o600,
+                dir_fd=directory_fd,
+            )
+        except FileExistsError:
+            continue
+        try:
+            return name, os.fdopen(opened, "wb")
+        except OSError:
+            os.close(opened)
+            os.unlink(name, dir_fd=directory_fd)
+            raise
+    raise ArchiveError("could not create a unique temporary archive")
 
 
 def _unchanged(expected: os.stat_result, actual: os.stat_result, path: Path) -> None:
@@ -145,38 +191,39 @@ def build_archive(source: Path, output: Path, epoch: int) -> None:
     if not stat.S_ISDIR(source_snapshot.st_mode):
         raise ArchiveError(f"source must be a real directory (not a symlink): {source}")
     output_parent = output.parent.resolve(strict=True)
-    if os.path.samefile(output_parent, source) or any(
-        os.path.samefile(parent, source) for parent in output_parent.parents
+    with (
+        _open_directory(source) as source_fd,
+        _open_directory(output_parent) as output_fd,
     ):
-        raise ArchiveError(f"output must be outside the source directory: {output}")
-    output_location = output_parent / output.name
-    with _open_directory(source) as source_fd:
         opened_source = os.fstat(source_fd)
         _unchanged(source_snapshot, opened_source, Path("src"))
-        temporary_path: Path | None = None
+        if _directory_is_within(output_fd, source_fd):
+            raise ArchiveError(f"output must be outside the source directory: {output}")
+        temporary_name, temporary = _create_temporary(output_fd, output.name)
         try:
-            with tempfile.NamedTemporaryFile(
-                mode="wb",
-                prefix=f".{output.name}.",
-                dir=output_parent,
-                delete=False,
-            ) as raw_archive:
-                temporary_path = Path(raw_archive.name)
-                with (
-                    gzip.GzipFile(
-                        filename="",
-                        mode="wb",
-                        compresslevel=9,
-                        fileobj=raw_archive,
-                        mtime=epoch,
-                    ) as compressed,
-                    tarfile.open(fileobj=compressed, mode="w|", format=tarfile.USTAR_FORMAT) as archive,
-                ):
-                    count = _archive_directory(archive, source_fd, Path(), opened_source, epoch, source)
-            os.replace(temporary_path, output_location)
+            with (
+                temporary as raw_archive,
+                gzip.GzipFile(
+                    filename="",
+                    mode="wb",
+                    compresslevel=9,
+                    fileobj=raw_archive,
+                    mtime=epoch,
+                ) as compressed,
+                tarfile.open(fileobj=compressed, mode="w|", format=tarfile.USTAR_FORMAT) as archive,
+            ):
+                count = _archive_directory(archive, source_fd, Path(), opened_source, epoch, source)
+            os.replace(
+                temporary_name,
+                output.name,
+                src_dir_fd=output_fd,
+                dst_dir_fd=output_fd,
+            )
         finally:
-            if temporary_path is not None:
-                temporary_path.unlink(missing_ok=True)
+            try:
+                os.unlink(temporary_name, dir_fd=output_fd)
+            except FileNotFoundError:
+                pass
 
     print(f"built {output} from {count} normalized entries at source epoch {epoch}")
 

--- a/tests/test_reproducible_source_archive.py
+++ b/tests/test_reproducible_source_archive.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import gzip
 import hashlib
+import importlib.util
 import os
 import shutil
 import socket
@@ -12,6 +13,7 @@ import sys
 import tarfile
 import tempfile
 from pathlib import Path
+from types import ModuleType
 
 import pytest
 
@@ -32,6 +34,14 @@ EXPECTED_MEMBERS = [
     "src/usr/local/pkg",
     SAFE_MEMBER,
 ]
+
+
+def _builder_module() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("issue2717_source_archive", BUILDER)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
 
 
 def _source_tree(parent: Path, *, mtime: int, ordinary_mode: int, executable_mode: int) -> Path:
@@ -126,6 +136,9 @@ def test_fresh_trees_produce_identical_normalized_archives(tmp_path: Path) -> No
         safe_member = archive.extractfile(SAFE_MEMBER)
         assert safe_member is not None
         assert safe_member.read() == b"metacharacters stay data\n"
+        executable_member = archive.extractfile(EXEC_MEMBER)
+        assert executable_member is not None
+        assert executable_member.read() == b"#!/bin/sh\nexit 0\n"
     assert not (first_source.parent / "escaped").exists()
 
 
@@ -173,6 +186,24 @@ def test_output_inside_source_is_rejected_without_clobbering_it(tmp_path: Path) 
     assert result.returncode != 0
     assert "output must be outside the source directory" in result.stderr
     assert output.read_bytes() == b"existing archive"
+
+
+def test_case_alias_output_inside_source_is_rejected(tmp_path: Path) -> None:
+    source = tmp_path / "Source"
+    source.mkdir()
+    (source / "ordinary.conf").write_text("ordinary\n", encoding="utf-8")
+    alias = tmp_path / "source"
+    if not alias.is_dir() or not os.path.samefile(source, alias):
+        pytest.skip("scratch filesystem is case-sensitive")
+    output = alias / "existing.tar.gz"
+    output.write_bytes(b"existing archive")
+
+    result = _run_builder(source, output)
+
+    assert result.returncode != 0
+    assert "output must be outside the source directory" in result.stderr
+    assert output.read_bytes() == b"existing archive"
+    assert not list(source.glob(f".{output.name}.*"))
 
 
 def test_output_symlink_is_replaced_without_touching_its_target(tmp_path: Path) -> None:
@@ -229,6 +260,98 @@ def test_socket_failure_is_contextual_and_preserves_existing_output() -> None:
         assert "AttributeError" not in result.stderr
         assert output.read_bytes() == b"existing archive"
         assert not list(root.glob(f".{output.name}.*"))
+
+
+@pytest.mark.parametrize("entry_kind", ["name", "link"])
+def test_ustar_limits_fail_contextually_without_replacing_output(tmp_path: Path, entry_kind: str) -> None:
+    source = tmp_path / "src"
+    source.mkdir()
+    if entry_kind == "name":
+        (source / ("n" * 101)).write_bytes(b"too long")
+    else:
+        (source / "long-link").symlink_to("t" * 101)
+    output = tmp_path / "existing.tar.gz"
+    output.write_bytes(b"existing archive")
+
+    result = _run_builder(source, output)
+
+    assert result.returncode != 0
+    assert "USTAR cannot encode source entry" in result.stderr
+    assert "Traceback" not in result.stderr
+    assert output.read_bytes() == b"existing archive"
+    assert not list(tmp_path.glob(f".{output.name}.*"))
+
+
+@pytest.mark.parametrize("entry_kind", ["file", "directory"])
+def test_source_entry_swap_cannot_escape_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, entry_kind: str) -> None:
+    source = tmp_path / "src"
+    source.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    victim = source / "victim"
+    if entry_kind == "file":
+        victim.write_bytes(b"PUBLIC")
+        (outside / "secret").write_bytes(b"SECRET")
+    else:
+        victim.mkdir()
+        (victim / "file").write_bytes(b"PUBLIC")
+        (outside / "file").write_bytes(b"SECRET")
+    output = tmp_path / "existing.tar.gz"
+    output.write_bytes(b"existing archive")
+    module = _builder_module()
+    real_stat = module.os.stat
+    swapped = False
+
+    def racing_stat(path: object, *args: object, **kwargs: object) -> os.stat_result:
+        nonlocal swapped
+        result = real_stat(path, *args, **kwargs)
+        if path == "victim" and kwargs.get("dir_fd") is not None and not swapped:
+            swapped = True
+            if entry_kind == "file":
+                victim.unlink()
+                victim.symlink_to(outside / "secret")
+            else:
+                shutil.rmtree(victim)
+                victim.symlink_to(outside, target_is_directory=True)
+        return result
+
+    monkeypatch.setattr(module.os, "stat", racing_stat)
+    with pytest.raises((OSError, module.ArchiveError)):
+        module.build_archive(source, output, SOURCE_EPOCH)
+
+    assert swapped
+    assert output.read_bytes() == b"existing archive"
+    assert not list(tmp_path.glob(f".{output.name}.*"))
+
+
+def test_output_parent_retarget_uses_stable_directory(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    source = tmp_path / "src"
+    source.mkdir()
+    (source / "ordinary.conf").write_text("ordinary\n", encoding="utf-8")
+    first = tmp_path / "first"
+    second = tmp_path / "second"
+    first.mkdir()
+    second.mkdir()
+    output_link = tmp_path / "output"
+    output_link.symlink_to(first, target_is_directory=True)
+    (first / "archive.tar.gz").write_bytes(b"old archive")
+    (second / "archive.tar.gz").write_bytes(b"other archive")
+    module = _builder_module()
+    real_replace = module.os.replace
+
+    def retargeting_replace(src: object, dst: object) -> None:
+        output_link.unlink()
+        output_link.symlink_to(second, target_is_directory=True)
+        real_replace(src, dst)
+
+    monkeypatch.setattr(module.os, "replace", retargeting_replace)
+    module.build_archive(source, output_link / "archive.tar.gz", SOURCE_EPOCH)
+
+    with tarfile.open(first / "archive.tar.gz", "r:gz") as archive:
+        assert [member.name for member in archive.getmembers()] == ["src", "src/ordinary.conf"]
+    assert (second / "archive.tar.gz").read_bytes() == b"other archive"
+    assert not list(first.glob(".archive.tar.gz.*"))
+    assert not list(second.glob(".archive.tar.gz.*"))
 
 
 def _release_job() -> str:

--- a/tests/test_reproducible_source_archive.py
+++ b/tests/test_reproducible_source_archive.py
@@ -11,6 +11,8 @@ import sys
 import tarfile
 from pathlib import Path
 
+import pytest
+
 ROOT = Path(__file__).resolve().parents[1]
 BUILDER = ROOT / "scripts" / "build-source-archive.py"
 WORKFLOW = ROOT / ".github" / "workflows" / "release.yml"
@@ -134,16 +136,45 @@ def test_source_change_changes_hash_and_member_content(tmp_path: Path) -> None:
         assert [member.name for member in archive.getmembers()] == EXPECTED_MEMBERS
 
 
-def test_release_workflow_pins_and_uses_the_source_archive_builder() -> None:
+def _release_job() -> str:
     workflow = WORKFLOW.read_text(encoding="utf-8")
-    release_job = workflow.split("  release:", 1)[1].split("\n  # ── 2b", 1)[0]
+    return workflow.split("  release:", 1)[1].split("\n  # ── 2b", 1)[0]
+
+
+def _assert_archive_tool_pin_precedes_build(release_job: str) -> None:
+    pin_name = "      - name: Pin source archive Python"
+    archive_name = "      - name: Build source archive"
+    pin_start = release_job.index(pin_name)
+    archive_start = release_job.index(archive_name)
+    pin_step = release_job[pin_start:].split("\n      - name:", 1)[0]
+
+    assert "uses: actions/setup-python@v6" in pin_step
+    assert 'python-version: "3.11.15"' in pin_step
+    assert pin_start < archive_start, "the exact source-archive Python pin must precede the archive build"
+
+
+def test_release_workflow_pins_and_uses_the_source_archive_builder() -> None:
+    release_job = _release_job()
     archive_step = release_job.split("      - name: Build source archive", 1)[1].split("\n      - name:", 1)[0]
 
     assert "runs-on: ubuntu-24.04" in release_job
-    assert "uses: actions/setup-python@v6" in release_job
-    assert 'python-version: "3.11.15"' in release_job
+    _assert_archive_tool_pin_precedes_build(release_job)
     assert "set -eu" in archive_step
     assert 'SOURCE_EPOCH="$(git show -s --format=%ct HEAD)"' in archive_step
     assert 'python3 "${GITHUB_WORKSPACE}/pfblockerng-src/scripts/build-source-archive.py"' in archive_step
     assert '--source src --output "$ARCHIVE" --epoch "$SOURCE_EPOCH"' in archive_step
     assert "tar -czf" not in archive_step
+
+
+def test_moving_archive_python_pin_after_build_goes_red() -> None:
+    release_job = _release_job()
+    pin_start = release_job.index("      - name: Pin source archive Python")
+    pin_end = release_job.index("\n      - name:", pin_start + 1)
+    pin_step = release_job[pin_start:pin_end]
+    without_pin = release_job[:pin_start] + release_job[pin_end:]
+    archive_start = without_pin.index("      - name: Build source archive")
+    archive_end = without_pin.index("\n      - name:", archive_start + 1)
+    moved = without_pin[:archive_end] + "\n" + pin_step + without_pin[archive_end:]
+
+    with pytest.raises(AssertionError, match="must precede"):
+        _assert_archive_tool_pin_precedes_build(moved)

--- a/tests/test_reproducible_source_archive.py
+++ b/tests/test_reproducible_source_archive.py
@@ -14,6 +14,7 @@ import tarfile
 import tempfile
 from pathlib import Path
 from types import ModuleType
+from typing import Any
 
 import pytest
 
@@ -340,10 +341,16 @@ def test_output_parent_retarget_uses_stable_directory(tmp_path: Path, monkeypatc
     module = _builder_module()
     real_replace = module.os.replace
 
-    def retargeting_replace(src: object, dst: object) -> None:
+    def retargeting_replace(
+        src: object,
+        dst: object,
+        *,
+        src_dir_fd: int | None = None,
+        dst_dir_fd: int | None = None,
+    ) -> None:
         output_link.unlink()
         output_link.symlink_to(second, target_is_directory=True)
-        real_replace(src, dst)
+        real_replace(src, dst, src_dir_fd=src_dir_fd, dst_dir_fd=dst_dir_fd)
 
     monkeypatch.setattr(module.os, "replace", retargeting_replace)
     module.build_archive(source, output_link / "archive.tar.gz", SOURCE_EPOCH)
@@ -353,6 +360,42 @@ def test_output_parent_retarget_uses_stable_directory(tmp_path: Path, monkeypatc
     assert (second / "archive.tar.gz").read_bytes() == b"other archive"
     assert not list(first.glob(".archive.tar.gz.*"))
     assert not list(second.glob(".archive.tar.gz.*"))
+
+
+def test_resolved_output_directory_replacement_uses_opened_identity(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source = tmp_path / "src"
+    source.mkdir()
+    (source / "ordinary.conf").write_text("ordinary\n", encoding="utf-8")
+    output_parent = tmp_path / "output"
+    replacement = tmp_path / "replacement"
+    moved = tmp_path / "moved-output"
+    output_parent.mkdir()
+    replacement.mkdir()
+    (output_parent / "archive.tar.gz").write_bytes(b"old archive")
+    (replacement / "archive.tar.gz").write_bytes(b"other archive")
+    module = _builder_module()
+    real_gzip = module.gzip.GzipFile
+    retargeted = False
+
+    def retargeting_gzip(*args: Any, **kwargs: Any) -> Any:
+        nonlocal retargeted
+        if not retargeted:
+            output_parent.rename(moved)
+            output_parent.symlink_to(replacement, target_is_directory=True)
+            retargeted = True
+        return real_gzip(*args, **kwargs)
+
+    monkeypatch.setattr(module.gzip, "GzipFile", retargeting_gzip)
+    module.build_archive(source, output_parent / "archive.tar.gz", SOURCE_EPOCH)
+
+    assert retargeted
+    with tarfile.open(moved / "archive.tar.gz", "r:gz") as archive:
+        assert [member.name for member in archive.getmembers()] == ["src", "src/ordinary.conf"]
+    assert (replacement / "archive.tar.gz").read_bytes() == b"other archive"
+    assert not list(moved.glob(".archive.tar.gz.*"))
+    assert not list(replacement.glob(".archive.tar.gz.*"))
 
 
 def _release_job() -> str:

--- a/tests/test_reproducible_source_archive.py
+++ b/tests/test_reproducible_source_archive.py
@@ -1,0 +1,149 @@
+"""Issue #2717: release source archives are reproducible across host metadata."""
+
+from __future__ import annotations
+
+import gzip
+import hashlib
+import os
+import shutil
+import subprocess
+import sys
+import tarfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+BUILDER = ROOT / "scripts" / "build-source-archive.py"
+WORKFLOW = ROOT / ".github" / "workflows" / "release.yml"
+SOURCE_EPOCH = 1_700_000_000
+SAFE_MEMBER = "src/usr/local/pkg/config file [test];$HOME.inc"
+EXEC_MEMBER = "src/usr/local/bin/run [safe];$(touch escaped).sh"
+EXPECTED_MEMBERS = [
+    "src",
+    "src/etc",
+    "src/etc/ordinary.conf",
+    "src/usr",
+    "src/usr/local",
+    "src/usr/local/bin",
+    EXEC_MEMBER,
+    "src/usr/local/pkg",
+    SAFE_MEMBER,
+]
+
+
+def _source_tree(parent: Path, *, mtime: int, ordinary_mode: int, executable_mode: int) -> Path:
+    source = parent / "source tree [fixture];$VAR" / "src"
+    ordinary = source / "etc" / "ordinary.conf"
+    safe = source / SAFE_MEMBER.removeprefix("src/")
+    executable = source / EXEC_MEMBER.removeprefix("src/")
+    for path, contents in (
+        (ordinary, b"ordinary\n"),
+        (safe, b"metacharacters stay data\n"),
+        (executable, b"#!/bin/sh\nexit 0\n"),
+        (source / "ignored.pyc", b"bytecode"),
+        (source / "__pycache__" / "ignored.cpython-311.pyc", b"cache"),
+        (source / "._Finder", b"AppleDouble"),
+        (source / ".DS_Store", b"Finder metadata"),
+    ):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(contents)
+    ordinary.chmod(ordinary_mode)
+    safe.chmod(ordinary_mode)
+    executable.chmod(executable_mode)
+
+    xattr = shutil.which("xattr")
+    if xattr:
+        subprocess.run(
+            [xattr, "-w", "com.apple.issue2717", "host-only", str(ordinary)],
+            check=True,
+            capture_output=True,
+        )
+
+    for path in sorted(source.rglob("*"), reverse=True):
+        os.utime(path, (mtime, mtime), follow_symlinks=False)
+    os.utime(source, (mtime, mtime), follow_symlinks=False)
+    return source
+
+
+def _build(source: Path, output: Path) -> bytes:
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(BUILDER),
+            "--source",
+            str(source),
+            "--output",
+            str(output),
+            "--epoch",
+            str(SOURCE_EPOCH),
+        ],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    return output.read_bytes()
+
+
+def test_fresh_trees_produce_identical_normalized_archives(tmp_path: Path) -> None:
+    first_source = _source_tree(tmp_path / "first", mtime=1_600_000_000, ordinary_mode=0o600, executable_mode=0o700)
+    second_source = _source_tree(tmp_path / "second", mtime=1_800_000_000, ordinary_mode=0o666, executable_mode=0o777)
+
+    first = _build(first_source, tmp_path / "first output [x];$VAR.tar.gz")
+    second = _build(second_source, tmp_path / "second output [x];$VAR.tar.gz")
+
+    assert hashlib.sha256(first).digest() == hashlib.sha256(second).digest()
+    assert first[:4] == b"\x1f\x8b\x08\x00"
+    assert int.from_bytes(first[4:8], "little") == SOURCE_EPOCH
+    assert first[8:10] == b"\x02\xff"
+
+    tar_bytes = gzip.decompress(first)
+    assert tar_bytes[257:265] == b"ustar\x0000"
+    assert b"LIBARCHIVE.xattr" not in tar_bytes
+    assert b"SCHILY.xattr" not in tar_bytes
+    with tarfile.open(tmp_path / "first output [x];$VAR.tar.gz", "r:gz") as archive:
+        members = archive.getmembers()
+        assert [member.name for member in members] == EXPECTED_MEMBERS
+        assert all(member.mtime == SOURCE_EPOCH for member in members)
+        assert all((member.uid, member.gid, member.uname, member.gname) == (0, 0, "root", "root") for member in members)
+        assert all(not member.pax_headers for member in members)
+        assert all(member.mode == 0o755 for member in members if member.isdir() or member.name == EXEC_MEMBER)
+        assert all(member.mode == 0o644 for member in members if member.isfile() and member.name != EXEC_MEMBER)
+        safe_member = archive.extractfile(SAFE_MEMBER)
+        assert safe_member is not None
+        assert safe_member.read() == b"metacharacters stay data\n"
+    assert not (first_source.parent / "escaped").exists()
+
+
+def test_source_change_changes_hash_and_member_content(tmp_path: Path) -> None:
+    source = _source_tree(tmp_path, mtime=1_600_000_000, ordinary_mode=0o644, executable_mode=0o755)
+    first_path = tmp_path / "before.tar.gz"
+    second_path = tmp_path / "after.tar.gz"
+    first = _build(source, first_path)
+
+    changed = source / "etc" / "ordinary.conf"
+    changed.write_bytes(b"changed source\n")
+    os.utime(changed, (1_900_000_000, 1_900_000_000))
+    second = _build(source, second_path)
+
+    assert hashlib.sha256(first).digest() != hashlib.sha256(second).digest()
+    with tarfile.open(second_path, "r:gz") as archive:
+        changed_member = archive.extractfile("src/etc/ordinary.conf")
+        assert changed_member is not None
+        assert changed_member.read() == b"changed source\n"
+        assert [member.name for member in archive.getmembers()] == EXPECTED_MEMBERS
+
+
+def test_release_workflow_pins_and_uses_the_source_archive_builder() -> None:
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+    release_job = workflow.split("  release:", 1)[1].split("\n  # ── 2b", 1)[0]
+    archive_step = release_job.split("      - name: Build source archive", 1)[1].split("\n      - name:", 1)[0]
+
+    assert "runs-on: ubuntu-24.04" in release_job
+    assert "uses: actions/setup-python@v6" in release_job
+    assert 'python-version: "3.11.15"' in release_job
+    assert "set -eu" in archive_step
+    assert 'SOURCE_EPOCH="$(git show -s --format=%ct HEAD)"' in archive_step
+    assert 'python3 "${GITHUB_WORKSPACE}/pfblockerng-src/scripts/build-source-archive.py"' in archive_step
+    assert '--source src --output "$ARCHIVE" --epoch "$SOURCE_EPOCH"' in archive_step
+    assert "tar -czf" not in archive_step

--- a/tests/test_reproducible_source_archive.py
+++ b/tests/test_reproducible_source_archive.py
@@ -193,8 +193,9 @@ def test_case_alias_output_inside_source_is_rejected(tmp_path: Path) -> None:
     source.mkdir()
     (source / "ordinary.conf").write_text("ordinary\n", encoding="utf-8")
     alias = tmp_path / "source"
-    if not alias.is_dir() or not os.path.samefile(source, alias):
-        pytest.skip("scratch filesystem is case-sensitive")
+    if not alias.is_dir():
+        alias.symlink_to(source, target_is_directory=True)
+    assert os.path.samefile(source, alias)
     output = alias / "existing.tar.gz"
     output.write_bytes(b"existing archive")
 

--- a/tests/test_reproducible_source_archive.py
+++ b/tests/test_reproducible_source_archive.py
@@ -6,9 +6,11 @@ import gzip
 import hashlib
 import os
 import shutil
+import socket
 import subprocess
 import sys
 import tarfile
+import tempfile
 from pathlib import Path
 
 import pytest
@@ -43,6 +45,8 @@ def _source_tree(parent: Path, *, mtime: int, ordinary_mode: int, executable_mod
         (executable, b"#!/bin/sh\nexit 0\n"),
         (source / "ignored.pyc", b"bytecode"),
         (source / "__pycache__" / "ignored.cpython-311.pyc", b"cache"),
+        (source / ".pyc" / "hidden.conf", b"exact pyc component"),
+        (source / "cache.pyc" / "hidden.conf", b"pyc directory"),
         (source / "._Finder", b"AppleDouble"),
         (source / ".DS_Store", b"Finder metadata"),
     ):
@@ -66,8 +70,8 @@ def _source_tree(parent: Path, *, mtime: int, ordinary_mode: int, executable_mod
     return source
 
 
-def _build(source: Path, output: Path) -> bytes:
-    result = subprocess.run(
+def _run_builder(source: Path, output: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
         [
             sys.executable,
             str(BUILDER),
@@ -83,6 +87,10 @@ def _build(source: Path, output: Path) -> bytes:
         text=True,
         check=False,
     )
+
+
+def _build(source: Path, output: Path) -> bytes:
+    result = _run_builder(source, output)
     assert result.returncode == 0, result.stderr
     return output.read_bytes()
 
@@ -106,6 +114,10 @@ def test_fresh_trees_produce_identical_normalized_archives(tmp_path: Path) -> No
     with tarfile.open(tmp_path / "first output [x];$VAR.tar.gz", "r:gz") as archive:
         members = archive.getmembers()
         assert [member.name for member in members] == EXPECTED_MEMBERS
+        assert all(
+            not any(part.endswith(".pyc") or part == "__pycache__" for part in Path(member.name).parts)
+            for member in members
+        )
         assert all(member.mtime == SOURCE_EPOCH for member in members)
         assert all((member.uid, member.gid, member.uname, member.gname) == (0, 0, "root", "root") for member in members)
         assert all(not member.pax_headers for member in members)
@@ -134,6 +146,89 @@ def test_source_change_changes_hash_and_member_content(tmp_path: Path) -> None:
         assert changed_member is not None
         assert changed_member.read() == b"changed source\n"
         assert [member.name for member in archive.getmembers()] == EXPECTED_MEMBERS
+
+
+def test_source_root_symlink_is_rejected(tmp_path: Path) -> None:
+    outside = tmp_path / "outside-host-directory"
+    outside.mkdir()
+    (outside / "host-only.conf").write_text("host bytes\n", encoding="utf-8")
+    source_link = tmp_path / "src"
+    source_link.symlink_to(outside, target_is_directory=True)
+    output = tmp_path / "archive.tar.gz"
+
+    result = _run_builder(source_link, output)
+
+    assert result.returncode != 0
+    assert "source must be a real directory (not a symlink)" in result.stderr
+    assert not output.exists()
+
+
+def test_output_inside_source_is_rejected_without_clobbering_it(tmp_path: Path) -> None:
+    source = _source_tree(tmp_path, mtime=1_600_000_000, ordinary_mode=0o644, executable_mode=0o755)
+    output = source / "existing.tar.gz"
+    output.write_bytes(b"existing archive")
+
+    result = _run_builder(source, output)
+
+    assert result.returncode != 0
+    assert "output must be outside the source directory" in result.stderr
+    assert output.read_bytes() == b"existing archive"
+
+
+def test_output_symlink_is_replaced_without_touching_its_target(tmp_path: Path) -> None:
+    source = tmp_path / "src"
+    source.mkdir()
+    (source / "ordinary.conf").write_text("ordinary\n", encoding="utf-8")
+    target = tmp_path / "outside-target"
+    target.write_bytes(b"outside bytes")
+    output = tmp_path / "archive.tar.gz"
+    output.symlink_to(target)
+
+    result = _run_builder(source, output)
+
+    assert result.returncode == 0, result.stderr
+    assert target.read_bytes() == b"outside bytes"
+    assert not output.is_symlink()
+    with tarfile.open(output, "r:gz") as archive:
+        assert [member.name for member in archive.getmembers()] == ["src", "src/ordinary.conf"]
+    assert not list(tmp_path.glob(f".{output.name}.*"))
+
+
+def test_unsupported_entry_failure_preserves_existing_output(tmp_path: Path) -> None:
+    source = tmp_path / "src"
+    source.mkdir()
+    (source / "ordinary.conf").write_text("ordinary\n", encoding="utf-8")
+    os.mkfifo(source / "z-special")
+    output = tmp_path / "existing.tar.gz"
+    output.write_bytes(b"existing archive")
+
+    result = _run_builder(source, output)
+
+    assert result.returncode != 0
+    assert "unsupported source entry" in result.stderr
+    assert output.read_bytes() == b"existing archive"
+    assert not list(tmp_path.glob(f".{output.name}.*"))
+
+
+def test_socket_failure_is_contextual_and_preserves_existing_output() -> None:
+    with tempfile.TemporaryDirectory(prefix="issue2717-", dir="/tmp") as directory:
+        root = Path(directory)
+        source = root / "src"
+        source.mkdir()
+        (source / "ordinary.conf").write_text("ordinary\n", encoding="utf-8")
+        socket_path = source / "z.socket"
+        output = root / "existing.tar.gz"
+        output.write_bytes(b"existing archive")
+
+        with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as unix_socket:
+            unix_socket.bind(str(socket_path))
+            result = _run_builder(source, output)
+
+        assert result.returncode != 0
+        assert f"unsupported source entry: {socket_path}" in result.stderr
+        assert "AttributeError" not in result.stderr
+        assert output.read_bytes() == b"existing archive"
+        assert not list(root.glob(f".{output.name}.*"))
 
 
 def _release_job() -> str:


### PR DESCRIPTION
## Summary

- replace host `tar -czf` with a stdlib USTAR + gzip source-archive builder
- derive every archive timestamp from the pinned source commit and normalize entry order, modes, ownership, names, and metadata
- pin the release archive producer to `ubuntu-24.04` and Python `3.11.15`
- anchor source traversal to no-follow directory/file descriptors and publish only a complete sibling-temp archive via atomic replace

Fixes #2717

## Competing hypotheses and probes

| Hypothesis | Probe | Result |
| --- | --- | --- |
| gzip wall-clock metadata alone changes repeated output | Ran the untouched workflow command twice, two seconds apart; compared headers and decompressed payloads | SHA-256 changed, first difference was byte 5, gzip headers differed at MTIME, and decompressed tar payloads were identical: **confirmed** |
| host tar semantics also change the payload | Inspected the untouched macOS/bsdtar archive's members and PAX headers | 222 members instead of the intended 111, including `._src`/AppleDouble entries and `LIBARCHIVE.xattr.com.apple.provenance`: **confirmed** |

## Correctness and review probes

| Finding / mutant | Untouched behavior | Fixed contract |
| --- | --- | --- |
| `.pyc/child` and `cache.pyc/child` | Leaked three members because only the leaf suffix was checked | Exclude when any relative component ends `.pyc` or equals `__pycache__` |
| root source symlink / output inside source | Outside state followed or output archived itself | Reject root symlink and source-descendant output by filesystem identity |
| case-folded `Source` / `source` aliases on Darwin | Same physical directory bypassed spelling-based containment | Walk output ancestors with `os.path.samefile` |
| file/directory swapped to symlink after stat | Outside `SECRET` bytes archived under regular headers | Descriptor-relative `O_NOFOLLOW`, same-descriptor metadata/content, before/after identity checks |
| output-parent symlink retarget | Replace failed and leaked the complete temp in the old directory | Resolve one stable output directory for temp, replace, and cleanup |
| output symlink / FIFO / Unix socket | Target or prior output clobbered; socket escaped as `AttributeError` | Atomic replace of link itself; contextual `ArchiveError`; prior bytes and temp cleanup preserved |
| 101-byte USTAR name/link target | Uncaught `ValueError`; `PAX_FORMAT` mutant survived | Contextual USTAR rejection; long-name/link fixtures make PAX mutant RED |
| same-length executable payload corruption | All 9 focused tests passed | Exact executable payload assertion makes mutant RED |
| moved Python pin step | Broad presence assertions passed | Exact setup-python 3.11.15 step must precede archive creation |

## Frozen implementation and evidence

| Field | Frozen value |
| --- | --- |
| Base | `e9f1eb813dfe7fb708baf5029e6afe90fbddd23e` (`origin/devel`, includes #2716) |
| Head | `4f9fb376839e35e0495a265e77bbd4b54184f95a` |
| Tree | `b69af655d65237eb43c3a937624e95bbf426000b` |
| Live-base rebase proof | All 7 patches were `=` by `git range-diff`; all commits Andre/Andre, good-signed, no Claude trailer |
| Source epoch used for repeat proof | `1787774590` (`git show -s --format=%ct HEAD`) |
| Release producer | `ubuntu-24.04`, `actions/setup-python@v6`, Python `3.11.15` |
| Tar contract | Python stdlib `tarfile.USTAR_FORMAT`; sorted `src/` entries; directories `0755`; executable files `0755`; other files `0644`; uid/gid `0`; uname/gname `root`; all mtimes = source epoch |
| Gzip contract | Python stdlib `gzip.GzipFile`; level 9; empty filename; source epoch MTIME; fixed `1f8b0800…02ff` header shape |
| Source/output contract | Descriptor-relative no-follow traversal; source identity checked before/after; output directory identity held by descriptor; secure descriptor-relative exclusive temp; full close then descriptor-relative atomic `os.replace` and cleanup |
| Combined workflow | #2716 dependency-builder/toolchain/handoff inputs and #2717 archive producer are both present |
| Production member proof | 111 normalized `src/` entries; zero `*.pyc`, `__pycache__`, AppleDouble, PAX, or xattr headers |
| Repeat SHA-256 | `cbf94d45a80e92bc80bf2811b6a6f6bcb23e03759e70e825b1b6863dbcdddbb0` both times; byte-identical |
| Changed-source SHA-256 | `5927a7af7bf872b35c72642faff61b0cc8bd8392d3a9b1fe76f7339284ab8dcd`; changed member content present, member set unchanged |
| Original pre-correctness frozen evidence | Blob `9cbf4a5f6f06c17da75ef8d756255f09ca6b503c`; `7 failed, 2 passed in 0.60s` against the pre-correctness helper |
| Canonical local gates | Post-rebase `GATES: PASS` against `origin/devel` after `4f9fb376` |

## Focused verification

| Frozen RED test | `git hash-object` | RED run tail |
| --- | --- | --- |
| `tests/test_reproducible_source_archive.py` | `5d25755723c703fc399a81d45eb98e42e57c22be` | `output-directory mutant: 1 failed, 15 passed; exec mutant: 1 failed, 15 passed; PAX mutant: 2 failed, 14 passed` |

```text
REVIEW-FIX RED against pre-fix helper:
6 failed, 9 passed in 0.61s

OUTPUT-DIRECTORY RETARGET RED (frozen final tests):
1 failed, 15 passed in 0.44s

EXECUTABLE-PAYLOAD MUTANT RED (frozen final tests):
1 failed, 15 passed in 0.43s

PAX-FORMAT MUTANT RED (frozen final tests):
2 failed, 14 passed in 0.43s

GREEN: uv run pytest tests/test_reproducible_source_archive.py -q
16 passed in 0.58s; skip-allowlist checker passed

CANONICAL: scripts/agent/run-gates.sh --diff origin/devel
GATES: PASS
```

Round one and independent re-reviews resolved every contract, correctness, test-honesty, and complexity finding. CodeRabbit's single merge-ready review found one resolved-output-directory substitution window; its fix is frozen RED/GREEN, the inline thread is replied/resolved, no second request was made, and final affected reviews are **CLEAN**. The final live-base rebase onto `e9f1eb81` is 7/7 patch-identical; post-rebase local gates and exact rebased-head required CI are **PASS**.

## Scope

Only `.github/workflows/release.yml`, `scripts/build-source-archive.py`, and `tests/test_reproducible_source_archive.py` change. Dependency builders, toolchains, handoff logic, tags, Releases, package assets, catalogues, Pages, and GHCR are untouched.

🤖 Generated by Oh My Pi and posted on behalf of @andrebrait.
