### PR TITLE
www: say what Flex feed-state actually disables

### DIFF
--- a/src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
@@ -1333,7 +1333,7 @@ $infotxt .= '	</dd>
 				<dt>On:</dt><dd>Enable List</dd>
 				<dt>Off:</dt><dd>Disable List</dd>
 				<dt>Hold:</dt><dd>Download List only once</dd>
-				<dt>Flex:</dt><dd>Downgrade the SSL Connection (Not Recommended)</dd>
+				<dt>Flex:</dt><dd>After a TLS failure, retry this feed with certificate verification disabled and a widened cipher list (Not Recommended). Only for feeds whose server has a broken certificate chain — the feed\'s contents are then unauthenticated.</dd>
 			</dl>
 		</dd>
 	<dt>Source:</dt>

--- a/tests/php/CategoryEditFlexHelpTextTest.php
+++ b/tests/php/CategoryEditFlexHelpTextTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Issue #2661 -- the Flex feed-state guideline must say what the retry disables.
+ *
+ * Flex is an operator-chosen per-feed exception: after cURL errors 35, 51 or 60
+ * the download retry turns certificate verification off and widens the cipher
+ * list to SSLv3. The category-edit Guidelines infoblock is the only user-facing
+ * description of that state. The page cannot be required off-appliance, so the
+ * executable help string is pinned from comment-free PHP.
+ */
+final class CategoryEditFlexHelpTextTest extends TestCase
+{
+	private static string $source;
+
+	public static function setUpBeforeClass(): void
+	{
+		self::$source = php_strip_whitespace(
+			dirname(__DIR__, 2) . '/src/usr/local/www/pfblockerng/pfblockerng_category_edit.php'
+		);
+		if (self::$source === '') {
+			throw new RuntimeException('test bootstrap: failed to read comment-free pfblockerng_category_edit.php');
+		}
+	}
+
+	public function testFlexHelpStatesCertificateVerificationIsDisabled(): void
+	{
+		$help = self::flexGuidelineHelp();
+
+		$this->assertStringContainsString(
+			'certificate verification disabled',
+			$help,
+			'Flex help must say certificate verification is turned off for that feed'
+		);
+		$this->assertStringContainsString(
+			'widened cipher list',
+			$help,
+			'Flex help must say the cipher list is widened on the retry'
+		);
+		$this->assertStringContainsString(
+			'Not Recommended',
+			$help,
+			'Flex help must keep the Not Recommended framing'
+		);
+		$this->assertStringContainsString(
+			'unauthenticated',
+			$help,
+			'Flex help must say the feed contents are then unauthenticated'
+		);
+		$this->assertStringNotContainsString(
+			'Downgrade the SSL Connection',
+			$help,
+			'Flex help must not hide the retry behind unspecific downgrade wording'
+		);
+	}
+
+	private static function flexGuidelineHelp(): string
+	{
+		if (preg_match('#<dt>Flex:</dt><dd>.*?</dd>#s', self::$source, $match) !== 1) {
+			self::fail('category-edit Guidelines infoblock is missing a Flex definition');
+		}
+		return $match[0];
+	}
+}

--- a/tests/php/CategoryEditFlexHelpTextTest.php
+++ b/tests/php/CategoryEditFlexHelpTextTest.php
@@ -15,21 +15,18 @@ use PHPUnit\Framework\TestCase;
  */
 final class CategoryEditFlexHelpTextTest extends TestCase
 {
-	private static string $source;
-
-	public static function setUpBeforeClass(): void
-	{
-		self::$source = php_strip_whitespace(
-			dirname(__DIR__, 2) . '/src/usr/local/www/pfblockerng/pfblockerng_category_edit.php'
-		);
-		if (self::$source === '') {
-			throw new RuntimeException('test bootstrap: failed to read comment-free pfblockerng_category_edit.php');
-		}
-	}
-
 	public function testFlexHelpStatesCertificateVerificationIsDisabled(): void
 	{
-		$help = self::flexGuidelineHelp();
+		$source = php_strip_whitespace(
+			dirname(__DIR__, 2) . '/src/usr/local/www/pfblockerng/pfblockerng_category_edit.php'
+		);
+		if ($source === '') {
+			throw new RuntimeException('test bootstrap: failed to read comment-free pfblockerng_category_edit.php');
+		}
+		if (preg_match('#<dt>Flex:</dt><dd>.*?</dd>#s', $source, $match) !== 1) {
+			self::fail('category-edit Guidelines infoblock is missing a Flex definition');
+		}
+		$help = $match[0];
 
 		$this->assertStringContainsString(
 			'certificate verification disabled',
@@ -56,13 +53,5 @@ final class CategoryEditFlexHelpTextTest extends TestCase
 			$help,
 			'Flex help must not hide the retry behind unspecific downgrade wording'
 		);
-	}
-
-	private static function flexGuidelineHelp(): string
-	{
-		if (preg_match('#<dt>Flex:</dt><dd>.*?</dd>#s', self::$source, $match) !== 1) {
-			self::fail('category-edit Guidelines infoblock is missing a Flex definition');
-		}
-		return $match[0];
 	}
 }

--- a/tests/smoke/ui/test_render_smoke.py
+++ b/tests/smoke/ui/test_render_smoke.py
@@ -2026,7 +2026,47 @@ def test_category_page_renders_reorder_wiring(
 # its PRESENCE needs one seeded no-sort row (dual-marked ui_e2e, like the
 # maxmind_key never-leak test above -- it mutates config.xml as setup).
 _CATEGORY_EDIT_IPV4_PAGE = "/pfblockerng/pfblockerng_category_edit.php?type=ipv4"
+_CATEGORY_EDIT_IPV6_PAGE = "/pfblockerng/pfblockerng_category_edit.php?type=ipv6"
 _CATEGORY_EDIT_DNSBL_PAGE = "/pfblockerng/pfblockerng_category_edit.php?type=dnsbl"
+
+
+@pytest.mark.parametrize(
+    "path",
+    (
+        pytest.param(_CATEGORY_EDIT_IPV4_PAGE, id="ipv4"),
+        pytest.param(_CATEGORY_EDIT_IPV6_PAGE, id="ipv6"),
+        pytest.param(_CATEGORY_EDIT_DNSBL_PAGE, id="dnsbl"),
+    ),
+)
+def test_category_edit_flex_help_states_certificate_verification_disabled(
+    path: str, webui: WebUI, php_error_log_guard: PhpErrorLogGuard
+) -> None:  # noqa: ARG001
+    """issue #2661: Flex help names what the TLS retry actually disables.
+
+    Given a category-edit Feeds page (IPv4, IPv6, or DNSBL — the State guideline
+    is shared across all three),
+    When GET,
+    Then the Guidelines infoblock says Flex retries with certificate verification
+    disabled, and the old 'Downgrade the SSL Connection' wording is gone.
+
+    Fail-before / pass-after: the new phrases are absent and the old sentence is
+    present on devel; the production edit inverts both.
+    """
+    resp = webui.get(path)
+    body = resp.text
+    result = evaluate_render(path, resp.status_code, body, ("Advanced Tuneables",))
+    assert result.ok, f"{path}: category-edit render oracle failed: {result.detail}"
+    assert "certificate verification disabled" in body, (
+        f"{path} is missing Flex help that certificate verification is disabled (issue #2661)"
+    )
+    assert "widened cipher list" in body, f"{path} is missing Flex help that the cipher list is widened (issue #2661)"
+    assert "Not Recommended" in body, f"{path} dropped the Flex 'Not Recommended' framing (issue #2661)"
+    assert "unauthenticated" in body, (
+        f"{path} is missing Flex help that the feed contents are then unauthenticated (issue #2661)"
+    )
+    assert "Downgrade the SSL Connection" not in body, (
+        f"{path} still uses the unspecific Flex 'Downgrade the SSL Connection' wording (issue #2661)"
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fixes #2661

Documentation only (help text). The category-edit Guidelines infoblock described Flex as "Downgrade the SSL Connection". After cURL errors 35, 51 or 60 the download retry turns certificate verification off and widens the cipher list to SSLv3; the help now says that, keeps **Not Recommended**, and notes the feed contents are then unauthenticated.

The Flex guideline is shared across IPv4, IPv6, and DNSBL category-edit pages. No other user-facing Flex description exists under `src/`. No download-path behaviour change.

#2726 (artifact v7 pin) is now on `devel`. This PR's unique commits are help-text + the inlined PHPUnit pin.

Round-1 follow-ups: PHPUnit pin inlined to the house `php_strip_whitespace` form; `ui-tests` label so Tier A can execute.

## Verification

- `scripts/agent/run-gates.sh --diff origin/devel` (content commit): coverage pairing, pytest, Ruff, mypy, php -l, PHPStan, PHPCS PASS. Local full PHPUnit on this PHP 8.5 host is not authoritative; Linux CI is.
- Focused: `vendor/bin/phpunit tests/php/CategoryEditFlexHelpTextTest.php` → `OK (1 test, 5 assertions)`
- CI Tests on `fdd19c9b`: success. Head is now `20e779db` on `devel` (after #2726 landed).
- Tier A executed on the stacked head `da687908` (run 32998503410): `test_category_edit_flex_help_states_certificate_verification_disabled` PASSED for ipv4, ipv6, and dnsbl on live VMs.

Frozen-RED supersession (round-2 test-honesty): the original RED blob was `141d048c632877f549ffa2d6bf56db9214e4c28e`. The inlined house form that ships is `8130ce60581c5a7947e4840a4bd878ed2c18de91`. Round-2 re-ran the five mutations against the shipping blob; all five still die.

| Frozen RED test | git hash-object | RED run tail |
| --- | --- | --- |
| `tests/php/CategoryEditFlexHelpTextTest.php` | 8130ce60581c5a7947e4840a4bd878ed2c18de91 | Flex help must say certificate verification is turned off for that feed / Failed asserting that '...Downgrade the SSL Connection...' contains "certificate verification disabled" (shipping blob after house-form inline; original RED `141d048c`) |
| `tests/smoke/ui/test_render_smoke.py` | 2ebf42c8cf63ba40bef68a9132ab2d90b68b1b23 | new `test_category_edit_flex_help_states_certificate_verification_disabled` absent on devel |

🤖 Generated by Grok and posted on behalf of @BBcan177.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Flex mode guidance to clearly explain TLS-failure retries, including disabled certificate verification and a widened cipher list.
  * Clarified that this behavior has limited applicability, may expose unauthenticated feed contents, and is **Not Recommended**.
* **Tests**
  * Added coverage to verify the updated guidance renders consistently across IPv4, IPv6, and DNSBL category-edit pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->