### PR TITLE
agent: add cross-platform tool bootstrap

### DIFF
--- a/.agents/context/repository-intelligence.md
+++ b/.agents/context/repository-intelligence.md
@@ -3,6 +3,11 @@
 Scope: cross-client repository discovery, exact code semantics, and persistent graphs.
 Load when: every agent session, from `AGENTS.md`.
 
+- Bootstrap or refresh a macOS/Debian agent host with
+  `sh scripts/agent/setup-agent-tools.sh <checkout>`. It installs or updates uv,
+  Serena, CodeGraph, Graphify, and Worktrunk; configures only detected clients;
+  disables Serena's web dashboard; and keeps Worktrunk worktrees outside the
+  repository root.
 - Initialize a checkout with `sh scripts/agent/init-worktree-tools.sh .`.
   `work-branch.sh --worktree` runs the same initializer after creating a worktree and
   removes the new worktree and branch if initialization fails; it uses Git directly
@@ -10,8 +15,10 @@ Load when: every agent session, from `AGENTS.md`.
   `.config/wt.toml` runs the initializer as its `pre-start` hook and prunes worktree metadata after
   Worktrunk merge and remove operations.
 - CodeGraph and Graphify are mandatory. The initializer runs
-  `scripts/agent/ensure-codegraph.sh` for the exact-root CodeGraph index first, then
-  `graphify update <root>`. Install Graphify with `uv tool install graphifyy==0.9.50`.
+  `scripts/agent/ensure-codegraph.sh` for the exact-root CodeGraph index first,
+  then runs `graphify extract <root> --code-only` when the root graph is absent
+  or `graphify update <root>` when it exists. Install Graphify with
+  `uv tool install graphifyy==0.9.50`.
 - Every worktree owns its ignored and untracked `graphify-out/` graph. Refresh it
   directly with `graphify update <root>`; there is no shared repository graph.
 - For indexed code discovery, understanding, cross-file architecture, call paths,

--- a/scripts/agent/init-worktree-tools.sh
+++ b/scripts/agent/init-worktree-tools.sh
@@ -23,7 +23,11 @@ main() {
 	root=$(CDPATH='' cd "$root" && pwd -P) || exit 2
 
 	sh "$(dirname "$0")/ensure-codegraph.sh" "$root" || exit $?
-	graphify update "$root" || exit $?
+	if [ -f "$root/graphify-out/graph.json" ]; then
+		graphify update "$root" || exit $?
+	else
+		graphify extract "$root" --code-only || exit $?
+	fi
 
 	case "${OMP_CLI:-}${PI_CLI:-}" in
 		'') ;;

--- a/scripts/agent/setup-agent-tools.sh
+++ b/scripts/agent/setup-agent-tools.sh
@@ -1,0 +1,258 @@
+#!/bin/sh
+# Install, update, and activate the supported agent intelligence tools.
+# Usage: sh scripts/agent/setup-agent-tools.sh [REPOSITORY]
+# Supports macOS and Debian-family Linux; reruns update tools and detected client integrations.
+
+set -eu
+
+usage() {
+	echo "usage: setup-agent-tools.sh [REPOSITORY]" >&2
+	exit 2
+}
+
+fail() {
+	echo "setup-agent-tools.sh: $*" >&2
+	exit 1
+}
+
+install_from_url() {
+	installer_url=$1
+	installer_file=$(mktemp "${TMPDIR:-/tmp}/setup-agent-tools.XXXXXX") || return 1
+	if curl -LsSf "$installer_url" > "$installer_file" && sh "$installer_file"; then
+		installer_status=0
+	else
+		installer_status=$?
+	fi
+	rm -f "$installer_file"
+	return "$installer_status"
+}
+
+install_linux_prerequisites() {
+	require_tool dpkg-query
+	set --
+	for package in ca-certificates curl git; do
+		if ! dpkg-query -W -f='${Status}' "$package" 2>/dev/null |
+			grep -q 'install ok installed'; then
+			set -- "$@" "$package"
+		fi
+	done
+	[ "$#" -gt 0 ] || return 0
+
+	require_tool apt-get
+	if [ "$(id -u)" -eq 0 ]; then
+		apt-get update
+		apt-get install -y "$@"
+	else
+		require_tool sudo
+		sudo apt-get update
+		sudo apt-get install -y "$@"
+	fi
+}
+
+configure_worktrunk() {
+	worktrunk_dir=${XDG_CONFIG_HOME:-$HOME/.config}/worktrunk
+	worktrunk_config=$worktrunk_dir/config.toml
+	worktrunk_path='worktree-path = "{{ repo_path }}/../.{{ repo }}_worktrees/{{ branch | sanitize }}"'
+	mkdir -p "$worktrunk_dir"
+	[ -f "$worktrunk_config" ] || touch "$worktrunk_config"
+	worktrunk_trailing_newline=1
+	if [ -s "$worktrunk_config" ]; then
+		worktrunk_last_byte_lines=$(tail -c 1 "$worktrunk_config" | wc -l | tr -d '[:space:]')
+		[ "$worktrunk_last_byte_lines" -eq 1 ] || worktrunk_trailing_newline=0
+	fi
+	worktrunk_tmp=$(mktemp "$worktrunk_dir/config.toml.XXXXXX") || return 1
+	if ! awk \
+		-v managed="$worktrunk_path" \
+		-v trailing_newline="$worktrunk_trailing_newline" \
+		-v single_key="'worktree-path'" \
+		-v basic_multiline='"""' \
+		-v literal_multiline="'''" '
+		function emit(line) {
+			if (emitted) printf "\n"
+			printf "%s", line
+			emitted = 1
+		}
+		function is_managed_key(line, equals, key) {
+			equals = index(line, "=")
+			if (!equals) return 0
+			key = substr(line, 1, equals - 1)
+			sub(/^[[:space:]]+/, "", key)
+			sub(/[[:space:]]+$/, "", key)
+			return key == "worktree-path" ||
+				key == "\"worktree-path\"" ||
+				key == single_key
+		}
+		BEGIN { root = 1; found = 0; emitted = 0; unsafe = 0 }
+		root && $0 !~ /^[[:space:]]*#/ &&
+			(index($0, basic_multiline) || index($0, literal_multiline)) {
+			unsafe = 1
+		}
+		root && index($0, "=") {
+			array_value = substr($0, index($0, "=") + 1)
+			sub(/^[[:space:]]+/, "", array_value)
+			if (substr(array_value, 1, 1) == "[") {
+				unsafe = 1
+			}
+		}
+		root && /^[[:space:]]*\[/ {
+			if (!found) {
+				emit(managed)
+				found = 1
+			}
+			root = 0
+		}
+		root && is_managed_key($0) {
+			if (!found) {
+				emit(managed)
+				found = 1
+			}
+			next
+		}
+		{ emit($0) }
+		END {
+			if (unsafe) exit 1
+			if (root && !found) emit(managed)
+			if (trailing_newline) printf "\n"
+		}
+	' "$worktrunk_config" > "$worktrunk_tmp"; then
+		rm -f "$worktrunk_tmp"
+		return 1
+	fi
+	mv "$worktrunk_tmp" "$worktrunk_config"
+}
+
+disable_serena_dashboard() {
+	serena_config=$HOME/.serena/serena_config.yml
+	[ -f "$serena_config" ] || fail "Serena did not create '$serena_config'"
+	serena_tmp=$(mktemp "$HOME/.serena/serena_config.yml.XXXXXX") || exit 1
+	if ! awk -v single_key="'web_dashboard'" '
+		function is_dashboard_key(line, colon, key) {
+			colon = index(line, ":")
+			if (!colon) return 0
+			key = substr(line, 1, colon - 1)
+			sub(/[[:space:]]+$/, "", key)
+			return key == "web_dashboard" ||
+				key == "\"web_dashboard\"" ||
+				key == single_key
+		}
+		is_dashboard_key($0) {
+			root_keys++
+			print "web_dashboard: false"
+			next
+		}
+		{ print }
+		END { if (root_keys != 1) exit 1 }
+	' "$serena_config" > "$serena_tmp"; then
+		rm -f "$serena_tmp"
+		return 1
+	fi
+	mv "$serena_tmp" "$serena_config"
+}
+
+configure_agents() {
+	if command -v claude >/dev/null 2>&1; then
+		serena setup claude-code
+		(cd "$HOME" && graphify claude install)
+	fi
+	if command -v codex >/dev/null 2>&1; then
+		serena setup codex
+		(cd "$HOME" && graphify codex install)
+	fi
+	if command -v grok >/dev/null 2>&1; then
+		serena setup grok
+		(cd "$HOME" && graphify install --platform agents)
+		if ! grok mcp doctor codegraph --json >/dev/null 2>&1; then
+			grok mcp remove codegraph >/dev/null 2>&1 || true
+			grok mcp add codegraph -- codegraph serve --mcp
+		fi
+	fi
+	if command -v pi >/dev/null 2>&1; then
+		(cd "$HOME" && graphify pi install)
+	fi
+}
+
+main() {
+	[ "$#" -le 1 ] || usage
+
+	# shellcheck source=scripts/agent/agent_env.sh
+	. "$(dirname "$0")/agent_env.sh"
+	scrub_git_env "$0"
+	require_tool uname
+	platform=$(uname -s)
+	case "$platform" in
+		Linux) install_linux_prerequisites ;;
+		Darwin) require_tool brew ;;
+		*) fail "unsupported platform '$platform' (expected Linux or Darwin)" ;;
+	esac
+
+	require_tool curl
+	require_tool git
+	target=${1:-.}
+	root=$(git -C "$target" rev-parse --show-toplevel 2>/dev/null) ||
+		fail "'$target' is not a git worktree"
+	root=$(CDPATH='' cd "$root" && pwd -P) || exit 2
+	setup_hooks=$root/scripts/setup-hooks.sh
+	init_tools=$root/scripts/agent/init-worktree-tools.sh
+	[ -f "$setup_hooks" ] || fail "required repository helper '$setup_hooks' is missing"
+	[ -f "$init_tools" ] || fail "required repository helper '$init_tools' is missing"
+
+	if [ -n "${XDG_BIN_HOME:-}" ]; then
+		xdg_bin_home=$XDG_BIN_HOME
+	elif [ -n "${XDG_DATA_HOME:-}" ]; then
+		xdg_bin_home=$XDG_DATA_HOME/../bin
+	else
+		xdg_bin_home=$HOME/.local/bin
+	fi
+	uv_tool_bin=${UV_TOOL_BIN_DIR:-$xdg_bin_home}
+	codegraph_bin=${CODEGRAPH_BIN_DIR:-$HOME/.local/bin}
+	cargo_bin=${CARGO_HOME:-$HOME/.cargo}/bin
+	PATH="$uv_tool_bin:$codegraph_bin:$xdg_bin_home:$cargo_bin:$PATH"
+	export PATH
+
+	case "$platform" in
+		Linux)
+			if command -v uv >/dev/null 2>&1; then
+				uv self update
+			else
+				install_from_url 'https://astral.sh/uv/install.sh'
+			fi
+			;;
+		Darwin)
+			if brew list --versions uv >/dev/null 2>&1; then
+				brew upgrade uv
+			else
+				brew install uv
+			fi
+			brew_uv_bin=$(brew --prefix uv)/bin
+			PATH="$brew_uv_bin:$PATH"
+			export PATH
+			;;
+	esac
+	require_tool uv
+	uv tool install --upgrade -p 3.13 serena-agent
+	uv tool install --upgrade graphifyy==0.9.50
+	require_tool serena
+	require_tool graphify
+
+	if command -v codegraph >/dev/null 2>&1; then
+		codegraph upgrade
+	else
+		install_from_url 'https://raw.githubusercontent.com/colbymchenry/codegraph/main/install.sh'
+	fi
+	require_tool codegraph
+	codegraph install -l global -y -t auto
+
+	install_from_url 'https://github.com/max-sixty/worktrunk/releases/latest/download/worktrunk-installer.sh'
+	require_tool wt
+	wt config shell install --yes
+	configure_worktrunk
+
+	serena init
+	disable_serena_dashboard
+	configure_agents
+
+	(cd "$root" && sh "$setup_hooks")
+	sh "$init_tools" "$root"
+}
+
+main "$@"

--- a/scripts/agent/setup-agent-tools.sh
+++ b/scripts/agent/setup-agent-tools.sh
@@ -18,7 +18,8 @@ fail() {
 install_from_url() {
 	installer_url=$1
 	installer_file=$(mktemp "${TMPDIR:-/tmp}/setup-agent-tools.XXXXXX") || return 1
-	if curl -LsSf "$installer_url" > "$installer_file" && sh "$installer_file"; then
+	if curl --proto '=https' --proto-redir '=https' -LsSf "$installer_url" > "$installer_file" &&
+		sh "$installer_file"; then
 		installer_status=0
 	else
 		installer_status=$?

--- a/tests/shell/agent_codegraph_spec.sh
+++ b/tests/shell/agent_codegraph_spec.sh
@@ -106,8 +106,9 @@ esac
 CODEGRAPH
     cat > "$stubdir/graphify" <<'GRAPHIFY'
 #!/bin/sh
-[ "$#" -eq 2 ] && [ "$1" = update ] || exit 9
-exit 0
+[ "$#" -eq 3 ] && [ "$1" = extract ] && [ "$3" = --code-only ] || exit 9
+mkdir -p "$2/graphify-out"
+true > "$2/graphify-out/graph.json"
 GRAPHIFY
     cat > "$stubdir/serena" <<'SERENA'
 #!/bin/sh

--- a/tests/shell/agent_tools_setup_spec.sh
+++ b/tests/shell/agent_tools_setup_spec.sh
@@ -1,0 +1,784 @@
+#shellcheck shell=sh
+# Cross-platform agent-tool bootstrap: installers are stubbed; repository effects use real fixtures.
+
+Describe 'setup-agent-tools.sh'
+  project_root="${SHELLSPEC_PROJECT_ROOT:-$PWD}"
+  script_abs="$project_root/scripts/agent/setup-agent-tools.sh"
+  canonical_worktree_path='worktree-path = "{{ repo_path }}/../.{{ repo }}_worktrees/{{ branch | sanitize }}"'
+
+  make_base_path() {
+    destination=$1
+    mkdir -p "$destination"
+    for tool in awk basename cat chmod cmp cp cut dirname env git grep head id install ln mkdir mktemp mv pwd readlink rm sed sh sort tail tee touch tr uniq wc; do
+      tool_path=$(command -v "$tool" 2>/dev/null) || continue
+      ln -s "$tool_path" "$destination/$tool"
+    done
+  }
+
+  setup() {
+    . "$project_root/scripts/lib/git-env-scrub.sh"
+    pfb_scrub_git_env
+    fixture=$(mktemp -d "${TMPDIR:-/tmp}/agent_tools_setup.XXXXXX") || return 1
+    fixture=$(cd "$fixture" && pwd -P) || return 1
+    home="$fixture/home root"
+    repository="$fixture/repository root"
+    xdg_config="$home/config root"
+    mkdir -p "$home" "$repository/scripts/agent"
+    git_fixture init -q "$repository" &&
+      git_fixture -C "$repository" -c user.email=t@t -c user.name=t -c commit.gpgsign=false \
+        commit -q --allow-empty -m init || return 1
+    mkdir -p "$repository/.agents/policy"
+    agent_marker="$repository/AGENTS.md"
+    policy_marker="$repository/.agents/policy/invariants.txt"
+    cat > "$agent_marker" <<'AGENTS_MARKER'
+# repository agent marker
+Load only tracked repository policy.
+AGENTS_MARKER
+    cat > "$policy_marker" <<'POLICY_MARKER'
+# repository policy marker
+preserve = true
+POLICY_MARKER
+    cp "$agent_marker" "$fixture/AGENTS.md.before"
+    cp "$policy_marker" "$fixture/policy.before"
+
+    helper_log="$fixture/helpers.log"
+    cat > "$repository/scripts/setup-hooks.sh" <<'SETUP_HOOKS'
+#!/bin/sh
+printf 'setup-hooks:%s\n' "$*" >> "$DEBIAN_HELPER_LOG"
+SETUP_HOOKS
+    cat > "$repository/scripts/agent/init-worktree-tools.sh" <<'INIT_WORKTREE'
+#!/bin/sh
+printf 'init-worktree-tools:%s\n' "$1" >> "$DEBIAN_HELPER_LOG"
+INIT_WORKTREE
+
+    basebin="$fixture/base-bin"
+    activebin="$fixture/active-bin"
+    installables="$fixture/installables"
+    mkdir -p "$activebin" "$installables"
+    make_base_path "$basebin"
+
+    tool_log="$fixture/tools.log"
+    apt_log="$fixture/apt.log"
+    curl_log="$fixture/curl.log"
+
+    cat > "$activebin/id" <<'ID'
+#!/bin/sh
+[ "$#" -eq 1 ] && [ "$1" = -u ] || exit 9
+printf '%s\n' "${DEBIAN_TEST_UID:-0}"
+ID
+    cat > "$activebin/uname" <<'UNAME'
+#!/bin/sh
+case "${1:-}" in
+  ''|-s) printf '%s\n' "${AGENT_TEST_OS:-Linux}" ;;
+  *) exit 9 ;;
+esac
+UNAME
+    cat > "$activebin/dpkg-query" <<'DPKG'
+#!/bin/sh
+package=
+for argument do package=$argument; done
+case ",${DEBIAN_MISSING_PACKAGES:-}," in
+  *,"$package",*) exit 1 ;;
+esac
+printf '%s\n' 'install ok installed'
+DPKG
+    cat > "$activebin/apt-get" <<'APT_GET'
+#!/bin/sh
+printf 'apt-get:%s\n' "$*" >> "$DEBIAN_APT_LOG"
+APT_GET
+    cat > "$activebin/sudo" <<'SUDO'
+#!/bin/sh
+printf 'sudo:%s\n' "$*" >> "$DEBIAN_APT_LOG"
+exec "$@"
+SUDO
+    cat > "$activebin/brew" <<'BREW'
+#!/bin/sh
+printf 'brew:%s\n' "$*" >> "$DEBIAN_TOOL_LOG"
+case "$*" in
+  'list --versions uv')
+    [ "${BREW_UV_INSTALLED:-1}" -eq 1 ] || exit 1
+    printf '%s\n' 'uv 0.8.0'
+    ;;
+  'install uv'|'upgrade uv')
+    mkdir -p "$BREW_UV_PREFIX/bin"
+    cp "$DEBIAN_INSTALLABLES/uv" "$BREW_UV_PREFIX/bin/uv"
+    ;;
+  '--prefix uv') printf '%s\n' "$BREW_UV_PREFIX" ;;
+  *) exit 9 ;;
+esac
+BREW
+    cat > "$activebin/curl" <<'CURL'
+#!/bin/sh
+url=
+for argument do
+  case "$argument" in
+    http://*|https://*) url=$argument ;;
+  esac
+done
+printf '%s\n' "$url" >> "$DEBIAN_CURL_LOG"
+case "$url" in
+  https://astral.sh/uv/install.sh)
+    cat <<'INSTALL_UV'
+#!/bin/sh
+uv_bin=${XDG_BIN_HOME:-$HOME/.local/bin}
+mkdir -p "$uv_bin"
+cp "$DEBIAN_INSTALLABLES/uv" "$uv_bin/uv"
+INSTALL_UV
+    ;;
+  https://raw.githubusercontent.com/colbymchenry/codegraph/main/install.sh)
+    cat <<'INSTALL_CODEGRAPH'
+#!/bin/sh
+codegraph_bin=${CODEGRAPH_BIN_DIR:-$HOME/.local/bin}
+mkdir -p "$codegraph_bin"
+cp "$DEBIAN_INSTALLABLES/codegraph" "$codegraph_bin/codegraph"
+INSTALL_CODEGRAPH
+    ;;
+  https://github.com/max-sixty/worktrunk/releases/latest/download/worktrunk-installer.sh)
+    cat <<'INSTALL_WORKTRUNK'
+#!/bin/sh
+worktrunk_bin=${CARGO_HOME:-$HOME/.cargo}/bin
+mkdir -p "$worktrunk_bin"
+cp "$DEBIAN_INSTALLABLES/wt" "$worktrunk_bin/wt"
+INSTALL_WORKTRUNK
+    ;;
+  *) exit 9 ;;
+esac
+CURL
+
+    cat > "$installables/uv" <<'UV'
+#!/bin/sh
+printf 'uv:%s\n' "$*" >> "$DEBIAN_TOOL_LOG"
+case "$*" in
+  'self update') ;;
+  'tool install --upgrade -p 3.13 serena-agent')
+    uv_tool_bin=${UV_TOOL_BIN_DIR:-${XDG_BIN_HOME:-$HOME/.local/bin}}
+    mkdir -p "$uv_tool_bin"
+    cp "$DEBIAN_INSTALLABLES/serena" "$uv_tool_bin/serena"
+    ;;
+  'tool install --upgrade graphifyy==0.9.50')
+    uv_tool_bin=${UV_TOOL_BIN_DIR:-${XDG_BIN_HOME:-$HOME/.local/bin}}
+    mkdir -p "$uv_tool_bin"
+    cp "$DEBIAN_INSTALLABLES/graphify" "$uv_tool_bin/graphify"
+    ;;
+  *) exit 9 ;;
+esac
+UV
+    cat > "$installables/serena" <<'SERENA'
+#!/bin/sh
+printf 'serena:%s\n' "$*" >> "$DEBIAN_TOOL_LOG"
+if [ "$#" -eq 1 ] && [ "$1" = init ]; then
+  mkdir -p "$HOME/.serena"
+  if [ ! -f "$HOME/.serena/serena_config.yml" ]; then
+    case "${SERENA_CONFIG_MODE:-root}" in
+      root)
+        cat > "$HOME/.serena/serena_config.yml" <<'CONFIG'
+# preserved
+web_dashboard: true
+projects:
+  demo:
+    web_dashboard: true
+CONFIG
+        ;;
+      missing-root)
+        cat > "$HOME/.serena/serena_config.yml" <<'CONFIG'
+projects:
+  demo:
+    web_dashboard: true
+CONFIG
+        ;;
+      double-root)
+        cat > "$HOME/.serena/serena_config.yml" <<'CONFIG'
+"web_dashboard": true
+projects:
+  demo:
+    web_dashboard: true
+CONFIG
+        ;;
+      single-root)
+        cat > "$HOME/.serena/serena_config.yml" <<'CONFIG'
+'web_dashboard': true
+projects:
+  demo:
+    web_dashboard: true
+CONFIG
+        ;;
+      *) exit 9 ;;
+    esac
+  fi
+fi
+SERENA
+    cat > "$installables/codegraph" <<'CODEGRAPH'
+#!/bin/sh
+printf 'codegraph:%s\n' "$*" >> "$DEBIAN_TOOL_LOG"
+case "$*" in
+  upgrade|'install -l global -y -t auto') ;;
+  *) exit 9 ;;
+esac
+CODEGRAPH
+    cat > "$installables/graphify" <<'GRAPHIFY'
+#!/bin/sh
+printf 'graphify:%s:%s\n' "$(pwd -P)" "$*" >> "$DEBIAN_TOOL_LOG"
+if [ "$*" = 'install --platform agents' ] && [ "$(pwd -P)" = "$DEBIAN_REPOSITORY" ]; then
+  printf '%s\n' '# graphify rewrote repository agents' > "$DEBIAN_REPOSITORY/AGENTS.md"
+  printf '%s\n' '# graphify rewrote repository policy' > "$DEBIAN_REPOSITORY/.agents/policy/invariants.txt"
+fi
+GRAPHIFY
+    cat > "$installables/wt" <<'WORKTRUNK'
+#!/bin/sh
+[ "$*" = 'config shell install --yes' ] || exit 9
+printf 'wt:%s\n' "$*" >> "$DEBIAN_TOOL_LOG"
+if [ ! -f "$WORKTRUNK_SHELL_ARTIFACT" ]; then
+  printf '%s\n' "$WORKTRUNK_SHELL_MARKER" > "$WORKTRUNK_SHELL_ARTIFACT"
+fi
+WORKTRUNK
+    for client in claude codex pi; do
+      cat > "$installables/$client" <<'CLIENT'
+#!/bin/sh
+exit 0
+CLIENT
+    done
+    cat > "$installables/grok" <<'GROK'
+#!/bin/sh
+printf 'grok:%s\n' "$*" >> "$DEBIAN_TOOL_LOG"
+case "$*" in
+  'mcp doctor codegraph --json') exit "${GROK_DOCTOR_RC:-0}" ;;
+esac
+GROK
+    chmod +x "$activebin/id" "$activebin/uname" "$activebin/dpkg-query" \
+      "$activebin/apt-get" "$activebin/sudo" "$activebin/brew" "$activebin/curl" "$installables"/*
+    for tool in uv serena codegraph graphify wt; do
+      cp "$installables/$tool" "$activebin/$tool"
+    done
+
+    worktrunk_config="$xdg_config/worktrunk/config.toml"
+    worktrunk_shell_artifact="$home/.worktrunk-shell-integration"
+    worktrunk_shell_marker='# worktrunk shell integration'
+    brew_prefix="$fixture/homebrew uv"
+    export HOME="$home"
+    export XDG_CONFIG_HOME="$xdg_config"
+    export DEBIAN_HELPER_LOG="$helper_log"
+    export DEBIAN_TOOL_LOG="$tool_log"
+    export DEBIAN_APT_LOG="$apt_log"
+    export DEBIAN_CURL_LOG="$curl_log"
+    export DEBIAN_INSTALLABLES="$installables"
+    export DEBIAN_REPOSITORY="$repository"
+    export WORKTRUNK_SHELL_ARTIFACT="$worktrunk_shell_artifact"
+    export WORKTRUNK_SHELL_MARKER="$worktrunk_shell_marker"
+    export BREW_UV_PREFIX="$brew_prefix"
+    unset CLAUDECODE CODEX_THREAD_ID GROK_AGENT GROK_SESSION_ID OMP_CLI PI_CLI
+    unset DEBIAN_MISSING_PACKAGES SERENA_CONFIG_MODE GROK_DOCTOR_RC AGENT_TEST_OS
+    unset BREW_UV_INSTALLED XDG_BIN_HOME UV_TOOL_BIN_DIR CODEGRAPH_BIN_DIR CARGO_HOME
+    PATH="$activebin:$basebin"; export PATH
+  }
+
+  enable_client() {
+    cp "$installables/$1" "$activebin/$1"
+  }
+
+  cleanup() {
+    rm -rf "$fixture"
+  }
+
+  BeforeEach 'setup'
+  AfterEach 'cleanup'
+
+  It 'installs only missing Linux prerequisites through sudo for a non-root user'
+    export DEBIAN_MISSING_PACKAGES=ca-certificates,curl,git
+    When run env DEBIAN_TEST_UID=1000 sh "$script_abs" "$repository"
+    The status should equal 0
+    The contents of file "$apt_log" should equal "$(printf '%s\n' \
+      'sudo:apt-get update' \
+      'apt-get:update' \
+      'sudo:apt-get install -y ca-certificates curl git' \
+      'apt-get:install -y ca-certificates curl git')"
+  End
+
+  It 'runs apt-get directly as Linux root and installs only the missing package subset'
+    export DEBIAN_MISSING_PACKAGES=git
+    When run env DEBIAN_TEST_UID=0 sh "$script_abs" "$repository"
+    The status should equal 0
+    The contents of file "$apt_log" should equal "$(printf '%s\n' \
+      'apt-get:update' \
+      'apt-get:install -y git')"
+  End
+
+  It 'uses official installers and current-process user paths on an initial Linux setup'
+    rm -f "$activebin/brew" "$activebin/uv" "$activebin/serena" "$activebin/codegraph" \
+      "$activebin/graphify" "$activebin/wt"
+    When run sh "$script_abs" "$repository"
+    The status should equal 0
+    The contents of file "$curl_log" should equal "$(printf '%s\n%s\n%s' \
+      'https://astral.sh/uv/install.sh' \
+      'https://raw.githubusercontent.com/colbymchenry/codegraph/main/install.sh' \
+      'https://github.com/max-sixty/worktrunk/releases/latest/download/worktrunk-installer.sh')"
+    The contents of file "$tool_log" should equal "$(printf '%s\n' \
+      'uv:tool install --upgrade -p 3.13 serena-agent' \
+      'uv:tool install --upgrade graphifyy==0.9.50' \
+      'codegraph:install -l global -y -t auto' \
+      'wt:config shell install --yes' \
+      'serena:init')"
+    The path "$home/.local/bin/uv" should be executable
+    The path "$home/.local/bin/serena" should be executable
+    The path "$home/.local/bin/graphify" should be executable
+    The path "$home/.local/bin/codegraph" should be executable
+    The path "$home/.cargo/bin/wt" should be executable
+  End
+
+  It 'resolves every initial Linux tool from its configured destination immediately'
+    rm -f "$activebin/uv" "$activebin/serena" "$activebin/codegraph" "$activebin/graphify" "$activebin/wt"
+    custom_xdg_bin="$fixture/custom xdg bin"
+    custom_uv_tool_bin="$fixture/custom uv tool bin"
+    custom_codegraph_bin="$fixture/custom codegraph bin"
+    custom_cargo_home="$fixture/custom cargo home"
+    When run env \
+      XDG_BIN_HOME="$custom_xdg_bin" \
+      UV_TOOL_BIN_DIR="$custom_uv_tool_bin" \
+      CODEGRAPH_BIN_DIR="$custom_codegraph_bin" \
+      CARGO_HOME="$custom_cargo_home" \
+      sh "$script_abs" "$repository"
+    The status should equal 0
+    The contents of file "$curl_log" should equal "$(printf '%s\n%s\n%s' \
+      'https://astral.sh/uv/install.sh' \
+      'https://raw.githubusercontent.com/colbymchenry/codegraph/main/install.sh' \
+      'https://github.com/max-sixty/worktrunk/releases/latest/download/worktrunk-installer.sh')"
+    The contents of file "$tool_log" should equal "$(printf '%s\n' \
+      'uv:tool install --upgrade -p 3.13 serena-agent' \
+      'uv:tool install --upgrade graphifyy==0.9.50' \
+      'codegraph:install -l global -y -t auto' \
+      'wt:config shell install --yes' \
+      'serena:init')"
+    The path "$custom_xdg_bin/uv" should be executable
+    The path "$custom_uv_tool_bin/serena" should be executable
+    The path "$custom_uv_tool_bin/graphify" should be executable
+    The path "$custom_codegraph_bin/codegraph" should be executable
+    The path "$custom_cargo_home/bin/wt" should be executable
+  End
+
+  It 'updates existing Linux uv and CodeGraph while rerunning global auto configuration'
+    When run sh "$script_abs" "$repository"
+    The status should equal 0
+    The contents of file "$curl_log" should equal \
+      'https://github.com/max-sixty/worktrunk/releases/latest/download/worktrunk-installer.sh'
+    The contents of file "$tool_log" should equal "$(printf '%s\n' \
+      'uv:self update' \
+      'uv:tool install --upgrade -p 3.13 serena-agent' \
+      'uv:tool install --upgrade graphifyy==0.9.50' \
+      'codegraph:upgrade' \
+      'codegraph:install -l global -y -t auto' \
+      'wt:config shell install --yes' \
+      'serena:init')"
+    The file "$apt_log" should not be exist
+  End
+
+  It 'installs a managed Homebrew uv when an unmanaged Darwin uv command exists'
+    cat > "$activebin/uv" <<'UNMANAGED_UV'
+#!/bin/sh
+printf 'uv-unmanaged:%s\n' "$*" >> "$DEBIAN_TOOL_LOG"
+exit 9
+UNMANAGED_UV
+    chmod +x "$activebin/uv"
+    When run env AGENT_TEST_OS=Darwin BREW_UV_INSTALLED=0 sh "$script_abs" "$repository"
+    The status should equal 0
+    The contents of file "$tool_log" should equal "$(printf '%s\n' \
+      'brew:list --versions uv' \
+      'brew:install uv' \
+      'brew:--prefix uv' \
+      'uv:tool install --upgrade -p 3.13 serena-agent' \
+      'uv:tool install --upgrade graphifyy==0.9.50' \
+      'codegraph:upgrade' \
+      'codegraph:install -l global -y -t auto' \
+      'wt:config shell install --yes' \
+      'serena:init')"
+    The contents of file "$curl_log" should equal \
+      'https://github.com/max-sixty/worktrunk/releases/latest/download/worktrunk-installer.sh'
+    The path "$brew_prefix/bin/uv" should be executable
+    The file "$apt_log" should not be exist
+  End
+
+  It 'upgrades a managed Homebrew uv from its formula prefix on every Darwin rerun'
+    rm -f "$activebin/uv"
+    When run env AGENT_TEST_OS=Darwin sh -c 'sh "$1" "$2" && sh "$1" "$2"' _ "$script_abs" "$repository"
+    The status should equal 0
+    The contents of file "$tool_log" should equal "$(printf '%s\n' \
+      'brew:list --versions uv' \
+      'brew:upgrade uv' \
+      'brew:--prefix uv' \
+      'uv:tool install --upgrade -p 3.13 serena-agent' \
+      'uv:tool install --upgrade graphifyy==0.9.50' \
+      'codegraph:upgrade' \
+      'codegraph:install -l global -y -t auto' \
+      'wt:config shell install --yes' \
+      'serena:init' \
+      'brew:list --versions uv' \
+      'brew:upgrade uv' \
+      'brew:--prefix uv' \
+      'uv:tool install --upgrade -p 3.13 serena-agent' \
+      'uv:tool install --upgrade graphifyy==0.9.50' \
+      'codegraph:upgrade' \
+      'codegraph:install -l global -y -t auto' \
+      'wt:config shell install --yes' \
+      'serena:init')"
+    Assert [ "$(grep -c '^https://github.com/max-sixty/worktrunk/releases/latest/download/worktrunk-installer.sh$' "$curl_log")" -eq 2 ]
+    The path "$brew_prefix/bin/uv" should be executable
+    The file "$apt_log" should not be exist
+  End
+
+  It 'uses the official CodeGraph installer and managed uv prefix for an initial Darwin setup'
+    rm -f "$activebin/uv" "$activebin/codegraph"
+    When run env AGENT_TEST_OS=Darwin sh "$script_abs" "$repository"
+    The status should equal 0
+    The contents of file "$curl_log" should equal "$(printf '%s\n%s' \
+      'https://raw.githubusercontent.com/colbymchenry/codegraph/main/install.sh' \
+      'https://github.com/max-sixty/worktrunk/releases/latest/download/worktrunk-installer.sh')"
+    The contents of file "$tool_log" should equal "$(printf '%s\n' \
+      'brew:list --versions uv' \
+      'brew:upgrade uv' \
+      'brew:--prefix uv' \
+      'uv:tool install --upgrade -p 3.13 serena-agent' \
+      'uv:tool install --upgrade graphifyy==0.9.50' \
+      'codegraph:install -l global -y -t auto' \
+      'wt:config shell install --yes' \
+      'serena:init')"
+    The path "$brew_prefix/bin/uv" should be executable
+    The path "$home/.local/bin/codegraph" should be executable
+    The file "$apt_log" should not be exist
+  End
+
+  It 'fails on Darwin when Homebrew is unavailable without touching repository helpers'
+    rm -f "$activebin/brew"
+    When run env AGENT_TEST_OS=Darwin sh "$script_abs" "$repository"
+    The status should not equal 0
+    The stderr should include 'brew'
+    The file "$apt_log" should not be exist
+    The file "$helper_log" should not be exist
+  End
+
+  It 'rejects an unsupported host before changing tools, helpers, or user configuration'
+    When run env AGENT_TEST_OS=FreeBSD sh "$script_abs" "$repository"
+    The status should not equal 0
+    The stderr should include 'unsupported platform'
+    The file "$apt_log" should not be exist
+    The file "$curl_log" should not be exist
+    The file "$tool_log" should not be exist
+    The file "$helper_log" should not be exist
+    The path "$home/.local" should not be exist
+    The path "$home/.cargo" should not be exist
+    The path "$worktrunk_config" should not be exist
+    The path "$home/.serena/serena_config.yml" should not be exist
+  End
+
+  It 'disables only the root Serena dashboard key and calls both repository helpers for the default repository'
+    When run sh -c 'cd "$1" && exec sh "$2"' _ "$repository" "$script_abs"
+    The status should equal 0
+    The contents of file "$home/.serena/serena_config.yml" should equal "$(printf '%s\n' \
+      '# preserved' \
+      'web_dashboard: false' \
+      'projects:' \
+      '  demo:' \
+      '    web_dashboard: true')"
+    The contents of file "$helper_log" should equal "$(printf 'setup-hooks:\ninit-worktree-tools:%s' "$repository")"
+    The contents of file "$tool_log" should include 'serena:init'
+    The contents of file "$tool_log" should include 'wt:config shell install --yes'
+    The contents of file "$tool_log" should include 'codegraph:install -l global -y -t auto'
+  End
+
+  It 'fails before repository initialization when Serena has no root dashboard key to disable'
+    export SERENA_CONFIG_MODE=missing-root
+    When run sh "$script_abs" "$repository"
+    The status should not equal 0
+    The contents of file "$home/.serena/serena_config.yml" should equal "$(printf '%s\n' \
+      'projects:' \
+      '  demo:' \
+      '    web_dashboard: true')"
+    The file "$helper_log" should not be exist
+    The contents of file "$tool_log" should include 'codegraph:install -l global -y -t auto'
+  End
+
+  It 'canonicalizes a double-quoted root Serena dashboard key without changing the nested key'
+    export SERENA_CONFIG_MODE=double-root
+    When run sh "$script_abs" "$repository"
+    The status should equal 0
+    The contents of file "$home/.serena/serena_config.yml" should equal "$(printf '%s\n' \
+      'web_dashboard: false' \
+      'projects:' \
+      '  demo:' \
+      '    web_dashboard: true')"
+    The contents of file "$tool_log" should include 'codegraph:install -l global -y -t auto'
+  End
+
+  It 'canonicalizes a single-quoted root Serena dashboard key without changing the nested key'
+    export SERENA_CONFIG_MODE=single-root
+    When run sh "$script_abs" "$repository"
+    The status should equal 0
+    The contents of file "$home/.serena/serena_config.yml" should equal "$(printf '%s\n' \
+      'web_dashboard: false' \
+      'projects:' \
+      '  demo:' \
+      '    web_dashboard: true')"
+    The contents of file "$tool_log" should include 'codegraph:install -l global -y -t auto'
+  End
+
+  It 'reruns detected Claude Code setup and its home-scoped Graphify installer on every invocation'
+    enable_client claude
+    When run sh -c 'sh "$1" "$2" && sh "$1" "$2"' _ "$script_abs" "$repository"
+    The status should equal 0
+    Assert [ "$(grep -c '^serena:setup claude-code$' "$tool_log")" -eq 2 ]
+    Assert [ "$(grep -Fxc "graphify:$home:claude install" "$tool_log")" -eq 2 ]
+    Assert [ "$(grep -c '^codegraph:install -l global -y -t auto$' "$tool_log")" -eq 2 ]
+    The contents of file "$tool_log" should not include 'serena:setup codex'
+    The contents of file "$tool_log" should not include 'serena:setup grok'
+    The contents of file "$tool_log" should not include "graphify:$home:codex install"
+    The contents of file "$tool_log" should not include "graphify:$home:pi install"
+    The contents of file "$tool_log" should not include 'grok:mcp'
+  End
+
+  It 'reruns only detected Codex setup and its home-scoped Graphify installer on every invocation'
+    enable_client codex
+    When run sh -c 'sh "$1" "$2" && sh "$1" "$2"' _ "$script_abs" "$repository"
+    The status should equal 0
+    Assert [ "$(grep -c '^serena:setup codex$' "$tool_log")" -eq 2 ]
+    Assert [ "$(grep -Fxc "graphify:$home:codex install" "$tool_log")" -eq 2 ]
+    Assert [ "$(grep -c '^codegraph:install -l global -y -t auto$' "$tool_log")" -eq 2 ]
+    The contents of file "$tool_log" should not include 'serena:setup claude-code'
+    The contents of file "$tool_log" should not include 'serena:setup grok'
+    The contents of file "$tool_log" should not include "graphify:$home:claude install"
+    The contents of file "$tool_log" should not include "graphify:$home:pi install"
+    The contents of file "$tool_log" should not include 'grok:mcp'
+  End
+
+  It 'reruns healthy Grok global skill setup without changing repository agent policy'
+    enable_client grok
+    When run sh -c 'cd "$1" && sh "$2" "$1" && sh "$2" "$1"' _ "$repository" "$script_abs"
+    The status should equal 0
+    Assert [ "$(grep -c '^serena:setup grok$' "$tool_log")" -eq 2 ]
+    Assert [ "$(grep -Fxc "graphify:$home:install --platform agents" "$tool_log")" -eq 2 ]
+    Assert [ "$(grep -c '^grok:mcp doctor codegraph --json$' "$tool_log")" -eq 2 ]
+    The contents of file "$tool_log" should not include 'grok:mcp remove codegraph'
+    The contents of file "$tool_log" should not include 'grok:mcp add codegraph'
+    The contents of file "$tool_log" should not include "graphify:$home:claude install"
+    The contents of file "$tool_log" should not include "graphify:$home:codex install"
+    The contents of file "$tool_log" should not include "graphify:$home:pi install"
+    Assert [ "$(grep -c '^codegraph:install -l global -y -t auto$' "$tool_log")" -eq 2 ]
+    Assert [ "$(cmp -s "$fixture/AGENTS.md.before" "$agent_marker"; printf '%s' "$?")" -eq 0 ]
+    Assert [ "$(cmp -s "$fixture/policy.before" "$policy_marker"; printf '%s' "$?")" -eq 0 ]
+  End
+
+  It 'repairs only an unhealthy detected Grok CodeGraph MCP entry with the canonical server command'
+    enable_client grok
+    export GROK_DOCTOR_RC=7
+    When run sh "$script_abs" "$repository"
+    The status should equal 0
+    The contents of file "$tool_log" should include "$(printf '%s\n%s\n%s' \
+      'grok:mcp doctor codegraph --json' \
+      'grok:mcp remove codegraph' \
+      'grok:mcp add codegraph -- codegraph serve --mcp')"
+    Assert [ "$(grep -c '^grok:mcp doctor codegraph --json$' "$tool_log")" -eq 1 ]
+    Assert [ "$(grep -c '^grok:mcp remove codegraph$' "$tool_log")" -eq 1 ]
+    Assert [ "$(grep -c '^grok:mcp add codegraph -- codegraph serve --mcp$' "$tool_log")" -eq 1 ]
+    Assert [ "$(grep -c '^codegraph:install -l global -y -t auto$' "$tool_log")" -eq 1 ]
+  End
+
+  It 'reruns detected Pi home-scoped Graphify installation without Serena client setup'
+    enable_client pi
+    When run sh -c 'sh "$1" "$2" && sh "$1" "$2"' _ "$script_abs" "$repository"
+    The status should equal 0
+    Assert [ "$(grep -Fxc "graphify:$home:pi install" "$tool_log")" -eq 2 ]
+    The contents of file "$tool_log" should not include 'serena:setup'
+    The contents of file "$tool_log" should not include "graphify:$home:claude install"
+    The contents of file "$tool_log" should not include "graphify:$home:codex install"
+    The contents of file "$tool_log" should not include 'install --platform agents'
+    The contents of file "$tool_log" should not include 'grok:mcp'
+    Assert [ "$(grep -c '^codegraph:install -l global -y -t auto$' "$tool_log")" -eq 2 ]
+  End
+
+  It 'ignores agent environment markers when no client executable is present'
+    When run env CLAUDECODE=1 CODEX_THREAD_ID=thread GROK_AGENT=1 GROK_SESSION_ID=session PI_CLI=1 \
+      sh "$script_abs" "$repository"
+    The status should equal 0
+    The contents of file "$tool_log" should include 'serena:init'
+    The contents of file "$tool_log" should not include 'serena:setup'
+    The contents of file "$tool_log" should not include 'graphify:'
+    The contents of file "$tool_log" should not include 'grok:mcp'
+    The contents of file "$tool_log" should include 'codegraph:install -l global -y -t auto'
+    The file "$apt_log" should not be exist
+    The contents of file "$curl_log" should equal \
+      'https://github.com/max-sixty/worktrunk/releases/latest/download/worktrunk-installer.sh'
+  End
+
+  It 'creates the canonical global Worktrunk key when the user config is missing'
+    When run sh "$script_abs" "$repository"
+    The status should equal 0
+    The contents of file "$worktrunk_config" should equal "$canonical_worktree_path"
+  End
+
+  It 'creates the canonical global Worktrunk key when the user config is empty'
+    mkdir -p "$(dirname "$worktrunk_config")"
+    : > "$worktrunk_config"
+    When run sh "$script_abs" "$repository"
+    The status should equal 0
+    The contents of file "$worktrunk_config" should equal "$canonical_worktree_path"
+  End
+
+  It 'replaces one existing global Worktrunk key without changing adjacent global values'
+    mkdir -p "$(dirname "$worktrunk_config")"
+    cat > "$worktrunk_config" <<'CONFIG'
+# global comment
+worktree-path = "/tmp/inside-repository"
+theme = "dark"
+CONFIG
+    When run sh "$script_abs" "$repository"
+    The status should equal 0
+    The contents of file "$worktrunk_config" should equal "$(printf '%s\n' \
+      '# global comment' \
+      "$canonical_worktree_path" \
+      'theme = "dark"')"
+    Assert [ "$(grep -Fxc "$canonical_worktree_path" "$worktrunk_config")" -eq 1 ]
+  End
+
+  It 'canonicalizes a double-quoted global Worktrunk key without changing a nested quoted key'
+    mkdir -p "$(dirname "$worktrunk_config")"
+    cat > "$worktrunk_config" <<'CONFIG'
+"worktree-path" = "/tmp/double-global"
+[projects."demo"]
+"worktree-path" = "/srv/double-nested"
+CONFIG
+    When run sh "$script_abs" "$repository"
+    The status should equal 0
+    The contents of file "$worktrunk_config" should equal "$(printf '%s\n' \
+      "$canonical_worktree_path" \
+      '[projects."demo"]' \
+      '"worktree-path" = "/srv/double-nested"')"
+    Assert [ "$(grep -Fxc "$canonical_worktree_path" "$worktrunk_config")" -eq 1 ]
+  End
+
+  It 'canonicalizes a single-quoted global Worktrunk key without changing a nested quoted key'
+    mkdir -p "$(dirname "$worktrunk_config")"
+    cat > "$worktrunk_config" <<'CONFIG'
+'worktree-path' = "/tmp/single-global"
+[projects."demo"]
+'worktree-path' = "/srv/single-nested"
+CONFIG
+    When run sh "$script_abs" "$repository"
+    The status should equal 0
+    The contents of file "$worktrunk_config" should equal "$(printf '%s\n' \
+      "$canonical_worktree_path" \
+      '[projects."demo"]' \
+      "'worktree-path' = \"/srv/single-nested\"")"
+    Assert [ "$(grep -Fxc "$canonical_worktree_path" "$worktrunk_config")" -eq 1 ]
+  End
+
+  It 'fails safely on root multiline TOML instead of parsing fake sections or keys'
+    mkdir -p "$(dirname "$worktrunk_config")"
+    cat > "$worktrunk_config" <<'CONFIG'
+description = """
+[not-a-table]
+worktree-path = "not-a-real-key"
+"""
+[projects."demo"]
+worktree-path = "/srv/demo"
+CONFIG
+    worktrunk_multiline_expected="$fixture/worktrunk-multiline.expected"
+    cp "$worktrunk_config" "$worktrunk_multiline_expected"
+    When run sh "$script_abs" "$repository"
+    The status should not equal 0
+    The contents of file "$worktrunk_config" should equal "$(cat "$worktrunk_multiline_expected")"
+    The value "$(wc -c < "$worktrunk_config" | tr -d '[:space:]')" should equal \
+      "$(wc -c < "$worktrunk_multiline_expected" | tr -d '[:space:]')"
+    The file "$helper_log" should not be exist
+  End
+
+  It 'inserts only the global Worktrunk key while preserving hostile comments, tables, and nested paths byte-for-byte'
+    mkdir -p "$(dirname "$worktrunk_config")"
+    cat > "$worktrunk_config" <<'CONFIG'
+# user comment
+editor = "vim"
+
+[projects."demo"]
+# nested comment
+worktree-path = "/srv/demo"
+color = "blue"
+
+[other]
+enabled = true
+CONFIG
+    When run sh "$script_abs" "$repository"
+    The status should equal 0
+    The contents of file "$worktrunk_config" should equal "$(printf '%s\n' \
+      '# user comment' \
+      'editor = "vim"' \
+      '' \
+      "$canonical_worktree_path" \
+      '[projects."demo"]' \
+      '# nested comment' \
+      'worktree-path = "/srv/demo"' \
+      'color = "blue"' \
+      '' \
+      '[other]' \
+      'enabled = true')"
+    Assert [ "$(grep -Fxc "$canonical_worktree_path" "$worktrunk_config")" -eq 1 ]
+    Assert [ "$(grep -Fxc 'worktree-path = "/srv/demo"' "$worktrunk_config")" -eq 1 ]
+  End
+
+  It 'preserves an unrelated final Worktrunk line without adding an EOF newline'
+    mkdir -p "$(dirname "$worktrunk_config")"
+    {
+      printf '%s\n' \
+        '# no-newline user comment' \
+        'editor = "vim"' \
+        '' \
+        '[projects."demo"]' \
+        'worktree-path = "/srv/demo"'
+      printf '%s' 'final-value = "keep byte-for-byte"'
+    } > "$worktrunk_config"
+    worktrunk_expected="$fixture/worktrunk-no-newline.expected"
+    {
+      printf '%s\n' \
+        '# no-newline user comment' \
+        'editor = "vim"' \
+        '' \
+        "$canonical_worktree_path" \
+        '[projects."demo"]' \
+        'worktree-path = "/srv/demo"'
+      printf '%s' 'final-value = "keep byte-for-byte"'
+    } > "$worktrunk_expected"
+    When run sh "$script_abs" "$repository"
+    The status should equal 0
+    The contents of file "$worktrunk_config" should equal "$(cat "$worktrunk_expected")"
+    The value "$(wc -c < "$worktrunk_config" | tr -d '[:space:]')" should equal \
+      "$(wc -c < "$worktrunk_expected" | tr -d '[:space:]')"
+  End
+
+  It 'updates tools and keeps one canonical Worktrunk key across repeated installer runs'
+    When run sh -c 'sh "$1" "$2" && sh "$1" "$2"' _ "$script_abs" "$repository"
+    The status should equal 0
+    The contents of file "$worktrunk_config" should equal "$canonical_worktree_path"
+    Assert [ "$(grep -Fxc "$canonical_worktree_path" "$worktrunk_config")" -eq 1 ]
+    Assert [ "$(grep -c '^uv:self update$' "$tool_log")" -eq 2 ]
+    Assert [ "$(grep -c '^uv:tool install --upgrade -p 3.13 serena-agent$' "$tool_log")" -eq 2 ]
+    Assert [ "$(grep -c '^uv:tool install --upgrade graphifyy==0.9.50$' "$tool_log")" -eq 2 ]
+    Assert [ "$(grep -c '^codegraph:upgrade$' "$tool_log")" -eq 2 ]
+    Assert [ "$(grep -c '^codegraph:install -l global -y -t auto$' "$tool_log")" -eq 2 ]
+    Assert [ "$(grep -c '^wt:config shell install --yes$' "$tool_log")" -eq 2 ]
+    The contents of file "$worktrunk_shell_artifact" should equal "$worktrunk_shell_marker"
+    Assert [ "$(grep -Fxc "$worktrunk_shell_marker" "$worktrunk_shell_artifact")" -eq 1 ]
+    Assert [ "$(grep -c '^https://github.com/max-sixty/worktrunk/releases/latest/download/worktrunk-installer.sh$' "$curl_log")" -eq 2 ]
+    Assert [ "$(grep -c '^setup-hooks:$' "$helper_log")" -eq 2 ]
+    Assert [ "$(grep -c "^init-worktree-tools:$repository$" "$helper_log")" -eq 2 ]
+  End
+
+  It 'requires both repository setup helpers before running either one'
+    rm -f "$repository/scripts/agent/init-worktree-tools.sh"
+    When run sh "$script_abs" "$repository"
+    The status should not equal 0
+    The stderr should include 'init-worktree-tools.sh'
+    The file "$helper_log" should not be exist
+  End
+
+  It 'rejects more than one repository argument'
+    When run sh "$script_abs" "$repository" extra
+    The status should equal 2
+    The stderr should include 'usage: setup-agent-tools.sh [REPOSITORY]'
+    The file "$tool_log" should not be exist
+    The file "$helper_log" should not be exist
+  End
+End

--- a/tests/shell/agent_tools_setup_spec.sh
+++ b/tests/shell/agent_tools_setup_spec.sh
@@ -613,7 +613,7 @@ UNMANAGED_UV
 
   It 'creates the canonical global Worktrunk key when the user config is empty'
     mkdir -p "$(dirname "$worktrunk_config")"
-    : > "$worktrunk_config"
+    true > "$worktrunk_config"
     When run sh "$script_abs" "$repository"
     The status should equal 0
     The contents of file "$worktrunk_config" should equal "$canonical_worktree_path"

--- a/tests/shell/agent_tools_setup_spec.sh
+++ b/tests/shell/agent_tools_setup_spec.sh
@@ -227,9 +227,6 @@ GRAPHIFY
 #!/bin/sh
 [ "$*" = 'config shell install --yes' ] || exit 9
 printf 'wt:%s\n' "$*" >> "$DEBIAN_TOOL_LOG"
-if [ ! -f "$WORKTRUNK_SHELL_ARTIFACT" ]; then
-  printf '%s\n' "$WORKTRUNK_SHELL_MARKER" > "$WORKTRUNK_SHELL_ARTIFACT"
-fi
 WORKTRUNK
     for client in claude codex pi; do
       cat > "$installables/$client" <<'CLIENT'
@@ -251,8 +248,6 @@ GROK
     done
 
     worktrunk_config="$xdg_config/worktrunk/config.toml"
-    worktrunk_shell_artifact="$home/.worktrunk-shell-integration"
-    worktrunk_shell_marker='# worktrunk shell integration'
     brew_prefix="$fixture/homebrew uv"
     export HOME="$home"
     export XDG_CONFIG_HOME="$xdg_config"
@@ -262,8 +257,6 @@ GROK
     export DEBIAN_CURL_LOG="$curl_log"
     export DEBIAN_INSTALLABLES="$installables"
     export DEBIAN_REPOSITORY="$repository"
-    export WORKTRUNK_SHELL_ARTIFACT="$worktrunk_shell_artifact"
-    export WORKTRUNK_SHELL_MARKER="$worktrunk_shell_marker"
     export BREW_UV_PREFIX="$brew_prefix"
     unset CLAUDECODE CODEX_THREAD_ID GROK_AGENT GROK_SESSION_ID OMP_CLI PI_CLI
     unset DEBIAN_MISSING_PACKAGES SERENA_CONFIG_MODE GROK_DOCTOR_RC AGENT_TEST_OS
@@ -759,8 +752,6 @@ CONFIG
     Assert [ "$(grep -c '^codegraph:upgrade$' "$tool_log")" -eq 2 ]
     Assert [ "$(grep -c '^codegraph:install -l global -y -t auto$' "$tool_log")" -eq 2 ]
     Assert [ "$(grep -c '^wt:config shell install --yes$' "$tool_log")" -eq 2 ]
-    The contents of file "$worktrunk_shell_artifact" should equal "$worktrunk_shell_marker"
-    Assert [ "$(grep -Fxc "$worktrunk_shell_marker" "$worktrunk_shell_artifact")" -eq 1 ]
     Assert [ "$(grep -c '^https://github.com/max-sixty/worktrunk/releases/latest/download/worktrunk-installer.sh$' "$curl_log")" -eq 2 ]
     Assert [ "$(grep -c '^setup-hooks:$' "$helper_log")" -eq 2 ]
     Assert [ "$(grep -c "^init-worktree-tools:$repository$" "$helper_log")" -eq 2 ]

--- a/tests/shell/agent_work_branch_spec.sh
+++ b/tests/shell/agent_work_branch_spec.sh
@@ -93,8 +93,19 @@ esac
 CODEGRAPH
     cat > "$stubdir/graphify" <<'GRAPHIFY'
 #!/bin/sh
-[ "$#" -eq 2 ] && [ "$1" = update ] || exit 9
-printf 'graphify:%s:%s\n' "$1" "$2" >> "$WB_DEFAULT_TOOL_LOG"
+case "$1" in
+  extract)
+    [ "$#" -eq 3 ] && [ "$3" = --code-only ] || exit 9
+    printf 'graphify:%s:%s:%s\n' "$1" "$2" "$3" >> "$WB_DEFAULT_TOOL_LOG"
+    mkdir -p "$2/graphify-out"
+    true > "$2/graphify-out/graph.json"
+    ;;
+  update)
+    [ "$#" -eq 2 ] || exit 9
+    printf 'graphify:%s:%s\n' "$1" "$2" >> "$WB_DEFAULT_TOOL_LOG"
+    ;;
+  *) exit 9 ;;
+esac
 GRAPHIFY
     chmod +x "$stubdir/codegraph" "$stubdir/graphify"
     export WB_REAL_GIT="$(command -v git)"
@@ -144,7 +155,7 @@ GIT
     The stderr should include 'Preparing worktree'
     The stderr should include 'Initializing CodeGraph in'
     The contents of file "$events" should equal "$(printf 'fetch\nadd')"
-    The contents of file "$default_tool_log" should equal "$(printf 'codegraph:init:%s/default-init\ngraphify:update:%s/default-init' "$fixture" "$fixture")"
+    The contents of file "$default_tool_log" should equal "$(printf 'codegraph:init:%s/default-init\ngraphify:extract:%s/default-init:--code-only' "$fixture" "$fixture")"
   End
 
   It 'aborts a configured origin fetch failure before add or initialization'

--- a/tests/shell/agent_worktree_tools_spec.sh
+++ b/tests/shell/agent_worktree_tools_spec.sh
@@ -42,9 +42,21 @@ esac
 CODEGRAPH
     cat > "$stubdir/graphify" <<'GRAPHIFY'
 #!/bin/sh
-[ "$#" -eq 2 ] && [ "$1" = update ] || exit 9
-printf 'graphify:%s:%s\n' "$1" "$2" >> "$WORKTREE_TOOL_LOG"
-exit "${GRAPHIFY_RC:-0}"
+case "$1" in
+  extract)
+    [ "$#" -eq 3 ] && [ "$3" = --code-only ] || exit 9
+    printf 'graphify:%s:%s:%s\n' "$1" "$2" "$3" >> "$WORKTREE_TOOL_LOG"
+    [ "${GRAPHIFY_RC:-0}" -eq 0 ] || exit "$GRAPHIFY_RC"
+    mkdir -p "$2/graphify-out"
+    true > "$2/graphify-out/graph.json"
+    ;;
+  update)
+    [ "$#" -eq 2 ] || exit 9
+    printf 'graphify:%s:%s\n' "$1" "$2" >> "$WORKTREE_TOOL_LOG"
+    exit "${GRAPHIFY_RC:-0}"
+    ;;
+  *) exit 9 ;;
+esac
 GRAPHIFY
     cat > "$stubdir/serena" <<'SERENA'
 #!/bin/sh
@@ -77,12 +89,21 @@ SERENA
   It 'runs CodeGraph then Graphify and skips Serena when OMP marks the invoking harness'
     When run env OMP_CLI=1 sh "$script_abs" "$worktree"
     The status should equal 0
-    The contents of file "$tool_log" should equal "$(printf 'codegraph:init:%s\ngraphify:update:%s' "$worktree" "$worktree")"
+    The contents of file "$tool_log" should equal "$(printf 'codegraph:init:%s\ngraphify:extract:%s:--code-only' "$worktree" "$worktree")"
     The stderr should include 'Initializing CodeGraph in'
   End
 
   It 'runs CodeGraph then Graphify and skips Serena when PI marks the invoking harness'
     When run env PI_CLI=1 sh "$script_abs" "$worktree"
+    The status should equal 0
+    The contents of file "$tool_log" should equal "$(printf 'codegraph:init:%s\ngraphify:extract:%s:--code-only' "$worktree" "$worktree")"
+    The stderr should include 'Initializing CodeGraph in'
+  End
+
+  It 'refreshes an existing Graphify root graph instead of extracting it again'
+    mkdir -p "$worktree/graphify-out"
+    true > "$worktree/graphify-out/graph.json"
+    When run env OMP_CLI=1 sh "$script_abs" "$worktree"
     The status should equal 0
     The contents of file "$tool_log" should equal "$(printf 'codegraph:init:%s\ngraphify:update:%s' "$worktree" "$worktree")"
     The stderr should include 'Initializing CodeGraph in'
@@ -108,31 +129,31 @@ SERENA
     The stderr should include 'graphify'
   End
 
-  It 'returns nonzero when Graphify update fails after CodeGraph succeeds'
+  It 'returns nonzero when initial Graphify extraction fails after CodeGraph succeeds'
     When run env OMP_CLI=1 GRAPHIFY_RC=19 sh "$script_abs" "$worktree"
     The status should not equal 0
-    The contents of file "$tool_log" should equal "$(printf 'codegraph:init:%s\ngraphify:update:%s' "$worktree" "$worktree")"
+    The contents of file "$tool_log" should equal "$(printf 'codegraph:init:%s\ngraphify:extract:%s:--code-only' "$worktree" "$worktree")"
     The stderr should include 'Initializing CodeGraph in'
   End
 
   It 'runs Serena project indexing at the exact root outside OMP when Serena is present'
     When run sh "$script_abs" "$worktree"
     The status should equal 0
-    The contents of file "$tool_log" should equal "$(printf 'codegraph:init:%s\ngraphify:update:%s\nserena:project:index:%s' "$worktree" "$worktree" "$worktree")"
+    The contents of file "$tool_log" should equal "$(printf 'codegraph:init:%s\ngraphify:extract:%s:--code-only\nserena:project:index:%s' "$worktree" "$worktree" "$worktree")"
     The stderr should include 'Initializing CodeGraph in'
   End
 
   It 'skips absent Serena outside OMP without weakening mandatory initialization'
     When run env PATH="$no_serena" sh "$script_abs" "$worktree"
     The status should equal 0
-    The contents of file "$tool_log" should equal "$(printf 'codegraph:init:%s\ngraphify:update:%s' "$worktree" "$worktree")"
+    The contents of file "$tool_log" should equal "$(printf 'codegraph:init:%s\ngraphify:extract:%s:--code-only' "$worktree" "$worktree")"
     The stderr should include 'Initializing CodeGraph in'
   End
 
   It 'propagates Serena indexing failure'
     When run env SERENA_RC=23 sh "$script_abs" "$worktree"
     The status should equal 23
-    The contents of file "$tool_log" should equal "$(printf 'codegraph:init:%s\ngraphify:update:%s\nserena:project:index:%s' "$worktree" "$worktree" "$worktree")"
+    The contents of file "$tool_log" should equal "$(printf 'codegraph:init:%s\ngraphify:extract:%s:--code-only\nserena:project:index:%s' "$worktree" "$worktree" "$worktree")"
     The stderr should include 'Initializing CodeGraph in'
   End
 End

--- a/tests/test_cross_agent_tooling.py
+++ b/tests/test_cross_agent_tooling.py
@@ -188,6 +188,7 @@ def test_repository_intelligence_initializes_each_worktree_directly() -> None:
         "scripts/agent/init-worktree-tools.sh",
         "scripts/agent/ensure-codegraph.sh",
         "graphify update",
+        "graphify extract",
         "serena project index",
         "OMP_CLI",
         "PI_CLI",
@@ -207,7 +208,6 @@ def test_repository_intelligence_initializes_each_worktree_directly() -> None:
         "graphify-store.py",
         ".git/graphify-store.lock",
         "temporary detached builder",
-        "graphify extract",
         "graphify cluster-only",
         "cluster-only",
     ):


### PR DESCRIPTION
Fixes #2722

Adds one POSIX `sh` bootstrap for macOS and Debian-family Linux. It installs or updates uv, Serena, CodeGraph, Graphify, and Worktrunk; refreshes detected Claude/Codex/Grok/Pi integrations; disables Serena's web dashboard; configures sibling Worktrunk paths; and initializes each repository's CodeGraph/Graphify/Serena state.

Verification:
- `sh -n scripts/agent/setup-agent-tools.sh scripts/agent/init-worktree-tools.sh`
- `shellcheck scripts/agent/setup-agent-tools.sh scripts/agent/init-worktree-tools.sh`
- focused ShellSpec: 98 examples, 0 failures
- final Tests workflow: all 23 jobs passed
- independent contract, correctness/hostile-input, test-honesty, and over-engineering reviews completed
- CodeRabbit finished; both findings fixed

| Frozen RED test | `git hash-object` | RED run tail |
| --- | --- | --- |
| `tests/shell/agent_codegraph_spec.sh` | `a6502d97b60a72056fda707fe891dc73655dc2d5` | `FAILED new worktree: expected graphify extract --code-only` |
| `tests/shell/agent_tools_setup_spec.sh` | `4862ef6c35a02d6c27eeda59b38297230750112d` | `FAILED setup-agent-tools.sh absent on baseline` |
| `tests/shell/agent_work_branch_spec.sh` | `2e383cdb22677cfa4600e5b3554da85fcb004270` | `FAILED co-located initializer: expected graphify extract --code-only` |
| `tests/shell/agent_worktree_tools_spec.sh` | `4aa755b2d133034a0c2edf07fa8df2adceb7d0f6` | `FAILED initializer: graphify update observed instead of extract` |
| `tests/test_cross_agent_tooling.py` | `ccc7be6832140e3aa6b93e9e3b75aa7e5b4231a6` | `FAILED routing lost graphify extract` |

CodeGraph's requested `-t auto` behavior is intentionally retained even when it creates dormant Claude configuration; owner explicitly accepted that side effect.