### PR TITLE
ci: pin artifact actions to shared v7 major

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -388,7 +388,7 @@ jobs:
           chmod 600 smoke_key
 
       - name: Download the built pfBlockerNG package
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v7
         with:
           name: ${{ needs.build-pkg.outputs.artifact }}
           path: pkg

--- a/.github/workflows/build-pkg-linux.yml
+++ b/.github/workflows/build-pkg-linux.yml
@@ -283,7 +283,7 @@ jobs:
 
       - name: Upload package
         if: always()
-        uses: actions/upload-artifact@v8
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ inputs.artifact_name }}
           path: ${{ steps.build.outputs.pkg_dir }}/*.pkg
@@ -297,7 +297,7 @@ jobs:
         # major) — or by the caller-supplied dep_artifact_name (W1) when the
         # caller's own fan-out is per-version and needs a per-row-unique name.
         if: steps.build.outputs.has_dep_pkgs == '1'
-        uses: actions/upload-artifact@v8
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ steps.build.outputs.dep_artifact_name }}
           path: ${{ steps.build.outputs.dep_pkg_dir }}/*.pkg

--- a/.github/workflows/module-durations.yml
+++ b/.github/workflows/module-durations.yml
@@ -86,7 +86,7 @@ jobs:
           }
 
       - name: Download the smoke run's diagnostics artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v7
         with:
           run-id: ${{ github.event.workflow_run.id || inputs.run_id }}
           github-token: ${{ github.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1305,7 +1305,7 @@ jobs:
         # false already isolates a failed leg, so it simply uploads nothing
         # and attach-pkgs/the publish healthcheck fail closed on the missing
         # asset.
-        uses: actions/upload-artifact@v8
+        uses: actions/upload-artifact@v7
         with:
           name: pfBlockerNG-relpkg-${{ matrix.variant }}-${{ matrix.pfsense_version }}
           path: ${{ env.PKG_PATH }}
@@ -1317,7 +1317,7 @@ jobs:
         # -- the exact row identity consumers compose. Never uploaded when
         # extra_pkgs is empty (no empty artifacts).
         if: env.HAS_DEP_PKGS == '1'
-        uses: actions/upload-artifact@v8
+        uses: actions/upload-artifact@v7
         with:
           name: pfBlockerNG-relpkg-deppkgs-${{ matrix.variant }}-${{ matrix.pfsense_version }}
           path: ${{ env.DEP_PKG_DIR }}/*.pkg
@@ -1362,7 +1362,7 @@ jobs:
         # py311-charset-normalizer) are deliberate release assets, frozen
         # alongside the branch .pkgs for the pkg-repo publish + EOL/route-only
         # story. The draft healthcheck counts only the effective asset matrix.
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v7
         with:
           pattern: pfBlockerNG-relpkg-*
           merge-multiple: true

--- a/.github/workflows/smoke-single.yml
+++ b/.github/workflows/smoke-single.yml
@@ -588,7 +588,7 @@ jobs:
         # pkg_artifact set (issue #857): download the shared per-leg .pkg
         # smoke.yml's build-pkg job already built. Blank: fall back to the
         # artifact this workflow's OWN build-pkg job just built above.
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v7
         with:
           name: ${{ inputs.pkg_artifact != '' && inputs.pkg_artifact || needs.build-pkg.outputs.artifact }}
           path: pkg
@@ -601,7 +601,7 @@ jobs:
       # build-pkg job's dep_artifact_name above (bare dispatch / repo-install.yml).
       - name: Download dep packages
         if: ${{ inputs.extra_pkgs != '' && inputs.extra_pkgs != '[]' }}
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v7
         with:
           name: ${{ inputs.dep_artifact != '' && inputs.dep_artifact || format('pfBlockerNG-deppkgs-{0}-{1}-s{2}', inputs.image_name, inputs.pfsense_version, inputs.shard) }}
           path: deppkgs
@@ -850,7 +850,7 @@ jobs:
       # the release gate (#1662).
       - name: Upload shard selection-status marker (leg-level empty-selection gate, issue #1767)
         if: always()
-        uses: actions/upload-artifact@v8
+        uses: actions/upload-artifact@v7
         with:
           name: smoke-shard-status-${{ inputs.image_name }}-${{ inputs.pfsense_version }}-s${{ inputs.shard }}
           path: smoke-diag/shard-selection-status
@@ -873,7 +873,7 @@ jobs:
 
       - name: Upload smoke diagnostics
         if: always()
-        uses: actions/upload-artifact@v8
+        uses: actions/upload-artifact@v7
         with:
           # Per-leg-per-shard name (issue #797) — also fixes the pre-existing
           # wart where every leg of a fan-out run uploaded the SAME bare

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -421,7 +421,7 @@ jobs:
       - name: Download per-shard selection-status markers
         if: needs.smoke.result == 'success'
         continue-on-error: true
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v7
         with:
           pattern: smoke-shard-status-*
           path: shard-status

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -537,7 +537,7 @@ jobs:
           chmod 600 smoke_key
 
       - name: Download the built pfBlockerNG package
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v7
         with:
           # pkg_artifact_prefix set: download the prebuilt artifact a caller
           # (e.g. release.yml) already published, named
@@ -572,7 +572,7 @@ jobs:
       #; blank -> this run's own build-pkg job's dep_artifact_name.
       - name: Download dep packages
         if: steps.depmajor.outputs.needed == '1'
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v7
         with:
           name: ${{ inputs.pkg_artifact_prefix != '' && format('{0}-deppkgs-{1}-{2}', inputs.pkg_artifact_prefix, matrix.variant, matrix.version) || format('pfBlockerNG-deppkgs-{0}-{1}', matrix.variant, matrix.version) }}
           path: deppkgs

--- a/tests/test_issue2231_workflow_hygiene.py
+++ b/tests/test_issue2231_workflow_hygiene.py
@@ -472,9 +472,6 @@ _KNOWN_ARTIFACT_MAJORS: dict[str, frozenset[int]] = {
     "download": frozenset({3, 4, 5, 6, 7, 8}),
 }
 _HIGHEST_COMMON_ARTIFACT_MAJOR = max(_KNOWN_ARTIFACT_MAJORS["upload"] & _KNOWN_ARTIFACT_MAJORS["download"])
-_LIVE_ARTIFACT_USES = re.compile(
-    r"uses:\s+actions/(?P<kind>upload|download)-artifact@v(?P<major>[0-9]+)(?:\.[0-9]+){0,2}"
-)
 _GH_EXPRESSION = re.compile(r"\$\{\{\s*(.*?)\s*\}\}")
 _UNRESOLVED_EXPRESSION = re.compile(r"<unresolved:(?P<expression>[^>]+)>")
 
@@ -863,6 +860,65 @@ def test_artifact_action_majors_match_per_producer_consumer_chain() -> None:
     assert not offences, "artifact chain hygiene failed:\n  " + "\n  ".join(offences)
 
 
+def _live_yaml_sources() -> dict[str, str]:
+    return {str(path.relative_to(ROOT)): path.read_text(encoding="utf-8") for path in _workflow_files()}
+
+
+def _iter_step_uses(document: Mapping[object, object], where: str) -> list[tuple[str, object]]:
+    """Step ``uses:`` from a workflow ``jobs.*.steps`` or a composite ``runs.steps``."""
+    found: list[tuple[str, object]] = []
+    jobs = document.get("jobs")
+    if isinstance(jobs, dict):
+        for job_name, job in jobs.items():
+            if not isinstance(job, dict):
+                continue
+            steps = job.get("steps")
+            if not isinstance(steps, list):
+                continue
+            for index, step in enumerate(steps):
+                if isinstance(step, dict) and "uses" in step:
+                    found.append((f"{where}:{job_name}:step-{index}", step.get("uses")))
+    runs = document.get("runs")
+    if isinstance(runs, dict):
+        steps = runs.get("steps")
+        if isinstance(steps, list):
+            for index, step in enumerate(steps):
+                if isinstance(step, dict) and "uses" in step:
+                    found.append((f"{where}:runs:step-{index}", step.get("uses")))
+    return found
+
+
+def _live_artifact_offences(sources: dict[str, str]) -> list[str]:
+    """issue #2725: every live upload/download-artifact pin must exist upstream
+    and sit at the highest major both actions publish.
+
+    Walks parsed YAML so quoted ``uses:``, folded scalars, and composite-action
+    steps are visible; comment lines are not pins.
+    """
+    offences: list[str] = []
+    for name, text in sources.items():
+        document = _workflow_document(text, name)
+        for location, uses in _iter_step_uses(document, name):
+            match = _artifact_action_match(uses, location)
+            if match is None:
+                continue
+            kind = match.group("kind")
+            major = int(match.group("major"))
+            known = _KNOWN_ARTIFACT_MAJORS[kind]
+            if major not in known:
+                offences.append(
+                    f"{location}: actions/{kind}-artifact@v{major} is not a known "
+                    f"upstream major (known: {sorted(known)})"
+                )
+            elif major != _HIGHEST_COMMON_ARTIFACT_MAJOR:
+                offences.append(
+                    f"{location}: pin actions/{kind}-artifact to "
+                    f"v{_HIGHEST_COMMON_ARTIFACT_MAJOR} (highest common existing major), "
+                    f"not v{major}"
+                )
+    return offences
+
+
 def test_live_artifact_actions_use_highest_common_existing_major() -> None:
     """issue #2725: producer/consumer major matching does not prove the pin
     exists upstream. ``upload-artifact@v8`` matched ``download-artifact@v8``
@@ -873,28 +929,54 @@ def test_live_artifact_actions_use_highest_common_existing_major() -> None:
     resolvable ref. Fixture YAML in this file is out of scope — those literals
     exercise the scanner, not GitHub's tag namespace.
     """
-    assert _HIGHEST_COMMON_ARTIFACT_MAJOR == 7
-    offences: list[str] = []
-    for name, text in _workflow_sources().items():
-        for line_no, line in enumerate(text.splitlines(), start=1):
-            match = _LIVE_ARTIFACT_USES.search(line)
-            if match is None:
-                continue
-            kind = match.group("kind")
-            major = int(match.group("major"))
-            known = _KNOWN_ARTIFACT_MAJORS[kind]
-            if major not in known:
-                offences.append(
-                    f"{name}:{line_no}: actions/{kind}-artifact@v{major} is not a known "
-                    f"upstream major (known: {sorted(known)})"
-                )
-            elif major != _HIGHEST_COMMON_ARTIFACT_MAJOR:
-                offences.append(
-                    f"{name}:{line_no}: pin actions/{kind}-artifact to "
-                    f"v{_HIGHEST_COMMON_ARTIFACT_MAJOR} (highest common existing major), "
-                    f"not v{major}"
-                )
+    offences = _live_artifact_offences(_live_yaml_sources())
     assert not offences, "live artifact pins failed:\n  " + "\n  ".join(offences)
+
+
+def test_live_artifact_gate_sees_quoted_uses_refs() -> None:
+    """Quoted ``uses:`` is a real workflow shape (this file's own fixtures) and
+    is the original #2725 incident with quotes added. A line regex that requires
+    an unquoted value misses it; a comment line is not a pin.
+    """
+    sources = {
+        "quoted.yml": """\
+on: workflow_dispatch
+jobs:
+  up:
+    steps:
+      - uses: "actions/upload-artifact@v8"
+        with: {name: pkg}
+  down:
+    needs: up
+    steps:
+      - uses: 'actions/download-artifact@v8'
+        with: {name: pkg}
+""",
+        "comment.yml": """\
+on: workflow_dispatch
+jobs:
+  x:
+    steps:
+      - run: "true"
+#      - uses: actions/upload-artifact@v8
+""",
+        ".github/actions/example/action.yml": """\
+runs:
+  using: composite
+  steps:
+    - uses: actions/upload-artifact@v8
+      with: {name: pkg}
+""",
+    }
+    offences = _live_artifact_offences(sources)
+    assert any("quoted.yml" in item and "upload-artifact@v8" in item and "not a known" in item for item in offences), (
+        offences
+    )
+    assert any("quoted.yml" in item and "download-artifact" in item and "not v8" in item for item in offences), offences
+    assert any("action.yml" in item and "upload-artifact@v8" in item and "not a known" in item for item in offences), (
+        offences
+    )
+    assert not any("comment.yml" in item for item in offences), offences
 
 
 def test_artifact_scanner_follows_needs_reusable_inputs_outputs_and_workflow_run() -> None:

--- a/tests/test_issue2231_workflow_hygiene.py
+++ b/tests/test_issue2231_workflow_hygiene.py
@@ -17,8 +17,9 @@ disables silently. These gates cover what actionlint cannot:
 3. The ``actionlint`` job keeps its embedded ShellCheck pass over ``run:``
    bodies, and no config filters that pass's findings away (issue #2241).
 4. Dispatchable workflows own top-level concurrency; artifact chains keep one
-   upload/download action major; container invocations pass ``--init``; and
-   downstream jobs consume prepared SHA pins (issue #2413).
+   upload/download action major at the highest major both actions publish
+   (issue #2725); container invocations pass ``--init``; and downstream jobs
+   consume prepared SHA pins (issue #2413).
 """
 
 from __future__ import annotations
@@ -464,6 +465,16 @@ _DownloadKey = tuple[str, str, int, int, tuple[tuple[str, str], ...], tuple[str,
 
 _ARTIFACT_ACTION_REF = re.compile(r"^actions/(?P<kind>upload|download)-artifact@.+$")
 _ARTIFACT_ACTION = re.compile(r"^actions/(?P<kind>upload|download)-artifact@v(?P<major>[0-9]+)(?:\.[0-9]+){0,2}$")
+# Frozen 2026-08-26 from the GitHub API (issue #2725). upload-artifact has no v8
+# tag (latest v7.0.1); download-artifact does (v8.0.1). Highest common is v7.
+_KNOWN_ARTIFACT_MAJORS: dict[str, frozenset[int]] = {
+    "upload": frozenset({4, 5, 6, 7}),
+    "download": frozenset({3, 4, 5, 6, 7, 8}),
+}
+_HIGHEST_COMMON_ARTIFACT_MAJOR = max(_KNOWN_ARTIFACT_MAJORS["upload"] & _KNOWN_ARTIFACT_MAJORS["download"])
+_LIVE_ARTIFACT_USES = re.compile(
+    r"uses:\s+actions/(?P<kind>upload|download)-artifact@v(?P<major>[0-9]+)(?:\.[0-9]+){0,2}"
+)
 _GH_EXPRESSION = re.compile(r"\$\{\{\s*(.*?)\s*\}\}")
 _UNRESOLVED_EXPRESSION = re.compile(r"<unresolved:(?P<expression>[^>]+)>")
 
@@ -850,6 +861,40 @@ def _artifact_chain_offences(sources: dict[str, str]) -> list[str]:
 def test_artifact_action_majors_match_per_producer_consumer_chain() -> None:
     offences = _artifact_chain_offences(_workflow_sources())
     assert not offences, "artifact chain hygiene failed:\n  " + "\n  ".join(offences)
+
+
+def test_live_artifact_actions_use_highest_common_existing_major() -> None:
+    """issue #2725: producer/consumer major matching does not prove the pin
+    exists upstream. ``upload-artifact@v8`` matched ``download-artifact@v8``
+    and passed every gate, then failed at Set up job.
+
+    Live workflow pins must be a known upstream major for that action and use
+    the highest major both actions publish, so the pair stays matched at a
+    resolvable ref. Fixture YAML in this file is out of scope — those literals
+    exercise the scanner, not GitHub's tag namespace.
+    """
+    assert _HIGHEST_COMMON_ARTIFACT_MAJOR == 7
+    offences: list[str] = []
+    for name, text in _workflow_sources().items():
+        for line_no, line in enumerate(text.splitlines(), start=1):
+            match = _LIVE_ARTIFACT_USES.search(line)
+            if match is None:
+                continue
+            kind = match.group("kind")
+            major = int(match.group("major"))
+            known = _KNOWN_ARTIFACT_MAJORS[kind]
+            if major not in known:
+                offences.append(
+                    f"{name}:{line_no}: actions/{kind}-artifact@v{major} is not a known "
+                    f"upstream major (known: {sorted(known)})"
+                )
+            elif major != _HIGHEST_COMMON_ARTIFACT_MAJOR:
+                offences.append(
+                    f"{name}:{line_no}: pin actions/{kind}-artifact to "
+                    f"v{_HIGHEST_COMMON_ARTIFACT_MAJOR} (highest common existing major), "
+                    f"not v{major}"
+                )
+    assert not offences, "live artifact pins failed:\n  " + "\n  ".join(offences)
 
 
 def test_artifact_scanner_follows_needs_reusable_inputs_outputs_and_workflow_run() -> None:

--- a/tests/test_smoke_leg_zero_selection_gate.py
+++ b/tests/test_smoke_leg_zero_selection_gate.py
@@ -106,7 +106,7 @@ def _shard_status_upload_step() -> list[str]:
 
 def test_smoke_single_uploads_shard_selection_status_marker() -> None:
     step_text = "\n".join(_shard_status_upload_step())
-    assert "uses: actions/upload-artifact@v7" in step_text, step_text
+    assert "uses: actions/upload-artifact@" in step_text, step_text
     assert re.search(r"if:\s*always\(\)", step_text), f"upload must run unconditionally, got:\n{step_text}"
     name_line = next(line for line in _shard_status_upload_step() if line.strip().startswith("name:"))
     assert "inputs.image_name" in name_line and "inputs.pfsense_version" in name_line and "inputs.shard" in name_line, (

--- a/tests/test_smoke_leg_zero_selection_gate.py
+++ b/tests/test_smoke_leg_zero_selection_gate.py
@@ -106,7 +106,7 @@ def _shard_status_upload_step() -> list[str]:
 
 def test_smoke_single_uploads_shard_selection_status_marker() -> None:
     step_text = "\n".join(_shard_status_upload_step())
-    assert "uses: actions/upload-artifact@v8" in step_text, step_text
+    assert "uses: actions/upload-artifact@v7" in step_text, step_text
     assert re.search(r"if:\s*always\(\)", step_text), f"upload must run unconditionally, got:\n{step_text}"
     name_line = next(line for line in _shard_status_upload_step() if line.strip().startswith("name:"))
     assert "inputs.image_name" in name_line and "inputs.pfsense_version" in name_line and "inputs.shard" in name_line, (


### PR DESCRIPTION
Fixes #2725

## Summary

`actions/upload-artifact@v8` does not exist. Workflows pinned to it fail at `Set up job` before any step runs. `actions/download-artifact@v8` does exist, so a blanket bump to v8 is wrong: the two actions are not on the same major.

This PR pins **both** actions to **v7** — the highest major where both exist — so producer and consumer majors stay matched at a resolvable ref. Same mismatch class as closed issue #2385 (`@v4` download after `@v7` upload).

A live-pin gate rejects any upload/download-artifact ref that is not a known upstream major for that action, or that is not the highest common major. The gate walks **parsed YAML** (quoted `uses:`, folded scalars, composite `action.yml` steps) via `_artifact_action_match`, so a quoted v8/v8 pair cannot match on majors and still miss the existence check. Comment lines are not pins. Fixture YAML in `test_issue2231_workflow_hygiene.py` and `test_issue2245_stateless_nightly.py` is unchanged — those literals exercise the scanner, not GitHub's tag namespace.

This was split out of #2723 (documentation-only Flex help text) so that PR can rebase onto this one.

## Files

| Path | Change |
| --- | --- |
| `.github/workflows/build-image.yml` | download v8 → v7 |
| `.github/workflows/build-pkg-linux.yml` | upload v8 → v7 (×2) |
| `.github/workflows/module-durations.yml` | download v8 → v7 |
| `.github/workflows/release.yml` | upload/download v8 → v7 (×3) |
| `.github/workflows/smoke-single.yml` | upload/download v8 → v7 (×4) |
| `.github/workflows/smoke.yml` | download v8 → v7 |
| `.github/workflows/ui-tests.yml` | download v8 → v7 (×2) |
| `tests/test_smoke_leg_zero_selection_gate.py` | marker upload is `upload-artifact` (major owned by the live gate) |
| `tests/test_issue2231_workflow_hygiene.py` | live-pin existence + highest-common gate (parsed YAML) |

Already-v7 pins (`test.yml`, `nightly.yml`, `image-refresh.yml`, `version-tracker.yml`, and the remaining upload in `ui-tests.yml` / `build-image.yml`) are untouched. `tests/test_issue2245_stateless_nightly.py` is the tenth `artifact@v8` path on `devel`; every hit is a scanner fixture, not a live pin.

## Verification

- RED on untouched `devel` (`4d03e615`), then GREEN after the workflow pin, same test bytes for the original two frozen files.
- Quoted-`uses:` gate: RED on the line-regex helper (`quoted.yml` upload v8 missing from offences; comment line false-positive), GREEN after the parsed-YAML walk. Same `test_live_artifact_gate_sees_quoted_uses_refs` body.
- `uv run pytest -q tests/test_issue2231_workflow_hygiene.py tests/test_smoke_leg_zero_selection_gate.py tests/test_ui_release_gate_wiring.py::test_release_yml_upload_and_download_artifact_majors_match` → **45 passed** (43 on the pin commit, plus the quoted-ref test and the extra live-gate helper coverage).
- `scripts/agent/run-gates.sh --diff origin/devel`: `GATES: PASS` (coverage pairing, pytest, Ruff, mypy)

| Frozen RED test | git hash-object | RED run tail |
| --- | --- | --- |
| `tests/test_issue2231_workflow_hygiene.py` | `5b83aceeaf52afaa669d4ab9563294c31ffadc80` | quoted `uses: "actions/upload-artifact@v8"` absent from offences on the line-regex helper; comment line false-positive (parse walk then GREEN, same test) |
| `tests/test_smoke_leg_zero_selection_gate.py` | `1aa1c2f33165efa61c9696011cfa02159f0f5167` | `assert "uses: actions/upload-artifact@v7" in step_text` — step still had `@v8` (assertion later dropped the major; action half remains) |

🤖 Generated by Grok and posted on behalf of @BBcan177.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **CI/CD**
  - Updated artifact upload and download workflows to use the supported common action version.
  - Preserved existing package, diagnostic, smoke-test, and release artifact handling.

- **Tests**
  - Added workflow validation to verify artifact action versions across workflow configurations.
  - Expanded coverage for quoted references, composite actions, and ignored comments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->