### PR TITLE
smoke: force pkg ABI on add when metadata rewrote config ABI

### DIFF
--- a/scripts/install-pkg.sh
+++ b/scripts/install-pkg.sh
@@ -119,7 +119,9 @@ pkg_add_lock_retry() {
         # Same-shell probe: a separate SSH round-trip can observe a different ABI
         # while first-boot metadata settles. The final pkg command supplies status.
         if [ -n "${SMOKE_ABI:-}" ]; then
-            _pkg_add="pkg -o ABI=${SMOKE_ABI} add"
+            # Quote ABI for dash; empty SMOKE_ABI is treated as unset by -n above.
+            _abi_q=$(printf '%s' "$SMOKE_ABI" | sed "s/'/'\\\\''/g")
+            _pkg_add="pkg -o ABI='${_abi_q}' add"
         else
             _pkg_add="pkg add"
         fi

--- a/scripts/install-pkg.sh
+++ b/scripts/install-pkg.sh
@@ -23,6 +23,10 @@
 #   SMOKE_DEP_PKGS   space-separated absolute paths of extra dep .pkg files,
 #                    scp'd + `pkg add`ed BEFORE the branch .pkg, in the given
 #                    order. Unset/empty (the default) -> skipped entirely.
+#   SMOKE_ABI        when set, each `pkg add` is `pkg -o ABI=$SMOKE_ABI add`
+#                    so a guest whose `pkg config ABI` drifted after
+#                    rc.update_pkg_metadata still accepts the matrix-built
+#                    local .pkg (issue #2730). Unset -> plain `pkg add`.
 #
 # POSIX sh; quoted expansions; absolute binary paths where it matters.
 
@@ -114,7 +118,12 @@ pkg_add_lock_retry() {
         _rc=0
         # Same-shell probe: a separate SSH round-trip can observe a different ABI
         # while first-boot metadata settles. The final pkg command supplies status.
-        _out=$(ssh_t "printf 'PFB_PKG_CONTEXT utc='; date -u '+%Y-%m-%dT%H:%M:%SZ'; printf 'PFB_PKG_CONTEXT absolute_abi='; /usr/local/sbin/pkg config ABI 2>&1 || true; printf 'PFB_PKG_CONTEXT path_pkg='; command -v pkg 2>&1 || true; printf 'PFB_PKG_CONTEXT path_abi='; pkg config ABI 2>&1 || true; printf 'PFB_PKG_CONTEXT boot_pkg_processes='; ps axww -o pid= -o comm= -o args= 2>&1 | awk '((\$2 == \"sh\" && \$3 == \"/bin/sh\" && (\$4 == \"/etc/rc.update_pkg_metadata\" || \$4 == \"/usr/local/sbin/pfSense-upgrade\" || \$4 == \"/usr/local/libexec/pfSense-upgrade\")) || (\$2 == \"lockf\" && \$0 ~ /\/tmp\/pfSense-upgrade\.lock/) || \$2 == \"pkg\" || \$2 == \"pkg-static\") { found=1; print } END { if (!found) print \"none\" }'; env ASSUME_ALWAYS_YES=yes pkg add '${_pkg_remote}'" 2>&1) || _rc=$?
+        if [ -n "${SMOKE_ABI:-}" ]; then
+            _pkg_add="pkg -o ABI=${SMOKE_ABI} add"
+        else
+            _pkg_add="pkg add"
+        fi
+        _out=$(ssh_t "printf 'PFB_PKG_CONTEXT utc='; date -u '+%Y-%m-%dT%H:%M:%SZ'; printf 'PFB_PKG_CONTEXT absolute_abi='; /usr/local/sbin/pkg config ABI 2>&1 || true; printf 'PFB_PKG_CONTEXT path_pkg='; command -v pkg 2>&1 || true; printf 'PFB_PKG_CONTEXT path_abi='; pkg config ABI 2>&1 || true; printf 'PFB_PKG_CONTEXT boot_pkg_processes='; ps axww -o pid= -o comm= -o args= 2>&1 | awk '((\$2 == \"sh\" && \$3 == \"/bin/sh\" && (\$4 == \"/etc/rc.update_pkg_metadata\" || \$4 == \"/usr/local/sbin/pfSense-upgrade\" || \$4 == \"/usr/local/libexec/pfSense-upgrade\")) || (\$2 == \"lockf\" && \$0 ~ /\/tmp\/pfSense-upgrade\.lock/) || \$2 == \"pkg\" || \$2 == \"pkg-static\") { found=1; print } END { if (!found) print \"none\" }'; env ASSUME_ALWAYS_YES=yes ${_pkg_add} '${_pkg_remote}'" 2>&1) || _rc=$?
         if [ -n "$_out" ]; then printf '%s\n' "$_out"; fi
         if [ "$_rc" -eq 0 ]; then return 0; fi
         case "$_out" in

--- a/tests/shell/install_pkg_spec.sh
+++ b/tests/shell/install_pkg_spec.sh
@@ -122,13 +122,32 @@ SCPEOF
     The contents of file "$SSH_LOG" should include "$(basename "$PKGFILE")"
   End
 
-  It 'SMOKE_ABI set -> pkg add forces that ABI (issue #2730)'
+  It 'SMOKE_ABI set -> pkg add forces that ABI quoted (issue #2730)'
     SMOKE_ABI=FreeBSD:15:amd64
     export SMOKE_ABI
     When run sh "$SCRIPT" root@dummy --pkg "$PKGFILE" --port 2222
     The status should be success
     The stdout should be present
-    The line 1 of contents of file "$SSH_LOG" should include 'pkg -o ABI=FreeBSD:15:amd64 add'
+    # ssh_t single-quotes the remote blob, so inner ABI quotes log as '\''.
+    The line 1 of contents of file "$SSH_LOG" should include "pkg -o ABI='\''FreeBSD:15:amd64'\'' add"
+  End
+
+  It 'SMOKE_ABI unset -> pkg add has no -o ABI (issue #2730)'
+    When run sh "$SCRIPT" root@dummy --pkg "$PKGFILE" --port 2222
+    The status should be success
+    The stdout should be present
+    The line 1 of contents of file "$SSH_LOG" should include 'pkg add'
+    The line 1 of contents of file "$SSH_LOG" should not include 'pkg -o ABI='
+  End
+
+  It 'SMOKE_ABI empty -> treated as unset (issue #2730)'
+    SMOKE_ABI=
+    export SMOKE_ABI
+    When run sh "$SCRIPT" root@dummy --pkg "$PKGFILE" --port 2222
+    The status should be success
+    The stdout should be present
+    The line 1 of contents of file "$SSH_LOG" should include 'pkg add'
+    The line 1 of contents of file "$SSH_LOG" should not include 'pkg -o ABI='
   End
 
   It 'logs pkg identity in the same remote shell immediately before pkg add'

--- a/tests/shell/install_pkg_spec.sh
+++ b/tests/shell/install_pkg_spec.sh
@@ -132,6 +132,16 @@ SCPEOF
     The line 1 of contents of file "$SSH_LOG" should include "pkg -o ABI='\''FreeBSD:15:amd64'\'' add"
   End
 
+  It 'SMOKE_ABI with a single quote is dash-escaped (issue #2730)'
+    SMOKE_ABI="FreeBSD:15:am'd64"
+    export SMOKE_ABI
+    When run sh "$SCRIPT" root@dummy --pkg "$PKGFILE" --port 2222
+    The status should be success
+    The stdout should be present
+    # sed-escape then ssh_t: an ABI quote becomes '\''\'\'''\'' in SSH_LOG.
+    The line 1 of contents of file "$SSH_LOG" should include "pkg -o ABI='\''FreeBSD:15:am'\''\\'\\'''\\''d64'\'' add"
+  End
+
   It 'SMOKE_ABI unset -> pkg add has no -o ABI (issue #2730)'
     When run sh "$SCRIPT" root@dummy --pkg "$PKGFILE" --port 2222
     The status should be success

--- a/tests/shell/install_pkg_spec.sh
+++ b/tests/shell/install_pkg_spec.sh
@@ -18,7 +18,7 @@ Describe 'install-pkg.sh'
 
   setup() {
     scrub_git_env
-    unset SMOKE_DEP_PKGS FAIL_PKG_ADD_MATCH EXEC_REMOTE_PKG_CONTEXT PFB_FAKE_PS_OUTPUT
+    unset SMOKE_DEP_PKGS SMOKE_ABI FAIL_PKG_ADD_MATCH EXEC_REMOTE_PKG_CONTEXT PFB_FAKE_PS_OUTPUT
     WORK="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/instpkgspec.XXXXXX")"
     FAKE_BIN="${WORK}/bin"
     mkdir -p "$FAKE_BIN"
@@ -54,7 +54,7 @@ esac
 # decrements it and fails with the REAL guest lock signature (observed verbatim
 # in run 31229687348) -- the transient/persistent lock cases drive this.
 case "$_a" in
-    *"pkg add"*)
+    *"pkg add"* | *"pkg -o ABI="*)
         if [ -f "${WORK}/lock.remaining" ]; then
             _n=$(cat "${WORK}/lock.remaining")
             if [ "$_n" -gt 0 ]; then
@@ -120,6 +120,15 @@ SCPEOF
     The contents of file "$SCP_LOG" should equal "$PKGFILE"
     The result of function pkg_add_count should equal 1
     The contents of file "$SSH_LOG" should include "$(basename "$PKGFILE")"
+  End
+
+  It 'SMOKE_ABI set -> pkg add forces that ABI (issue #2730)'
+    SMOKE_ABI=FreeBSD:15:amd64
+    export SMOKE_ABI
+    When run sh "$SCRIPT" root@dummy --pkg "$PKGFILE" --port 2222
+    The status should be success
+    The stdout should be present
+    The line 1 of contents of file "$SSH_LOG" should include 'pkg -o ABI=FreeBSD:15:amd64 add'
   End
 
   It 'logs pkg identity in the same remote shell immediately before pkg add'

--- a/tests/smoke/conftest.py
+++ b/tests/smoke/conftest.py
@@ -356,7 +356,7 @@ def _pkg_abi_parseable(abi: str) -> bool:
     them as pkg-config ABI drift.
     """
     parts = abi.split(":")
-    return len(parts) >= 2 and bool(parts[0]) and parts[1].isdigit()
+    return len(parts) >= 2 and bool(parts[0]) and parts[1].isascii() and parts[1].isdigit()
 
 
 def _abi_major(abi: str) -> str:
@@ -387,6 +387,7 @@ def _log_guest_identity(vm: SmokeVM) -> None:
     )
     observed_abi = "?"
     observed_freebsd_version = "?"
+    observed_kernel_release = "?"
     observed_pkg_client = "?"
     observed_pkg_pkg = "?"
     for line in result.stdout.splitlines():
@@ -395,6 +396,8 @@ def _log_guest_identity(vm: SmokeVM) -> None:
             observed_abi = line[len("abi=") :]
         elif line.startswith("freebsd_version="):
             observed_freebsd_version = line[len("freebsd_version=") :]
+        elif line.startswith("kernel_release="):
+            observed_kernel_release = line[len("kernel_release=") :]
         elif line.startswith("pkg_client="):
             observed_pkg_client = line[len("pkg_client=") :]
         elif line.startswith("pkg_pkg="):
@@ -414,12 +417,23 @@ def _log_guest_identity(vm: SmokeVM) -> None:
                 f"guest pkg ABI {observed_abi} does not match expected SMOKE_ABI {expected_abi} "
                 "(unreadable pkg ABI; issue #2730)"
             )
+        if observed_abi.split(":", 1)[0] != expected_abi.split(":", 1)[0]:
+            raise RuntimeError(
+                f"guest pkg ABI {observed_abi} OS name does not match expected SMOKE_ABI "
+                f"{expected_abi} (issue #2730 — drift-allow is FreeBSD major only)"
+            )
         # row 2: the userland major itself, independent of what pkg claims its ABI is.
         if _dot_major(observed_freebsd_version) != expected_major:
             raise RuntimeError(
                 f"guest /bin/freebsd-version {observed_freebsd_version} does not match expected "
-                f"SMOKE_ABI {expected_abi} (major mismatch; issue #2242 — a foreign FreeBSD "
+                f"SMOKE_ABI {expected_abi} (major mismatch; issue #2730 — a foreign FreeBSD "
                 "userland replaced the guest's own, refusing to pkg add)"
+            )
+        if _dot_major(observed_kernel_release) != expected_major:
+            raise RuntimeError(
+                f"guest kernel {observed_kernel_release} does not match expected "
+                f"SMOKE_ABI {expected_abi} (major mismatch; issue #2730 — a 16 kernel "
+                "is not config-ABI drift)"
             )
         if observed_os_major != expected_os_major:
             print(f"PFB_GUEST_IDENTITY pkg_abi_drift={observed_abi} forcing_add_abi={expected_abi}")

--- a/tests/smoke/conftest.py
+++ b/tests/smoke/conftest.py
@@ -388,25 +388,30 @@ def _log_guest_identity(vm: SmokeVM) -> None:
             observed_pkg_client = line[len("pkg_client=") :]
         elif line.startswith("pkg_pkg="):
             observed_pkg_pkg = line[len("pkg_pkg=") :]
-    # issue #2242 row 1: live pfSense repository metadata rewrote the effective ABI
-    # mid-run; fail before pkg add rather than let a stale/foreign package land. Arch is
-    # deliberately not compared — only OS/major.
+    # issue #2730: `pkg config ABI` can flip (15→16) after rc.update_pkg_metadata on a
+    # guest whose kernel and freebsd-version stay on the matrix major. Row 2 (userland
+    # major) is the wrong-image abort. A parseable pkg-ABI drift with a matching
+    # userland is not a refuse — install-pkg.sh adds with `pkg -o ABI=$SMOKE_ABI`.
+    # Unreadable/placeholder pkg ABI still fails closed. Arch is not compared.
     expected_abi = os.environ.get("SMOKE_ABI", "")
-    if expected_abi and _abi_os_major(observed_abi) != _abi_os_major(expected_abi):
-        raise RuntimeError(
-            f"guest pkg ABI {observed_abi} does not match expected SMOKE_ABI {expected_abi} "
-            "(OS/major mismatch; issue #2242 — live pfSense repository metadata rewrote the "
-            "effective ABI, refusing to pkg add)"
-        )
     if expected_abi:
-        # row 2: the userland major itself, independent of what pkg claims its ABI is.
+        expected_os_major = _abi_os_major(expected_abi)
+        observed_os_major = _abi_os_major(observed_abi)
         expected_major = _abi_major(expected_abi)
+        if observed_os_major != expected_os_major and (observed_abi in {"", "?"} or ":" not in observed_abi):
+            raise RuntimeError(
+                f"guest pkg ABI {observed_abi} does not match expected SMOKE_ABI {expected_abi} "
+                "(unreadable pkg ABI; issue #2242)"
+            )
+        # row 2: the userland major itself, independent of what pkg claims its ABI is.
         if _dot_major(observed_freebsd_version) != expected_major:
             raise RuntimeError(
                 f"guest /bin/freebsd-version {observed_freebsd_version} does not match expected "
                 f"SMOKE_ABI {expected_abi} (major mismatch; issue #2242 — a foreign FreeBSD "
                 "userland replaced the guest's own, refusing to pkg add)"
             )
+        if observed_os_major != expected_os_major:
+            print(f"PFB_GUEST_IDENTITY pkg_abi_drift={observed_abi} forcing_add_abi={expected_abi}")
         # row 3: the pkg CLIENT binary's own major vs the major of the pkg PACKAGE it
         # thinks it has installed — a foreign pkg binary can replace the client without
         # updating pkg's own package record, or vice versa.

--- a/tests/smoke/conftest.py
+++ b/tests/smoke/conftest.py
@@ -348,6 +348,17 @@ def _abi_os_major(abi: str) -> str:
     return ":".join(abi.split(":")[:2])
 
 
+def _pkg_abi_parseable(abi: str) -> bool:
+    """True when ``abi`` is ``OS:<digits>[:arch...]``.
+
+    Empty, placeholder, missing colon, empty major, or a non-numeric major
+    are unreadable — issue #2730 fails those closed rather than treating
+    them as pkg-config ABI drift.
+    """
+    parts = abi.split(":")
+    return len(parts) >= 2 and bool(parts[0]) and parts[1].isdigit()
+
+
 def _abi_major(abi: str) -> str:
     """Second ``:``-separated field of a pkg ABI string (``FreeBSD:15:amd64`` -> ``15``)."""
     parts = abi.split(":")
@@ -398,10 +409,10 @@ def _log_guest_identity(vm: SmokeVM) -> None:
         expected_os_major = _abi_os_major(expected_abi)
         observed_os_major = _abi_os_major(observed_abi)
         expected_major = _abi_major(expected_abi)
-        if observed_os_major != expected_os_major and (observed_abi in {"", "?"} or ":" not in observed_abi):
+        if not _pkg_abi_parseable(observed_abi):
             raise RuntimeError(
                 f"guest pkg ABI {observed_abi} does not match expected SMOKE_ABI {expected_abi} "
-                "(unreadable pkg ABI; issue #2242)"
+                "(unreadable pkg ABI; issue #2730)"
             )
         # row 2: the userland major itself, independent of what pkg claims its ABI is.
         if _dot_major(observed_freebsd_version) != expected_major:

--- a/tests/test_smoke_boot_identity.py
+++ b/tests/test_smoke_boot_identity.py
@@ -143,6 +143,45 @@ def test_log_guest_identity_allows_pkg_abi_drift_when_userland_major_matches(
     assert "forcing_add_abi=FreeBSD:15:amd64" in printed
 
 
+def test_log_guest_identity_refuses_when_userland_major_moved_with_pkg_abi(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """issue #2730 escalation: a 16 userland plus a 16 pkg ABI is not agreement.
+
+    Drift-allow is only when freebsd-version stays on the matrix major. Row 2
+    still refuses a real OS upgrade, even if pkg config ABI matches that upgrade.
+    """
+    monkeypatch.setenv("SMOKE_ABI", "FreeBSD:15:amd64")
+    vm = _IdentityVM(_identity_stdout("abi=FreeBSD:16:amd64", freebsd_version_line="freebsd_version=16.0-CURRENT"))
+
+    with pytest.raises(RuntimeError, match=r"freebsd-version") as exc_info:
+        smoke_conftest._log_guest_identity(cast(smoke_conftest.SmokeVM, vm))
+
+    assert "16.0-CURRENT" in str(exc_info.value)
+    assert "FreeBSD:15:amd64" in str(exc_info.value)
+
+
+@pytest.mark.parametrize(
+    "abi_line",
+    [
+        "abi=",
+        "abi= ",
+        "abi=?",
+        "abi=FreeBSD:",
+        "abi=FreeBSD:x:amd64",
+        "abi=not-an-abi",
+        "abi=FreeBSD",
+    ],
+)
+def test_log_guest_identity_refuses_unreadable_pkg_abi(monkeypatch: pytest.MonkeyPatch, abi_line: str) -> None:
+    """issue #2730: unreadable/placeholder pkg ABI fails closed, not as drift."""
+    monkeypatch.setenv("SMOKE_ABI", "FreeBSD:15:amd64")
+    vm = _IdentityVM(_identity_stdout(abi_line))
+
+    with pytest.raises(RuntimeError, match=r"unreadable pkg ABI"):
+        smoke_conftest._log_guest_identity(cast(smoke_conftest.SmokeVM, vm))
+
+
 def test_log_guest_identity_allows_matching_abi_os_major(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("SMOKE_ABI", "FreeBSD:15:amd64")
     vm = _IdentityVM(_identity_stdout("abi=FreeBSD:15:amd64"))

--- a/tests/test_smoke_boot_identity.py
+++ b/tests/test_smoke_boot_identity.py
@@ -122,20 +122,25 @@ def _identity_stdout(
     return "\n".join(lines) + "\n"
 
 
-def test_log_guest_identity_raises_on_abi_os_major_mismatch(
+def test_log_guest_identity_allows_pkg_abi_drift_when_userland_major_matches(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    # issue #2242: live pfSense repository metadata rewrote the effective ABI mid-run
+    """issue #2730: rc.update_pkg_metadata can flip `pkg config ABI` to 16
+    on a CE 2.8 guest whose kernel and freebsd-version stay 15.0-CURRENT.
+
+    Row 2 (userland major) is the wrong-image abort. A parseable pkg-ABI drift
+    with a matching userland must not refuse the boot — install-pkg.sh then
+    adds with ``pkg -o ABI=$SMOKE_ABI``.
+    """
     monkeypatch.setenv("SMOKE_ABI", "FreeBSD:15:amd64")
     vm = _IdentityVM(_identity_stdout("abi=FreeBSD:16:amd64"))
 
-    with pytest.raises(RuntimeError) as exc_info:
-        smoke_conftest._log_guest_identity(cast(smoke_conftest.SmokeVM, vm))
+    smoke_conftest._log_guest_identity(cast(smoke_conftest.SmokeVM, vm))  # must not raise
 
-    assert "FreeBSD:16:amd64" in str(exc_info.value)
-    assert "FreeBSD:15:amd64" in str(exc_info.value)
     printed = capsys.readouterr().out
-    assert "PFB_GUEST_IDENTITY abi=FreeBSD:16:amd64" in printed, "diagnostics must survive the raise"
+    assert "PFB_GUEST_IDENTITY abi=FreeBSD:16:amd64" in printed
+    assert "PFB_GUEST_IDENTITY freebsd_version=15.0-CURRENT" in printed
+    assert "forcing_add_abi=FreeBSD:15:amd64" in printed
 
 
 def test_log_guest_identity_allows_matching_abi_os_major(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_smoke_boot_identity.py
+++ b/tests/test_smoke_boot_identity.py
@@ -105,6 +105,7 @@ def _identity_stdout(
     abi_line: str | None,
     *,
     freebsd_version_line: str = "freebsd_version=15.0-CURRENT",
+    kernel_release_line: str = "kernel_release=15.0-CURRENT",
     pkg_client_line: str = "pkg_client=1.21.3",
     pkg_pkg_line: str = "pkg_pkg=1.21.3_8",
 ) -> str:
@@ -113,7 +114,7 @@ def _identity_stdout(
     lines = [
         "etc_version=2.8.1-RELEASE",
         "versionpatch=0",
-        "kernel_release=15.0-CURRENT",
+        kernel_release_line,
         "kernel_version=FreeBSD 15 build",
     ]
     if abi_line is not None:
@@ -159,6 +160,32 @@ def test_log_guest_identity_refuses_when_userland_major_moved_with_pkg_abi(
 
     assert "16.0-CURRENT" in str(exc_info.value)
     assert "FreeBSD:15:amd64" in str(exc_info.value)
+
+
+@pytest.mark.parametrize("abi_line", ["abi=Linux:16:amd64", "abi=Debian:16:amd64"])
+def test_log_guest_identity_refuses_foreign_os_name(monkeypatch: pytest.MonkeyPatch, abi_line: str) -> None:
+    """issue #2730: drift-allow is FreeBSD major only, not a foreign OS name."""
+    monkeypatch.setenv("SMOKE_ABI", "FreeBSD:15:amd64")
+    vm = _IdentityVM(_identity_stdout(abi_line))
+
+    with pytest.raises(RuntimeError, match=r"OS name"):
+        smoke_conftest._log_guest_identity(cast(smoke_conftest.SmokeVM, vm))
+
+
+def test_log_guest_identity_refuses_kernel_major_mismatch_even_when_userland_matches(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """issue #2730: a 16 kernel is not config-ABI drift, even if freebsd-version stays 15."""
+    monkeypatch.setenv("SMOKE_ABI", "FreeBSD:15:amd64")
+    vm = _IdentityVM(
+        _identity_stdout(
+            "abi=FreeBSD:16:amd64",
+            kernel_release_line="kernel_release=16.0-CURRENT",
+        )
+    )
+
+    with pytest.raises(RuntimeError, match=r"kernel"):
+        smoke_conftest._log_guest_identity(cast(smoke_conftest.SmokeVM, vm))
 
 
 @pytest.mark.parametrize(
@@ -212,7 +239,7 @@ def test_log_guest_identity_raises_on_abi_fallback_placeholder(monkeypatch: pyte
 
 
 def test_log_guest_identity_allows_arch_only_mismatch(monkeypatch: pytest.MonkeyPatch) -> None:
-    # arch is deliberately not compared here — only OS/major (issue #2242 scope)
+    # arch is not compared; OS name and numeric major still must match (issue #2730)
     monkeypatch.setenv("SMOKE_ABI", "FreeBSD:15:amd64")
     vm = _IdentityVM(_identity_stdout("abi=FreeBSD:15:aarch64"))
 


### PR DESCRIPTION
## Summary

Issue #2242 (closed) is not the `Fixes` target. Residual: on CE 2.8.1, `rc.update_pkg_metadata` can rewrite **pkg config ABI** 15→16 while `freebsd-version` and the kernel stay `15.0-CURRENT`. The identity gate then aborted the smoke boot before any test body ran (`guest pkg ABI … does not match expected SMOKE_ABI`). That is an ERROR, not a product FAIL.

This PR:

1. Keeps the freebsd-version **major** guard as the wrong-image abort.
2. Allows a parseable pkg-config ABI drift when userland major still matches (prints `pkg_abi_drift=` / `forcing_add_abi=`).
3. Still fails closed on unreadable/placeholder pkg ABI.
4. When `SMOKE_ABI` is set, `scripts/install-pkg.sh` runs `pkg -o ABI=$SMOKE_ABI add`. Unset stays `pkg add`.
5. Parseable drift requires matching OS name (`FreeBSD`); `Linux:16:amd64` refuses. Kernel major must match the matrix major.

Not #2402 / #2403 (extra_pkgs dest-routing). Not #2405 (Nightly empty `dep_artifacts`). Do not pin `expected_abi=16`. `#2458` `wait_boot_complete` already waits until metadata is present; this is post-present config-ABI drift.

## Evidence

Lab 2026-08-26, grok-smoke, same CE 2.8.1 qcow:

- 18:03Z / 18:05Z: ERROR, pkg config ABI=16, freebsd-version=15.0-CURRENT. Test body never ran.
- 19:00Z local lab run of `#2635` (not a GitHub SHA; stacked PR #2732 unique commits `676d9ed5` / `ddcf4276`): PASS `test_blacklist_nongzip_body_fails_closed`. That boot did **not** drift; the force-ABI path was not the one that unblocked add. The allow-drift identity gate is what stops the false abort when drift does happen.

## Tests

- `tests/test_smoke_boot_identity.py` — 36 passed locally (`uv run pytest tests/test_smoke_boot_identity.py`).
- `tests/shell/install_pkg_spec.sh` — 16 examples, 0 failures (`shellspec --shell dash`).

## Verification

Pinned blob `d9adefaa` against the true merge-base guard (`71c45233`): **12 failed / 24 passed**. That is 9 from `00965ced` (row-1 removed) plus 3 from `bd2b04ae` (OS-name + kernel). Green at `bd2b04ae`: **36 passed**, hash unchanged.

Quote-bearing `SMOKE_ABI`: mutation dropping the sed escape fails the new shellspec example.

| Frozen RED test | git hash-object | RED run tail |
| --- | --- | --- |
| `tests/test_smoke_boot_identity.py` | `d9adefaa2822215fd628dc74f974c83e4f6ac893` | 12 failed / 24 passed vs merge-base `71c45233` (`Linux:16:amd64`, `Debian:16:amd64`, kernel 16, plus 00965ced row-1 cases) |
| `tests/shell/install_pkg_spec.sh` | `2d364cf07c2d76f00a4f5615aaf6165dd2b510c8` | quote-bearing `SMOKE_ABI=FreeBSD:15:am'd64`; sed-removed mutation FAILED that example (unescaped `'d64`) |
| `tests/smoke/conftest.py` | `20a986d49685ef006233f66a5393f3bfa12ade3c` | implementation under test (pairing requires a tests/** row; this blob is the guard, not frozen across red/green) |

Fixes #2730

🤖 Generated by Grok and posted on behalf of @BBcan177.
