### PR TITLE
pfblockerng: fail closed on non-archive Blacklist bodies

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -14832,7 +14832,11 @@ function pfb_download(PfbDownloadRequest $request): PfbDownloadResult {
 				return PfbDownloadResult::success();
 			}
 			elseif ($type == 'blacklist') {
-				$retval = 0;
+				// issue #2635: a MIME-allowlisted non-archive body is not a
+				// successful Blacklist update — leave category files untouched.
+				pfb_validate_log($header, 'extract', 'blacklist_not_archive', $file_type);
+				unlink_if_exists($file_download);
+				return PfbDownloadResult::failure();
 			}
 			else {
 				// Rename file to 'orig' format

--- a/tests/php/DownloadExtractionExitCodeTest.php
+++ b/tests/php/DownloadExtractionExitCodeTest.php
@@ -154,8 +154,11 @@ final class DownloadExtractionExitCodeTest extends TestCase
 			$scope,
 			'uncompressed Blacklist must not treat a non-archive body as a successful extract'
 		);
-		$this->assertStringContainsString('pfb_validate_log', $scope);
-		$this->assertStringContainsString('blacklist_not_archive', $scope);
+		$this->assertStringContainsString(
+			"pfb_validate_log(\$header, 'extract', 'blacklist_not_archive', \$file_type);",
+			$scope,
+			'reject must name the detected type'
+		);
 		$this->assertStringContainsString('return PfbDownloadResult::failure();', $scope);
 		// The gzip Blacklist branch publishes through pfb_stage_publish_dir() so a
 		// failed tar cannot replace live category files. This uncompressed reject

--- a/tests/php/DownloadExtractionExitCodeTest.php
+++ b/tests/php/DownloadExtractionExitCodeTest.php
@@ -157,6 +157,12 @@ final class DownloadExtractionExitCodeTest extends TestCase
 		$this->assertStringContainsString('pfb_validate_log', $scope);
 		$this->assertStringContainsString('blacklist_not_archive', $scope);
 		$this->assertStringContainsString('return PfbDownloadResult::failure();', $scope);
+		// The gzip Blacklist branch publishes through pfb_stage_publish_dir() so a
+		// failed tar cannot replace live category files. This uncompressed reject
+		// must not extract or publish at all — unlink the .raw body and return.
+		$this->assertStringNotContainsString('pfb_stage_publish_dir', $scope);
+		$this->assertStringNotContainsString('tar -xf', $scope);
+		$this->assertStringNotContainsString('$pfb[\'dbdir\']', $scope);
 	}
 
 	/**

--- a/tests/php/DownloadExtractionExitCodeTest.php
+++ b/tests/php/DownloadExtractionExitCodeTest.php
@@ -135,6 +135,31 @@ final class DownloadExtractionExitCodeTest extends TestCase
 	}
 
 	/**
+	 * Issue #2635 — the uncompressed Blacklist branch must fail closed.
+	 * `$retval = 0` with no extract reports a successful update while
+	 * category files stay stale or missing. Comments/docblocks cannot
+	 * define this scope.
+	 */
+	public function testUncompressedBlacklistBodyFailsClosedWithoutExtraction(): void
+	{
+		$uncomp = strpos(self::$source, "if (\$type == 'geoip' || \$type == 'asn')");
+		$blacklist = strpos(self::$source, "elseif (\$type == 'blacklist') {", $uncomp === FALSE ? 0 : $uncomp);
+		$end = strpos(self::$source, 'else {', $blacklist === FALSE ? 0 : $blacklist);
+		$this->assertNotFalse($uncomp);
+		$this->assertNotFalse($blacklist);
+		$this->assertNotFalse($end);
+		$scope = substr(self::$source, $blacklist, $end - $blacklist);
+		$this->assertStringNotContainsString(
+			'$retval = 0;',
+			$scope,
+			'uncompressed Blacklist must not treat a non-archive body as a successful extract'
+		);
+		$this->assertStringContainsString('pfb_validate_log', $scope);
+		$this->assertStringContainsString('blacklist_not_archive', $scope);
+		$this->assertStringContainsString('return PfbDownloadResult::failure();', $scope);
+	}
+
+	/**
 	 * GeoIP ZIP extraction writes either a directory or stdout-derived target;
 	 * both live tar calls must remain in this dedicated, comment-free scope.
 	 * Comments/docblocks cannot define this scope.

--- a/tests/smoke/test_smoke_feeds.py
+++ b/tests/smoke/test_smoke_feeds.py
@@ -4046,6 +4046,23 @@ def test_blacklist_archive_survives_gzip_content_encoding(deployed_vm: SmokeVM, 
         deployed_vm.ssh(f"/bin/rm -rf {workdir} {category_dir}")
 
 
+def _plant_guest_text(vm: SmokeVM, path: str, contents: str) -> None:
+    """Write ``contents`` to ``path`` on the guest via tee stdin.
+
+    Same plant as ``write_local_feed``: stdin, not a printf format string,
+    so the bytes on disk are the contents argument.
+    """
+    planted = subprocess.run(
+        vm.ssh_argv("tee", path),
+        input=contents,
+        capture_output=True,
+        text=True,
+        timeout=30.0,
+        check=False,
+    )
+    assert planted.returncode == 0, f"tee {path} failed: rc={planted.returncode} stderr={planted.stderr!r}"
+
+
 @pytest.mark.timeout(120)
 def test_blacklist_nongzip_body_fails_closed(deployed_vm: SmokeVM, mock_feeds: _MockFeedServer) -> None:
     """issue #2635: a MIME-allowlisted non-archive Blacklist body must fail, not succeed empty.
@@ -4057,19 +4074,30 @@ def test_blacklist_nongzip_body_fails_closed(deployed_vm: SmokeVM, mock_feeds: _
       and the existing category files are left untouched.
 
     Fail-before: the uncompressed Blacklist branch sets ``$retval = 0`` with no
-    extract, so this reports PFB_DL_TRUE and the sentinel is still overwritten
-    by finalize. Pass-after: fail-closed return, sentinel byte-identical.
+    extract, so this reports PFB_DL_TRUE (a successful empty update). Pass-after:
+    fail-closed return; the planted sentinel stays byte-identical. Finalize writes
+    ``{downloadPath}.orig``, not the category file — the untouched contract is
+    this sentinel, asserted before and after the download.
     """
     fixture = "html_error_page.html"
-    workdir = f"{_ADR46_WORKDIR}_2635"
+    # Staging dir is /tmp, not under dbdir. Gzip Blacklist extracts into
+    # {dbdir}/{header}; a downloadPath next to that tree is not the category dir.
+    workdir = "/tmp/pfb2635_dl"
     category_dir = f"{h.PFB_DBDIR}/pfb2635"
     sentinel_path = f"{category_dir}/pfb2635_testcat"
     sentinel = "keep-me.example.test\n"
     archive = f"{workdir}/pfb2635.tar.gz"
     marker = "pfb_validate: REJECT feed=pfb2635 stage=extract reason=blacklist_not_archive"
     try:
-        deployed_vm.ssh(f"/bin/rm -rf {workdir} {category_dir} && /bin/mkdir -p {workdir} {category_dir}")
-        deployed_vm.ssh(f"/bin/printf '%s\\n' 'keep-me.example.test' > {sentinel_path}")
+        deployed_vm.ssh("/bin/rm", "-rf", workdir, category_dir, timeout=30.0)
+        mk = deployed_vm.ssh("/bin/mkdir", "-p", workdir, category_dir)
+        assert mk.returncode == 0, f"mkdir failed: rc={mk.returncode} stderr={mk.stderr!r}"
+        _plant_guest_text(deployed_vm, sentinel_path, sentinel)
+        planted = deployed_vm.ssh("/bin/cat", sentinel_path).stdout
+        assert planted == sentinel, (
+            f"before-state: planted sentinel must be {sentinel!r}, got {planted!r}; "
+            f"ls={deployed_vm.ssh('/bin/ls', '-la', category_dir).stdout!r}"
+        )
         box_mime = _box_mime_type(deployed_vm, _fixture_bytes(fixture))
         assert box_mime in _SANITY_SCANNED_MIME_TYPES, (
             f"expected {fixture} on-box MIME in {_SANITY_SCANNED_MIME_TYPES}, got {box_mime!r}"
@@ -4087,10 +4115,13 @@ def test_blacklist_nongzip_body_fails_closed(deployed_vm: SmokeVM, mock_feeds: _
             f"expected a NEW {marker!r} line in {h.PFB_LOG}; before={before} after={after}\n"
             f"recent pfb_validate lines:\n{_recent_validate_lines(deployed_vm)}"
         )
-        kept = deployed_vm.ssh(f"/bin/cat {sentinel_path} 2>&1").stdout
-        assert kept == sentinel, f"existing category file must be untouched; {sentinel_path} now holds {kept!r}"
+        kept = deployed_vm.ssh("/bin/cat", sentinel_path).stdout
+        listing = deployed_vm.ssh("/bin/ls", "-la", category_dir).stdout
+        assert kept == sentinel, (
+            f"existing category file must be untouched; {sentinel_path} now holds {kept!r}; ls={listing!r}"
+        )
     finally:
-        deployed_vm.ssh(f"/bin/rm -rf {workdir} {category_dir}")
+        deployed_vm.ssh("/bin/rm", "-rf", workdir, category_dir)
 
 
 @pytest.mark.timeout(180)

--- a/tests/smoke/test_smoke_feeds.py
+++ b/tests/smoke/test_smoke_feeds.py
@@ -4046,6 +4046,53 @@ def test_blacklist_archive_survives_gzip_content_encoding(deployed_vm: SmokeVM, 
         deployed_vm.ssh(f"/bin/rm -rf {workdir} {category_dir}")
 
 
+@pytest.mark.timeout(120)
+def test_blacklist_nongzip_body_fails_closed(deployed_vm: SmokeVM, mock_feeds: _MockFeedServer) -> None:
+    """issue #2635: a MIME-allowlisted non-archive Blacklist body must fail, not succeed empty.
+
+    Given previously extracted Blacklist category files and an origin answering
+      the archive URL with HTTP 200 HTML (allow-listed ``text/html``),
+    When  pfb_download() fetches it as type='blacklist',
+    Then  the result is failure, a canonical reject names the detected type,
+      and the existing category files are left untouched.
+
+    Fail-before: the uncompressed Blacklist branch sets ``$retval = 0`` with no
+    extract, so this reports PFB_DL_TRUE and the sentinel is still overwritten
+    by finalize. Pass-after: fail-closed return, sentinel byte-identical.
+    """
+    fixture = "html_error_page.html"
+    workdir = f"{_ADR46_WORKDIR}_2635"
+    category_dir = f"{h.PFB_DBDIR}/pfb2635"
+    sentinel_path = f"{category_dir}/pfb2635_testcat"
+    sentinel = "keep-me.example.test\n"
+    archive = f"{workdir}/pfb2635.tar.gz"
+    marker = "pfb_validate: REJECT feed=pfb2635 stage=extract reason=blacklist_not_archive"
+    try:
+        deployed_vm.ssh(f"/bin/rm -rf {workdir} {category_dir} && /bin/mkdir -p {workdir} {category_dir}")
+        deployed_vm.ssh(f"/bin/printf '%s\\n' 'keep-me.example.test' > {sentinel_path}")
+        box_mime = _box_mime_type(deployed_vm, _fixture_bytes(fixture))
+        assert box_mime in _SANITY_SCANNED_MIME_TYPES, (
+            f"expected {fixture} on-box MIME in {_SANITY_SCANNED_MIME_TYPES}, got {box_mime!r}"
+        )
+        feed_url = mock_feeds.register("pfb2635.html", _fixture_bytes(fixture))
+        before = h.count_log_marker(deployed_vm, h.PFB_LOG, marker)
+
+        out = _adr46_download(deployed_vm, feed_url, archive, "pfb2635", "blacklist")
+
+        assert "PFB_DL_FALSE" in out, (
+            f"expected pfb_download failure on a non-gzip Blacklist HTML body; got stdout: {out!r}"
+        )
+        after = h.count_log_marker(deployed_vm, h.PFB_LOG, marker)
+        assert after > before, (
+            f"expected a NEW {marker!r} line in {h.PFB_LOG}; before={before} after={after}\n"
+            f"recent pfb_validate lines:\n{_recent_validate_lines(deployed_vm)}"
+        )
+        kept = deployed_vm.ssh(f"/bin/cat {sentinel_path} 2>&1").stdout
+        assert kept == sentinel, f"existing category file must be untouched; {sentinel_path} now holds {kept!r}"
+    finally:
+        deployed_vm.ssh(f"/bin/rm -rf {workdir} {category_dir}")
+
+
 @pytest.mark.timeout(180)
 def test_blacklist_download_name_keys_on_provider_id(deployed_vm: SmokeVM, mock_feeds: _MockFeedServer) -> None:
     """issue #2636: the UT1 download name comes from the provider id, not from a literal feed URL.


### PR DESCRIPTION
## Summary

`pfb_download()` treated a MIME-allowlisted non-archive Blacklist body (`text/html`, `text/plain`, `inode/x-empty`) as a successful update: the uncompressed `elseif ($type == 'blacklist')` branch set `$retval = 0` with no extract. The UI/log showed success while category files stayed stale or missing.

This PR rejects that body, logs `blacklist_not_archive` with the detected type, unlinks the download, and returns failure. Existing category files are not touched.

Owner note (issue comment 2026-08-22): `#2638` will accept `application/x-tar` as a first-class archive. That narrows which bodies reach this branch; it does not remove the fail-loud contract for HTML/text.

Stacked on #2731 (issue #2730). Unique commits here do not include that smoke ABI commit. Retarget to `devel` after #2731 lands — do not use a closing keyword for #2730 in this body.

The new uncompressed `return` precedes the `:14852` success gate, so an HTML body does **not** write a content-hash sidecar. A stale `{orig}.xxhash128` may survive on upgraded boxes; it has no consumer on the Blacklist `dbdir` tarball path.

Gzip Blacklist fall-through (empty `.orig`) is #2735, not this PR.

## Tests

- PHPUnit `testUncompressedBlacklistBodyFailsClosedWithoutExtraction` — pins `$retval = 0` is gone, full `pfb_validate_log(..., $file_type)` call, `return PfbDownloadResult::failure()`. Local: `DownloadExtractionExitCodeTest` 11 tests OK (PHP 8.5.9).
- Smoke `test_blacklist_nongzip_body_fails_closed` — plant sentinel via tee, HTML body → `PFB_DL_FALSE` + `blacklist_not_archive` + sentinel unchanged. Blob `198c87bd`. Lab PASS of these bytes 20260826T190003Z (not a GitHub SHA; unique commits on this PR `676d9ed5` / `ddcf4276` / `cce45173`).

## Verification

| Frozen RED test | git hash-object | RED run tail |
| --- | --- | --- |
| `tests/php/DownloadExtractionExitCodeTest.php` | `37ac12b3cd3a7399ab4758e14c478395a6d7b1f4` | `reject must name the detected type` when `$file_type` dropped from `pfb_validate_log` |
| `tests/smoke/test_smoke_feeds.py` | `198c87bd08ae29d92856463cec85faba4c544bca` | RED `/srv/Smoke/results/20260826T205701Z-smoke` rc=1 192s, 1 failed / 1007 deselected, `PFB_DL_TRUE` (planted sentinel and MIME passed first); GREEN `/srv/Smoke/results/20260826T210037Z-smoke` rc=0 101s, 1 passed / 1007 deselected. Both hashes 198c87bd. claude-smoke, LXC pool. |

Fixes #2635

🤖 Generated by Grok and posted on behalf of @BBcan177.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Blacklist downloads that are not valid archives are now rejected, removed, and logged clearly.
  * Existing category data is preserved when an invalid blacklist download is received.

* **Tests**
  * Added coverage for non-archive blacklist responses, including HTML error pages.
  * Verified failed downloads do not trigger extraction or overwrite existing data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->