### PR TITLE
pfblockerng: return from gzip Blacklist success arm

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -14869,8 +14869,8 @@ function pfb_download(PfbDownloadRequest $request): PfbDownloadResult {
 			// an uncompressed feed, where $file_download was already renamed away (above)
 			// into $orig_download -- byte-identical to what was fetched, so the fallback is
 			// exact, not an approximation.  This covers both local and remote standard feeds
-			// (any path that finalises a plain .orig here).  The geoip/asn early-returns
-			// above do not reach this block, so they correctly never get a sidecar.
+			// (any path that finalises a plain .orig here).  The geoip/asn/top1m/blacklist
+			// archive early-returns above do not reach this block, so they correctly never get a sidecar.
 			pfb_download_finalize_text(
 				"{$orig_download}",
 				"{$orig_download}",

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -14432,6 +14432,8 @@ function pfb_download(PfbDownloadRequest $request): PfbDownloadResult {
 
 					// Create update file indicator for update process
 					touch("{$pfb['dbdir']}/{$filename}/{$filename}.update");
+					// issue #2735: do not fall through into @touch($orig_download).
+					return PfbDownloadResult::success();
 				}
 				else {
 					pfb_logger("\n Invalid filename [{$filename}]", 1);
@@ -14881,7 +14883,7 @@ function pfb_download(PfbDownloadRequest $request): PfbDownloadResult {
 			// would consume the change signal and make the loops' norm-skip gate
 			// wrongly reuse stale staging (caught live by
 			// test_cron_detects_changed_local_feed). The geoip/asn/top1m/blacklist
-			// archive paths early-return above and never reach the text pipeline.
+			// archive paths return above (issue #2735) and never reach the text pipeline.
 
 			// Process Emerging Threats IQRisk if required
 			if (strpos($list_url, 'iprepdata.txt') !== FALSE) {

--- a/tests/php/DownloadExtractionExitCodeTest.php
+++ b/tests/php/DownloadExtractionExitCodeTest.php
@@ -132,6 +132,8 @@ final class DownloadExtractionExitCodeTest extends TestCase
 		$scope = substr(self::$source, $blacklist, $end - $blacklist);
 		$this->assertMatchesRegularExpression('/exec\(pfb_extract_cmd\(".*tar -xf .*\\$output, \\$retval\);/', $scope);
 		$this->assertStringContainsString('pfb_download_extraction_succeeded($retval)', $scope);
+		// issue #2735: success must return, not fall through into @touch($orig_download).
+		$this->assertStringContainsString('return PfbDownloadResult::success();', $scope);
 	}
 
 	/**

--- a/tests/php/DownloadExtractionExitCodeTest.php
+++ b/tests/php/DownloadExtractionExitCodeTest.php
@@ -132,8 +132,12 @@ final class DownloadExtractionExitCodeTest extends TestCase
 		$scope = substr(self::$source, $blacklist, $end - $blacklist);
 		$this->assertMatchesRegularExpression('/exec\(pfb_extract_cmd\(".*tar -xf .*\\$output, \\$retval\);/', $scope);
 		$this->assertStringContainsString('pfb_download_extraction_succeeded($retval)', $scope);
-		// issue #2735: success must return, not fall through into @touch($orig_download).
-		$this->assertStringContainsString('return PfbDownloadResult::success();', $scope);
+		// issue #2735: success return is immediately after the update marker (not a
+		// decoy elsewhere in the 1710-byte scope).
+		$this->assertMatchesRegularExpression(
+			'/touch\("\{\$pfb\[.dbdir.\]\}\/\{\$filename\}\/\{\$filename\}\.update"\);\s*return PfbDownloadResult::success\(\);/',
+			$scope
+		);
 	}
 
 	/**
@@ -161,6 +165,7 @@ final class DownloadExtractionExitCodeTest extends TestCase
 			$scope,
 			'reject must name the detected type'
 		);
+		$this->assertStringContainsString('unlink_if_exists($file_download);', $scope);
 		$this->assertStringContainsString('return PfbDownloadResult::failure();', $scope);
 		// The gzip Blacklist branch publishes through pfb_stage_publish_dir() so a
 		// failed tar cannot replace live category files. This uncompressed reject


### PR DESCRIPTION
## Summary

The gzip Blacklist archive path in `pfb_download()` finished with `touch(.../{filename}.update)` and **no `return`**. Control fell into the shared text-pipeline tail, which `@touch($orig_download)` and created a **zero-length `{feed}.orig`**. Sibling archive paths (top1m) already return success.

This PR returns `PfbDownloadResult::success()` after the update marker, matching top1m. The text-pipeline comment now states that the blacklist archive path returns.

Not #2632 (retained `.raw` is the uncompressed no-op, #2635 / #2732). Not #2638.

Stacked on #2732. Unique commit is `30d6f894` only. No closing keyword for #2635 or #2730.

## Verification

PHPUnit `testGzipBlacklistBodyCapturesAndChecksTarExit` asserted `return PfbDownloadResult::success();` **before** the production return: RED (scope ended at `touch(...update)`). Same test blob GREEN after the return. PHP 8.5.9, 11 tests, 59 assertions.

| Frozen RED test | git hash-object | RED run tail |
| --- | --- | --- |
| `tests/php/DownloadExtractionExitCodeTest.php` | `ef4e050ba69b52959a5ce3f5247c165fcb838ace` | gzip Blacklist scope lacked `return PfbDownloadResult::success();` (fell through after `touch(...update)`) |

Fixes #2735

🤖 Generated by Grok and posted on behalf of @BBcan177.
