### PR TITLE
ci: add scripted refresh for artifact-action majors

### DIFF
--- a/scripts/misc/update_artifact_action_majors.py
+++ b/scripts/misc/update_artifact_action_majors.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+"""update_artifact_action_majors.py -- refresh ``_KNOWN_ARTIFACT_MAJORS``.
+
+``tests/test_issue2231_workflow_hygiene.py`` freezes the published major tags of
+``actions/upload-artifact`` and ``actions/download-artifact``. The live-pin gate
+requires every ``uses:`` to exist upstream and sit at the highest major both
+actions publish (issue #2725 / #2726). This script refreshes that table from
+GitHub's git matching-refs API so a future upload-artifact v8 (or the next
+common major) can be adopted without hand-editing the two frozensets.
+
+Data source
+-----------
+https://api.github.com/repos/actions/{upload,download}-artifact/git/matching-refs/tags
+-- JSON array of ``{ref, object, ...}``. HTML is refused; this script never
+scrapes tag pages.
+
+Extraction
+----------
+A tag contributes its major only when the ref is ``refs/tags/vN`` or
+``refs/tags/vN.N.N`` (optional patch). Unprefixed tags (``1.0.0``) and suffix
+variants (``v3-node20``) are ignored — they are not pin-able ``@vN`` refs.
+
+Highest common is ``max(upload & download)``. A major that exists on only one
+action must not raise the pin and must not silently allow a mismatched pair
+(issue #2385 / #2728). An empty intersection is refused.
+
+Output
+------
+Rewrites the ``_KNOWN_ARTIFACT_MAJORS`` assignment (and its Frozen comment) in
+the hygiene test. The derived ``_HIGHEST_COMMON_ARTIFACT_MAJOR = max(...)``
+line is left untouched. Churn guard: the Frozen date is rewritten only when
+the parsed majors actually change.
+
+Usage
+-----
+    python scripts/misc/update_artifact_action_majors.py           # rewrite in place
+    python scripts/misc/update_artifact_action_majors.py --check   # exit 1 if stale
+
+Dev-host tooling: run from the repo root on a dev box (never the appliance).
+Optional ``GH_TOKEN`` / ``GITHUB_TOKEN`` raises the unauthenticated rate limit.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.request
+from collections.abc import Mapping
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+API_URL = "https://api.github.com/repos/actions/{kind}-artifact/git/matching-refs/tags"
+KINDS = ("upload", "download")
+DEFAULT_HYGIENE_FILE = Path(__file__).resolve().parent.parent.parent / "tests/test_issue2231_workflow_hygiene.py"
+
+_TAG_REF = re.compile(r"^refs/tags/v(?P<major>[0-9]+)(?:\.[0-9]+){0,2}$")
+_TABLE_RE = re.compile(
+    r"# Frozen [^\n]*(?:\n# [^\n]*)*\n"
+    r"_KNOWN_ARTIFACT_MAJORS: dict\[str, frozenset\[int\]\] = \{.*?\n\}",
+    re.DOTALL,
+)
+_EXISTING_RE = re.compile(
+    r'"upload": frozenset\(\{(?P<upload>[0-9, ]+)\}\),\s*'
+    r'"download": frozenset\(\{(?P<download>[0-9, ]+)\}\),'
+)
+
+
+def parse_tag_refs(payload: object) -> frozenset[int]:
+    """Return published ``@vN`` majors from a matching-refs JSON payload.
+
+    Accepts a decoded list or a JSON string. HTML, a non-list, or an entry
+    without a string ``ref`` is refused — never treated as an empty tag set.
+    """
+    if isinstance(payload, str):
+        try:
+            payload = json.loads(payload)
+        except json.JSONDecodeError:
+            raise SystemExit("Refusing to rewrite: tag payload is not a JSON list") from None
+    if not isinstance(payload, list):
+        raise SystemExit("Refusing to rewrite: tag payload is not a JSON list")
+    majors: set[int] = set()
+    for item in payload:
+        if not isinstance(item, dict) or not isinstance(item.get("ref"), str):
+            raise SystemExit("Refusing to rewrite: tag payload entry missing string 'ref'")
+        match = _TAG_REF.fullmatch(item["ref"])
+        if match is not None:
+            majors.add(int(match.group("major")))
+    return frozenset(majors)
+
+
+def highest_common(majors: Mapping[str, frozenset[int]]) -> int:
+    """Highest major both actions publish. Union is never used."""
+    shared = majors["upload"] & majors["download"]
+    if not shared:
+        raise SystemExit("Refusing to rewrite: upload and download majors have an empty intersection")
+    return max(shared)
+
+
+def require_plausible(majors: Mapping[str, frozenset[int]]) -> None:
+    """Refuse an empty per-action set (truncated/HTML-as-JSON must not wipe the table)."""
+    for kind, values in majors.items():
+        if not values:
+            raise SystemExit(f"Refusing to rewrite: {kind}-artifact has no published majors")
+    highest_common(majors)
+
+
+def _frozenset_literal(values: frozenset[int]) -> str:
+    return "frozenset({" + ", ".join(str(v) for v in sorted(values)) + "})"
+
+
+def render_table(majors: Mapping[str, frozenset[int]], synced: str, highest: int) -> str:
+    """Render the Frozen comment plus the ``_KNOWN_ARTIFACT_MAJORS`` assignment."""
+    return (
+        f"# Frozen {synced} from the GitHub API (issue #2728). Highest common is v{highest}.\n"
+        "_KNOWN_ARTIFACT_MAJORS: dict[str, frozenset[int]] = {\n"
+        f'    "upload": {_frozenset_literal(majors["upload"])},\n'
+        f'    "download": {_frozenset_literal(majors["download"])},\n'
+        "}\n"
+    )
+
+
+def replace_table(source: str, table_block: str) -> str:
+    """Replace the Frozen comment + table assignment; leave the max(...) derivation."""
+    if _TABLE_RE.search(source) is None:
+        raise SystemExit("Refusing to rewrite: _KNOWN_ARTIFACT_MAJORS table not found")
+    return _TABLE_RE.sub(table_block.rstrip(), source, count=1)
+
+
+def existing_majors(source: str) -> dict[str, frozenset[int]] | None:
+    match = _EXISTING_RE.search(source)
+    if match is None:
+        return None
+
+    def _parse(group: str) -> frozenset[int]:
+        return frozenset(int(part.strip()) for part in group.split(",") if part.strip())
+
+    return {"upload": _parse(match.group("upload")), "download": _parse(match.group("download"))}
+
+
+def fetch_tag_payload(kind: str, timeout: float = 15) -> Any:
+    """GET matching-refs for one artifact action. JSON only; HTML is a hard fail."""
+    url = API_URL.format(kind=kind)
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "User-Agent": "pfBlockerNG-update-artifact-action-majors",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    request = urllib.request.Request(url, headers=headers)
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as resp:  # noqa: S310 (fixed https host)
+            raw = resp.read().decode("utf-8")
+    except (urllib.error.URLError, TimeoutError, OSError) as exc:
+        raise SystemExit(f"Refusing to rewrite: failed to fetch {url}: {exc}") from None
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"Refusing to rewrite: fetched body is not JSON: {exc}") from None
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="exit non-zero if _KNOWN_ARTIFACT_MAJORS is out of date vs a fresh fetch; changes nothing",
+    )
+    parser.add_argument(
+        "--target",
+        type=Path,
+        default=None,
+        help="hygiene test path (default: tests/test_issue2231_workflow_hygiene.py)",
+    )
+    args = parser.parse_args(argv)
+    target = args.target if args.target is not None else DEFAULT_HYGIENE_FILE
+
+    majors = {kind: parse_tag_refs(fetch_tag_payload(kind)) for kind in KINDS}
+    require_plausible(majors)
+    highest = highest_common(majors)
+
+    old = target.read_text(encoding="utf-8")
+    current = existing_majors(old)
+    if current == majors:
+        print(f"_KNOWN_ARTIFACT_MAJORS is up to date (highest common v{highest}).")
+        return 0
+    if args.check:
+        print(
+            f"_KNOWN_ARTIFACT_MAJORS is OUT OF DATE "
+            f"(upload {sorted(majors['upload'])} download {sorted(majors['download'])}; "
+            f"highest common v{highest})."
+        )
+        return 1
+
+    synced = datetime.now(timezone.utc).date().isoformat()
+    target.write_text(replace_table(old, render_table(majors, synced, highest)), encoding="utf-8")
+    print(f"_KNOWN_ARTIFACT_MAJORS regenerated; highest common is v{highest}.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/misc/update_artifact_action_majors.py
+++ b/scripts/misc/update_artifact_action_majors.py
@@ -172,14 +172,8 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="exit non-zero if _KNOWN_ARTIFACT_MAJORS is out of date vs a fresh fetch; changes nothing",
     )
-    parser.add_argument(
-        "--target",
-        type=Path,
-        default=None,
-        help="hygiene test path (default: tests/test_issue2231_workflow_hygiene.py)",
-    )
     args = parser.parse_args(argv)
-    target = args.target if args.target is not None else DEFAULT_HYGIENE_FILE
+    target = DEFAULT_HYGIENE_FILE
 
     majors = {kind: parse_tag_refs(fetch_tag_payload(kind)) for kind in KINDS}
     require_plausible(majors)

--- a/tests/test_issue2231_workflow_hygiene.py
+++ b/tests/test_issue2231_workflow_hygiene.py
@@ -465,11 +465,10 @@ _DownloadKey = tuple[str, str, int, int, tuple[tuple[str, str], ...], tuple[str,
 
 _ARTIFACT_ACTION_REF = re.compile(r"^actions/(?P<kind>upload|download)-artifact@.+$")
 _ARTIFACT_ACTION = re.compile(r"^actions/(?P<kind>upload|download)-artifact@v(?P<major>[0-9]+)(?:\.[0-9]+){0,2}$")
-# Frozen 2026-08-26 from the GitHub API (issue #2725). upload-artifact has no v8
-# tag (latest v7.0.1); download-artifact does (v8.0.1). Highest common is v7.
+# Frozen 2026-08-27 from the GitHub API (issue #2728). Highest common is v7.
 _KNOWN_ARTIFACT_MAJORS: dict[str, frozenset[int]] = {
-    "upload": frozenset({4, 5, 6, 7}),
-    "download": frozenset({3, 4, 5, 6, 7, 8}),
+    "upload": frozenset({1, 2, 3, 4, 5, 6, 7}),
+    "download": frozenset({1, 2, 3, 4, 5, 6, 7, 8}),
 }
 _HIGHEST_COMMON_ARTIFACT_MAJOR = max(_KNOWN_ARTIFACT_MAJORS["upload"] & _KNOWN_ARTIFACT_MAJORS["download"])
 _GH_EXPRESSION = re.compile(r"\$\{\{\s*(.*?)\s*\}\}")

--- a/tests/test_update_artifact_action_majors.py
+++ b/tests/test_update_artifact_action_majors.py
@@ -1,0 +1,238 @@
+"""Tests for scripts/misc/update_artifact_action_majors.py — refresh of
+``_KNOWN_ARTIFACT_MAJORS`` in tests/test_issue2231_workflow_hygiene.py.
+
+No network: every test drives the pure parse/render/replace functions (or
+main() with fetch monkeypatched) against recorded GitHub tag-ref fixtures.
+The live matching-refs fetch is never exercised here.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from tests import test_issue2231_workflow_hygiene as hygiene
+
+_TOOL = Path(__file__).resolve().parent.parent / "scripts" / "misc" / "update_artifact_action_majors.py"
+_spec = importlib.util.spec_from_file_location("update_artifact_action_majors", _TOOL)
+assert _spec is not None and _spec.loader is not None
+uaam = importlib.util.module_from_spec(_spec)
+sys.modules[_spec.name] = uaam
+_spec.loader.exec_module(uaam)
+
+_HYGIENE_SNIPPET = """\
+# Frozen 2026-08-26 from the GitHub API (issue #2725). upload-artifact has no v8
+# tag (latest v7.0.1); download-artifact does (v8.0.1). Highest common is v7.
+_KNOWN_ARTIFACT_MAJORS: dict[str, frozenset[int]] = {
+    "upload": frozenset({4, 5, 6, 7}),
+    "download": frozenset({3, 4, 5, 6, 7, 8}),
+}
+_HIGHEST_COMMON_ARTIFACT_MAJOR = max(_KNOWN_ARTIFACT_MAJORS["upload"] & _KNOWN_ARTIFACT_MAJORS["download"])
+"""
+
+_V7_LIVE_PINS = """\
+on: workflow_dispatch
+jobs:
+  up:
+    steps:
+      - uses: actions/upload-artifact@v7
+        with: {name: pkg}
+  down:
+    needs: up
+    steps:
+      - uses: actions/download-artifact@v7
+        with: {name: pkg}
+"""
+
+
+def _refs(*tags: str) -> list[dict[str, str]]:
+    return [{"ref": f"refs/tags/{tag}"} for tag in tags]
+
+
+def _current_api_fixture() -> dict[str, list[dict[str, str]]]:
+    """Recorded shape: upload has no v8; download does. Highest common is 7."""
+    return {
+        "upload": _refs("1.0.0", "v3-node20", "v4", "v4.3.4", "v5", "v6", "v7", "v7.0.1"),
+        "download": _refs("v3", "v4", "v5", "v6", "v7", "v8", "v8.0.1"),
+    }
+
+
+# --------------------------------------------------------------------------- #
+# parse — published major tags from the matching-refs JSON
+# --------------------------------------------------------------------------- #
+
+
+def test_parse_tag_refs_keeps_exact_and_semver_majors_drops_unprefixed_and_suffix() -> None:
+    majors = uaam.parse_tag_refs(_refs("1.0.0", "v3-node20", "v4", "v4.3.4", "v7", "v7.0.1"))
+    assert majors == frozenset({4, 7})
+    assert 1 not in majors
+    assert 3 not in majors
+
+
+def test_parse_tag_refs_refuses_html_and_non_list_payloads() -> None:
+    with pytest.raises(SystemExit, match="not a JSON list"):
+        uaam.parse_tag_refs("<html>tags</html>")
+    with pytest.raises(SystemExit, match="not a JSON list"):
+        uaam.parse_tag_refs({"ref": "refs/tags/v7"})
+
+
+def test_parse_tag_refs_refuses_missing_or_non_string_ref() -> None:
+    with pytest.raises(SystemExit, match="missing string 'ref'"):
+        uaam.parse_tag_refs([{"object": {"sha": "abc"}}])
+    with pytest.raises(SystemExit, match="missing string 'ref'"):
+        uaam.parse_tag_refs([{"ref": 7}])
+
+
+def test_parse_tag_refs_accepts_json_text() -> None:
+    payload = json.dumps(_refs("v7", "v7.0.1"))
+    assert uaam.parse_tag_refs(payload) == frozenset({7})
+
+
+# --------------------------------------------------------------------------- #
+# highest common — intersection, never union (issue #2385 / #2728)
+# --------------------------------------------------------------------------- #
+
+
+def test_highest_common_stays_7_when_upload_has_no_v8() -> None:
+    majors = {kind: uaam.parse_tag_refs(payload) for kind, payload in _current_api_fixture().items()}
+    assert majors["upload"] == frozenset({4, 5, 6, 7})
+    assert 8 not in majors["upload"]
+    assert uaam.highest_common(majors) == 7
+
+
+def test_highest_common_becomes_8_when_fixture_adds_upload_v8() -> None:
+    payloads = _current_api_fixture()
+    payloads["upload"] = payloads["upload"] + _refs("v8", "v8.0.0")
+    majors = {kind: uaam.parse_tag_refs(payload) for kind, payload in payloads.items()}
+    assert uaam.highest_common(majors) == 8
+
+
+def test_one_sided_new_major_does_not_raise_highest_common() -> None:
+    payloads = _current_api_fixture()
+    payloads["download"] = payloads["download"] + _refs("v9")
+    majors = {kind: uaam.parse_tag_refs(payload) for kind, payload in payloads.items()}
+    assert 9 in majors["download"]
+    assert 9 not in majors["upload"]
+    assert uaam.highest_common(majors) == 7
+
+
+def test_empty_intersection_is_refused() -> None:
+    majors = {"upload": frozenset({4}), "download": frozenset({8})}
+    with pytest.raises(SystemExit, match="empty intersection"):
+        uaam.highest_common(majors)
+
+
+def test_empty_action_majors_are_refused() -> None:
+    with pytest.raises(SystemExit, match="no published majors"):
+        uaam.require_plausible({"upload": frozenset(), "download": frozenset({3, 4})})
+
+
+# --------------------------------------------------------------------------- #
+# rewrite — table only; highest-common stays derived
+# --------------------------------------------------------------------------- #
+
+
+def test_replace_table_rewrites_known_majors_and_leaves_derivation() -> None:
+    majors = {"upload": frozenset({4, 5, 6, 7, 8}), "download": frozenset({3, 4, 5, 6, 7, 8})}
+    rendered = uaam.render_table(majors, synced="2026-08-27", highest=8)
+    updated = uaam.replace_table(_HYGIENE_SNIPPET, rendered)
+    assert "_KNOWN_ARTIFACT_MAJORS" in updated
+    assert "frozenset({4, 5, 6, 7, 8})" in updated
+    assert (
+        '_HIGHEST_COMMON_ARTIFACT_MAJOR = max(_KNOWN_ARTIFACT_MAJORS["upload"] '
+        '& _KNOWN_ARTIFACT_MAJORS["download"])' in updated
+    )
+    assert "issue #2728" in updated
+    assert "2026-08-27" in updated
+    assert "issue #2725" not in updated
+
+
+def test_check_exits_1_when_table_is_stale_and_0_when_current(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    target = tmp_path / "hygiene.py"
+    target.write_text(_HYGIENE_SNIPPET, encoding="utf-8")
+    payloads = _current_api_fixture()
+    payloads["upload"] = payloads["upload"] + _refs("v8")
+
+    def fake_fetch(kind: str, timeout: float = 15) -> Any:
+        return payloads[kind]
+
+    monkeypatch.setattr(uaam, "fetch_tag_payload", fake_fetch)
+    monkeypatch.setattr(uaam, "DEFAULT_HYGIENE_FILE", target)
+    assert uaam.main(["--check"]) == 1
+    assert target.read_text(encoding="utf-8") == _HYGIENE_SNIPPET
+    assert uaam.main([]) == 0
+    rewritten = target.read_text(encoding="utf-8")
+    assert "frozenset({4, 5, 6, 7, 8})" in rewritten
+    assert uaam.main(["--check"]) == 0
+
+
+# --------------------------------------------------------------------------- #
+# live-pin gate — refresh must not weaken parse + highest-common (issue #2726)
+# --------------------------------------------------------------------------- #
+
+
+def test_upload_v8_fixture_reports_drift_on_remaining_v7_pins(monkeypatch: pytest.MonkeyPatch) -> None:
+    payloads = _current_api_fixture()
+    payloads["upload"] = payloads["upload"] + _refs("v8")
+    majors = {kind: uaam.parse_tag_refs(payload) for kind, payload in payloads.items()}
+    highest = uaam.highest_common(majors)
+    assert highest == 8
+    monkeypatch.setattr(hygiene, "_KNOWN_ARTIFACT_MAJORS", majors)
+    monkeypatch.setattr(hygiene, "_HIGHEST_COMMON_ARTIFACT_MAJOR", highest)
+    offences = hygiene._live_artifact_offences({"w.yml": _V7_LIVE_PINS})
+    assert any("upload-artifact" in item and "v8" in item and "not v7" in item for item in offences), offences
+    assert any("download-artifact" in item and "v8" in item and "not v7" in item for item in offences), offences
+
+
+def test_one_sided_major_does_not_silently_allow_a_mismatched_pair(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A refresh that adds v9 to download only must not accept a v9/v9 pair:
+    upload@v9 is still unpublished, so the parse-based existence gate must
+    reject it. Highest common stays 7 (#2385 / #2728).
+    """
+    payloads = _current_api_fixture()
+    payloads["download"] = payloads["download"] + _refs("v9")
+    majors = {kind: uaam.parse_tag_refs(payload) for kind, payload in payloads.items()}
+    highest = uaam.highest_common(majors)
+    assert highest == 7
+    monkeypatch.setattr(hygiene, "_KNOWN_ARTIFACT_MAJORS", majors)
+    monkeypatch.setattr(hygiene, "_HIGHEST_COMMON_ARTIFACT_MAJOR", highest)
+    sources = {
+        "w.yml": """\
+on: workflow_dispatch
+jobs:
+  up:
+    steps:
+      - uses: actions/upload-artifact@v9
+        with: {name: pkg}
+  down:
+    needs: up
+    steps:
+      - uses: actions/download-artifact@v9
+        with: {name: pkg}
+"""
+    }
+    offences = hygiene._live_artifact_offences(sources)
+    assert any("upload-artifact@v9" in item and "not a known" in item for item in offences), offences
+    assert any("download-artifact" in item and "not v9" in item for item in offences), offences
+    mismatched = {
+        "w.yml": """\
+on: workflow_dispatch
+jobs:
+  up:
+    steps:
+      - uses: actions/upload-artifact@v7
+        with: {name: pkg}
+  down:
+    needs: up
+    steps:
+      - uses: actions/download-artifact@v9
+        with: {name: pkg}
+"""
+    }
+    chain = hygiene._artifact_chain_offences(mismatched)
+    assert any("mismatches producers" in item for item in chain), chain


### PR DESCRIPTION
no-test-needed: tests/test_issue2231_workflow_hygiene.py table widening is data-truthfulness; live-pin accept/reject sets are identical (only @v7 accepted). Behaviour of the refresh is pinned by tests/test_update_artifact_action_majors.py Frozen RED row.

## Summary

The frozen `_KNOWN_ARTIFACT_MAJORS` table in `tests/test_issue2231_workflow_hygiene.py` was a dated GitHub API snapshot. When `actions/upload-artifact@v8` ships, the live-pin gate stays stale-conservative until someone hand-edits the two frozensets.

This PR adds `scripts/misc/update_artifact_action_majors.py`, same shape as the HSTS/PSL/TLD refresh tools: GitHub **matching-refs JSON only** (HTML is refused; no tag-page scrape). Highest common stays `max(upload ∩ download)`, so a refresh that adds a major to only one action cannot raise the pin or silently allow a mismatched pair.

First live run records upload `{1–7}` / download `{1–8}`. Highest common remains **v7** (upload still has no v8 tag). Live `uses:` pins are unchanged; the parse-based existence + highest-common gate is untouched.

## Verification

`tests/test_update_artifact_action_majors.py` imported the missing script: RED (`FileNotFoundError`). Same test blob GREEN after the script. 13 passed. PHP 3.11.15 / pytest-9.1.1.

| Frozen RED test | git hash-object | RED run tail |
| --- | --- | --- |
| `tests/test_update_artifact_action_majors.py` | `633dfe4b07b5765fb82b112647d739408d6e2794` | collection `FileNotFoundError`: `scripts/misc/update_artifact_action_majors.py` missing |

Fixture rows: no upload v8 → highest common 7; fixture adds upload v8 → highest common 8 and `_live_artifact_offences` reports drift on remaining v7 pins; download-only v9 does not raise highest common and does not allow a v9/v9 pair.

Fixes #2728

🤖 Generated by Grok and posted on behalf of @BBcan177.
