### PR TITLE
pfblockerng: fail closed on bzip2/zip Blacklist bodies

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -14465,6 +14465,12 @@ function pfb_download(PfbDownloadRequest $request): PfbDownloadResult {
 				unlink_if_exists($file_download);
 				return PfbDownloadResult::failure();
 			}
+			if ($type == 'blacklist') {
+				// issue #2739: bzip2 is not extracted into the Blacklist category tree.
+				pfb_validate_log($header, 'extract', 'blacklist_not_archive', $file_type);
+				unlink_if_exists($file_download);
+				return PfbDownloadResult::failure();
+			}
 			$reject_detail = array();
 			if (!pfb_filter(array("{$file_dwn_esc}", "{$file_download}", "{$list_download}"), PFB_FILTER_FILE_MIME_COMPRESSED, 'pfb_download', '', FALSE, $reject_detail)) {
 				pfb_validate_log($header, 'inner', 'compressed_mime_not_allowed', pfb_reject_detail_summary($reject_detail));
@@ -14485,6 +14491,12 @@ function pfb_download(PfbDownloadRequest $request): PfbDownloadResult {
 		elseif ($file_type == 'application/zip') {
 			if (!pfb_validate_archive($file_download, $file_type)) {
 				pfb_validate_log($header, 'structural', 'probe_failed', "{$file_type} " . basename($file_download));
+				unlink_if_exists($file_download);
+				return PfbDownloadResult::failure();
+			}
+			if ($type == 'blacklist') {
+				// issue #2739: zip is not extracted into the Blacklist category tree.
+				pfb_validate_log($header, 'extract', 'blacklist_not_archive', $file_type);
 				unlink_if_exists($file_download);
 				return PfbDownloadResult::failure();
 			}

--- a/tests/php/DownloadExtractionExitCodeTest.php
+++ b/tests/php/DownloadExtractionExitCodeTest.php
@@ -121,7 +121,14 @@ final class DownloadExtractionExitCodeTest extends TestCase
 			$scope,
 			'reject must name the detected type'
 		);
-		$reject_scope = substr($scope, $reject, $publish - $reject);
+		$brace = strpos($scope, '{', $reject);
+		$this->assertNotFalse($brace);
+		$reject_scope = substr($scope, $reject, self::closingBraceExclusive($scope, $brace) - $reject);
+		$this->assertSame(
+			1,
+			substr_count($reject_scope, 'return PfbDownloadResult::failure();'),
+			'reject scope must not swallow a sibling failure return'
+		);
 		$this->assertStringContainsString('unlink_if_exists($file_download);', $reject_scope);
 		$this->assertStringContainsString('return PfbDownloadResult::failure();', $reject_scope);
 		$this->assertStringNotContainsString('pfb_stage_publish', $reject_scope);
@@ -270,7 +277,14 @@ final class DownloadExtractionExitCodeTest extends TestCase
 			$scope,
 			'reject must name the detected type'
 		);
-		$reject_scope = substr($scope, $reject, $geoip - $reject);
+		$brace = strpos($scope, '{', $reject);
+		$this->assertNotFalse($brace);
+		$reject_scope = substr($scope, $reject, self::closingBraceExclusive($scope, $brace) - $reject);
+		$this->assertSame(
+			1,
+			substr_count($reject_scope, 'return PfbDownloadResult::failure();'),
+			'reject scope must not swallow a sibling failure return'
+		);
 		$this->assertStringContainsString('unlink_if_exists($file_download);', $reject_scope);
 		$this->assertStringContainsString('return PfbDownloadResult::failure();', $reject_scope);
 		$this->assertStringNotContainsString('pfb_stage_publish', $reject_scope);
@@ -299,5 +313,23 @@ final class DownloadExtractionExitCodeTest extends TestCase
 		$this->assertStringContainsString('pfb_download_extraction_succeeded($retval)', $scope);
 		$this->assertStringNotContainsString('file_exists("{$orig_download}")', $scope);
 		$this->assertStringNotContainsString('unlink_if_exists("{$orig_download}")', $scope);
+	}
+
+	/** Exclusive end index of the brace block whose `{` is at `$openBrace`. */
+	private static function closingBraceExclusive(string $source, int $openBrace): int
+	{
+		$depth = 0;
+		$length = strlen($source);
+		for ($index = $openBrace; $index < $length; $index++) {
+			if ($source[$index] === '{') {
+				$depth++;
+			} elseif ($source[$index] === '}') {
+				$depth--;
+				if ($depth === 0) {
+					return $index + 1;
+				}
+			}
+		}
+		return $length;
 	}
 }

--- a/tests/php/DownloadExtractionExitCodeTest.php
+++ b/tests/php/DownloadExtractionExitCodeTest.php
@@ -99,6 +99,36 @@ final class DownloadExtractionExitCodeTest extends TestCase
 	}
 
 	/**
+	 * Issue #2739 — a bzip2 Blacklist body must fail closed. The arm
+	 * extracts onto $orig_download for IP feeds; Blacklist has no category
+	 * extract here, so a successful empty update is a lie. Comments and
+	 * docblocks cannot define this scope.
+	 */
+	public function testBzip2BlacklistBodyFailsClosedWithoutExtraction(): void
+	{
+		$bzip2 = strpos(self::$source, "elseif (\$file_type == 'application/x-bzip2') {");
+		$zip = strpos(self::$source, "elseif (\$file_type == 'application/zip') {", $bzip2 === FALSE ? 0 : $bzip2);
+		$this->assertNotFalse($bzip2);
+		$this->assertNotFalse($zip);
+		$scope = substr(self::$source, $bzip2, $zip - $bzip2);
+		$reject = strpos($scope, "if (\$type == 'blacklist') {");
+		$publish = strpos($scope, 'if (!pfb_stage_publish($orig_download,');
+		$this->assertNotFalse($reject, $scope);
+		$this->assertNotFalse($publish, $scope);
+		$this->assertLessThan($publish, $reject, 'Blacklist reject must run before the IP-feed extract');
+		$this->assertStringContainsString(
+			"pfb_validate_log(\$header, 'extract', 'blacklist_not_archive', \$file_type);",
+			$scope,
+			'reject must name the detected type'
+		);
+		$reject_scope = substr($scope, $reject, $publish - $reject);
+		$this->assertStringContainsString('unlink_if_exists($file_download);', $reject_scope);
+		$this->assertStringContainsString('return PfbDownloadResult::failure();', $reject_scope);
+		$this->assertStringNotContainsString('pfb_stage_publish', $reject_scope);
+		$this->assertStringNotContainsString('$pfb[\'dbdir\']', $reject_scope);
+	}
+
+	/**
 	 * pfb_download() gunzips TOP1M into a staged file before publication; this
 	 * live filesystem/exec path is pinned independently of all other branches.
 	 * Comments/docblocks cannot define this scope.
@@ -215,6 +245,37 @@ final class DownloadExtractionExitCodeTest extends TestCase
 		$scope = substr(self::$source, $top1m, $blacklist - $top1m);
 		$this->assertMatchesRegularExpression('/exec\(pfb_extract_cmd\(".*tar -xf .*\\$output, \\$retval\);/', $scope);
 		$this->assertStringContainsString('pfb_download_extraction_succeeded($retval)', $scope);
+	}
+
+	/**
+	 * Issue #2739 — a zip Blacklist body must fail closed. After geoip/top1m
+	 * return, the arm falls into stdout extract onto $orig_download and the
+	 * text pipeline. Blacklist has no category extract here. Comments and
+	 * docblocks cannot define this scope.
+	 */
+	public function testZipBlacklistBodyFailsClosedWithoutExtraction(): void
+	{
+		$zip = strpos(self::$source, "elseif (\$file_type == 'application/zip') {");
+		$uncomp = strpos(self::$source, "if (\$type == 'geoip' || \$type == 'asn')", $zip === FALSE ? 0 : $zip);
+		$this->assertNotFalse($zip);
+		$this->assertNotFalse($uncomp);
+		$scope = substr(self::$source, $zip, $uncomp - $zip);
+		$reject = strpos($scope, "if (\$type == 'blacklist') {");
+		$geoip = strpos($scope, "if (\$type == 'geoip') {");
+		$this->assertNotFalse($reject, $scope);
+		$this->assertNotFalse($geoip, $scope);
+		$this->assertLessThan($geoip, $reject, 'Blacklist reject must run before zip geoip/generic extract');
+		$this->assertStringContainsString(
+			"pfb_validate_log(\$header, 'extract', 'blacklist_not_archive', \$file_type);",
+			$scope,
+			'reject must name the detected type'
+		);
+		$reject_scope = substr($scope, $reject, $geoip - $reject);
+		$this->assertStringContainsString('unlink_if_exists($file_download);', $reject_scope);
+		$this->assertStringContainsString('return PfbDownloadResult::failure();', $reject_scope);
+		$this->assertStringNotContainsString('pfb_stage_publish', $reject_scope);
+		$this->assertStringNotContainsString('tar -xf', $reject_scope);
+		$this->assertStringNotContainsString('$pfb[\'dbdir\']', $reject_scope);
 	}
 
 	/**

--- a/tests/smoke/test_smoke_feeds.py
+++ b/tests/smoke/test_smoke_feeds.py
@@ -57,7 +57,7 @@ import shlex
 import subprocess
 import tarfile
 import zipfile
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 
 import pytest
 
@@ -4110,6 +4110,86 @@ def test_blacklist_nongzip_body_fails_closed(deployed_vm: SmokeVM, mock_feeds: _
         assert "PFB_DL_FALSE" in out, (
             f"expected pfb_download failure on a non-gzip Blacklist HTML body; got stdout: {out!r}"
         )
+        after = h.count_log_marker(deployed_vm, h.PFB_LOG, marker)
+        assert after > before, (
+            f"expected a NEW {marker!r} line in {h.PFB_LOG}; before={before} after={after}\n"
+            f"recent pfb_validate lines:\n{_recent_validate_lines(deployed_vm)}"
+        )
+        kept = deployed_vm.ssh("/bin/cat", sentinel_path).stdout
+        listing = deployed_vm.ssh("/bin/ls", "-la", category_dir).stdout
+        assert kept == sentinel, (
+            f"existing category file must be untouched; {sentinel_path} now holds {kept!r}; ls={listing!r}"
+        )
+    finally:
+        deployed_vm.ssh("/bin/rm", "-rf", workdir, category_dir)
+
+
+def _blacklist_bzip2_body() -> bytes:
+    return bz2.compress(b"keep-me.example.test\n")
+
+
+def _blacklist_zip_body() -> bytes:
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr("list.txt", "keep-me.example.test\n")
+    return buf.getvalue()
+
+
+@pytest.mark.parametrize(
+    ("kind", "suffix", "mime", "body_fn"),
+    [
+        ("bzip2", ".bz2", "application/x-bzip2", _blacklist_bzip2_body),
+        ("zip", ".zip", "application/zip", _blacklist_zip_body),
+    ],
+)
+@pytest.mark.timeout(120)
+def test_blacklist_bzip2_or_zip_body_fails_closed(
+    deployed_vm: SmokeVM,
+    mock_feeds: _MockFeedServer,
+    kind: str,
+    suffix: str,
+    mime: str,
+    body_fn: Callable[[], bytes],
+) -> None:
+    """issue #2739: a bzip2 or zip Blacklist body must fail, not succeed empty.
+
+    Given previously extracted Blacklist category files and an origin answering
+      the archive URL with HTTP 200 valid bzip2 or zip bytes,
+    When  pfb_download() fetches it as type='blacklist',
+    Then  the result is failure, a canonical reject names the detected type,
+      and the existing category files are left untouched.
+
+    Fail-before: those arms have no Blacklist branch, so a valid archive
+    extracts onto ``.orig`` and returns success while ``{dbdir}/{provider}/``
+    is unchanged. Pass-after: the ``blacklist_not_archive`` reject; the planted
+    sentinel stays byte-identical.
+    """
+    header = f"pfb2739{kind}"
+    workdir = f"/tmp/{header}_dl"
+    category_dir = f"{h.PFB_DBDIR}/{header}"
+    sentinel_path = f"{category_dir}/{header}_testcat"
+    sentinel = "keep-me.example.test\n"
+    archive = f"{workdir}/{header}{suffix}"
+    marker = f"pfb_validate: REJECT feed={header} stage=extract reason=blacklist_not_archive"
+    body = body_fn()
+    try:
+        deployed_vm.ssh("/bin/rm", "-rf", workdir, category_dir, timeout=30.0)
+        mk = deployed_vm.ssh("/bin/mkdir", "-p", workdir, category_dir)
+        assert mk.returncode == 0, f"mkdir failed: rc={mk.returncode} stderr={mk.stderr!r}"
+        _plant_guest_text(deployed_vm, sentinel_path, sentinel)
+        planted = deployed_vm.ssh("/bin/cat", sentinel_path).stdout
+        assert planted == sentinel, (
+            f"before-state: planted sentinel must be {sentinel!r}, got {planted!r}; "
+            f"ls={deployed_vm.ssh('/bin/ls', '-la', category_dir).stdout!r}"
+        )
+        box_mime = _box_mime_type(deployed_vm, body)
+        assert box_mime == mime, f"expected on-box MIME {mime!r} for {kind}, got {box_mime!r}"
+        feed_url = mock_feeds.register(f"{header}{suffix}", body)
+        before = h.count_log_marker(deployed_vm, h.PFB_LOG, marker)
+
+        out = _adr46_download(deployed_vm, feed_url, archive, header, "blacklist")
+
+        assert "PFB_DL_FALSE" in out, f"expected pfb_download failure on a {kind} Blacklist body; got stdout: {out!r}"
         after = h.count_log_marker(deployed_vm, h.PFB_LOG, marker)
         assert after > before, (
             f"expected a NEW {marker!r} line in {h.PFB_LOG}; before={before} after={after}\n"


### PR DESCRIPTION
## Summary

#2635 fail-closed the **uncompressed** Blacklist arm. #2735 returned from the **gzip** Blacklist success path. A Blacklist body that libmagic types as **bzip2** or **zip** still fell through: bzip2 always `pfb_stage_publish($orig_download, …)`, zip falls into the generic stdout extract after geoip/top1m, then the text pipeline, and reports success while `{dbdir}/{provider}/` is stale or empty.

This PR copies the `blacklist_not_archive` reject from the uncompressed arm into both compressed arms, immediately after `pfb_validate_archive`, before any extract. The reject names `$file_type` and unlinks the `.raw` body.

Not #2635 / #2732 (uncompressed — merged). Not #2735 / #2737 (gzip — merged). Not #2738 (stale `.orig` residue). Not #2638 (`application/x-tar` as a first-class archive type), though that work will change which bodies reach these arms (`application/x-tar`).

## Verification

PHPUnit `testBzip2BlacklistBodyFailsClosedWithoutExtraction` and `testZipBlacklistBodyFailsClosedWithoutExtraction` asserted the reject **before** the production `if ($type == 'blacklist')` blocks: RED (`if ($type == 'blacklist')` missing in each arm). Same test blob GREEN after. PHP 8.5.9; class 13 tests, 81 assertions.

Smoke: `test_blacklist_bzip2_or_zip_body_fails_closed` (bzip2 + zip) matches `test_blacklist_nongzip_body_fails_closed`. Live-VM run is queued on grok-smoke after the in-flight nightly.

| Frozen RED test | git hash-object | RED run tail |
| --- | --- | --- |
| `tests/php/DownloadExtractionExitCodeTest.php` | `71f52fc66a93a8c685a0789e2e44ee1c523258a8` | bzip2/zip arms lacked `if ($type == 'blacklist')` before extract; `Failed asserting that false is not false` |

Fixes #2739

🤖 Generated by Grok and posted on behalf of @BBcan177.