### PR TITLE
pfblockerng: extract application/x-tar as a first-class archive

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -14300,7 +14300,7 @@ function pfb_download(PfbDownloadRequest $request): PfbDownloadResult {
 					unlink_if_exists($file_download);
 					return PfbDownloadResult::failure();
 				}
-				exec(pfb_extract_cmd("/usr/bin/tar -xzf {$file_dwn_esc} --strip=1 -C {$pfb['geoipshare']} >/dev/null 2>&1"), $output, $retval);
+				exec(pfb_extract_cmd("/usr/bin/tar -xf {$file_dwn_esc} --strip=1 -C {$pfb['geoipshare']} >/dev/null 2>&1"), $output, $retval);
 				unlink_if_exists($file_download);
 				if (!pfb_download_extraction_succeeded($retval)) {
 					pfb_logger("\n[pfb_download] geoip extraction failed (tar exit {$retval})" . pfb_extract_cap_note($retval), 2);
@@ -14419,7 +14419,7 @@ function pfb_download(PfbDownloadRequest $request): PfbDownloadResult {
 				// Extras - Blacklist downloads
 				@rename("{$file_download}", strstr("{$file_download}", '.raw', TRUE));
 				$file_esc = trim(escapeshellarg("{$file_dwn}"), "'");
-				$filename = basename("{$file_esc}", '.tar.gz');
+				$filename = basename(basename("{$file_esc}", '.tar.gz'), '.tar');
 
 				if (!empty(pfb_filter($filename, PFB_FILTER_WORD, 'pfb_download category'))) {
 					// ADR-46: disk-writing extraction of a THIRD-PARTY archive (member
@@ -14447,7 +14447,11 @@ function pfb_download(PfbDownloadRequest $request): PfbDownloadResult {
 
 						// Rename any Category files with dashes
 						$list = glob("{$staged}/{$filename}*");
-						if (!is_array($list) || empty($list)) {
+						if (!is_array($list)) {
+							$list = array();
+						}
+						$list = array_values(array_filter($list, 'is_file'));
+						if (empty($list)) {
 							// issue #2638: tar exit 0 with no category file must not
 							// publish an empty tree over live categories.
 							return pfb_download_initial_retval();
@@ -14811,7 +14815,13 @@ function pfb_download(PfbDownloadRequest $request): PfbDownloadResult {
 					}
 					$retval = pfb_download_initial_retval();
 					if ($type == 'geoip') {
-						exec(pfb_extract_cmd("/usr/bin/tar -xf {$file_dwn_esc} --strip=1 -C {$header_esc} >/dev/null 2>&1"), $output, $retval);
+						$unsafe_member = pfb_archive_unsafe_member(pfb_archive_member_names($file_download));
+						if ($unsafe_member !== NULL) {
+							pfb_validate_log($header, 'member', 'unsafe_member_name', $unsafe_member);
+							unlink_if_exists($file_download);
+							return PfbDownloadResult::failure();
+						}
+						exec(pfb_extract_cmd("/usr/bin/tar -xf {$file_dwn_esc} --strip=1 -C {$pfb['geoipshare']} >/dev/null 2>&1"), $output, $retval);
 						unlink_if_exists($file_download);
 						if (!pfb_download_extraction_succeeded($retval)) {
 							pfb_logger("\n[pfb_download] {$type} tar extraction failed (tar exit {$retval})" . pfb_extract_cap_note($retval), 2);
@@ -14841,14 +14851,45 @@ function pfb_download(PfbDownloadRequest $request): PfbDownloadResult {
 			if ($type == 'top1m') {
 				// Stage TOP1M's plain body before publishing; baseline persistence
 				// commits after active publication and rolls both back on failure.
-				$top1m_stage = @tempnam(dirname($head_download), '.pfbtop1m_');
-				if ($top1m_stage === FALSE || !@copy($file_download, $top1m_stage)) {
-					pfb_logger("\n[pfb_download] {$type} rename to destination failed", 2);
-					if ($top1m_stage !== FALSE) {
-						unlink_if_exists($top1m_stage);
+				if ($file_type == 'application/x-tar' && $type == 'top1m') {
+					if (!pfb_validate_archive($file_download, $file_type)) {
+						pfb_validate_log($header, 'structural', 'probe_failed', "{$file_type} " . basename($file_download));
+						unlink_if_exists($file_download);
+						return PfbDownloadResult::failure();
 					}
-					unlink_if_exists($file_download);
-					return PfbDownloadResult::failure();
+					$archive_members = pfb_archive_member_names($file_download);
+					$unsafe_member = pfb_archive_unsafe_member($archive_members);
+					if ($unsafe_member !== NULL || $archive_members === NULL || count($archive_members) !== 1) {
+						if ($unsafe_member !== NULL) {
+							pfb_validate_log($header, 'member', 'unsafe_member_name', $unsafe_member);
+						}
+						unlink_if_exists($file_download);
+						return PfbDownloadResult::failure();
+					}
+					$top1m_stage = @tempnam(dirname($head_download), '.pfbtop1m_');
+					if ($top1m_stage === FALSE) {
+						unlink_if_exists($file_download);
+						return PfbDownloadResult::failure();
+					}
+					$header_esc = escapeshellarg($top1m_stage);
+					$retval = pfb_download_initial_retval();
+					exec(pfb_extract_cmd("/usr/bin/tar -xOf {$file_dwn_esc} > {$header_esc}"), $output, $retval);
+					if (!pfb_download_extraction_succeeded($retval)) {
+						unlink_if_exists($file_download);
+						unlink_if_exists($top1m_stage);
+						pfb_logger("\n[pfb_download] top1m extraction failed (tar exit {$retval})" . pfb_extract_cap_note($retval), 2);
+						return PfbDownloadResult::failure();
+					}
+				} else {
+					$top1m_stage = @tempnam(dirname($head_download), '.pfbtop1m_');
+					if ($top1m_stage === FALSE || !@copy($file_download, $top1m_stage)) {
+						pfb_logger("\n[pfb_download] {$type} rename to destination failed", 2);
+						if ($top1m_stage !== FALSE) {
+							unlink_if_exists($top1m_stage);
+						}
+						unlink_if_exists($file_download);
+						return PfbDownloadResult::failure();
+					}
 				}
 				if (!pfb_top1m_candidate_valid($top1m_stage, $top1m_provider)) {
 					pfb_validate_log($header, 'top1m', 'semantic_invalid', basename($top1m_stage));
@@ -14924,8 +14965,6 @@ function pfb_download(PfbDownloadRequest $request): PfbDownloadResult {
 			}
 			elseif ($type == 'blacklist') {
 				if ($file_type == 'application/x-tar') {
-					// issue #2638: a plain tar is the Blacklist category archive
-					// after a proxy decoded the outer gzip — extract, do not fail-closed.
 					if (!pfb_validate_archive($file_download, $file_type)) {
 						pfb_validate_log($header, 'structural', 'probe_failed', "{$file_type} " . basename($file_download));
 						unlink_if_exists($file_download);
@@ -14953,7 +14992,11 @@ function pfb_download(PfbDownloadRequest $request): PfbDownloadResult {
 							return $retval;
 						}
 						$list = glob("{$staged}/{$filename}*");
-						if (!is_array($list) || empty($list)) {
+						if (!is_array($list)) {
+							$list = array();
+						}
+						$list = array_values(array_filter($list, 'is_file'));
+						if (empty($list)) {
 							return pfb_download_initial_retval();
 						}
 						foreach ($list as $verify) {
@@ -14965,6 +15008,9 @@ function pfb_download(PfbDownloadRequest $request): PfbDownloadResult {
 					})) {
 						pfb_logger("\n[pfb_download] blacklist extraction failed (tar exit {$retval})" . pfb_extract_cap_note($retval), 2);
 						return PfbDownloadResult::failure();
+					}
+					foreach (array("{$file_dwn}.orig", "{$file_dwn}.xxhash128", "{$file_dwn}.md5") as $blacklist_stale) {
+						unlink_if_exists($blacklist_stale);
 					}
 					touch("{$pfb['dbdir']}/{$filename}/{$filename}.update");
 					return PfbDownloadResult::success();

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -14871,9 +14871,9 @@ function pfb_download(PfbDownloadRequest $request): PfbDownloadResult {
 						unlink_if_exists($file_download);
 						return PfbDownloadResult::failure();
 					}
-					$header_esc = escapeshellarg($top1m_stage);
+					$top1m_stage_esc = escapeshellarg($top1m_stage);
 					$retval = pfb_download_initial_retval();
-					exec(pfb_extract_cmd("/usr/bin/tar -xOf {$file_dwn_esc} > {$header_esc}"), $output, $retval);
+					exec(pfb_extract_cmd("/usr/bin/tar -xOf {$file_dwn_esc} > {$top1m_stage_esc}"), $output, $retval);
 					if (!pfb_download_extraction_succeeded($retval)) {
 						unlink_if_exists($file_download);
 						unlink_if_exists($top1m_stage);

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -14933,7 +14933,7 @@ function pfb_download(PfbDownloadRequest $request): PfbDownloadResult {
 					}
 					@rename("{$file_download}", strstr("{$file_download}", '.raw', TRUE));
 					$file_esc = trim(escapeshellarg("{$file_dwn}"), "'");
-					$filename = basename("{$file_esc}", '.tar.gz');
+					$filename = basename(basename("{$file_esc}", '.tar.gz'), '.tar');
 					if (empty(pfb_filter($filename, PFB_FILTER_WORD, 'pfb_download category'))) {
 						pfb_logger("\n Invalid filename [{$filename}]", 1);
 						return PfbDownloadResult::failure();

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -489,7 +489,8 @@ $pfb['mime_types'] = array_flip(array(	'inode/x-empty',
 					'application/gzip',
 					'application/x-gzip',
 					'application/x-bzip2',
-					'application/zip'));
+					'application/zip',
+					'application/x-tar'));
 
 // pfb_filter constants
 define('PFB_FILTER_HTML', 1);
@@ -1129,6 +1130,8 @@ function pfb_archive_probe(string $canonical_type): ?array {
 			return array('/usr/bin/gunzip', '-t');
 		case 'application/x-bzip2':
 			return array('/usr/bin/bzip2', '-t');
+		case 'application/x-tar':
+			return array('/usr/bin/tar', '-tf');
 		default:
 			return NULL;
 	}
@@ -2181,7 +2184,7 @@ function pfb_filter($input, $type, $reference='Unknown', $default='', $escape=FA
 					if ($output[0] === 'application/octet-stream' || empty($output[0])) {
 						$recovered = pfb_octet_recover_type(
 							$input[1],
-							array('application/zip', 'application/gzip', 'application/x-bzip2'),
+							array('application/zip', 'application/gzip', 'application/x-bzip2', 'application/x-tar'),
 							'pfb_validate_archive'
 						);
 					}
@@ -14444,11 +14447,14 @@ function pfb_download(PfbDownloadRequest $request): PfbDownloadResult {
 
 						// Rename any Category files with dashes
 						$list = glob("{$staged}/{$filename}*");
-						if (is_array($list) && !empty($list)) {
-							foreach ($list as $verify) {
-								if (strpos(basename($verify), '-') !== FALSE) {
-									rename($verify, dirname($verify) . '/' . str_replace('-', '_', basename($verify)));
-								}
+						if (!is_array($list) || empty($list)) {
+							// issue #2638: tar exit 0 with no category file must not
+							// publish an empty tree over live categories.
+							return pfb_download_initial_retval();
+						}
+						foreach ($list as $verify) {
+							if (strpos(basename($verify), '-') !== FALSE) {
+								rename($verify, dirname($verify) . '/' . str_replace('-', '_', basename($verify)));
 							}
 						}
 						return $retval;
@@ -14474,15 +14480,21 @@ function pfb_download(PfbDownloadRequest $request): PfbDownloadResult {
 			}
 			else {
 				$reject_detail = array();
-				if (!pfb_filter(array("{$file_dwn_esc}", "{$file_download}", "{$list_download}"), PFB_FILTER_FILE_MIME_COMPRESSED, 'pfb_download', '', FALSE, $reject_detail)) {
+				$inner_type = pfb_filter(array("{$file_dwn_esc}", "{$file_download}", "{$list_download}"), PFB_FILTER_FILE_MIME_COMPRESSED, 'pfb_download', '', FALSE, $reject_detail);
+				if (!$inner_type) {
 					pfb_validate_log($header, 'inner', 'compressed_mime_not_allowed', pfb_reject_detail_summary($reject_detail));
 					return PfbDownloadResult::failure();
 				}
 				pfb_logger('.', 1);
 				$retval = pfb_download_initial_retval();
+				$extract_tar = ($inner_type == 'application/x-tar');
 				if (!pfb_stage_publish($orig_download,
-				    static function (string $staged) use ($file_dwn_esc, &$output, &$retval): int {
-					exec(pfb_extract_cmd("/usr/bin/gunzip -c {$file_dwn_esc} > " . escapeshellarg($staged)), $output, $retval);
+				    static function (string $staged) use ($file_dwn_esc, $extract_tar, &$output, &$retval): int {
+					if ($extract_tar) {
+						exec(pfb_extract_cmd("set -o pipefail; /usr/bin/gunzip -c {$file_dwn_esc} | /usr/bin/tar -xOf - > " . escapeshellarg($staged)), $output, $retval);
+					} else {
+						exec(pfb_extract_cmd("/usr/bin/gunzip -c {$file_dwn_esc} > " . escapeshellarg($staged)), $output, $retval);
+					}
 					return $retval;
 				})) {
 					pfb_logger("\n[pfb_download] gzip extraction failed (gunzip exit {$retval})" . pfb_extract_cap_note($retval), 2);
@@ -14504,15 +14516,21 @@ function pfb_download(PfbDownloadRequest $request): PfbDownloadResult {
 				return PfbDownloadResult::failure();
 			}
 			$reject_detail = array();
-			if (!pfb_filter(array("{$file_dwn_esc}", "{$file_download}", "{$list_download}"), PFB_FILTER_FILE_MIME_COMPRESSED, 'pfb_download', '', FALSE, $reject_detail)) {
+			$inner_type = pfb_filter(array("{$file_dwn_esc}", "{$file_download}", "{$list_download}"), PFB_FILTER_FILE_MIME_COMPRESSED, 'pfb_download', '', FALSE, $reject_detail);
+			if (!$inner_type) {
 				pfb_validate_log($header, 'inner', 'compressed_mime_not_allowed', pfb_reject_detail_summary($reject_detail));
 				return PfbDownloadResult::failure();
 			}
 			pfb_logger('.', 1);
 			$retval = pfb_download_initial_retval();
+			$extract_tar = ($inner_type == 'application/x-tar');
 			if (!pfb_stage_publish($orig_download,
-			    static function (string $staged) use ($file_dwn_esc, &$output, &$retval): int {
-				exec(pfb_extract_cmd("/usr/bin/bzip2 -dkc {$file_dwn_esc} > " . escapeshellarg($staged)), $output, $retval);
+			    static function (string $staged) use ($file_dwn_esc, $extract_tar, &$output, &$retval): int {
+				if ($extract_tar) {
+					exec(pfb_extract_cmd("set -o pipefail; /usr/bin/bzip2 -dkc {$file_dwn_esc} | /usr/bin/tar -xOf - > " . escapeshellarg($staged)), $output, $retval);
+				} else {
+					exec(pfb_extract_cmd("/usr/bin/bzip2 -dkc {$file_dwn_esc} > " . escapeshellarg($staged)), $output, $retval);
+				}
 				return $retval;
 			})) {
 				pfb_logger("\n[pfb_download] bzip2 extraction failed (bzip2 exit {$retval})" . pfb_extract_cap_note($retval), 2);
@@ -14785,6 +14803,33 @@ function pfb_download(PfbDownloadRequest $request): PfbDownloadResult {
 		else {
 			// Uncompressed file format.
 			if ($type == 'geoip' || $type == 'asn') {
+				if ($file_type == 'application/x-tar') {
+					if (!pfb_validate_archive($file_download, $file_type)) {
+						pfb_validate_log($header, 'structural', 'probe_failed', "{$file_type} " . basename($file_download));
+						unlink_if_exists($file_download);
+						return PfbDownloadResult::failure();
+					}
+					$retval = pfb_download_initial_retval();
+					if ($type == 'geoip') {
+						exec(pfb_extract_cmd("/usr/bin/tar -xf {$file_dwn_esc} --strip=1 -C {$header_esc} >/dev/null 2>&1"), $output, $retval);
+						unlink_if_exists($file_download);
+						if (!pfb_download_extraction_succeeded($retval)) {
+							pfb_logger("\n[pfb_download] {$type} tar extraction failed (tar exit {$retval})" . pfb_extract_cap_note($retval), 2);
+							return PfbDownloadResult::failure();
+						}
+						return PfbDownloadResult::success();
+					}
+					if (!pfb_stage_publish($head_download,
+					    static function (string $staged) use ($file_dwn_esc, &$output, &$retval): int {
+						exec(pfb_extract_cmd("/usr/bin/tar -xOf {$file_dwn_esc} > " . escapeshellarg($staged)), $output, $retval);
+						return $retval;
+					})) {
+						unlink_if_exists($file_download);
+						return PfbDownloadResult::failure();
+					}
+					unlink_if_exists($file_download);
+					return PfbDownloadResult::success();
+				}
 				// Existing MaxMind/ASN path: preserve the direct rename contract.
 				$renamed = @rename("{$file_download}", "{$head_download}");
 				if (!$renamed) {
@@ -14878,6 +14923,52 @@ function pfb_download(PfbDownloadRequest $request): PfbDownloadResult {
 				return PfbDownloadResult::success();
 			}
 			elseif ($type == 'blacklist') {
+				if ($file_type == 'application/x-tar') {
+					// issue #2638: a plain tar is the Blacklist category archive
+					// after a proxy decoded the outer gzip — extract, do not fail-closed.
+					if (!pfb_validate_archive($file_download, $file_type)) {
+						pfb_validate_log($header, 'structural', 'probe_failed', "{$file_type} " . basename($file_download));
+						unlink_if_exists($file_download);
+						return PfbDownloadResult::failure();
+					}
+					@rename("{$file_download}", strstr("{$file_download}", '.raw', TRUE));
+					$file_esc = trim(escapeshellarg("{$file_dwn}"), "'");
+					$filename = basename("{$file_esc}", '.tar.gz');
+					if (empty(pfb_filter($filename, PFB_FILTER_WORD, 'pfb_download category'))) {
+						pfb_logger("\n Invalid filename [{$filename}]", 1);
+						return PfbDownloadResult::failure();
+					}
+					$unsafe_member = pfb_archive_unsafe_member(pfb_archive_member_names($file_dwn));
+					if ($unsafe_member !== NULL) {
+						pfb_validate_log($header, 'member', 'unsafe_member_name', $unsafe_member);
+						unlink_if_exists($file_dwn);
+						return PfbDownloadResult::failure();
+					}
+					$cmd = "--include='*domains' -s',.*/\\(.*\\)/\\(.*\\)/domains,{$filename}_\\1_\\2,' -s',.*/\\(.*\\)/domains,{$filename}_\\1,'";
+					$retval = pfb_download_initial_retval();
+					if (!pfb_stage_publish_dir("{$pfb['dbdir']}/{$filename}",
+					    static function (string $staged) use ($file_dwn, $filename, $cmd, &$output, &$retval): int {
+						exec(pfb_extract_cmd("/usr/bin/tar -xf " . escapeshellarg("{$file_dwn}") . " {$cmd} -C " . escapeshellarg("{$staged}/") . " >/dev/null 2>&1"), $output, $retval);
+						if (!pfb_download_extraction_succeeded($retval)) {
+							return $retval;
+						}
+						$list = glob("{$staged}/{$filename}*");
+						if (!is_array($list) || empty($list)) {
+							return pfb_download_initial_retval();
+						}
+						foreach ($list as $verify) {
+							if (strpos(basename($verify), '-') !== FALSE) {
+								rename($verify, dirname($verify) . '/' . str_replace('-', '_', basename($verify)));
+							}
+						}
+						return $retval;
+					})) {
+						pfb_logger("\n[pfb_download] blacklist extraction failed (tar exit {$retval})" . pfb_extract_cap_note($retval), 2);
+						return PfbDownloadResult::failure();
+					}
+					touch("{$pfb['dbdir']}/{$filename}/{$filename}.update");
+					return PfbDownloadResult::success();
+				}
 				// issue #2635: a MIME-allowlisted non-archive body is not a
 				// successful Blacklist update — leave category files untouched.
 				pfb_validate_log($header, 'extract', 'blacklist_not_archive', $file_type);
@@ -14885,13 +14976,31 @@ function pfb_download(PfbDownloadRequest $request): PfbDownloadResult {
 				return PfbDownloadResult::failure();
 			}
 			else {
-				// Rename file to 'orig' format
-				$renamed = @rename("{$file_download}", "{$orig_download}");
-				if (!$renamed) {
-					pfb_logger("\n[pfb_download] {$header} rename to .orig failed", 2);
-					return PfbDownloadResult::failure();
+				if ($file_type == 'application/x-tar') {
+					if (!pfb_validate_archive($file_download, $file_type)) {
+						pfb_validate_log($header, 'structural', 'probe_failed', "{$file_type} " . basename($file_download));
+						unlink_if_exists($file_download);
+						return PfbDownloadResult::failure();
+					}
+					$retval = pfb_download_initial_retval();
+					if (!pfb_stage_publish($orig_download,
+					    static function (string $staged) use ($file_dwn_esc, &$output, &$retval): int {
+						exec(pfb_extract_cmd("/usr/bin/tar -xOf {$file_dwn_esc} > " . escapeshellarg($staged)), $output, $retval);
+						return $retval;
+					})) {
+						pfb_logger("\n[pfb_download] tar extraction failed (tar exit {$retval})" . pfb_extract_cap_note($retval), 2);
+						unlink_if_exists($file_download);
+						return PfbDownloadResult::failure();
+					}
+				} else {
+					// Rename file to 'orig' format
+					$renamed = @rename("{$file_download}", "{$orig_download}");
+					if (!$renamed) {
+						pfb_logger("\n[pfb_download] {$header} rename to .orig failed", 2);
+						return PfbDownloadResult::failure();
+					}
+					$retval = 0;
 				}
-				$retval = 0;
 			}
 		}
 

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -14851,7 +14851,7 @@ function pfb_download(PfbDownloadRequest $request): PfbDownloadResult {
 			if ($type == 'top1m') {
 				// Stage TOP1M's plain body before publishing; baseline persistence
 				// commits after active publication and rolls both back on failure.
-				if ($file_type == 'application/x-tar' && $type == 'top1m') {
+				if ($file_type == 'application/x-tar') {
 					if (!pfb_validate_archive($file_download, $file_type)) {
 						pfb_validate_log($header, 'structural', 'probe_failed', "{$file_type} " . basename($file_download));
 						unlink_if_exists($file_download);

--- a/tests/php/ArchiveProbeTest.php
+++ b/tests/php/ArchiveProbeTest.php
@@ -43,6 +43,13 @@ final class ArchiveProbeTest extends TestCase
 		$this->assertSame(['/usr/bin/bzip2', '-t'], pfb_archive_probe('application/x-bzip2'));
 	}
 
+	public function test_probe_x_tar_returns_tar_tf(): void
+	{
+		// issue #2638: a newly accepted archive type must have a structural probe;
+		// without it pfb_validate_archive() treats x-tar as "non-archive: nothing to test".
+		$this->assertSame(['/usr/bin/tar', '-tf'], pfb_archive_probe('application/x-tar'));
+	}
+
 	public function test_probe_removed_archive_returns_null(): void
 	{
 		// Removed archive formats have no structural probe and must not reach an extractor.

--- a/tests/php/ArchiveValidateTest.php
+++ b/tests/php/ArchiveValidateTest.php
@@ -60,6 +60,17 @@ final class ArchiveValidateTest extends TestCase
 		$this->assertFalse($result, 'Archive probe exit 1 must return FALSE (archive is corrupt/invalid)');
 	}
 
+	public function test_x_tar_probe_exit_1_returns_false(): void
+	{
+		// issue #2638: accepting x-tar without a failing probe would wave a corrupt
+		// tar through as "non-archive: nothing to test".
+		$runner = fn(array $argv): int => 1;
+
+		$result = pfb_validate_archive('/var/db/pfblockerng/feed.tar', 'application/x-tar', $runner);
+
+		$this->assertFalse($result, 'x-tar probe exit 1 must return FALSE');
+	}
+
 	public function test_archive_type_runner_exit_2_returns_false(): void
 	{
 		// Any non-zero exit code signals failure, not just exit 1.

--- a/tests/php/DownloadExtractionExitCodeTest.php
+++ b/tests/php/DownloadExtractionExitCodeTest.php
@@ -227,12 +227,33 @@ final class DownloadExtractionExitCodeTest extends TestCase
 		);
 		$this->assertStringContainsString('unlink_if_exists($file_download);', $scope);
 		$this->assertStringContainsString('return PfbDownloadResult::failure();', $scope);
-		// The gzip Blacklist branch publishes through pfb_stage_publish_dir() so a
-		// failed tar cannot replace live category files. This uncompressed reject
-		// must not extract or publish at all — unlink the .raw body and return.
-		$this->assertStringNotContainsString('pfb_stage_publish_dir', $scope);
-		$this->assertStringNotContainsString('tar -xf', $scope);
-		$this->assertStringNotContainsString('$pfb[\'dbdir\']', $scope);
+		// issue #2638 extracts application/x-tar in this same elseif; HTML/plain
+		// still fail closed. The no-extract assertions live on the reject arm
+		// via blacklist_not_archive + failure return above.
+	}
+
+	/**
+	 * Issue #2638 — an uncompressed application/x-tar Blacklist body must be
+	 * extracted into the category tree, not fail-closed as a non-archive.
+	 * Comments/docblocks cannot define this scope.
+	 */
+	public function testUncompressedTarBlacklistBodyExtractsCategories(): void
+	{
+		$uncomp = strpos(self::$source, "if (\$type == 'geoip' || \$type == 'asn')");
+		$blacklist = strpos(self::$source, "elseif (\$type == 'blacklist') {", $uncomp === FALSE ? 0 : $uncomp);
+		$end = strpos(self::$source, 'else {', $blacklist === FALSE ? 0 : $blacklist);
+		$this->assertNotFalse($uncomp);
+		$this->assertNotFalse($blacklist);
+		$this->assertNotFalse($end);
+		$scope = substr(self::$source, $blacklist, $end - $blacklist);
+		$this->assertStringContainsString("if (\$file_type == 'application/x-tar') {", $scope);
+		$this->assertStringContainsString('pfb_stage_publish_dir', $scope);
+		$this->assertStringContainsString('/usr/bin/tar -xf', $scope);
+		$reject = strpos($scope, "pfb_validate_log(\$header, 'extract', 'blacklist_not_archive', \$file_type);");
+		$tar = strpos($scope, "if (\$file_type == 'application/x-tar') {");
+		$this->assertNotFalse($reject);
+		$this->assertNotFalse($tar);
+		$this->assertLessThan($reject, $tar, 'x-tar extract must run before the non-archive reject');
 	}
 
 	/**

--- a/tests/php/DownloadExtractionExitCodeTest.php
+++ b/tests/php/DownloadExtractionExitCodeTest.php
@@ -249,6 +249,8 @@ final class DownloadExtractionExitCodeTest extends TestCase
 		$this->assertStringContainsString("if (\$file_type == 'application/x-tar') {", $scope);
 		$this->assertStringContainsString('pfb_stage_publish_dir', $scope);
 		$this->assertStringContainsString('/usr/bin/tar -xf', $scope);
+		// issue #2632 smoke: downloadPath may end in .tar, not .tar.gz; WORD rejects a leftover dot.
+		$this->assertStringContainsString("basename(basename(\"{\$file_esc}\", '.tar.gz'), '.tar')", $scope);
 		$reject = strpos($scope, "pfb_validate_log(\$header, 'extract', 'blacklist_not_archive', \$file_type);");
 		$tar = strpos($scope, "if (\$file_type == 'application/x-tar') {");
 		$this->assertNotFalse($reject);

--- a/tests/php/DownloadExtractionExitCodeTest.php
+++ b/tests/php/DownloadExtractionExitCodeTest.php
@@ -56,7 +56,10 @@ final class DownloadExtractionExitCodeTest extends TestCase
 		$this->assertNotFalse($geoip);
 		$this->assertNotFalse($asn);
 		$scope = substr(self::$source, $geoip, $asn - $geoip);
-		$this->assertMatchesRegularExpression('/exec\(pfb_extract_cmd\(".*tar -xzf .*\\$output, \\$retval\);/', $scope);
+		// issue #2638: bsdtar auto-detects compression; -xf serves gzip and plain tar.
+		$this->assertMatchesRegularExpression('/exec\(pfb_extract_cmd\(".*tar -xf .*\\$output, \\$retval\);/', $scope);
+		$this->assertStringContainsString('-C {$pfb[\'geoipshare\']}', $scope);
+		$this->assertStringContainsString('pfb_archive_unsafe_member', $scope);
 		$this->assertStringContainsString('pfb_download_extraction_succeeded($retval)', $scope);
 	}
 
@@ -336,6 +339,53 @@ final class DownloadExtractionExitCodeTest extends TestCase
 		$this->assertStringNotContainsString('pfb_stage_publish', $reject_scope);
 		$this->assertStringNotContainsString('tar -xf', $reject_scope);
 		$this->assertStringNotContainsString('$pfb[\'dbdir\']', $reject_scope);
+	}
+
+	/**
+	 * Issue #2638 B7 — uncompressed geoip x-tar must not tar -C a .mmdb file
+	 * path ($header). Disk-writing extract goes to geoipshare and keeps ADR-46.
+	 * Comments/docblocks cannot define this scope.
+	 */
+	public function testUncompressedGeoipTarDoesNotExtractIntoHeaderFile(): void
+	{
+		$uncomp = strpos(self::$source, "if (\$type == 'geoip' || \$type == 'asn')");
+		$top1m = strpos(self::$source, "if (\$type == 'top1m') {", $uncomp === FALSE ? 0 : $uncomp);
+		$this->assertNotFalse($uncomp);
+		$this->assertNotFalse($top1m);
+		$scope = substr(self::$source, $uncomp, $top1m - $uncomp);
+		$this->assertStringNotContainsString(
+			'-C {$header_esc}',
+			$scope,
+			'geoip tar -C must be geoipshare, not $header (.mmdb file)'
+		);
+	}
+
+	/**
+	 * Issue #2638 B9 — glob() matches directories, so a *domains directory
+	 * satisfies an empty($list) guard. Category publish must count files.
+	 * Comments/docblocks cannot define this scope.
+	 */
+	public function testBlacklistEmptyTreeGuardCountsFilesNotDirectories(): void
+	{
+		$this->assertStringContainsString(
+			"array_filter(\$list, 'is_file')",
+			self::$source,
+			'glob() of staged categories must drop directory hits before the empty-tree guard'
+		);
+	}
+
+	/**
+	 * Issue #2638 B2 — a plain-tar TOP1M body must extract, not copy-as-text.
+	 * Route into the zip/container archive branch. Comments/docblocks cannot
+	 * define this scope.
+	 */
+	public function testPlainTarTop1mRoutesThroughArchiveExtract(): void
+	{
+		$this->assertStringContainsString(
+			"\$file_type == 'application/x-tar' && \$type == 'top1m'",
+			self::$source,
+			'plain tar TOP1M must extract as a container archive, not copy-as-text'
+		);
 	}
 
 	/**

--- a/tests/php/DownloadExtractionExitCodeTest.php
+++ b/tests/php/DownloadExtractionExitCodeTest.php
@@ -218,21 +218,31 @@ final class DownloadExtractionExitCodeTest extends TestCase
 		$this->assertNotFalse($blacklist);
 		$this->assertNotFalse($end);
 		$scope = substr(self::$source, $blacklist, $end - $blacklist);
+		$tar = strpos($scope, "if (\$file_type == 'application/x-tar') {");
+		$this->assertNotFalse($tar);
+		$tarBrace = strpos($scope, '{', $tar);
+		$this->assertNotFalse($tarBrace);
+		$reject_scope = substr($scope, self::closingBraceExclusive($scope, $tarBrace));
 		$this->assertStringNotContainsString(
 			'$retval = 0;',
-			$scope,
+			$reject_scope,
 			'uncompressed Blacklist must not treat a non-archive body as a successful extract'
 		);
 		$this->assertStringContainsString(
 			"pfb_validate_log(\$header, 'extract', 'blacklist_not_archive', \$file_type);",
-			$scope,
+			$reject_scope,
 			'reject must name the detected type'
 		);
-		$this->assertStringContainsString('unlink_if_exists($file_download);', $scope);
-		$this->assertStringContainsString('return PfbDownloadResult::failure();', $scope);
-		// issue #2638 extracts application/x-tar in this same elseif; HTML/plain
-		// still fail closed. The no-extract assertions live on the reject arm
-		// via blacklist_not_archive + failure return above.
+		$this->assertSame(
+			1,
+			substr_count($reject_scope, 'return PfbDownloadResult::failure();'),
+			'reject scope must not swallow the x-tar arm failure return'
+		);
+		$this->assertStringContainsString('unlink_if_exists($file_download);', $reject_scope);
+		$this->assertStringContainsString('return PfbDownloadResult::failure();', $reject_scope);
+		$this->assertStringNotContainsString('pfb_stage_publish_dir', $reject_scope);
+		$this->assertStringNotContainsString('tar -xf', $reject_scope);
+		$this->assertStringNotContainsString('$pfb[\'dbdir\']', $reject_scope);
 	}
 
 	/**
@@ -254,6 +264,7 @@ final class DownloadExtractionExitCodeTest extends TestCase
 		$this->assertStringContainsString('/usr/bin/tar -xf', $scope);
 		// issue #2632 smoke: downloadPath may end in .tar, not .tar.gz; WORD rejects a leftover dot.
 		$this->assertStringContainsString("basename(basename(\"{\$file_esc}\", '.tar.gz'), '.tar')", $scope);
+		$this->assertStringContainsString('pfb_archive_unsafe_member', $scope);
 		$reject = strpos($scope, "pfb_validate_log(\$header, 'extract', 'blacklist_not_archive', \$file_type);");
 		$tar = strpos($scope, "if (\$file_type == 'application/x-tar') {");
 		$this->assertNotFalse($reject);
@@ -367,10 +378,10 @@ final class DownloadExtractionExitCodeTest extends TestCase
 	 */
 	public function testBlacklistEmptyTreeGuardCountsFilesNotDirectories(): void
 	{
-		$this->assertStringContainsString(
-			"array_filter(\$list, 'is_file')",
-			self::$source,
-			'glob() of staged categories must drop directory hits before the empty-tree guard'
+		$this->assertSame(
+			2,
+			substr_count(self::$source, "array_filter(\$list, 'is_file')"),
+			'both Blacklist staging sites must drop directory glob hits'
 		);
 	}
 
@@ -381,11 +392,16 @@ final class DownloadExtractionExitCodeTest extends TestCase
 	 */
 	public function testPlainTarTop1mRoutesThroughArchiveExtract(): void
 	{
-		$this->assertStringContainsString(
-			"\$file_type == 'application/x-tar' && \$type == 'top1m'",
-			self::$source,
-			'plain tar TOP1M must extract as a container archive, not copy-as-text'
-		);
+		$uncomp = strpos(self::$source, "if (\$type == 'geoip' || \$type == 'asn')");
+		$top1m = strpos(self::$source, "if (\$type == 'top1m') {", $uncomp === FALSE ? 0 : $uncomp);
+		$blacklist = strpos(self::$source, "elseif (\$type == 'blacklist') {", $top1m === FALSE ? 0 : $top1m);
+		$this->assertNotFalse($uncomp);
+		$this->assertNotFalse($top1m);
+		$this->assertNotFalse($blacklist);
+		$scope = substr(self::$source, $top1m, $blacklist - $top1m);
+		$this->assertStringContainsString("if (\$file_type == 'application/x-tar') {", $scope);
+		$this->assertStringContainsString('tar -xOf', $scope);
+		$this->assertStringContainsString('count($archive_members) !== 1', $scope);
 	}
 
 	/**

--- a/tests/php/PfbMimeAllowlistTest.php
+++ b/tests/php/PfbMimeAllowlistTest.php
@@ -92,7 +92,7 @@ final class PfbMimeAllowlistTest extends TestCase
 		$this->assertTrue(pfb_mime_in_allowlist('text/plain', $this->allowlist));
 	}
 
-	public function test_shipped_allowlist_rejects_tar_feeds(): void
+	public function test_shipped_allowlist_accepts_tar_feeds(): void
 	{
 		$shipped = $GLOBALS['pfb_shipped_mime_types'] ?? [];
 
@@ -105,9 +105,9 @@ final class PfbMimeAllowlistTest extends TestCase
 			pfb_mime_in_allowlist('application/x-bzip2', $shipped),
 			'plain bzip2 feeds must still reach the compressed MIME gate'
 		);
-		$this->assertFalse(
+		$this->assertTrue(
 			pfb_mime_in_allowlist('application/x-tar', $shipped),
-			'raw tar and tar payloads inside gzip/bzip2 must be rejected'
+			'issue #2638: a tar is extractable — outer and inner gates must admit it'
 		);
 	}
 

--- a/tests/php/PfbTarMimeRejectionTest.php
+++ b/tests/php/PfbTarMimeRejectionTest.php
@@ -29,9 +29,11 @@ final class PfbTarMimeRejectionTest extends TestCase
 
 		$tarBytes = file_get_contents($this->path('feed.tar'));
 		$this->writeGzip('feed.tar.gz', $tarBytes);
-		$this->writeBzip2('feed.tar.bz2', $tarBytes);
 		$this->writeGzip('feed.txt.gz', self::FEED);
-		$this->writeBzip2('feed.txt.bz2', self::FEED);
+		if (function_exists('bzcompress')) {
+			$this->writeBzip2('feed.tar.bz2', $tarBytes);
+			$this->writeBzip2('feed.txt.bz2', self::FEED);
+		}
 
 		$zip = new ZipArchive();
 		if ($zip->open($this->path('feed.zip'), ZipArchive::CREATE | ZipArchive::OVERWRITE) !== TRUE ||
@@ -71,6 +73,9 @@ final class PfbTarMimeRejectionTest extends TestCase
 
 	public function test_tar_bzip2_is_accepted_at_inner_gate(): void
 	{
+		if (!function_exists('bzcompress')) {
+			$this->markTestSkipped('ext-bz2 is not loaded');
+		}
 		$path = $this->path('feed.tar.bz2');
 		$this->assertSame('application/x-bzip2', $this->filter($path, PFB_FILTER_FILE_MIME));
 		$this->assertSame('application/x-tar', $this->filter($path, PFB_FILTER_FILE_MIME_COMPRESSED));
@@ -87,6 +92,9 @@ final class PfbTarMimeRejectionTest extends TestCase
 
 	public function test_plain_bzip2_remains_accepted(): void
 	{
+		if (!function_exists('bzcompress')) {
+			$this->markTestSkipped('ext-bz2 is not loaded');
+		}
 		$path = $this->path('feed.txt.bz2');
 		$this->assertSame('application/x-bzip2', $this->filter($path, PFB_FILTER_FILE_MIME));
 		$this->assertSame('text/plain', $this->filter($path, PFB_FILTER_FILE_MIME_COMPRESSED));

--- a/tests/php/PfbTarMimeRejectionTest.php
+++ b/tests/php/PfbTarMimeRejectionTest.php
@@ -54,23 +54,27 @@ final class PfbTarMimeRejectionTest extends TestCase
 		}
 	}
 
-	public function test_raw_tar_is_rejected_at_outer_gate(): void
+	public function test_raw_tar_is_accepted_at_outer_gate(): void
 	{
-		$this->assertTarRejected('feed.tar', PFB_FILTER_FILE_MIME);
+		$path = $this->path('feed.tar');
+		$this->assertSame('application/x-tar', $this->filter($path, PFB_FILTER_FILE_MIME));
+		$this->assertFileExists($path);
 	}
 
-	public function test_tar_gzip_is_rejected_at_inner_gate(): void
+	public function test_tar_gzip_is_accepted_at_inner_gate(): void
 	{
 		$path = $this->path('feed.tar.gz');
 		$this->assertSame('application/gzip', $this->filter($path, PFB_FILTER_FILE_MIME));
-		$this->assertTarRejected('feed.tar.gz', PFB_FILTER_FILE_MIME_COMPRESSED);
+		$this->assertSame('application/x-tar', $this->filter($path, PFB_FILTER_FILE_MIME_COMPRESSED));
+		$this->assertFileExists($path);
 	}
 
-	public function test_tar_bzip2_is_rejected_at_inner_gate(): void
+	public function test_tar_bzip2_is_accepted_at_inner_gate(): void
 	{
 		$path = $this->path('feed.tar.bz2');
 		$this->assertSame('application/x-bzip2', $this->filter($path, PFB_FILTER_FILE_MIME));
-		$this->assertTarRejected('feed.tar.bz2', PFB_FILTER_FILE_MIME_COMPRESSED);
+		$this->assertSame('application/x-tar', $this->filter($path, PFB_FILTER_FILE_MIME_COMPRESSED));
+		$this->assertFileExists($path);
 	}
 
 	public function test_plain_gzip_remains_accepted(): void
@@ -94,16 +98,6 @@ final class PfbTarMimeRejectionTest extends TestCase
 		$path = $this->path('feed.zip');
 		$this->assertSame('application/zip', $this->filter($path, PFB_FILTER_FILE_MIME));
 		$this->assertFileExists($path);
-	}
-
-	private function assertTarRejected(string $name, int $filter): void
-	{
-		$path = $this->path($name);
-		$detail = [];
-
-		$this->assertFalse($this->filter($path, $filter, $detail));
-		$this->assertSame('application/x-tar', $detail['mime'] ?? NULL);
-		$this->assertFileDoesNotExist($path);
 	}
 
 	private function filter(string $path, int $filter, ?array &$detail = NULL): string|false

--- a/tests/skip-allowlist.txt
+++ b/tests/skip-allowlist.txt
@@ -34,6 +34,8 @@ phpunit:PfbFlockBoundedTest::testBoundedAcquireRealErrorReturnsFalsePromptlyWith
 phpunit:RsyncSizeRefusalTest::test_rsync_body_over_the_ceiling_is_refused_with_a_named_reason  # macOS host lacks /usr/local/bin/rsync (openrsync lives at /usr/bin); Linux CI installs it there (issue #2667)
 phpunit:RsyncSizeRefusalTest::test_rsync_body_under_the_ceiling_still_downloads  # macOS host lacks /usr/local/bin/rsync; Linux CI installs it there (issue #2667)
 phpunit:RsyncSizeRefusalTest::test_rsync_fetch_under_a_kernel_tiny_ceiling_never_succeeds  # macOS host lacks /usr/local/bin/rsync; Linux CI installs it there (issue #2667)
+phpunit:PfbTarMimeRejectionTest::test_tar_bzip2_is_accepted_at_inner_gate  # ext-bz2 absent on some host PHP builds; CI loads it
+phpunit:PfbTarMimeRejectionTest::test_plain_bzip2_remains_accepted  # ext-bz2 absent on some host PHP builds; CI loads it
 
 # ShellSpec -- macOS/BSD host lacks the GNU stat/date/touch branch exercised in Linux CI.
 shellspec:tests/shell/pfblockerng_adr26_locale_spec.sh::ADR-26 — pfb_list_orig_by_mtime() diagnostic listing (Phase 3) lists *.orig oldest-first as "<YYYY-MM-DD> <HH:MM><TAB><name>" (ISO date, path + .orig stripped)  # GNU-only off-box branch; BSD branch is covered live by ADR-04 smoke

--- a/tests/smoke/test_smoke_feeds.py
+++ b/tests/smoke/test_smoke_feeds.py
@@ -4095,11 +4095,15 @@ def test_ip_tar_feed_imports_members(deployed_vm: SmokeVM, mock_feeds: _MockFeed
     publishes the inner list and the member IP loads.
     """
     payload = _ADR44_BODY.encode()
+    framing = b"NOT-A-LIST-TOKEN\n"
     buf = io.BytesIO()
     with tarfile.open(fileobj=buf, mode="w") as tar:
         info = tarfile.TarInfo("list.txt")
         info.size = len(payload)
         tar.addfile(info, io.BytesIO(payload))
+        readme = tarfile.TarInfo("README")
+        readme.size = len(framing)
+        tar.addfile(readme, io.BytesIO(framing))
     feed_url = mock_feeds.register("adr2638.tar", buf.getvalue())
     spec = h.IpCase(aliasname="adr2638tar", feed_url=feed_url, header="adr2638tar", family="v4")
     assert spec.alias not in h.pfctl_tables(deployed_vm), f"{spec.alias} present before the tar feed was ever loaded"
@@ -4108,6 +4112,50 @@ def test_ip_tar_feed_imports_members(deployed_vm: SmokeVM, mock_feeds: _MockFeed
         assert h.member_present(members, _ADR44_MEMBER), (
             f"expected {_ADR44_MEMBER!r} in {spec.alias} after tar extraction, got: {members}"
         )
+        framing = "NOT-A-LIST-TOKEN"
+        assert not any(framing in m or "README" in m for m in members), (
+            f"tar framing must not reach the alias; members={members}"
+        )
+
+
+def _blacklist_tar_domains_dir_only(top: str, category: str) -> bytes:
+    """Case-3 archive: the only *domains match is a directory (issue #2638)."""
+    raw = io.BytesIO()
+    with tarfile.open(fileobj=raw, mode="w") as tar:
+        info = tarfile.TarInfo(f"{top}/{category}/domains")
+        info.type = tarfile.DIRTYPE
+        tar.addfile(info)
+    return raw.getvalue()
+
+
+@pytest.mark.timeout(120)
+def test_blacklist_plain_tar_directory_only_keeps_categories(deployed_vm: SmokeVM, mock_feeds: _MockFeedServer) -> None:
+    """issue #2638 case 3: a *domains directory must not publish over live categories.
+
+    Given previously extracted Blacklist category files and a tar whose only
+      ``*domains`` match is a directory (bsdtar exit 0, zero files),
+    When  pfb_download() fetches it as type='blacklist',
+    Then  the download fails and the planted category file is unchanged.
+    """
+    workdir = "/tmp/pfb2638_c3"
+    category_dir = f"{h.PFB_DBDIR}/pfb2638c3"
+    sentinel_path = f"{category_dir}/pfb2638c3_testcat"
+    sentinel = "keep-me.example.test\n"
+    archive = f"{workdir}/pfb2638c3.tar"
+    try:
+        deployed_vm.ssh("/bin/rm", "-rf", workdir, category_dir, timeout=30.0)
+        mk = deployed_vm.ssh("/bin/mkdir", "-p", workdir, category_dir)
+        assert mk.returncode == 0, f"mkdir failed: rc={mk.returncode} stderr={mk.stderr!r}"
+        _plant_guest_text(deployed_vm, sentinel_path, sentinel)
+        before = deployed_vm.ssh(f"/bin/cat {sentinel_path} 2>&1").stdout
+        assert before == sentinel
+        feed_url = mock_feeds.register("pfb2638c3.tar", _blacklist_tar_domains_dir_only("pfb2638c3", "testcat"))
+        out = _adr46_download(deployed_vm, feed_url, archive, "pfb2638c3", "blacklist")
+        assert "PFB_DL_TRUE" not in out, f"directory-only tar must not succeed; got {out!r}"
+        after = deployed_vm.ssh(f"/bin/cat {sentinel_path} 2>&1").stdout
+        assert after == sentinel, f"live category must survive; before={before!r} after={after!r}"
+    finally:
+        deployed_vm.ssh("/bin/rm", "-rf", workdir, category_dir)
 
 
 def _plant_guest_text(vm: SmokeVM, path: str, contents: str) -> None:

--- a/tests/smoke/test_smoke_feeds.py
+++ b/tests/smoke/test_smoke_feeds.py
@@ -4046,6 +4046,70 @@ def test_blacklist_archive_survives_gzip_content_encoding(deployed_vm: SmokeVM, 
         deployed_vm.ssh(f"/bin/rm -rf {workdir} {category_dir}")
 
 
+def _blacklist_tar(top: str, category: str, domain: str) -> bytes:
+    """UT1-shaped blacklist archive as a plain tar (issue #2632 / #2638)."""
+    payload = f"{domain}\n".encode()
+    raw = io.BytesIO()
+    with tarfile.open(fileobj=raw, mode="w") as tar:
+        info = tarfile.TarInfo(f"{top}/{category}/domains")
+        info.size = len(payload)
+        tar.addfile(info, io.BytesIO(payload))
+    return raw.getvalue()
+
+
+@pytest.mark.timeout(120)
+def test_blacklist_plain_tar_extracts_categories(deployed_vm: SmokeVM, mock_feeds: _MockFeedServer) -> None:
+    """issue #2638: a plain-tar Blacklist body extracts categories (the #2632 unpack).
+
+    Given an origin serving a UT1-shaped tar (no gzip wrapper),
+    When  pfb_download() fetches it as type='blacklist',
+    Then  the download succeeds and the category file is extracted.
+    """
+    domain = h.unique_domain("pfb2638")
+    workdir = "/tmp/pfb2638_dl"
+    archive = f"{workdir}/pfb2638.tar"
+    category_dir = f"{h.PFB_DBDIR}/pfb2638"
+    try:
+        deployed_vm.ssh("/bin/rm", "-rf", workdir, category_dir, timeout=30.0)
+        mk = deployed_vm.ssh("/bin/mkdir", "-p", workdir)
+        assert mk.returncode == 0, f"mkdir failed: rc={mk.returncode} stderr={mk.stderr!r}"
+        box_mime = _box_mime_type(deployed_vm, _blacklist_tar("pfb2638", "testcat", domain))
+        assert box_mime == "application/x-tar", f"expected application/x-tar, got {box_mime!r}"
+        feed_url = mock_feeds.register("pfb2638.tar", _blacklist_tar("pfb2638", "testcat", domain))
+        out = _adr46_download(deployed_vm, feed_url, archive, "pfb2638", "blacklist")
+        assert "PFB_DL_TRUE" in out, f"expected pfb_download success on a plain-tar Blacklist body; got {out!r}"
+        extracted = deployed_vm.ssh(f"/bin/cat {category_dir}/pfb2638_testcat 2>&1").stdout
+        assert domain in extracted, (
+            f"expected {domain!r} in {category_dir}/pfb2638_testcat; got {extracted!r}; "
+            f"ls={deployed_vm.ssh(f'/bin/ls -A {category_dir} 2>&1').stdout!r}"
+        )
+    finally:
+        deployed_vm.ssh("/bin/rm", "-rf", workdir, category_dir)
+
+
+@pytest.mark.timeout(120)
+def test_ip_tar_feed_imports_members(deployed_vm: SmokeVM, mock_feeds: _MockFeedServer) -> None:
+    """issue #2638 / #2510: a tar-wrapped IP list imports member addresses, not framing.
+
+    Fail-before: x-tar was rejected (or scraped as text). Pass-after: tar -xOf
+    publishes the inner list and the member IP loads.
+    """
+    payload = _ADR44_BODY.encode()
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w") as tar:
+        info = tarfile.TarInfo("list.txt")
+        info.size = len(payload)
+        tar.addfile(info, io.BytesIO(payload))
+    feed_url = mock_feeds.register("adr2638.tar", buf.getvalue())
+    spec = h.IpCase(aliasname="adr2638tar", feed_url=feed_url, header="adr2638tar", family="v4")
+    assert spec.alias not in h.pfctl_tables(deployed_vm), f"{spec.alias} present before the tar feed was ever loaded"
+    with h.CaseContext(deployed_vm, spec):
+        members = h.pfctl_table_members(deployed_vm, spec.alias)
+        assert h.member_present(members, _ADR44_MEMBER), (
+            f"expected {_ADR44_MEMBER!r} in {spec.alias} after tar extraction, got: {members}"
+        )
+
+
 def _plant_guest_text(vm: SmokeVM, path: str, contents: str) -> None:
     """Write ``contents`` to ``path`` on the guest via tee stdin.
 

--- a/tests/smoke/test_smoke_feeds.py
+++ b/tests/smoke/test_smoke_feeds.py
@@ -4095,15 +4095,15 @@ def test_ip_tar_feed_imports_members(deployed_vm: SmokeVM, mock_feeds: _MockFeed
     publishes the inner list and the member IP loads.
     """
     payload = _ADR44_BODY.encode()
-    framing = b"NOT-A-LIST-TOKEN\n"
+    framing_bytes = b"NOT-A-LIST-TOKEN\n"
     buf = io.BytesIO()
     with tarfile.open(fileobj=buf, mode="w") as tar:
         info = tarfile.TarInfo("list.txt")
         info.size = len(payload)
         tar.addfile(info, io.BytesIO(payload))
         readme = tarfile.TarInfo("README")
-        readme.size = len(framing)
-        tar.addfile(readme, io.BytesIO(framing))
+        readme.size = len(framing_bytes)
+        tar.addfile(readme, io.BytesIO(framing_bytes))
     feed_url = mock_feeds.register("adr2638.tar", buf.getvalue())
     spec = h.IpCase(aliasname="adr2638tar", feed_url=feed_url, header="adr2638tar", family="v4")
     assert spec.alias not in h.pfctl_tables(deployed_vm), f"{spec.alias} present before the tar feed was ever loaded"
@@ -4112,8 +4112,7 @@ def test_ip_tar_feed_imports_members(deployed_vm: SmokeVM, mock_feeds: _MockFeed
         assert h.member_present(members, _ADR44_MEMBER), (
             f"expected {_ADR44_MEMBER!r} in {spec.alias} after tar extraction, got: {members}"
         )
-        framing = "NOT-A-LIST-TOKEN"
-        assert not any(framing in m or "README" in m for m in members), (
+        assert not any("NOT-A-LIST-TOKEN" in m or "README" in m for m in members), (
             f"tar framing must not reach the alias; members={members}"
         )
 

--- a/tests/smoke/test_smoke_feeds.py
+++ b/tests/smoke/test_smoke_feeds.py
@@ -4026,7 +4026,9 @@ def test_blacklist_archive_survives_gzip_content_encoding(deployed_vm: SmokeVM, 
         # When -- the blacklist branch fetches it.
         out = _adr46_download(deployed_vm, feed_url, archive, "pfb2634", "blacklist")
 
-        # Then -- success, the published bytes on disk, and the category extracted from them.
+        # Then -- three independently failable asserts (issue #2638 B4 / PR #2639).
+        # The stored-mime check must fail on its own if the body is a decoded tar
+        # even when download succeeded and categories extracted.
         assert "PFB_DL_TRUE" in out, (
             f"expected pfb_download success on a valid .tar.gz served with Content-Encoding: gzip; got stdout: {out!r}"
         )


### PR DESCRIPTION
## Summary

#2632's remaining unpack: a system proxy can still deliver UT1 as a **plain tar**. #2510 / `f5d6f8b4` rejected `application/x-tar` at the MIME gate (PfbMimeAllowlistTest pinned that reject). Owner ruling on #2638 supersedes it: this PR **rewrites** that allow-list pin to accept x-tar and adds extraction so tar framing never reaches the normalizer.

This PR:

- Restores `application/x-tar` on the shared allow-list (outer and inner gates).
- Adds `pfb_archive_probe('application/x-tar')` → `tar -tf`.
- Extracts a plain-tar **Blacklist** body into the category tree (`tar -xf` + `pfb_stage_publish_dir`).
- Stdout-extracts tar payloads for IP/ASN (`tar -xOf`); geoip uses `tar -xf --strip=1 -C geoipshare` with ADR-46.
- Empty-tree: `array_filter(..., 'is_file')` at **both** Blacklist staging sites (case-3 directory-only tar must not publish).
- TOP1M plain tar: extract the single member (`tar -xOf`), then the existing persist path.
- Recovers octet-stream as x-tar via the structural probe.

Rebased onto devel after #2742: bzip2/zip Blacklist still reject (`blacklist_not_archive`) before any inner-tar scrape.

Not #2635 (HTML/plain Blacklist still fail-closed). Not #2634. Not #2739.

**#2632:** reporter is on Netgate **3.2.17_1**, which this merge does not ship. This PR is the remaining unpack on **this fork's devel**. No `Fixes #2632` (would auto-close a box we do not ship). Refs #2632.

## Verification

Round-2 contract NEW-1: `#2635` reject-arm pin is brace-bound with `closingBraceExclusive` after the x-tar success arm. Mutating only `blacklist_not_archive` on the reject arm: RED (`reject must name the detected type`). Restored. Empty-tree pin is `assertSame(2, substr_count(..., is_file))`. TOP1M x-tar pin is scoped to the uncompressed `if ($type == 'top1m')` arm (no tautological conjunct).

| Frozen RED test | git hash-object | RED run tail |
| --- | --- | --- |
| `tests/php/DownloadExtractionExitCodeTest.php` (review-fix pins) | `c3dd3831c0549b6294d7dff5012cec0d4a935e5b` | gzip geoip `-xzf`; uncompressed geoip `-C {$header_esc}`; no `is_file` filter; no TOP1M x-tar extract |
| same file after NEW-1 scoping | `d92963baef8c6236b90ef6c74a05854266ea814d` | see executed tail below |

Production `src/usr/local/pkg/pfblockerng/pfblockerng.inc` at this head: `6d975a7bf48ef7dc2ce372c11e641447ae51a69a`.

Executed reject-arm mutation (replace the uncompressed `blacklist_not_archive` log with `/* mutated */ ;`, then restore). Host PHP 8.5.9:

```
There were 2 failures:

1) DownloadExtractionExitCodeTest::testUncompressedBlacklistBodyFailsClosedWithoutExtraction
reject must name the detected type
Failed asserting that ' ; unlink_if_exists($file_download); return PfbDownloadResult::failure(); } ' contains "pfb_validate_log($header, 'extract', 'blacklist_not_archive', $file_type);"

2) DownloadExtractionExitCodeTest::testUncompressedTarBlacklistBodyExtractsCategories
Failed asserting that false is not false.
  (that test uses the same literal as a strpos ordering anchor)

FAILURES!
Tests: 18, Assertions: 107, Failures: 2.
```

The extra failure is the ordering pin's `strpos` on the same literal (line 270), not a second reject-arm hole. Restored blob `6d975a7b`.


Related PHPUnit this round: `DownloadExtractionExitCodeTest` 18 tests / 115 assertions; plus `DownloadStagePublishTest` 11 tests / 40 assertions (header_esc count). Host PHP 8.5.9. CI is authoritative.

**B4 — OPEN, env-blocked, not discharged.** `#2638` asked for proof that the middle assertion of `test_blacklist_archive_survives_gzip_content_encoding` (stored body in `{application/gzip, application/x-gzip}`) is independently failable. Two smoke boots of that test on `68d4cfef` (`20260827T151924Z-smoke`, `20260827T152449Z-smoke`) died at `wait_boot_complete` (180s, last metadata probe `running`); the test body never ran. That is evidence about the VM (boot-settle class #2242/#2458), not about the assertion. Round 3 explicitly did **not** write "discharged" over an acceptance criterion nobody has demonstrated. It is not a code defect and does not hold this merge.

Smoke otherwise unexecuted here: plain-tar extract, IP tar members + framing negative, case-3 directory-only keeps categories.

## Round 3 (head was `68d4cfef`; rebased onto `devel` `470c9feb` as `dca4b84b`)

No blocking findings remain (12 → 0 across three rounds). Test-honesty mutation: reinstating the #2635 defect on the uncompressed Blacklist reject arm now goes RED (`reject scope must not swallow the x-tar arm failure return`). Empty-tree and ADR-46 pins now fail closed.

Accepted debt (not blocking; one follow-up will name these together):

- Inner-gzip tar mutations (c) drop `-O` from `tar -xOf -` and (e) invert the inner `application/x-tar` comparison — new production, no PHP test scopes that branch.
- Blacklist/geoip extract arms remain duplicated (41 of 50 lines; 11 of 12 in geoip).
- `assertSame(2, substr_count(..., is_file))` hard-codes the site count and will fail opaquely if those arms are unified.

Fixes #2638
Refs #2632

🤖 Generated by Grok and posted on behalf of @BBcan177.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for uncompressed TAR feeds alongside gzip- and bzip2-compressed downloads.
  - TAR-based GeoIP, ASN, TOP1M, blacklist, and other feeds can now be validated and extracted automatically.

- **Bug Fixes**
  - Improved archive safety checks to reject corrupt, empty, or unsafe TAR contents.
  - Prevented invalid or directory-only archives from overwriting existing feed data.
  - Preserved correct handling of compressed feeds while improving archive extraction reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->