### PR TITLE
tests: support Darwin size-ceiling refusal

### DIFF
--- a/tests/php/DownloadSizeCeilingTest.php
+++ b/tests/php/DownloadSizeCeilingTest.php
@@ -95,34 +95,39 @@ final class DownloadSizeCeilingTest extends TestCase
 	 * Given  a wrapped command whose ceiling is two blocks and whose child
 	 *        writes one MiB
 	 * When   the command runs through the same exec() the extraction sites use
-	 * Then   the child is killed for exceeding the file-size limit, exec()
-	 *        reports the nonzero status the extraction gates already reject,
-	 *        and the output stops far short of what was asked for.
-	 *
-	 * The brace group only silences the shell's own "Filesize limit exceeded"
-	 * notice so the suite output stays readable; the wrapped command is verbatim.
+	 * Then   Linux reports SIGXFSZ, Darwin reports dd's EFBIG exit, the
+	 *        extraction gates reject either, and output stays within the ceiling.
 	 */
-	public function test_extract_cmd_ceiling_kills_a_child_that_writes_past_it(): void
+	public function test_extract_cmd_ceiling_stops_a_child_that_writes_past_it(): void
 	{
 		if (!is_executable('/bin/dd')) {
 			$this->markTestSkipped('/bin/dd not available on this host');
 		}
 
+		$blocks = 2;
 		$target = $this->dir . '/overflow.bin';
+		$stderr = $this->dir . '/overflow.err';
 		$output = [];
 		$retval = 0;
 		exec(
-			'{ ' . pfb_extract_cmd('/bin/dd if=/dev/zero of=' . escapeshellarg($target) . ' bs=1024 count=1024', 2) . '; } 2>/dev/null',
+			'{ ' . pfb_extract_cmd('LC_ALL=C /bin/dd if=/dev/zero of=' . escapeshellarg($target) . ' bs=1024 count=1024',
+				$blocks) . '; } 2>' . escapeshellarg($stderr),
 			$output,
 			$retval
 		);
 
-		$this->assertSame(PFB_EXTRACT_SIGXFSZ_EXIT, $retval,
-			'a write past the ceiling must surface as the SIGXFSZ exit status');
+		if (PHP_OS_FAMILY === 'Darwin') {
+			$this->assertSame(1, $retval, 'Darwin dd must surface RLIMIT_FSIZE as its EFBIG exit');
+			$this->assertStringStartsWith("dd: {$target}: File too large\n", (string) file_get_contents($stderr),
+				'Darwin exit 1 must be the diagnosed EFBIG refusal, not an arbitrary failure');
+		} else {
+			$this->assertSame(PFB_EXTRACT_SIGXFSZ_EXIT, $retval,
+				'a write past the ceiling must surface as the SIGXFSZ exit status');
+		}
 		$this->assertFalse(pfb_download_extraction_succeeded($retval),
 			'the extraction gates must read the capped run as a failure');
-		$this->assertLessThan(1024 * 1024, filesize($target),
-			'the ceiling must stop the write, not merely report on it');
+		$this->assertLessThanOrEqual($blocks * 1024, filesize($target),
+			'the ceiling must bound the output, not merely report on it');
 	}
 
 	/**

--- a/tests/php/DownloadSizeCeilingTest.php
+++ b/tests/php/DownloadSizeCeilingTest.php
@@ -126,7 +126,9 @@ final class DownloadSizeCeilingTest extends TestCase
 		}
 		$this->assertFalse(pfb_download_extraction_succeeded($retval),
 			'the extraction gates must read the capped run as a failure');
-		$this->assertLessThanOrEqual($blocks * 1024, filesize($target),
+		$size = filesize($target);
+		$this->assertNotFalse($size, 'the capped writer must leave measurable output');
+		$this->assertLessThanOrEqual($blocks * 1024, $size,
 			'the ceiling must bound the output, not merely report on it');
 	}
 


### PR DESCRIPTION
## Summary

- Require Darwin's diagnosed `dd` EFBIG contract: exit 1 plus an exact `File too large` error prefix.
- Retain the exact 153 (`128 + SIGXFSZ`) contract on Linux and every non-Darwin host.
- Prove independently that a requested 1 MiB write produces no more than the portable two-block maximum of 2 KiB.

## Diagnosis

The unchanged focused test failed on live `devel` (`faff2e2b4d37e3eeb0c275ef478514c65d028206`) with exit 1 instead of 153.

A probe through the real `pfb_extract_cmd()` helper compared three mechanisms:

| Hypothesis | Discriminating observation | Verdict |
| --- | --- | --- |
| The kernel terminates `dd` with SIGXFSZ | Process reports `signaled=true`, signal 25, shell status 153 | Refuted: `signaled=false`, `termsig=0` |
| Darwin `dd` handles `write(2)` EFBIG and exits 1 | Child status 1, `File too large`, bounded output | Confirmed |
| The shell wrapper remaps an underlying 153 to 1 | Instrumented child status differs from wrapper status | Refuted: child and wrapper both returned 1 |

Executed on Darwin 25.6.0, arm64, PHP 8.5.9:

```text
exact.stderr="dd: <target>: File too large\n..."
exact.proc_status={"signaled":false,"exitcode":1,"termsig":0}
exact.proc_close=1
exact.output_size=2048
instrumented.stdout="child_status=1\n"
instrumented.proc_close=1
instrumented.output_size=2048
```

The ceiling is effective; production remains unchanged. Every production caller already rejects every nonzero extraction status.

## Cross-platform contract

| Platform | Required status/error | Independent ceiling proof | Result |
| --- | --- | --- | --- |
| macOS / Darwin | Exact exit 1 and stderr starts `dd: <target>: File too large` | 1 MiB requested; output at most 2 KiB | PASS locally |
| Linux | Exact exit 153 / SIGXFSZ | 1 MiB requested; output at most 2 KiB | PASS on fixed-head CI, PHP 8.3 and 8.5 |

No generic-nonzero assertion is introduced.

## Verification

```text
vendor/bin/phpunit --filter test_extract_cmd_ceiling_stops_a_child_that_writes_past_it tests/php/DownloadSizeCeilingTest.php
OK (1 test, 6 assertions)

vendor/bin/phpunit tests/php/DownloadSizeCeilingTest.php
OK (15 tests, 70 assertions)

scripts/agent/run-gates.sh --diff origin/devel
GATE PASS: php -l tests/php/DownloadSizeCeilingTest.php
GATE PASS: vendor/bin/phpunit
GATE PASS: composer phpstan
GATE PASS: composer phpcs -- --standard=phpcs.xml.dist src/
GATES: PASS
```

## Frozen RED

Not applicable to production: this is a test-only platform-contract correction, with no production behavior edit. The unchanged live-base test (blob `59a45628ac997ce56c05f5990749fc0ba37c8aa2`) was executed before the test edit and failed only on `1 is identical to 153`.

Fixes #2685

🤖 Generated by Oh My Pi and posted on behalf of @andrebrait.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded extraction ceiling coverage for platform-specific command outcomes.
  * Confirmed extraction stops when output reaches the configured two-block limit.
  * Verified both supported failure modes are rejected and output remains within the ceiling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->