### PR TITLE
ci: preserve release extra package output

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1263,7 +1263,8 @@ jobs:
             release/3.3) EXTRA_PKGS='[]' ;;
             *) EXTRA_PKGS="$MATRIX_EXTRA_PKGS" ;;
           esac
-          echo "extra_pkgs=${EXTRA_PKGS}" >> "$GITHUB_OUTPUT"
+          EXTRA_PKGS="$(printf '%s' "$EXTRA_PKGS" | jq -c .)"
+          printf 'extra_pkgs=%s\n' "$EXTRA_PKGS" >> "$GITHUB_OUTPUT"
 
       - name: Write the destination-bound build record
         env:

--- a/tests/test_release_tag_after_verify.py
+++ b/tests/test_release_tag_after_verify.py
@@ -826,6 +826,30 @@ def test_release_33_never_runs_live_suites(tmp_path: Path, tag: str, force_suite
     assert outputs["run_suites"] == "false", outputs
 
 
+def _parse_github_outputs(path: Path) -> dict[str, str]:
+    lines = path.read_text(encoding="utf-8").splitlines()
+    outputs: dict[str, str] = {}
+    index = 0
+    while index < len(lines):
+        line = lines[index]
+        if "<<" in line.partition("=")[0]:
+            key, delimiter = line.split("<<", 1)
+            assert key and delimiter, f"invalid GitHub output record: {line!r}"
+            value_lines: list[str] = []
+            index += 1
+            while index < len(lines) and lines[index] != delimiter:
+                value_lines.append(lines[index])
+                index += 1
+            assert index < len(lines), f"unterminated GitHub output record for {key!r}"
+            outputs[key] = "\n".join(value_lines)
+        else:
+            key, separator, value = line.partition("=")
+            assert key and separator, f"invalid GitHub output record: {line!r}"
+            outputs[key] = value
+        index += 1
+    return outputs
+
+
 def _run_extra_pkgs_decision(tmp_path: Path, source: str, extra_pkgs: str) -> str:
     script = _step_run_script(_step(_jobs()["build-pkgs-portable"], "Resolve release-line extras"))
     output_file = tmp_path / "extra_pkgs_output"
@@ -843,16 +867,27 @@ def _run_extra_pkgs_decision(tmp_path: Path, source: str, extra_pkgs: str) -> st
         text=True,
     )
     assert completed.returncode == 0, completed.stdout + completed.stderr
-    return output_file.read_text().removeprefix("extra_pkgs=").strip()
+    outputs = _parse_github_outputs(output_file)
+    assert set(outputs) == {"extra_pkgs"}, outputs
+    return outputs["extra_pkgs"]
 
 
 def test_release_33_suppresses_matrix_extra_packages(tmp_path: Path) -> None:
     assert _run_extra_pkgs_decision(tmp_path, "release/3.3", '["textproc/py-charset-normalizer"]') == "[]"
 
 
-def test_other_release_lines_keep_matrix_extra_packages(tmp_path: Path) -> None:
-    extras = '["textproc/py-charset-normalizer"]'
-    assert _run_extra_pkgs_decision(tmp_path, "release/4.0", extras) == extras
+@pytest.mark.parametrize(
+    "extra_pkgs",
+    [
+        [],
+        ["textproc/py-charset-normalizer"],
+        ["textproc/py-charset-normalizer", "security/ca_root_nss"],
+        ["category/line\nbreak", "__EXTRA_PKGS__", "category/name<<__EXTRA_PKGS__", 'category/quote"and\\slash'],
+    ],
+)
+def test_other_release_lines_keep_matrix_extra_packages(tmp_path: Path, extra_pkgs: list[str]) -> None:
+    rendered = json.dumps(extra_pkgs, indent=2)
+    assert json.loads(_run_extra_pkgs_decision(tmp_path, "release/4.0", rendered)) == extra_pkgs
 
 
 def test_build_record_keeps_the_original_release_33_matrix_row(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- compact the release matrix's `extra_pkgs` JSON before exporting it as a single GitHub Actions output record
- write the record with POSIX `printf` so JSON escapes are not reinterpreted, while preserving the exact dependency array and downstream consumers
- execute the real `Resolve release-line extras` shell body against GitHub output-file parsing semantics for empty, non-empty, multiple, and hostile JSON rows

## Frozen RED proof

Frozen workflow base: `f3c7e3178eff885d1c681b638c8c0044f17cfda2`  
Frozen regression blob: `32ce4823fddb23c33a83282381d00936b6dd548f`

Command:

```text
uv run pytest tests/test_release_tag_after_verify.py -k 'release_33_suppresses_matrix_extra_packages or other_release_lines_keep_matrix_extra_packages' -q
```

| Frozen RED test | `git hash-object` | RED run tail |
| --- | --- | --- |
| `tests/test_release_tag_after_verify.py` | `32ce4823fddb23c33a83282381d00936b6dd548f` | `3 failed, 2 passed`; non-empty pretty JSON produced an invalid second output-file record |

| Row | Multiline matrix input | Untouched workflow result | Contract |
| --- | --- | --- | --- |
| release/3.3 suppression | one dependency | PASS | emits exact `[]` |
| release/4.0 Plus | empty array | PASS | emits exact `[]` |
| release/4.0 CE | one dependency | FAIL: `invalid GitHub output record: '  "textproc/py-charset-normalizer"'` | preserve one-element array |
| release/4.0 multiple | two dependencies | FAIL: `invalid GitHub output record: '  "textproc/py-charset-normalizer",'` | preserve ordered two-element array |
| release/4.0 hostile | newline, delimiter token, `<<`, quote, backslash | FAIL: `invalid GitHub output record: '  "category/line'` | preserve every decoded string exactly |

RED summary: `3 failed, 2 passed`. The production workflow was then changed without changing the frozen test blob. GREEN summary: `5 passed`.

## Verification

- `uv run pytest tests/test_release_tag_after_verify.py tests/test_release_ci_path_consistency.py -q` — `145 passed`
- `actionlint .github/workflows/release.yml` — pass
- `sh scripts/agent/run-gates.sh --diff origin/devel` — coverage pairing, full pytest, Ruff check, Ruff format check, and mypy all pass
- no live release/canary dispatch; no `release/4.0`, tag, Release, dependency, or downstream publication mutation

Fixes #2746

🤖 Generated by Oh My Pi and posted on behalf of @andrebrait.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release processing for extra package lists by ensuring output is consistently compact and correctly formatted.
  * Enhanced handling of package lists containing no entries, one entry, multiple entries, or special characters.

* **Tests**
  * Expanded release validation coverage, including support for different output formats and improved detection of malformed release data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->