### PR TITLE
tests: execute Ports parity examples

### DIFF
--- a/tests/shell/build_leg_ports_parity_env.sh
+++ b/tests/shell/build_leg_ports_parity_env.sh
@@ -5,7 +5,7 @@
 # leg clones that bounded checkout through build-leg.sh.
 
 Describe 'build-leg.sh real Ports parity'
-  It 'native package bytes match a direct portable-builder invocation' env:ports
+  native_parity() {
     [ -n "${REAL_PORTS_DIR:-}" ] || { echo 'REAL_PORTS_DIR is required' >&2; return 1; }
     [ -n "${PARITY_CHANNEL:-}" ] || { echo 'PARITY_CHANNEL is required' >&2; return 1; }
     [ -n "${PARITY_VARIANT:-}" ] || { echo 'PARITY_VARIANT is required' >&2; return 1; }
@@ -48,9 +48,15 @@ Describe 'build-leg.sh real Ports parity'
     fi
     cmp -s "$direct" "$routed" || {
       echo "native parity mismatch: direct=$direct routed=$routed" >&2; return 1; }
+  }
+
+  It 'native package bytes match a direct portable-builder invocation' env:ports
+    When call native_parity
+    The status should be success
+    The stderr should include '==> wrote'
   End
 
-  It 'project build-record package bytes match a direct portable-builder invocation' env:ports
+  project_parity() {
     [ -n "${REAL_PORTS_DIR:-}" ] || { echo 'REAL_PORTS_DIR is required' >&2; return 1; }
     for name in PARITY_VARIANT PARITY_ABI PARITY_PY_FLAVOR PARITY_PHP; do
       eval "value=\${$name:-}"
@@ -177,5 +183,11 @@ PY
       --out-dir "${work}/routed")"
     cmp -s "$direct" "$routed" || {
       echo "project parity mismatch: direct=$direct routed=$routed" >&2; return 1; }
+  }
+
+  It 'project build-record package bytes match a direct portable-builder invocation' env:ports
+    When call project_parity
+    The status should be success
+    The stderr should include '==> wrote'
   End
 End

--- a/tests/shell/build_leg_ports_parity_env.sh
+++ b/tests/shell/build_leg_ports_parity_env.sh
@@ -19,32 +19,32 @@ Describe 'build-leg.sh real Ports parity'
     [ -n "$DASH" ] || { echo 'dash is required' >&2; return 1; }
     git -C "$REAL_PORTS_DIR" rev-parse --verify HEAD >/dev/null 2>&1 || {
       echo 'REAL_PORTS_DIR must be a Git checkout' >&2; return 1; }
-    work="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/buildlegports.XXXXXX")"
-    trap 'rm -rf "$work"' EXIT INT TERM
-    ports_sha="$(git -C "$REAL_PORTS_DIR" rev-parse HEAD)"
-    ports_url="$(git -C "$REAL_PORTS_DIR" remote get-url origin)"
-    export SOURCE_DATE_EPOCH=1780000000 PFB_RUN_ROOT="${work}/runs" RUN_ID=native-parity
+    work="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/buildlegports.XXXXXX")" || return 1
+    trap 'rm -rf "$work"' EXIT INT TERM || return 1
+    ports_sha="$(git -C "$REAL_PORTS_DIR" rev-parse HEAD)" || return 1
+    ports_url="$(git -C "$REAL_PORTS_DIR" remote get-url origin)" || return 1
+    export SOURCE_DATE_EPOCH=1780000000 PFB_RUN_ROOT="${work}/runs" RUN_ID=native-parity || return 1
     if [ "$PARITY_CHANNEL" = nightly ]; then
-      source_sha="$(git -C "$PFB_ROOT" rev-parse HEAD)"
-      nightly_version="20260813153045.$(printf '%.7s' "$source_sha")"
+      source_sha="$(git -C "$PFB_ROOT" rev-parse HEAD)" || return 1
+      nightly_version="20260813153045.$(printf '%.7s' "$source_sha")" || return 1
       direct="$(python3 "${PFB_ROOT}/scripts/build-pkg-portable.py" \
         --ports "$REAL_PORTS_DIR" --channel "$PARITY_CHANNEL" --variant "$PARITY_VARIANT" \
         --abi "$PARITY_ABI" --py-flavor "$PARITY_PY_FLAVOR" --php "$PARITY_PHP" \
-        --local-src "$PFB_ROOT" --pkgversion "$nightly_version" --out "${work}/direct")"
+        --local-src "$PFB_ROOT" --pkgversion "$nightly_version" --out "${work}/direct")" || return 1
       routed="$(sh "${PFB_ROOT}/scripts/build-leg.sh" \
         --ports-repo "$ports_url" --ports-ref "$ports_sha" \
         --channel "$PARITY_CHANNEL" --variant "$PARITY_VARIANT" --abi "$PARITY_ABI" \
         --py-flavor "$PARITY_PY_FLAVOR" --php "$PARITY_PHP" \
-        --pkgversion "$nightly_version" --out-dir "${work}/routed")"
+        --pkgversion "$nightly_version" --out-dir "${work}/routed")" || return 1
     else
       direct="$(python3 "${PFB_ROOT}/scripts/build-pkg-portable.py" \
         --ports "$REAL_PORTS_DIR" --channel "$PARITY_CHANNEL" --variant "$PARITY_VARIANT" \
         --abi "$PARITY_ABI" --py-flavor "$PARITY_PY_FLAVOR" --php "$PARITY_PHP" \
-        --local-src "$PFB_ROOT" --out "${work}/direct")"
+        --local-src "$PFB_ROOT" --out "${work}/direct")" || return 1
       routed="$(sh "${PFB_ROOT}/scripts/build-leg.sh" \
         --ports-repo "$ports_url" --ports-ref "$ports_sha" \
         --channel "$PARITY_CHANNEL" --variant "$PARITY_VARIANT" --abi "$PARITY_ABI" \
-        --py-flavor "$PARITY_PY_FLAVOR" --php "$PARITY_PHP" --out-dir "${work}/routed")"
+        --py-flavor "$PARITY_PY_FLAVOR" --php "$PARITY_PHP" --out-dir "${work}/routed")" || return 1
     fi
     cmp -s "$direct" "$routed" || {
       echo "native parity mismatch: direct=$direct routed=$routed" >&2; return 1; }
@@ -59,7 +59,7 @@ Describe 'build-leg.sh real Ports parity'
   project_parity() {
     [ -n "${REAL_PORTS_DIR:-}" ] || { echo 'REAL_PORTS_DIR is required' >&2; return 1; }
     for name in PARITY_VARIANT PARITY_ABI PARITY_PY_FLAVOR PARITY_PHP; do
-      eval "value=\${$name:-}"
+      eval "value=\${$name:-}" || return 1
       [ -n "$value" ] || { echo "$name is required" >&2; return 1; }
     done
     for tool in git python3 zstd; do
@@ -67,22 +67,22 @@ Describe 'build-leg.sh real Ports parity'
     done
     DASH="${DASH:-$(command -v dash 2>/dev/null || true)}"
     [ -n "$DASH" ] || { echo 'dash is required' >&2; return 1; }
-    work="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/buildlegrecord.XXXXXX")"
-    trap 'rm -rf "$work"' EXIT INT TERM
-    ports_sha="$(git -C "$REAL_PORTS_DIR" rev-parse HEAD)"
-    source_sha="$(git -C "$PFB_ROOT" rev-parse HEAD)"
-    nightly_version="20260813153045.$(printf '%.7s' "$source_sha")"
+    work="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/buildlegrecord.XXXXXX")" || return 1
+    trap 'rm -rf "$work"' EXIT INT TERM || return 1
+    ports_sha="$(git -C "$REAL_PORTS_DIR" rev-parse HEAD)" || return 1
+    source_sha="$(git -C "$PFB_ROOT" rev-parse HEAD)" || return 1
+    nightly_version="20260813153045.$(printf '%.7s' "$source_sha")" || return 1
     source_checkout="${work}/source"
-    git clone -q --shared "$PFB_ROOT" "$source_checkout"
-    git -C "$source_checkout" checkout -q "$source_sha"
+    git clone -q --shared "$PFB_ROOT" "$source_checkout" || return 1
+    git -C "$source_checkout" checkout -q "$source_sha" || return 1
     # Project records intentionally use the current nightly recipe: unlike release
     # channels it needs no historical source tag, while the target facts remain the
     # caller's resolved variant/ABI/PHP/Python inputs.
-    ports_url="$(git -C "$REAL_PORTS_DIR" remote get-url origin)"
+    ports_url="$(git -C "$REAL_PORTS_DIR" remote get-url origin)" || return 1
     sh "${PFB_ROOT}/scripts/sparse-clone-ports.sh" \
       "$ports_url" "$ports_sha" "$REAL_PORTS_DIR" \
-      nightly "$PARITY_PHP" "$PARITY_PY_FLAVOR"
-    python3 - "$work/record.json" "$ports_sha" "$source_sha" "$nightly_version" <<'PY'
+      nightly "$PARITY_PHP" "$PARITY_PY_FLAVOR" || return 1
+    python3 - "$work/record.json" "$ports_sha" "$source_sha" "$nightly_version" <<'PY' || return 1
 import json
 import os
 import sys
@@ -169,18 +169,18 @@ record = {
 record["build_input_digest"] = build_input_digest(record)
 Path(path).write_text(json.dumps(record, sort_keys=True, separators=(",", ":")) + "\n", encoding="utf-8")
 PY
-    export SOURCE_DATE_EPOCH=1780000000 PFB_RUN_ROOT="${work}/runs" RUN_ID=record-parity
+    export SOURCE_DATE_EPOCH=1780000000 PFB_RUN_ROOT="${work}/runs" RUN_ID=record-parity || return 1
     direct="$(python3 "${PFB_ROOT}/scripts/build-pkg-portable.py" \
       --ports "$REAL_PORTS_DIR" --channel nightly --variant "$PARITY_VARIANT" \
       --abi "$PARITY_ABI" --py-flavor "$PARITY_PY_FLAVOR" --php "$PARITY_PHP" \
       --local-src "$source_checkout" --pkgversion "$nightly_version" \
-      --build-record "$work/record.json" --out "${work}/direct")"
+      --build-record "$work/record.json" --out "${work}/direct")" || return 1
     routed="$(sh "${PFB_ROOT}/scripts/build-leg.sh" \
       --ports-repo "$ports_url" --ports-ref "$ports_sha" \
       --channel nightly --variant "$PARITY_VARIANT" --abi "$PARITY_ABI" \
       --py-flavor "$PARITY_PY_FLAVOR" --php "$PARITY_PHP" --pkgversion "$nightly_version" \
       --local-src "$source_checkout" --build-record "$work/record.json" \
-      --out-dir "${work}/routed")"
+      --out-dir "${work}/routed")" || return 1
     cmp -s "$direct" "$routed" || {
       echo "project parity mismatch: direct=$direct routed=$routed" >&2; return 1; }
   }


### PR DESCRIPTION
## Summary

- move each real Ports parity body into a callable ShellSpec evaluation
- assert successful byte comparison while retaining real builder stderr as executed evidence
- preserve the native and project build-record setup, direct/routed builders, and mismatch diagnostics

## Frozen RED

Against `0144be205856bcaee819d825d16413fe5ac33fcc`, the unchanged spec blob `6d51c649c0746bc266061943e708110f42287d04` produced:

```text
Running: /opt/homebrew/bin/dash [sh]
pp
2 examples, 0 failures, 2 pendings
```

The frozen JUnit report SHA-256 is `5a1b0bbefd771ecef777eb231da167c28edf3cf0e823b51d9e688c7edd6d1b6f`. The unchanged skip checker exited 1 with exactly the two issue IDs, both reason `Not yet implemented`.

## Verification

- exact live-row focused ShellSpec command under dash: `2 examples, 0 failures`; JUnit `tests=2 failures=0 skipped=0`
- unchanged `check_skip_allowlist.py --suite ports-parity`: exit 0 with no allowlist change
- direct-package byte mutant: native example failed its status assertion with exit 101
- routed-package byte mutant: project build-record example failed its status assertion with exit 101
- missing `REAL_PORTS_DIR`: both examples failed status 1, so setup errors cannot pass
- independent verifier: PASS for RED replay, GREEN replay, both mutations, full diff, coverage matrix, and test honesty
- `scripts/agent/run-gates.sh --diff origin/devel`: `GATES: PASS`

No production build semantics, workflow sequencing, allowlist, package publication, Pages, or GHCR state changed. The live Nightly canary remains a separate post-landing action.

Fixes #2749

🤖 Generated by Oh My Pi and posted on behalf of @andrebrait.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored parity test flows for clearer validation of native and project builds.
  * Improved failure reporting when setup, cloning, record generation, or build steps fail.
  * Added explicit checks for successful execution and expected build output.
  * Preserved byte-level comparisons for native builds and build-record comparisons for project builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->