### PR TITLE
pfblockerng: bound the rsync feed ingest path

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -812,6 +812,17 @@ jobs:
           /usr/bin/tar --version | grep -q '^bsdtar'
           tar --version | grep -q 'GNU tar'
 
+      - name: Put rsync at /usr/local/bin/rsync
+        # The code under test execs the absolute path /usr/local/bin/rsync (where the
+        # appliance ships it); Debian's package installs /usr/bin/rsync, so without the
+        # symlink the issue #2667 rsync cases skip on every matrix leg while the suite
+        # still reads green -- the same trap as the bsdtar step above.
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends rsync
+          sudo ln -sf "$(command -v rsync)" /usr/local/bin/rsync
+          /usr/local/bin/rsync --version | grep -qi '^rsync'
+
       - name: Set up PHP ${{ matrix.php-version }}
         uses: shivammathur/setup-php@v2
         with:

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -13788,11 +13788,38 @@ function pfb_download(PfbDownloadRequest $request): PfbDownloadResult {
 		}
 		$rsync_src_esc = escapeshellarg("{$rsync_src}");
 
+		// issue #2667: bound the rsync ingest path, which writes the fetched body
+		// straight to {file}.raw and was bounded by neither #2658 ceiling. Two halves:
+		//  - kernel backstop: run rsync under pfb_extract_cmd()'s ulimit -f at TWICE
+		//    the ceiling. rsync writes through an atomic temp file and renames only on
+		//    a clean exit, so a body just over the ceiling must still land whole for
+		//    the named check below; the backstop bounds what can hit disk even beyond
+		//    that. Its kill surfaces as rsync's own nonzero exit ("File too large" on
+		//    openrsync, SIGXFSZ status on GNU) -- the existing nonzero-exit gate refuses.
+		//  - named refusal: a body that lands whole but over the ceiling is refused,
+		//    removed, and logged stage=size reason=rsync_too_large, so an operator can
+		//    tell "too large" from any other rsync failure on every platform.
+		// --max-size was rejected: probed, openrsync exits 0 silently when the SOURCE
+		// exceeds it (it bounds per-file transfer, not refusal), so it cannot be the
+		// bound alone. $pfb['rsync_max_bytes'] is the test seam, mirroring #2658's
+		// $pfb['curl_defaults'] ceiling seam.
+		$rsync_ceiling = isset($GLOBALS['pfb']['rsync_max_bytes']) ? (int) $GLOBALS['pfb']['rsync_max_bytes'] : PFB_DOWNLOAD_MAX_BYTES;
 		// exec() returns the command's LAST output line, not its exit status; the
 		// real return code rides in the third argument. Test that, so a normal
 		// rsync transfer (which prints progress/stats) is not mistaken for a failure.
-		exec("/usr/local/bin/rsync --timeout=5 {$rsync_src_esc} {$file_dwn_esc}", $rsync_output, $rsync_rc);
+		// ulimit -f counts 512-byte blocks, so twice the ceiling is ceiling / 256;
+		// integer division keeps the bound exact for every ceiling (a float cast is
+		// undefined once 2 * ceiling leaves the integer range).
+		$rsync_blocks = intdiv($rsync_ceiling, 256);
+		exec(pfb_extract_cmd("/usr/local/bin/rsync --timeout=5 {$rsync_src_esc} {$file_dwn_esc}", $rsync_blocks), $rsync_output, $rsync_rc);
 		if ($rsync_rc === 0) {
+			clearstatcache(TRUE, "{$file_dwn}.raw");
+			$rsync_size = @filesize("{$file_dwn}.raw");
+			if ($rsync_size === FALSE || $rsync_size > $rsync_ceiling) {
+				pfb_validate_log($header, 'size', 'rsync_too_large', pfb_redact_url($list_url));
+				unlink_if_exists("{$file_dwn}.raw");
+				return PfbDownloadResult::failure();
+			}
 			$http_status = '200';
 		} else {
 			$rsync_msg = trim(implode(' ', $rsync_output));

--- a/tests/php/DownloadSizeCeilingTest.php
+++ b/tests/php/DownloadSizeCeilingTest.php
@@ -299,9 +299,6 @@ final class DownloadSizeCeilingTest extends TestCase
 	public function test_every_extraction_exec_runs_under_the_ceiling(): void
 	{
 		$allowed = [
-			// Fetches a feed body; writes no archive output. Its own fetch is bounded
-			// by neither ceiling (rsync is not a libcurl transfer) -- issue #2667.
-			'exec("/usr/local/bin/rsync --timeout=5 {$rsync_src_esc} {$file_dwn_esc}", $rsync_output, $rsync_rc);',
 			// Helper-script calls that post-process an ALREADY-extracted text feed.
 			'exec("{$pfb[\'script\']} whoisconvert {$header_esc} {$vtype} {$list_url_esc} {$elog}");',
 			'exec("{$pfb[\'script\']} asn_table {$elog}");',

--- a/tests/php/RsyncSizeRefusalTest.php
+++ b/tests/php/RsyncSizeRefusalTest.php
@@ -1,0 +1,206 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Issue #2667 — the rsync feed path had no size bound at either half of ingest.
+ *
+ * #2658 capped the fetched body (CURLOPT_MAXFILESIZE_LARGE) and the extracted
+ * output (ulimit -f); neither reaches the rsync branch, which writes the fetched
+ * body straight to {file}.raw. These tests drive the REAL pfb_download() rsync
+ * branch against a local source file with the ceiling lowered through
+ * $pfb['rsync_max_bytes'] — the same test seam #2658 used for the cURL ceiling
+ * via $pfb['curl_defaults'] — so a handful of kilobytes is "over-large".
+ * The source path reaches the branch through $pfb['dbdir'], which PFB_FILTER_URL's
+ * local-path arm already honours, and the feed-host filter is switched off
+ * through its documented General-settings opt-out (a filesystem path has no
+ * host for the resolve+pin guard to vet).
+ *
+ * Two enforcement halves, one named refusal:
+ *  - the kernel half runs rsync under pfb_extract_cmd()'s ulimit -f at TWICE the
+ *    ceiling — rsync writes through an atomic temp file and renames only on a
+ *    clean exit, so a body over the ceiling must still land whole for the check
+ *    below to name it; the backstop bounds what can hit disk even beyond that
+ *    (its kill surfaces as rsync's own nonzero exit — probed: openrsync prints
+ *    "File too large", GNU rsync's Linux status differs per build, never asserted);
+ *  - the size check half names the refusal deterministically on every platform:
+ *    a body that lands whole but over the ceiling is refused, removed, and logged
+ *    stage=size reason=rsync_too_large.
+ */
+#[CoversFunction('pfb_download')]
+final class RsyncSizeRefusalTest extends TestCase
+{
+	/** Ceiling used for the refusal tests only — far below the fixture body. */
+	private const OVER_CEILING_BYTES = 4 * 1024;
+
+	/** Fixture source size: over OVER_CEILING_BYTES, under every shipped ceiling. */
+	private const SOURCE_BYTES = 8 * 1024;
+
+	private string $workdir = '';
+
+	/** @var array<string,mixed> saved $GLOBALS['pfb'] keys (sentinel FALSE = was unset) */
+	private array $saved = [];
+
+	/** @var array<string,mixed> saved fixture globals (absent key = was unset) */
+	private array $savedGlobals = [];
+
+	protected function setUp(): void
+	{
+		if (!is_executable('/usr/local/bin/rsync')) {
+			$this->markTestSkipped('/usr/local/bin/rsync not available on this host');
+		}
+		$workdir = tempnam(sys_get_temp_dir(), 'pfbrsz');
+		$this->assertNotFalse($workdir);
+		$this->assertTrue(unlink($workdir) && mkdir($workdir, 0700));
+		$this->workdir = $workdir;
+
+		foreach (['config'] as $g) {
+			if (array_key_exists($g, $GLOBALS)) {
+				$this->savedGlobals[$g] = $GLOBALS[$g];
+			}
+		}
+		$GLOBALS['config'] = [];
+		// Documented opt-out for the resolve+pin guard (General settings
+		// 'pfb_feed_internal_filter'); a local rsync source has no host to vet.
+		config_set_path('installedpackages/pfblockerng/config/0/pfb_feed_internal_filter', 'off');
+
+		foreach (['log', 'errlog', 'pnow', 'runlog', 'runlog_active', 'dbdir', 'rsync_max_bytes', 'mime_types'] as $k) {
+			$this->saved[$k] = array_key_exists($k, $GLOBALS['pfb'] ?? []) ? $GLOBALS['pfb'][$k] : FALSE;
+		}
+		unset($GLOBALS['pfb']['runlog'], $GLOBALS['pfb']['runlog_active']);
+		$GLOBALS['pfb']['log']    = "{$workdir}/pfblockerng.log";
+		$GLOBALS['pfb']['errlog'] = "{$workdir}/error.log";
+		$GLOBALS['pfb']['pnow']   = 'now';
+		// PFB_FILTER_URL's local-path arm accepts sources under $pfb['dbdir'].
+		$GLOBALS['pfb']['dbdir']  = $workdir;
+		// The MIME gate on the ingested body reads $pfb['mime_types']; restore the
+		// shipped allow-list (bootstrap snapshot) so this fixture is order-independent.
+		$GLOBALS['pfb']['mime_types'] = $GLOBALS['pfb_shipped_mime_types'] ?? [];
+
+		file_put_contents("{$workdir}/source.txt", str_repeat('A', self::SOURCE_BYTES));
+	}
+
+	protected function tearDown(): void
+	{
+		foreach ($this->saved as $k => $prev) {
+			if ($prev === FALSE) {
+				unset($GLOBALS['pfb'][$k]);
+			} else {
+				$GLOBALS['pfb'][$k] = $prev;
+			}
+		}
+		foreach ($this->savedGlobals as $g => $prev) {
+			$GLOBALS[$g] = $prev;
+		}
+		$this->savedGlobals = [];
+		if ($this->workdir !== '' && is_dir($this->workdir)) {
+			foreach ((array) glob("{$this->workdir}/*") as $f) {
+				@unlink((string) $f);
+			}
+			rmdir($this->workdir);
+		}
+	}
+
+	private function logText(): string
+	{
+		return (string) @file_get_contents((string) $GLOBALS['pfb']['log']);
+	}
+
+	private function fetch(string $header): PfbDownloadResult
+	{
+		return pfb_download(new PfbDownloadRequest(
+			listUrl: "{$this->workdir}/source.txt",
+			downloadPath: "{$this->workdir}/feed",
+			flex: FALSE,
+			header: $header,
+			format: 'rsync',
+			logType: 1,
+			versionType: '',
+			timeout: 30,
+			type: '',
+			username: '',
+			password: '',
+			sourceInterface: FALSE,
+			extraHeaders: array(),
+		));
+	}
+
+	/**
+	 * Scenario: an rsync body over the ceiling is refused and named.
+	 *
+	 * Given a local rsync source of 8 KiB against a 4 KiB ceiling (the kernel
+	 *   backstop at twice the ceiling lets it land whole for the named check)
+	 * When pfb_download() fetches it with format 'rsync'
+	 * Then the download fails, no body survives on disk, and the log carries the
+	 *   distinguishable stage=size reason=rsync_too_large refusal — not just a
+	 *   bare exit code.
+	 */
+	public function test_rsync_body_over_the_ceiling_is_refused_with_a_named_reason(): void
+	{
+		$GLOBALS['pfb']['rsync_max_bytes'] = self::OVER_CEILING_BYTES;
+
+		$result = $this->fetch('RsyncOversize');
+
+		$this->assertFalse($result->success, 'an over-large rsync body must not download successfully');
+		$this->assertFileDoesNotExist("{$this->workdir}/feed.raw",
+			'the over-large body must not be left on disk');
+		$this->assertStringContainsString('stage=size reason=rsync_too_large', $this->logText(),
+			'the refusal must be logged distinguishably, not as a generic rsync failure');
+	}
+
+	/**
+	 * Scenario: an rsync body under the ceiling is untouched.
+	 *
+	 * Given the same 8 KiB source with the ceiling above it
+	 * When pfb_download() fetches it
+	 * Then the transfer succeeds and the whole body is published downstream —
+	 *   proving the refusal above is a real branch, not an always-reject path.
+	 */
+	public function test_rsync_body_under_the_ceiling_still_downloads(): void
+	{
+		$GLOBALS['pfb']['rsync_max_bytes'] = 1024 * 1024;
+
+		$result = $this->fetch('RsyncUnderCeiling');
+
+		$this->assertTrue($result->success, 'a body under the ceiling must still download');
+		$this->assertStringNotContainsString('reason=rsync_too_large', $this->logText());
+		// A successful text ingest renames {file}.raw to {file}.orig (finalise may
+		// append a trailing newline); the whole body must be in what survives.
+		$size = @filesize("{$this->workdir}/feed.orig");
+		$this->assertNotFalse($size, 'the published body must survive as feed.orig');
+		$this->assertGreaterThanOrEqual(self::SOURCE_BYTES, $size, 'the whole body must arrive intact');
+	}
+
+	/**
+	 * Scenario: the rsync fetch runs under the kernel write ceiling.
+	 *
+	 * Given a ceiling so far below the source that even the twice-ceiling kernel
+	 *   backstop kills the writer mid-transfer (portable across rsync
+	 *   implementations -- probed on openrsync and GNU rsync 3.4.1, both exit
+	 *   nonzero once the write hits the limit)
+	 * When pfb_download() fetches it
+	 * Then the download fails through the rsync-exit gate, before the post-fetch
+	 *   size check ever sees a body: the kernel half carries the refusal on its
+	 *   own, so no implementation difference can let a body through that the
+	 *   ceiling was set to refuse. rsync's own exit code and wording are never
+	 *   asserted (implementation-specific); only pfBlockerNG's own log line is.
+	 */
+	public function test_rsync_fetch_under_a_kernel_tiny_ceiling_never_succeeds(): void
+	{
+		$GLOBALS['pfb']['rsync_max_bytes'] = 512;
+
+		$result = $this->fetch('RsyncKernelCapped');
+
+		$this->assertFalse($result->success,
+			'a writer killed by the file-size ceiling must never read as a successful fetch');
+		$log = $this->logText();
+		$this->assertStringContainsString('RSYNC Failed', $log,
+			'the kernel bound must stop the transfer itself, surfacing as a failed rsync exit');
+		$this->assertStringNotContainsString('reason=rsync_too_large', $log,
+			'the post-fetch size check must not be what saves this case -- that would leave '
+			. 'the kernel bound untested, so a body over the ceiling could land whole on disk');
+	}
+}

--- a/tests/skip-allowlist.txt
+++ b/tests/skip-allowlist.txt
@@ -31,6 +31,9 @@ phpunit:OctetStreamRecoveryWiringTest::test_octet_stream_archive_recovered_to_zi
 phpunit:PfbFeedNormalizeTest::testBomAndZwjAreStrippedAsNonPrintable  # platform locale data (PHP 8.3 and 8.5)
 phpunit:PfbFeedNormalizeTest::testInteriorNbspIsDataWhileTrailingNbspIsTrimmed  # platform locale data (PHP 8.3 and 8.5)
 phpunit:PfbFlockBoundedTest::testBoundedAcquireRealErrorReturnsFalsePromptlyWithTimedOutFalse  # PHP 8.3's php://memory can fail flock(); absent from the PHP 8.5 report (informational there)
+phpunit:RsyncSizeRefusalTest::test_rsync_body_over_the_ceiling_is_refused_with_a_named_reason  # macOS host lacks /usr/local/bin/rsync (openrsync lives at /usr/bin); Linux CI installs it there (issue #2667)
+phpunit:RsyncSizeRefusalTest::test_rsync_body_under_the_ceiling_still_downloads  # macOS host lacks /usr/local/bin/rsync; Linux CI installs it there (issue #2667)
+phpunit:RsyncSizeRefusalTest::test_rsync_fetch_under_a_kernel_tiny_ceiling_never_succeeds  # macOS host lacks /usr/local/bin/rsync; Linux CI installs it there (issue #2667)
 
 # ShellSpec -- macOS/BSD host lacks the GNU stat/date/touch branch exercised in Linux CI.
 shellspec:tests/shell/pfblockerng_adr26_locale_spec.sh::ADR-26 — pfb_list_orig_by_mtime() diagnostic listing (Phase 3) lists *.orig oldest-first as "<YYYY-MM-DD> <HH:MM><TAB><name>" (ISO date, path + .orig stripped)  # GNU-only off-box branch; BSD branch is covered live by ADR-04 smoke


### PR DESCRIPTION
Bound the rsync feed ingest path in `pfb_download()` (issue #2667).

**Problem.** The rsync branch wrote the fetched body straight to `{file}.raw` with neither size ceiling from #2658 applied, and its failure log could not distinguish "too large" from any other rsync error.

**Design — two enforcement halves:**
1. Kernel backstop: rsync now runs under `pfb_extract_cmd()`'s `ulimit -f` at twice the ceiling, so writes beyond it are killed by the kernel regardless of rsync variant behavior.
2. Named refusal: a body that lands whole but exceeds the ceiling is removed and logged `stage=size reason=rsync_too_large`, mirroring the curl path's distinguishable refusal.

The kernel blocks are set to twice the ceiling deliberately: rsync writes via atomic temp+rename, so a body just over the ceiling must land whole for the size check to name it; the kernel bound caps what can hit disk beyond that. The count is `intdiv($rsync_ceiling, 256)` — `ulimit -f` counts 512-byte blocks, so twice the ceiling is `ceiling / 256`, and integer division keeps the bound exact instead of relying on a float cast that is undefined once `2 * ceiling` leaves the integer range. Hostile seam values (`0`, negative, non-numeric, `PHP_INT_MAX`) were probed and all fail closed: rsync cannot write, the fetch fails, nothing is published.

**Why not `--max-size`:** probed on both variants — openrsync exits 0 silently when the source exceeds `--max-size`, so the flag cannot be the bound alone.

**Test seam:** `$GLOBALS['pfb']['rsync_max_bytes']` defaults to `PFB_DOWNLOAD_MAX_BYTES`, mirroring #2658's curl ceiling seam. Tests (`tests/php/RsyncSizeRefusalTest.php`) drive the real branch through the dbdir local-path seam: over-ceiling refusal with named reason and no leftover `.raw`; under-ceiling success with the whole body published; kernel-tiny-ceiling fails through the rsync-exit gate *and* asserts the post-fetch size check was not what saved it, so the kernel half is proved on its own. The stale rsync entry in `DownloadSizeCeilingTest`'s exec allow-list is removed — that invariant now covers the wrapped call.

**RED/GREEN evidence:** RED executed on pristine origin/devel with the final test bytes: refusal + kernel-cap tests fail, and the invariant test fails once its allow-list entry is removed (correct detection). GREEN after the fix: 3/3 pass; a per-test JUnit diff of the full suite against a pristine-devel baseline in the same container shows zero change-attributable newly-failing tests. Mutation-tested against five defect injections (drop the size check, drop the kernel bound, loosen the kernel bound 256×, invert the comparison, oversize the under-ceiling fixture) — each fails a named assertion. Host skips (macOS lacks `/usr/local/bin/rsync`) recorded in `tests/skip-allowlist.txt`; the CI job installs rsync at that path so the cases cannot silently skip on the runner.

| Frozen RED test | git hash-object | RED run tail |
| --- | --- | --- |
| `tests/php/RsyncSizeRefusalTest.php` | `9e3b84432cfc98a0d226da07add63907cbce27e5` | `test_rsync_body_over_the_ceiling_is_refused_with_a_named_reason: an over-large rsync body must not download successfully — Failed asserting that true is false.; test_rsync_fetch_under_a_kernel_tiny_ceiling_never_succeeds: a writer killed by the file-size ceiling must never read as a successful fetch — Failed asserting that true is false.` |
| `tests/php/DownloadSizeCeilingTest.php` | `32aa03b601108fb98b724309859e4e799c3790a1` | `test_every_extraction_exec_runs_under_the_ceiling: unguarded exec() in pfb_download(): exec("/usr/local/bin/rsync --timeout=5 {$rsync_src_esc} {$file_dwn_esc}", ...) — Failed asserting that null is not null. (line 332)` |
| `tests/skip-allowlist.txt` | `631a1b98a679eff24aee715b7dc087878ab0cdf6` | `scripts/agent/run-gates.sh on macOS host before the entries existed: error: 3 skip(s) not on tests/skip-allowlist.txt (the three RsyncSizeRefusalTest cases) → GATES: FAIL; GATES: PASS after adding them` |

Fixes #2667


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Added size limits to rsync downloads to prevent oversized files from being accepted.
  - Oversized or incomplete downloads are now rejected, removed, and recorded with a clear reason.
  - Downloads within the configured limit continue to work normally.

- **Tests**
  - Added coverage for oversized, valid, and kernel-limited rsync downloads.
  - Improved test environment setup and platform-specific handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->