### PR TITLE
install.sh: document fetch-to-file not fetch|sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ under the **Apache License 2.0**.
 Run this **on the firewall** over SSH (as root), picking the channel you want:
 
 ```sh
-fetch -qo - https://pkg.pfblockerng.com/install.sh | sh -s -- --channel stable
+t=$(mktemp "${TMPDIR:-/tmp}/pfb-install.XXXXXX") && fetch -T 60 -o "$t" https://pkg.pfblockerng.com/install.sh && [ -s "$t" ] && /bin/sh "$t" --channel stable; e=$?; [ -n "$t" ] && rm -f "$t"; (exit $e)
 ```
 
 One command from **any** starting state: a fresh firewall, an existing Netgate
@@ -109,7 +109,7 @@ Run the same one-liner as [Installation](#installation), just with a
 different `--channel`:
 
 ```sh
-fetch -qo - https://pkg.pfblockerng.com/install.sh | sh -s -- --channel edge
+t=$(mktemp "${TMPDIR:-/tmp}/pfb-install.XXXXXX") && fetch -T 60 -o "$t" https://pkg.pfblockerng.com/install.sh && [ -s "$t" ] && /bin/sh "$t" --channel edge; e=$?; [ -n "$t" ] && rm -f "$t"; (exit $e)
 ```
 
 It moves the subscription, moves the installed package onto it, replaces a

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -11,17 +11,20 @@
 # nothing (check-then-act throughout). Four near-identical per-channel wrapper
 # scripts added nothing but drift risk over a single --channel argument.
 #
-# WHY EVERY pkg(8) CALL REDIRECTS STDIN FROM /dev/null: the published form is piped into
-# `sh` (`fetch -qo - .../install.sh | sh -s -- --channel <ch>`), so the script's own
-# stdin IS the script text — any child process that reads stdin without redirection
-# would consume trailing script bytes and corrupt the run.
+# WHY EVERY pkg(8) CALL REDIRECTS STDIN FROM /dev/null: a leftover pipe user
+# (`fetch | sh`) still exists in the wild, and under that form the script's own
+# stdin IS the script text — any child that reads stdin without redirection would
+# consume trailing script bytes and corrupt the run. The documented form is
+# mktemp + fetch-to-file (issue #2754): a POSIX pipeline's status is the last
+# command, so `fetch | sh` exits 0 when fetch delivers zero bytes (`sh` on empty
+# stdin succeeds). `[ -s "$t" ]` also refuses a successful empty write.
 #
 # Usage:
 #   install.sh --channel <stable|testing|edge|nightly>   subscribe + install/converge
 #   install.sh -h|--help                                  this text
 #
 # Published at https://${PFB_REPO_HOST}/install.sh; run ON the box:
-#   fetch -qo - https://${PFB_REPO_HOST}/install.sh | sh -s -- --channel stable
+#   t=$(mktemp "${TMPDIR:-/tmp}/pfb-install.XXXXXX") && fetch -T 60 -o "$t" https://${PFB_REPO_HOST}/install.sh && [ -s "$t" ] && /bin/sh "$t" --channel stable; e=$?; [ -n "$t" ] && rm -f "$t"; (exit $e)
 #
 # Env (all overridable; forks/staging/tests set these):
 #   PKG_BIN           pkg(8) binary path (default: /usr/local/sbin/pkg)
@@ -308,7 +311,12 @@ Usage:
   install.sh -h|--help                                  this text
 
 Published at https://${PFB_REPO_HOST}/install.sh; run ON the box:
-  fetch -qo - https://${PFB_REPO_HOST}/install.sh | sh -s -- --channel <stable|testing|edge|nightly>
+USAGE
+    # Single-quoted format: dash/set -u must not expand $t or $(mktemp) while
+    # printing help. ${PFB_REPO_HOST} is the %s argument (issue #2756).
+    # shellcheck disable=SC2016
+    printf '  t=$(mktemp "${TMPDIR:-/tmp}/pfb-install.XXXXXX") && fetch -T 60 -o "$t" https://%s/install.sh && [ -s "$t" ] && /bin/sh "$t" --channel <stable|testing|edge|nightly>; e=$?; [ -n "$t" ] && rm -f "$t"; (exit $e)\n' "${PFB_REPO_HOST}"
+    cat <<'USAGE_TAIL'
 
 Installs the boot-time repo-conf generator hook (ADR-39), subscribes this box to the
 named channel ALONE (retiring any other pfBlockerNG channel conf), then installs or
@@ -323,7 +331,7 @@ Exit codes:
      catalogue offers nothing, or pkg version -t gave no usable answer
   5  a pkg operation (delete/install) failed, including a package-script failure while pkg exited 0
   6  post-install verification failed
-USAGE
+USAGE_TAIL
 }
 
 # pfb_emit_embedded_hook — print the rc.d generator hook to stdout. In the repository
@@ -332,7 +340,7 @@ USAGE
 # directly from a checkout via HOOK_SRC. The pkg-owned website renderer replaces
 # the body between the PFB_EMBED markers with the hook in a single-quoted
 # heredoc, producing the self-contained install.sh served at <base>/install.sh
-# for `fetch | sh`.
+# for leftover `fetch | sh` users and the published fetch-to-file form.
 pfb_emit_embedded_hook() {
     # PFB_EMBED_HOOK_BEGIN — do not edit; replaced by the pkg-owned website renderer.
     printf 'install.sh: no embedded hook in this copy — run from a checkout, or use the published %s/install.sh\n' "https://${PFB_REPO_HOST}" >&2

--- a/tests/test_install_sh_published_form.py
+++ b/tests/test_install_sh_published_form.py
@@ -1,0 +1,185 @@
+"""The published install one-liner must fail when fetch fails (issue #2754).
+
+A POSIX pipeline's status is the last command. ``fetch | sh`` therefore exits 0
+when fetch delivers zero bytes — ``sh`` on empty stdin is a success. Measured
+on FreeBSD /bin/sh on a live pfSense clone: NXDOMAIN, HTTPS timeout, and
+``sh </dev/null`` all returned 0 and left the package unchanged.
+
+The documented form is mktemp + fetch-to-file + non-empty gate + ``sh``, then
+cleanup that preserves the fetch/sh status, so an empty or failed fetch cannot
+report success.
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+INSTALL_SH = ROOT / "scripts" / "install.sh"
+README = ROOT / "README.md"
+
+# Exact published recipe (README uses the public host; usage() templates it).
+_FETCH_TO_FILE = (
+    't=$(mktemp "${TMPDIR:-/tmp}/pfb-install.XXXXXX") && '
+    'fetch -T 60 -o "$t" https://pkg.pfblockerng.com/install.sh && '
+    '[ -s "$t" ] && '
+    '/bin/sh "$t" --channel'
+)
+_STATUS_CLEANUP = '; e=$?; [ -n "$t" ] && rm -f "$t"; (exit $e)'
+_PIPE_FORM = "fetch -qo - https://pkg.pfblockerng.com/install.sh | sh -s -- --channel"
+# usage() prints the recipe via a single-quoted printf so set -u cannot
+# expand $t. Pin that format string, not an unquoted heredoc body.
+_USAGE_PRINTF = (
+    'printf \'  t=$(mktemp "${TMPDIR:-/tmp}/pfb-install.XXXXXX") && '
+    'fetch -T 60 -o "$t" https://%s/install.sh && '
+    '[ -s "$t" ] && '
+    '/bin/sh "$t" --channel <stable|testing|edge|nightly>; '
+    'e=$?; [ -n "$t" ] && rm -f "$t"; (exit $e)\\n\' '
+    '"${PFB_REPO_HOST}"'
+)
+
+
+def _recipe(channel: str) -> str:
+    return f"{_FETCH_TO_FILE} {channel}{_STATUS_CLEANUP}"
+
+
+def _readme_sh_fence(channel: str) -> str:
+    """Return the README ``sh`` fence that installs ``channel``.
+
+    The executable pins run THIS text, not a parallel copy of the recipe, so a
+    documented pipe form cannot stay green behind a hardcoded fetch-to-file stub.
+    """
+    text = README.read_text(encoding="utf-8")
+    fences: list[str] = []
+    rest = text
+    while "```sh" in rest:
+        rest = rest.split("```sh", 1)[1]
+        block, rest = rest.split("```", 1)
+        fences.append(block.strip())
+    matches = [block for block in fences if f"--channel {channel}" in block]
+    assert matches, f"no README sh fence for --channel {channel}"
+    return matches[0]
+
+
+def _run_recipe(
+    tmp_path: Path,
+    *,
+    body: bytes,
+    fetch_rc: int,
+    channel: str = "stable",
+) -> subprocess.CompletedProcess[str]:
+    """Execute the README recipe with a stub ``fetch`` on PATH."""
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+    body_file = tmp_path / "fetch-body"
+    body_file.write_bytes(body)
+    fetch = bindir / "fetch"
+    # Handles both the leftover pipe (`fetch -qo - URL`) and fetch-to-file (`-o FILE`).
+    fetch.write_text(
+        "#!/bin/sh\n"
+        "out=\n"
+        "while [ $# -gt 0 ]; do\n"
+        "  case $1 in\n"
+        "    -o|-qo) out=$2; shift 2 ;;\n"
+        "    -T) shift 2 ;;\n"
+        "    -q) shift ;;\n"
+        "    *) shift ;;\n"
+        "  esac\n"
+        "done\n"
+        f"rc={fetch_rc}\n"
+        'if [ "$rc" -ne 0 ]; then\n'
+        '  exit "$rc"\n'
+        "fi\n"
+        'if [ -z "$out" ] || [ "$out" = \'-\' ]; then\n'
+        f'  cat "{body_file}"\n'
+        "else\n"
+        f'  cat "{body_file}" > "$out"\n'
+        "fi\n"
+        "exit 0\n",
+        encoding="utf-8",
+    )
+    fetch.chmod(fetch.stat().st_mode | stat.S_IXUSR)
+    env = os.environ.copy()
+    env["PATH"] = f"{bindir}{os.pathsep}{env.get('PATH', '')}"
+    env["TMPDIR"] = str(tmp_path)
+    return subprocess.run(
+        ["dash", "-c", _readme_sh_fence(channel)],
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_readme_install_recipes_are_fetch_to_file_not_a_pipe() -> None:
+    """Given the README install recipes
+    When a reader copies them onto a firewall
+    Then they gate on fetch's exit and a non-empty body, not on sh reading empty stdin.
+    """
+    text = README.read_text(encoding="utf-8")
+    assert _PIPE_FORM not in text
+    assert _recipe("stable") in text
+    assert _recipe("edge") in text
+
+
+def test_install_sh_usage_documents_fetch_to_file_not_a_pipe() -> None:
+    """Given install.sh usage()
+    When an operator reads the published one-liner
+    Then it is mktemp + fetch-to-file + a non-empty gate, not the fail-open pipe.
+    """
+    text = INSTALL_SH.read_text(encoding="utf-8")
+    fn = text.split("usage() {", 1)[1].split("pfb_emit_embedded_hook", 1)[0]
+    assert "fetch -qo - https://" not in fn
+    assert " | sh -s -- --channel" not in fn
+    assert _USAGE_PRINTF in fn
+
+
+def test_published_form_fails_closed_on_empty_fetch_body(tmp_path: Path) -> None:
+    """Given a stub fetch that writes zero bytes and exits 0
+    When the published one-liner runs
+    Then the overall status is non-zero — empty body is not a successful install.
+    """
+    result = _run_recipe(tmp_path, body=b"", fetch_rc=0)
+    assert result.returncode != 0, result.stderr
+
+
+def test_published_form_fails_closed_when_fetch_fails(tmp_path: Path) -> None:
+    """Given a stub fetch that exits non-zero
+    When the published one-liner runs
+    Then the overall status is non-zero and sh is not invoked on an empty file.
+    """
+    result = _run_recipe(tmp_path, body=b"exit 0\n", fetch_rc=1)
+    assert result.returncode != 0, result.stderr
+
+
+def test_published_form_runs_sh_on_nonempty_body(tmp_path: Path) -> None:
+    """Given a stub fetch that writes a script exiting 42
+    When the published one-liner runs
+    Then that script is executed — the form still reaches sh on a real body.
+    """
+    result = _run_recipe(tmp_path, body=b"exit 42\n", fetch_rc=0)
+    assert result.returncode == 42, result.stderr
+
+
+def test_help_prints_usage_without_running_the_documented_mktemp(tmp_path: Path) -> None:
+    """The documented one-liner is printed via single-quoted printf.
+    An unquoted heredoc body dies under ``set -u`` and would create a temp file.
+    """
+    env = os.environ.copy()
+    env["TMPDIR"] = str(tmp_path)
+    proc = subprocess.run(
+        ["sh", str(INSTALL_SH), "--help"],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    leftovers = sorted(p.name for p in tmp_path.iterdir() if p.name.startswith("pfb-install"))
+    assert proc.returncode == 0, proc.stderr
+    assert "Usage:" in proc.stdout
+    assert "https://pkg.pfblockerng.com/install.sh" in proc.stdout
+    assert leftovers == [], leftovers

--- a/tests/test_issue2456_pkg_ownership.py
+++ b/tests/test_issue2456_pkg_ownership.py
@@ -163,7 +163,13 @@ class SourcePublicationBoundaryTests(unittest.TestCase):
     def test_source_readme_install_recipes_match_the_pkg_client_contract(self) -> None:
         for channel in ("stable", "edge"):
             self.assertIn(
-                f"fetch -qo - https://pkg.pfblockerng.com/install.sh | sh -s -- --channel {channel}",
+                (
+                    't=$(mktemp "${TMPDIR:-/tmp}/pfb-install.XXXXXX") && '
+                    'fetch -T 60 -o "$t" https://pkg.pfblockerng.com/install.sh && '
+                    '[ -s "$t" ] && '
+                    f'/bin/sh "$t" --channel {channel}'
+                    '; e=$?; [ -n "$t" ] && rm -f "$t"; (exit $e)'
+                ),
                 README,
             )
 


### PR DESCRIPTION
Part of #2754 (item 1 of 4). Does **not** touch `pfblockerng.inc`.

## Problem

The published one-liner was `fetch | sh`. A POSIX pipeline's status is the last command, so a failed or empty fetch still exits 0: `sh` on empty stdin succeeds. Measured on FreeBSD `/bin/sh` on a live pfSense clone: NXDOMAIN, HTTPS timeout, and `sh </dev/null` all returned 0 and left the package unchanged.

## Change

Documented form is mktemp + fetch-to-file + `[ -s "$t" ]` + `sh`, then cleanup that preserves fetch/sh status (`e=$?; rm -f; (exit $e)`).

`usage()` prints that recipe with a **single-quoted printf** and `${PFB_REPO_HOST}` as `%s`. That is a clarity choice (literal vs expanded split is explicit), not a dash-compatibility workaround: on smoke-1, dash 0.5.12-12 *does* strip `\$` in an unquoted heredoc the same as bash. The printf form also prevents `$(mktemp)` in an unquoted heredoc from creating a temp file as a side effect of `--help`.

The leftover `fetch | sh` pipe is still mentioned in comments because wild leftover users exist (#2390); it is no longer the documented install form.

## Tests

- `tests/test_install_sh_published_form.py` — README/usage pin the fetch-to-file recipe; stub fetch: empty body and fetch-fail → non-zero; nonempty body still reaches `sh`; `--help` exits 0, expands the host to `pkg.pfblockerng.com`, and creates **no** `pfb-install*` temp file.
- Local GREEN after the usage() printf: 11 tests including the five CI `--help` failures from 369dcae1 (`t: parameter not set`).

| Frozen RED test | git hash-object | RED run tail |
| --- | --- | --- |
| `tests/test_install_sh_published_form.py` | `cca5276f5041746bff9beb995411099d661355c8` | `scripts/install.sh: 306: t: parameter not set` |
| `tests/test_issue2456_pkg_ownership.py` | `9dc84ab5eb9f2dfed072b7b0f663cc3df7a9c188` | `AssertionError: fetch-to-file recipe missing from README` |

## Known gaps

- Hermetic stub `fetch` on Linux dash, not FreeBSD `fetch(1)`.
- No live-VM re-run of the published one-liner on a pfSense guest (clone SSH denied).
- FreeBSD ash heredoc/`fetch -o` symlink probes still outstanding; same guest if one comes up.
- The published landing page at pkg.pfblockerng.com (pfBlockerNG/pkg) still serves the old `fetch | sh` one-liner. That is outside this repo; not closed by this PR.

Part of #2754 (item 1 of 4)

🤖 Generated by Grok and posted on behalf of @BBcan177.