### PR TITLE
test: pin install.sh git exec bit, not umask mode

### DIFF
--- a/tests/test_install_sh_git_exec_bit.py
+++ b/tests/test_install_sh_git_exec_bit.py
@@ -1,0 +1,27 @@
+"""install.sh must stay executable in git's index (issue #2754).
+
+Git tracks one mode bit: 100644 vs 100755. An exact-mode assert like 0o755
+tests the checkout umask, not the repository — that is why the old
+test_gen_landing.py equality died under umask 002 (0775 vs 0755).
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_install_sh_is_executable_in_the_git_index() -> None:
+    """Given scripts/install.sh in the git index
+    When git reports its mode
+    Then the exec bit is set (100755), independent of checkout umask.
+    """
+    out = subprocess.check_output(
+        ["git", "ls-files", "-s", "--", "scripts/install.sh"],
+        cwd=ROOT,
+        text=True,
+    )
+    mode = out.split()[0]
+    assert mode == "100755", out

--- a/tests/test_install_sh_git_exec_bit.py
+++ b/tests/test_install_sh_git_exec_bit.py
@@ -23,5 +23,5 @@ def test_install_sh_is_executable_in_the_git_index() -> None:
         cwd=ROOT,
         text=True,
     )
-    mode = out.split()[0]
-    assert mode == "100755", out
+    lines = out.splitlines()
+    assert len(lines) == 1 and lines[0].split()[0] == "100755", out


### PR DESCRIPTION
Part of #2754 (item 3 of 4). Does **not** touch `pfblockerng.inc`.

Git tracks one mode bit: `100644` vs `100755`. An exact-mode assert like `0o755` tests the checkout umask, not the repository — that is why the old `test_gen_landing.py` equality died under umask 002 (`0775` vs `0755`).

This pin uses `git ls-files -s` and requires `100755`. No production change; `scripts/install.sh` is already executable in the index.

Known gaps: none. Behaviour-preserving pin of existing git mode.

Round 1 requested.

Co-Authored-By: grok <grok@noreply.localhost>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage to verify the installation script retains executable permissions in the repository.
  * Ensures permission checks are reliable regardless of the local checkout’s umask.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->