### PR TITLE
ci: derive nightly pkgversion from one helper

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -138,9 +138,7 @@ jobs:
             '{tools_sha: $tools_sha, matrix_sha: $matrix_sha, build: $build, route: $route}')"
           MATRIX_DIGEST="$(printf '%s' "$MATRIX_PAYLOAD" | sha256sum | cut -d' ' -f1)"
           mkdir -p plan
-          BUILD_TIMESTAMP="$(date -u +%Y%m%d%H%M%S)"
-          SOURCE_SHORT_SHA="$(printf '%.7s' "$SOURCE_SHA")"
-          PKG_VERSION="${BUILD_TIMESTAMP}.${SOURCE_SHORT_SHA}"
+          PKG_VERSION="$(sh "$TRUSTED_DIR/scripts/nightly-pkgversion.sh" "$SOURCE_SHA")"
           python3 "$TRUSTED_DIR/scripts/build-dep-pkg-portable.py" --print-toolchain \
             > plan/dependency-builder.json
           printf '%s\n' "$BUILD_MATRIX" > plan/build-matrix.json

--- a/.github/workflows/smoke-single.yml
+++ b/.github/workflows/smoke-single.yml
@@ -678,8 +678,7 @@ jobs:
           RUN_ID="$(sh scripts/select-box.sh --print-id)"
           export RUN_ID
           SOURCE_SHA="$(git rev-parse HEAD)"
-          SOURCE_SHORT_SHA="$(printf '%.7s' "$SOURCE_SHA")"
-          NIGHTLY_VERSION="$(date -u +%Y%m%d%H%M%S).${SOURCE_SHORT_SHA}"
+          NIGHTLY_VERSION="$(sh scripts/nightly-pkgversion.sh "$SOURCE_SHA")"
           PKG="$(sh scripts/build-leg.sh \
             --channel    nightly \
             --abi        "$ABI" \

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -471,6 +471,7 @@ identically locally and in CI.
 | [`smoke-on-box.sh`](smoke-on-box.sh) | On-box smoke entrypoint: checkout, ports update, image pull, build, run. |
 | [`run-smoke.sh`](run-smoke.sh) | Canonical pytest argv emitter for the smoke suite (same script CI and local use). |
 | [`build-leg.sh`](build-leg.sh) | Build a `.pkg` for a specific leg (ABI, channel, version). |
+| [`nightly-pkgversion.sh`](nightly-pkgversion.sh) | `YYYYMMDDHHMMSS.<7-sha>` for `--channel nightly`. Called from `nightly.yml`, `smoke-single.yml`, and `smoke-on-box.sh` (from the just-checked-out HEAD). `local-smoke.sh` forwards an explicit override only — it does not derive from the orchestrator clone, which can diverge from `--git-remote` (issue #2754). |
 | [`sparse-clone-ports.sh`](sparse-clone-ports.sh) | Blobless sparse clone of FreeBSD-ports to the needed port dirs only. |
 
 ## Two install paths: CI/local vs release

--- a/scripts/local-smoke.sh
+++ b/scripts/local-smoke.sh
@@ -14,6 +14,7 @@
 # Usage:
 #   scripts/local-smoke.sh [--ref REF] [--abi ABI] [--marker M] [--filter EXPR]
 #                          [--no-two-vm] [--shards N] [--git-remote URL|NAME]
+#                          [--pkgversion V]
 #
 # Required (env):
 #   PFB_BOXES   space-separated ssh targets, e.g. "root@10.0.0.23 root@10.0.0.24"
@@ -27,6 +28,11 @@
 #               build-pkg-linux.yml builds, issue #2166). The channel picks the port,
 #               and the port names the package, so a run on the wrong channel verifies a
 #               differently-named artifact than CI ships (issue #2206).
+#   --pkgversion V  nightly identity YYYYMMDDHHMMSS.<7-sha>, forwarded to
+#               smoke-on-box.sh. Omit to let smoke-on-box.sh derive it from the
+#               box's just-checked-out HEAD (the commit it actually builds).
+#               Do not derive from this clone: --git-remote may point at a
+#               fork/mirror whose ref is a different commit (issue #2754).
 #   --marker M  pytest -m marker (default: smoke); see also --filter
 #   --filter EXPR  pytest -k filter expression (optional)
 #   --no-two-vm skip civm image pull and LAN-client tests
@@ -104,6 +110,7 @@ _SHARDS=1
 # Per-run, never box state: repointing each box's origin is persistent and invisible
 # in the artifacts, so a forgotten switch-back silently changes every later run.
 _GIT_REMOTE="${PFB_GIT_REMOTE:-origin}"
+_PKGVERSION="${PFB_NIGHTLY_PKGVERSION:-}"
 
 while [ "$#" -gt 0 ]; do
     case "$1" in
@@ -115,6 +122,7 @@ while [ "$#" -gt 0 ]; do
         --no-two-vm) _NO_TWO_VM=1;        shift ;;
         --shards)   shift; _SHARDS="$1"; shift ;;
         --git-remote) shift; _GIT_REMOTE="$1"; shift ;;
+        --pkgversion) shift; _PKGVERSION="$1"; shift ;;
         --) shift; break ;;
         -*) printf 'local-smoke: unknown flag: %s\n' "$1" >&2; exit 2 ;;
         *)  break ;;
@@ -206,6 +214,14 @@ _PFSENSE_REF_Q="$(_sq "${SMOKE_PFSENSE_REF:-}")"
 _CIVM_REF_Q="$(_sq "${CIVM_REF:-}")"
 
 _ob_flags="--ref '$_REF_Q' --abi '$_ABI_Q' --channel '$_CHANNEL' --marker '$_MARKER_Q'"
+# Nightly identity: smoke-on-box.sh derives from the just-checked-out HEAD
+# (definitionally the built commit). Forward an explicit override only —
+# deriving here from the orchestrator clone stamps a different SHA when
+# --git-remote's ref diverges, and hard-fails when the ref is remote-only
+# (issue #2754 M1). Other channels never forward the flag.
+if [ "$_CHANNEL" = nightly ] && [ -n "$_PKGVERSION" ]; then
+    _ob_flags="$_ob_flags --pkgversion '$(_sq "$_PKGVERSION")'"
+fi
 if [ -n "$_FILTER" ]; then
     _ob_flags="$_ob_flags --filter '$(_sq "$_FILTER")'"
 fi

--- a/scripts/nightly-pkgversion.sh
+++ b/scripts/nightly-pkgversion.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+# shellcheck shell=sh
+# nightly-pkgversion.sh — YYYYMMDDHHMMSS.<7-character source SHA> (issue #2754).
+#
+# nightly.yml, smoke-single.yml, and smoke-on-box.sh call this same helper so a
+# local nightly smoke cannot silently build a different pkgversion than CI.
+#
+# Usage:
+#   nightly-pkgversion.sh <source-sha>
+# Prints one line to stdout. <source-sha> is a hex git object name, at least 7
+# characters; the helper lowercases and takes the first 7.
+
+set -eu
+
+if [ "$#" -ne 1 ]; then
+    printf 'nightly-pkgversion: usage: nightly-pkgversion.sh <source-sha>\n' >&2
+    exit 2
+fi
+_sha=$1
+case "$_sha" in
+    *[!0-9a-fA-F]* | "")
+        printf 'nightly-pkgversion: source sha must be hex\n' >&2
+        exit 2
+        ;;
+esac
+if [ "${#_sha}" -lt 7 ]; then
+    printf 'nightly-pkgversion: source sha too short\n' >&2
+    exit 2
+fi
+_short=$(printf '%.7s' "$_sha" | tr 'A-F' 'a-f')
+printf '%s.%s\n' "$(date -u +%Y%m%d%H%M%S)" "$_short"

--- a/scripts/smoke-on-box.sh
+++ b/scripts/smoke-on-box.sh
@@ -15,6 +15,12 @@
 #   --channel C      pkg channel to build: stable|testing|edge|nightly (default: edge).
 #                    The channel selects the port, and the port names the package, so this
 #                    decides WHICH artifact the suite installs (issue #2206).
+#   --pkgversion V   nightly identity YYYYMMDDHHMMSS.<7-sha>. When omitted on
+#                    --channel nightly, derived from scripts/nightly-pkgversion.sh
+#                    using the just-checked-out HEAD (the commit this script
+#                    builds, issue #2754). An explicit flag or
+#                    PFB_NIGHTLY_PKGVERSION is the documented exception: the
+#                    operator may stamp any identity. Ignored on other channels.
 #   --marker M       pytest -m marker (default: smoke)
 #   --filter EXPR    pytest -k filter expr (default: none)
 #   --no-two-vm      skip civm image pull and set NO_TWO_VM=1
@@ -66,6 +72,7 @@ set -eu
 _REF=""        # resolved below (HEAD) if not given
 _ABI="FreeBSD:15:amd64"  # version-literal-ok: local-dev default; overridden by --abi
 _CHANNEL="edge"          # the devel branch's release line; overridden by --channel
+_PKGVERSION="${PFB_NIGHTLY_PKGVERSION:-}"
 _MARKER="smoke"
 _FILTER=""
 _NO_TWO_VM=0
@@ -118,6 +125,7 @@ while [ "$#" -gt 0 ]; do
         --ref)      shift; _REF="$1";    shift ;;
         --abi)      shift; _ABI="$1";    shift ;;
         --channel)  shift; _CHANNEL="$1"; shift ;;
+        --pkgversion) shift; _PKGVERSION="$1"; shift ;;
         --marker)   shift; _MARKER="$1"; shift ;;
         --filter)   shift; _FILTER="$1";      shift ;;
         --no-two-vm) _NO_TWO_VM=1;       shift ;;
@@ -305,14 +313,26 @@ export SMOKE_STUB_DNS_PORT="${SMOKE_STUB_DNS_PORT:-53}"
 pkill -9 -f qemu-system-x86_64 2>/dev/null || true
 
 # ── Step 5: build .pkg ─────────────────────────────────────────────────────── #
+# Nightly builds require explicit --pkgversion (YYYYMMDDHHMMSS.<7-sha>).
+# Derive from the just-checked-out HEAD so the identity matches what this
+# run builds (issue #2754). An explicit --pkgversion / PFB_NIGHTLY_PKGVERSION
+# is the operator override and is not re-derived.
 printf 'smoke-on-box: building .pkg (abi=%s channel=%s)...\n' "$_ABI" "$_CHANNEL" >&2
-SMOKE_PKG="$(sh scripts/build-leg.sh \
+set -- \
     --ports-dir  "$PORTS_DIR" \
     --channel    "$_CHANNEL" \
     --abi        "$_ABI" \
     --php        "$_php_ver" \
     --py-flavor  "$_py_flavor" \
-    --local-src  "$REPO_ROOT")"
+    --local-src  "$REPO_ROOT"
+if [ "$_CHANNEL" = nightly ]; then
+    if [ -z "$_PKGVERSION" ]; then
+        _PKGVERSION="$(sh scripts/nightly-pkgversion.sh "$(git -C "$REPO_ROOT" rev-parse HEAD)")"
+    fi
+    set -- "$@" --pkgversion "$_PKGVERSION"
+    printf 'smoke-on-box: nightly pkgversion %s\n' "$_PKGVERSION" >&2
+fi
+SMOKE_PKG="$(sh scripts/build-leg.sh "$@")"
 export SMOKE_PKG
 printf 'smoke-on-box: pkg built: %s\n' "$SMOKE_PKG" >&2
 

--- a/tests/shell/local_smoke_pkgversion_spec.sh
+++ b/tests/shell/local_smoke_pkgversion_spec.sh
@@ -1,0 +1,100 @@
+#shellcheck shell=sh
+# local_smoke_pkgversion_spec.sh — issue #2754: nightly --pkgversion on the bootstrap argv.
+#
+# WHY THIS EXISTS: a substring pin on comments stayed green after the nightly
+# pkgversion block was deleted. This spec records the bootstrap argv through
+# the PFB_SELECT_BOX seam (no ssh, no box, no build).
+#
+# IDENTITY RULE (M1): local-smoke.sh must NOT derive the nightly SHA from the
+# orchestrator clone. The box fetches --ref from --git-remote and checks that
+# out; smoke-on-box.sh derives from that HEAD. Deriving here stamps a package
+# with a commit the box did not build when the two repos diverge, and hard-fails
+# before contacting the box when the ref exists only on the remote.
+#
+# RED→GREEN: --channel nightly without --pkgversion must not put --pkgversion on
+# the argv (smoke-on-box.sh derives after checkout). An override must appear
+# verbatim. --channel edge must not grow a --pkgversion. A --ref that does not
+# exist in the orchestrator clone plus --git-remote must still reach select-box
+# (today local-smoke.sh dies in rev-parse before any call).
+
+Describe 'local-smoke.sh --pkgversion (issue #2754)'
+  SCRIPT="${PFB_ROOT}/scripts/local-smoke.sh"
+
+  setup() {
+    scrub_git_env
+    unset PFB_REF PFB_NIGHTLY_PKGVERSION
+    WORK="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/localsmokepkgver.XXXXXX")"
+    CALLS_DIR="${WORK}/calls"
+    mkdir -p "$CALLS_DIR"
+
+    FAKE_SELECT_BOX="${WORK}/fake-select-box.sh"
+    cat > "$FAKE_SELECT_BOX" <<'FAKEEOF'
+#!/bin/sh
+_call_file="$(mktemp "${CALLS_DIR}/call.XXXXXX")"
+printf '%s\n' "$*" > "$_call_file"
+exit 0
+FAKEEOF
+    chmod +x "$FAKE_SELECT_BOX"
+
+    HEAD_SHA="$(git_fixture -C "$PFB_ROOT" rev-parse HEAD)"
+    HEAD_SHORT="$(printf '%.7s' "$HEAD_SHA")"
+
+    TMPDIR="$WORK"
+    PFB_SELECT_BOX="$FAKE_SELECT_BOX"
+    PFB_BOXES="dummy@dummy"
+    export PFB_SELECT_BOX PFB_BOXES WORK CALLS_DIR TMPDIR HEAD_SHA HEAD_SHORT
+  }
+
+  teardown() {
+    rm -rf "$WORK"
+  }
+
+  BeforeEach 'setup'
+  AfterEach  'teardown'
+
+  call_count() { find "$CALLS_DIR" -type f 2>/dev/null | wc -l | tr -d ' '; }
+
+  run_and_diag() {
+    _out="$(sh "$SCRIPT" "$@" 2>&1)"
+    _rc=$?
+    printf 'exit=%s\n' "$_rc"
+    printf 'calls=%s\n' "$(call_count)"
+    printf '%s\n' "$_out"
+    cat "$CALLS_DIR"/* 2>/dev/null
+    return 0
+  }
+
+  It 'does not put a derived --pkgversion on --channel nightly'
+    When call run_and_diag --ref HEAD --channel nightly
+    The line 1 of output should equal 'exit=0'
+    The line 2 of output should equal 'calls=1'
+    The output should include "--channel 'nightly'"
+    The output should not include "--pkgversion"
+  End
+
+  It 'forwards an explicit --pkgversion verbatim on --channel nightly'
+    When call run_and_diag --ref HEAD --channel nightly --pkgversion 20260101120000.abcdef0
+    The line 1 of output should equal 'exit=0'
+    The line 2 of output should equal 'calls=1'
+    The output should include "--pkgversion '20260101120000.abcdef0'"
+    The output should not include ".${HEAD_SHORT}'"
+  End
+
+  It 'does not put --pkgversion on --channel edge'
+    When call run_and_diag --ref HEAD --channel edge --pkgversion 20260101120000.abcdef0
+    The line 1 of output should equal 'exit=0'
+    The line 2 of output should equal 'calls=1'
+    The output should include "--channel 'edge'"
+    The output should not include "--pkgversion"
+  End
+
+  It 'does not resolve --ref against the orchestrator clone for nightly identity'
+    When call run_and_diag --ref dummy --channel nightly --git-remote https://example.invalid/fork.git
+    The line 1 of output should equal 'exit=0'
+    The line 2 of output should equal 'calls=1'
+    The output should include "--channel 'nightly'"
+    The output should include "--ref 'dummy'"
+    The output should not include "--pkgversion"
+    The output should not include "cannot resolve"
+  End
+End

--- a/tests/shell/smoke_on_box_pkgversion_spec.sh
+++ b/tests/shell/smoke_on_box_pkgversion_spec.sh
@@ -1,0 +1,131 @@
+#shellcheck shell=sh
+# smoke_on_box_pkgversion_spec.sh — issue #2754: nightly --pkgversion on build-leg argv.
+#
+# WHY THIS EXISTS: after issue #2754 M1, nightly identity is derived HERE from
+# the just-checked-out HEAD, not in local-smoke.sh. local_smoke_pkgversion_spec.sh
+# pins that the orchestrator does not stamp a SHA from its own clone. This spec
+# drives smoke-on-box.sh so the derivation-and-override branch (the nightly block
+# before build-leg.sh) cannot be deleted while the suite stays green. Same
+# PFB_ONBOX_* seams as smoke_on_box_spec.sh; build-leg.sh is stubbed to record
+# argv and print a fake .pkg. The run then dies on the missing guest SSH key —
+# after the argv is written.
+#
+# RED→GREEN: deleting the nightly block from smoke-on-box.sh leaves --channel
+# nightly with no --pkgversion on the recorded build-leg argv. The helper-derived
+# example is the pin that the identity matches FAKE_ROOT's HEAD (the built commit).
+
+Describe 'smoke-on-box.sh --pkgversion (issue #2754)'
+  SCRIPT="${PFB_ROOT}/scripts/smoke-on-box.sh"
+
+  setup() {
+    scrub_git_env
+    unset PFB_NIGHTLY_PKGVERSION SMOKE_GHCR_TOKEN SMOKE_SSH_KEY
+    WORK="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/onboxpkgver.XXXXXX")"
+    FAKE_ROOT="${WORK}/repo"
+    mkdir -p "${FAKE_ROOT}/scripts/lib" "${WORK}/bin"
+
+    cp "${PFB_ROOT}/scripts/lib/git-env-scrub.sh" "${FAKE_ROOT}/scripts/lib/"
+    cp "${PFB_ROOT}/scripts/lib/smoke-tier.sh"    "${FAKE_ROOT}/scripts/lib/"
+    cp "${PFB_ROOT}/scripts/lib/lan-registry.sh"  "${FAKE_ROOT}/scripts/lib/"
+    cp "${PFB_ROOT}/scripts/nightly-pkgversion.sh" "${FAKE_ROOT}/scripts/"
+
+    cat > "${FAKE_ROOT}/scripts/sparse-clone-ports.sh" <<'STUBEOF'
+#!/bin/sh
+exit 0
+STUBEOF
+    chmod +x "${FAKE_ROOT}/scripts/sparse-clone-ports.sh"
+
+    cat > "${FAKE_ROOT}/scripts/read-version-matrix.sh" <<'STUBEOF'
+#!/bin/sh
+printf '%s\n' '[{"freebsd_major":"15","php_version":"8.3","py_flavor":"py311","extra_pkgs":[]}]'
+STUBEOF
+    chmod +x "${FAKE_ROOT}/scripts/read-version-matrix.sh"
+
+    BUILD_LEG_ARGV="${WORK}/build-leg-argv"
+    cat > "${FAKE_ROOT}/scripts/build-leg.sh" <<STUBEOF
+#!/bin/sh
+printf '%s\n' "\$*" > "${BUILD_LEG_ARGV}"
+printf '%s\n' "${WORK}/fake.pkg"
+exit 0
+STUBEOF
+    chmod +x "${FAKE_ROOT}/scripts/build-leg.sh"
+
+    cat > "${WORK}/bin/oras" <<'STUBEOF'
+#!/bin/sh
+case "$*" in
+    resolve*) printf '%s\n' 'sha256:manifest'; exit 0 ;;
+    *manifest\ fetch*)
+        case "$*" in
+            *--descriptor*) printf '{"digest":"sha256:manifest"}\n' ;;
+            *) printf '%s\n' '{"annotations":{"org.opencontainers.image.version":"2.8"}}' ;;
+        esac
+        exit 0
+        ;;
+    *\ pull\ *|pull\ *)
+        true > pfsense.qcow2
+        exit 0
+        ;;
+esac
+exit 0
+STUBEOF
+    chmod +x "${WORK}/bin/oras"
+
+    cat > "${WORK}/bin/uv" <<'STUBEOF'
+#!/bin/sh
+exit 0
+STUBEOF
+    chmod +x "${WORK}/bin/uv"
+
+    for _absent in qemu-system-x86_64 qemu-img iptables dig ssh pkill curl zstd tar unzip; do
+        printf '#!/bin/sh\nexit 0\n' > "${WORK}/bin/${_absent}"
+        chmod +x "${WORK}/bin/${_absent}"
+    done
+    PATH="${WORK}/bin:${PATH}"
+    export PATH
+
+    git_fixture -C "$FAKE_ROOT" init --quiet . >/dev/null 2>&1
+    git_fixture -C "$FAKE_ROOT" -c user.name=t -c user.email=t@example.com \
+        commit --quiet --allow-empty -m seed >/dev/null 2>&1
+    HEAD_SHA="$(git_fixture -C "$FAKE_ROOT" rev-parse HEAD)"
+    HEAD_SHORT="$(printf '%.7s' "$HEAD_SHA")"
+
+    printf '53\n' > "${WORK}/port-floor"
+    PFB_ONBOX_PORT_FLOOR_FILE="${WORK}/port-floor"
+    PFB_ONBOX_REPO_ROOT="$FAKE_ROOT"
+    PFB_ONBOX_PORTS_DIR="${WORK}/ports"
+    PFB_ONBOX_IMAGES_DIR="${WORK}/images"
+    export WORK FAKE_ROOT BUILD_LEG_ARGV HEAD_SHA HEAD_SHORT \
+        PFB_ONBOX_REPO_ROOT PFB_ONBOX_PORTS_DIR PFB_ONBOX_IMAGES_DIR \
+        PFB_ONBOX_PORT_FLOOR_FILE
+  }
+
+  teardown() { rm -rf "$WORK"; }
+
+  BeforeEach 'setup'
+  AfterEach  'teardown'
+
+  run_to_build() {
+    sh "$SCRIPT" --no-two-vm "$@" >/dev/null 2>&1 || true
+    [ -f "$BUILD_LEG_ARGV" ] || { printf 'no-argv\n'; return 0; }
+    cat "$BUILD_LEG_ARGV"
+  }
+
+  It 'puts a helper-derived --pkgversion on build-leg for --channel nightly'
+    When call run_to_build --channel nightly
+    The output should include "--channel nightly"
+    The output should include "--pkgversion "
+    The output should include ".${HEAD_SHORT}"
+  End
+
+  It 'forwards an explicit --pkgversion verbatim to build-leg on nightly'
+    When call run_to_build --channel nightly --pkgversion 20260101120000.abcdef0
+    The output should include "--pkgversion 20260101120000.abcdef0"
+    The output should not include ".${HEAD_SHORT}"
+  End
+
+  It 'does not put --pkgversion on build-leg for --channel edge'
+    When call run_to_build --channel edge --pkgversion 20260101120000.abcdef0
+    The output should include "--channel edge"
+    The output should not include "--pkgversion"
+  End
+End

--- a/tests/test_issue2245_stateless_nightly.py
+++ b/tests/test_issue2245_stateless_nightly.py
@@ -24,9 +24,7 @@ def test_every_nightly_invocation_builds_without_durable_state() -> None:
 
     assert 'TOOLS_SHA="$(git -C "$TRUSTED_DIR" rev-parse HEAD)"' in workflow
     assert 'SOURCE_SHA="$(git -C "$SOURCE_DIR" rev-parse HEAD)"' in workflow
-    assert 'BUILD_TIMESTAMP="$(date -u +%Y%m%d%H%M%S)"' in workflow
-    assert 'SOURCE_SHORT_SHA="$(printf \'%.7s\' "$SOURCE_SHA")"' in workflow
-    assert 'PKG_VERSION="${BUILD_TIMESTAMP}.${SOURCE_SHORT_SHA}"' in workflow
+    assert 'PKG_VERSION="$(sh "$TRUSTED_DIR/scripts/nightly-pkgversion.sh" "$SOURCE_SHA")"' in workflow
     assert "queue: max" in workflow
     assert "nightly-state" not in workflow
     assert 'nightly_provenance.py" allocate' not in workflow

--- a/tests/test_issue2347_short_nightly_sha.py
+++ b/tests/test_issue2347_short_nightly_sha.py
@@ -24,8 +24,7 @@ def test_nightly_version_uses_seven_character_source_sha() -> None:
 def test_nightly_workflow_shortens_only_the_package_version_sha() -> None:
     workflow = NIGHTLY_WORKFLOW.read_text(encoding="utf-8")
 
-    assert 'SOURCE_SHORT_SHA="$(printf \'%.7s\' "$SOURCE_SHA")"' in workflow
-    assert 'PKG_VERSION="${BUILD_TIMESTAMP}.${SOURCE_SHORT_SHA}"' in workflow
+    assert 'PKG_VERSION="$(sh "$TRUSTED_DIR/scripts/nightly-pkgversion.sh" "$SOURCE_SHA")"' in workflow
     assert "printf '%s\\n' \"$SOURCE_SHA\" > plan/source-sha" in workflow
 
 
@@ -33,6 +32,5 @@ def test_smoke_fixture_keeps_full_sha_annotation() -> None:
     workflow = SMOKE_WORKFLOW.read_text(encoding="utf-8")
     nightly = extract_between(workflow, "- name: Build a nightly .pkg", "\n      # ADR-24")
 
-    assert 'SOURCE_SHORT_SHA="$(printf \'%.7s\' "$SOURCE_SHA")"' in nightly
-    assert 'NIGHTLY_VERSION="$(date -u +%Y%m%d%H%M%S).${SOURCE_SHORT_SHA}"' in nightly
+    assert 'NIGHTLY_VERSION="$(sh scripts/nightly-pkgversion.sh "$SOURCE_SHA")"' in nightly
     assert '--annotate   "commit=${SOURCE_SHA}"' in nightly

--- a/tests/test_nightly_pkgversion.py
+++ b/tests/test_nightly_pkgversion.py
@@ -1,0 +1,116 @@
+"""Nightly pkgversion is derived in one place (issue #2754).
+
+nightly.yml, smoke-single.yml, and smoke-on-box.sh must call the same helper
+so a local nightly smoke cannot silently build a different pkgversion than CI.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+from pathlib import Path
+
+from scripts import release_version as rv
+
+ROOT = Path(__file__).resolve().parents[1]
+HELPER = ROOT / "scripts" / "nightly-pkgversion.sh"
+NIGHTLY_YML = ROOT / ".github" / "workflows" / "nightly.yml"
+SMOKE_SINGLE_YML = ROOT / ".github" / "workflows" / "smoke-single.yml"
+
+_SHA = "fd978e098ecdd3b982c7a3f8e02fefde36df14e5"
+_VERSION_RE = re.compile(r"^[0-9]{14}\.[0-9a-f]{7}$")
+
+
+def test_nightly_pkgversion_helper_exists() -> None:
+    """Given the shared nightly identity helper
+    When the tree is checked
+    Then the script is tracked. Callers invoke it with ``sh``, so the git
+    exec bit is not load-bearing.
+    """
+    assert HELPER.is_file()
+    tracked = subprocess.check_output(
+        ["git", "ls-files", "--", "scripts/nightly-pkgversion.sh"],
+        cwd=ROOT,
+        text=True,
+    ).strip()
+    assert tracked == "scripts/nightly-pkgversion.sh"
+
+
+def test_nightly_pkgversion_helper_emits_utc_seconds_plus_short_sha() -> None:
+    """Given a 40-character source SHA
+    When the helper runs
+    Then the printed version is YYYYMMDDHHMMSS.<7-hex> and validates.
+    """
+    result = subprocess.run(
+        ["dash", str(HELPER), _SHA],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    version = result.stdout.strip()
+    assert _VERSION_RE.fullmatch(version), version
+    assert version.endswith(".fd978e0")
+    assert rv.validate_nightly_version(version, source_sha=_SHA) == version
+
+
+def test_nightly_pkgversion_helper_uses_utc_not_local_time() -> None:
+    """``date -u`` is load-bearing: a local-time helper would disagree across TZs."""
+    env_utc = {**os.environ, "TZ": "UTC"}
+    env_east = {**os.environ, "TZ": "America/New_York"}
+    utc = subprocess.run(
+        ["dash", str(HELPER), _SHA],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env_utc,
+    )
+    east = subprocess.run(
+        ["dash", str(HELPER), _SHA],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env_east,
+    )
+    assert utc.returncode == 0, utc.stderr
+    assert east.returncode == 0, east.stderr
+    a, b = utc.stdout.strip(), east.stdout.strip()
+    assert _VERSION_RE.fullmatch(a), a
+    assert _VERSION_RE.fullmatch(b), b
+    assert a.endswith(".fd978e0")
+    assert b.endswith(".fd978e0")
+    # Local clocks in these zones differ by hours; UTC stamps agree within 2s.
+    assert abs(int(a.split(".", 1)[0]) - int(b.split(".", 1)[0])) <= 2, (a, b)
+
+
+def test_nightly_pkgversion_helper_rejects_short_sha() -> None:
+    """Given a SHA shorter than 7 hex characters
+    When the helper runs
+    Then it exits non-zero rather than padding or guessing.
+    """
+    result = subprocess.run(
+        ["dash", str(HELPER), "abc"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode != 0
+    assert result.stdout == ""
+
+
+def test_nightly_yml_and_smoke_single_call_the_same_helper() -> None:
+    """Given CI nightly and repo-flow smoke
+    When each workflow derives a nightly pkgversion
+    Then both invoke scripts/nightly-pkgversion.sh rather than inlining date+sha.
+    """
+    nightly = NIGHTLY_YML.read_text(encoding="utf-8")
+    smoke = SMOKE_SINGLE_YML.read_text(encoding="utf-8")
+    assert 'PKG_VERSION="$(sh "$TRUSTED_DIR/scripts/nightly-pkgversion.sh" "$SOURCE_SHA")"' in nightly
+    assert 'NIGHTLY_VERSION="$(sh scripts/nightly-pkgversion.sh "$SOURCE_SHA")"' in smoke
+    assert 'PKG_VERSION="${BUILD_TIMESTAMP}.${SOURCE_SHORT_SHA}"' not in nightly
+    assert 'NIGHTLY_VERSION="$(date -u +%Y%m%d%H%M%S).${SOURCE_SHORT_SHA}"' not in smoke

--- a/tests/test_nightly_workflow_contract.py
+++ b/tests/test_nightly_workflow_contract.py
@@ -62,8 +62,7 @@ def test_nightly_workflow_exists_and_is_branch_independent() -> None:
     assert "refs/tags/${PORTS_REF}^{}" in text
     assert "LC_ALL=C sort -u" in text
     assert "^[0-9a-f]{40}$" in text
-    assert 'SOURCE_SHORT_SHA="$(printf \'%.7s\' "$SOURCE_SHA")"' in text
-    assert 'PKG_VERSION="${BUILD_TIMESTAMP}.${SOURCE_SHORT_SHA}"' in text
+    assert 'PKG_VERSION="$(sh "$TRUSTED_DIR/scripts/nightly-pkgversion.sh" "$SOURCE_SHA")"' in text
 
     forbidden = ("gh release", "git tag", "git push", "release notes", "PORTVERSION")
     assert not any(token in text for token in forbidden), "Nightly workflow must not publish or mutate Ports"

--- a/tests/test_ui_release_gate_wiring.py
+++ b/tests/test_ui_release_gate_wiring.py
@@ -1145,8 +1145,7 @@ def test_smoke_single_nightly_fixture_uses_utc_timestamp_and_source_sha() -> Non
     text = SMOKE_SINGLE_WORKFLOW.read_text(encoding="utf-8")
     nightly = extract_between(text, "- name: Build a nightly .pkg", "\n      # ADR-24")
     assert 'SOURCE_SHA="$(git rev-parse HEAD)"' in nightly, nightly
-    assert 'SOURCE_SHORT_SHA="$(printf \'%.7s\' "$SOURCE_SHA")"' in nightly, nightly
-    assert 'NIGHTLY_VERSION="$(date -u +%Y%m%d%H%M%S).${SOURCE_SHORT_SHA}"' in nightly, nightly
+    assert 'NIGHTLY_VERSION="$(sh scripts/nightly-pkgversion.sh "$SOURCE_SHA")"' in nightly, nightly
     assert '--annotate   "commit=${SOURCE_SHA}"' in nightly, nightly
     assert "github.sha" not in nightly, nightly
     assert "NIGHTLY_COUNT" not in nightly, nightly


### PR DESCRIPTION
Part of #2754 (item 2 of 4). Does **not** touch `pfblockerng.inc`.

Nightly builds require explicit `--pkgversion` (`YYYYMMDDHHMMSS.<7-sha>`). `nightly.yml` and `smoke-single.yml` each inlined that derivation; `smoke-on-box.sh` omitted it, so a local `--channel nightly` run died in the builder.

`nightly.yml`, `smoke-single.yml`, and `smoke-on-box.sh` call `scripts/nightly-pkgversion.sh`. `smoke-on-box.sh` derives from the just-checked-out HEAD (the commit it actually builds). `local-smoke.sh` forwards an explicit override only — it does not derive from the orchestrator clone, which can diverge from `--git-remote` (independent-review M1). Callers invoke the helper with `sh`, so the git exec bit is not load-bearing.

History is **one commit** on current `devel` (`60d16bd8` / `06fbd9d6`). The previous 21-commit contents-API sequence is gone; it had PLACEHOLDER / truncated workflow blobs that must not land.

`tests/shell/local_smoke_pkgversion_spec.sh` records the bootstrap argv through `PFB_SELECT_BOX` (no ssh, no build): no derived `--pkgversion` on `--channel nightly`, override verbatim, no `--pkgversion` on `--channel edge`, and `--ref dummy --channel nightly --git-remote URL` must reach select-box (must not `rev-parse` the orchestrator clone). `tests/shell/smoke_on_box_pkgversion_spec.sh` pins that smoke-on-box derives from the built HEAD.

Known gaps: no live-VM re-run of `--channel nightly` on this PR.

| Frozen RED test | git hash-object | RED run tail |
| --- | --- | --- |
| `tests/test_nightly_pkgversion.py` | `7498584f57c0c2dfb0c62181a3a264681826620b` | `FAILED helper missing; SOURCE_SHORT_SHA still inlined` |
| `tests/test_issue2245_stateless_nightly.py` | `7f604e88b14d8528c520d0b096dde27f7d878a55` | `FAILED PKG_VERSION=BUILD_TIMESTAMP.SOURCE_SHORT_SHA` |
| `tests/test_issue2347_short_nightly_sha.py` | `85cb1ceee1801ae1f7389aa7ece27573847c3666` | `FAILED SOURCE_SHORT_SHA not in nightly.yml` |
| `tests/test_nightly_workflow_contract.py` | `d9543a19ea57e0045a2d22c67ed625e164c5a983` | `FAILED SOURCE_SHORT_SHA not in nightly.yml` |
| `tests/test_ui_release_gate_wiring.py` | `cb24a2fbc488df1052142ceeceb1550bb6de3837` | `FAILED SOURCE_SHORT_SHA not in smoke-single.yml` |
| `tests/shell/local_smoke_pkgversion_spec.sh` | `39537f79481e70261ef47925fdb7c0769d215a59` | `F..F derived --pkgversion still present; dummy ref exit=2 cannot resolve` |
| `tests/shell/smoke_on_box_pkgversion_spec.sh` | `c186363adf10625b0f31cb70a7e8ae725350b49c` | `expected build-leg argv to include --pkgversion` |

Independent-review M1 (major): `local-smoke.sh` used to derive the nightly SHA from the orchestrator clone while the box fetched `--git-remote`. Fixed on this SHA by stopping that derivation; smoke-on-box already derives from checked-out HEAD when the flag is omitted. The `local_smoke_pkgversion_spec.sh` hash is the inverted spec frozen before the production edit; it was byte-identical after GREEN.

Co-Authored-By: grok


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added consistent nightly package versioning using UTC timestamps and shortened source identifiers.
  * Added support for explicitly forwarding nightly package versions during local and on-box smoke runs.
  * Ensured non-nightly channels ignore nightly package version settings.

* **Bug Fixes**
  * Improved nightly smoke workflows to preserve package identity consistently across build environments.

* **Tests**
  * Added coverage for version formatting, validation, workflow integration, and channel-specific behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->