### PR TITLE
tests: make document landmarks load-bearing in bounded slices

### DIFF
--- a/tests/_workflow_steps.py
+++ b/tests/_workflow_steps.py
@@ -21,8 +21,8 @@ import re
 
 def extract_step(workflow: str, step_name: str) -> str:
     """Return the body of the ``- name: <step_name>`` step in ``workflow``,
-    bounded to the next sibling step at the same indentation (or end-of-file
-    when it is the last step in its job).
+    bounded to the next list item at the same indentation — which may be one in a
+    LATER job — or end-of-file when no such item follows.
 
     Raises ``ValueError`` naming the missing marker if the step is absent — a
     silent empty-string slice would let every ``in`` assertion against it pass
@@ -61,11 +61,9 @@ def extract_job(workflow: str, job_name: str) -> str:
 
 
 def extract_after(text: str, marker: str) -> str:
-    """Return the part of ``text`` after the first ``marker``.
-
-    ``ValueError`` naming ``marker`` when it is absent — the ``split(marker, 1)[1]``
-    form raises a bare ``IndexError`` that names nothing.
-    """
+    """``text`` after the first ``marker``; absent or empty ``marker`` raises
+    ``ValueError`` naming it (``split(marker, 1)[1]`` raises a bare ``IndexError``)."""
+    _reject_empty(marker)
     start = text.find(marker)
     if start < 0:
         raise ValueError(f"marker {marker!r} not found in text")
@@ -73,11 +71,9 @@ def extract_after(text: str, marker: str) -> str:
 
 
 def extract_before(text: str, marker: str) -> str:
-    """Return the part of ``text`` before the first ``marker``.
-
-    ``ValueError`` naming ``marker`` when it is absent — this is the silent case:
-    ``split(marker, 1)[0]`` returns the whole string and the slice stops bounding.
-    """
+    """``text`` before the first ``marker``; absent or empty ``marker`` raises
+    ``ValueError`` naming it. This is the silent case ``split(marker, 1)[0]`` hides."""
+    _reject_empty(marker)
     end = text.find(marker)
     if end < 0:
         raise ValueError(f"marker {marker!r} not found in text")
@@ -85,6 +81,12 @@ def extract_before(text: str, marker: str) -> str:
 
 
 def extract_between(text: str, start_marker: str, end_marker: str) -> str:
-    """Return the region of ``text`` between ``start_marker`` and the next
-    ``end_marker`` after it; either one absent raises ``ValueError`` naming it."""
+    """``text`` between ``start_marker`` and the FIRST ``end_marker`` after it."""
     return extract_before(extract_after(text, start_marker), end_marker)
+
+
+def _reject_empty(marker: str) -> None:
+    # "" is found everywhere, so it bounds nothing — the shape these helpers exist
+    # to remove. `str.split("", 1)` raised instead; keep that floor.
+    if not marker:
+        raise ValueError("marker must not be empty")

--- a/tests/_workflow_steps.py
+++ b/tests/_workflow_steps.py
@@ -28,6 +28,7 @@ def extract_step(workflow: str, step_name: str) -> str:
     silent empty-string slice would let every ``in`` assertion against it pass
     vacuously instead of failing for the right reason.
     """
+    _reject_empty(step_name)
     marker = re.compile(rf"^( *)- name: {re.escape(step_name)}\n", re.MULTILINE)
     match = marker.search(workflow)
     if match is None:
@@ -49,6 +50,7 @@ def extract_job(workflow: str, job_name: str) -> str:
     same script needs this: a file-global index comparison can otherwise pair a
     step in one job with a step in another.
     """
+    _reject_empty(job_name)
     marker = re.compile(rf"^  {re.escape(job_name)}:\n", re.MULTILINE)
     match = marker.search(workflow)
     if match is None:
@@ -61,8 +63,8 @@ def extract_job(workflow: str, job_name: str) -> str:
 
 
 def extract_after(text: str, marker: str) -> str:
-    """``text`` after the first ``marker``; absent or empty ``marker`` raises
-    ``ValueError`` naming it (``split(marker, 1)[1]`` raises a bare ``IndexError``)."""
+    """``text`` after the first ``marker``. An absent ``marker`` raises ``ValueError``
+    naming it, where ``split(marker, 1)[1]`` raised a bare ``IndexError``."""
     _reject_empty(marker)
     start = text.find(marker)
     if start < 0:
@@ -71,8 +73,8 @@ def extract_after(text: str, marker: str) -> str:
 
 
 def extract_before(text: str, marker: str) -> str:
-    """``text`` before the first ``marker``; absent or empty ``marker`` raises
-    ``ValueError`` naming it. This is the silent case ``split(marker, 1)[0]`` hides."""
+    """``text`` before the first ``marker``. An absent ``marker`` raises ``ValueError``
+    naming it — the silent case ``split(marker, 1)[0]`` hid by returning everything."""
     _reject_empty(marker)
     end = text.find(marker)
     if end < 0:
@@ -81,12 +83,14 @@ def extract_before(text: str, marker: str) -> str:
 
 
 def extract_between(text: str, start_marker: str, end_marker: str) -> str:
-    """``text`` between ``start_marker`` and the FIRST ``end_marker`` after it."""
+    """``text`` between ``start_marker`` and the FIRST ``end_marker`` after it; either
+    one absent raises ``ValueError`` naming it."""
     return extract_before(extract_after(text, start_marker), end_marker)
 
 
 def _reject_empty(marker: str) -> None:
-    # "" is found everywhere, so it bounds nothing — the shape these helpers exist
-    # to remove. `str.split("", 1)` raised instead; keep that floor.
+    # "" matches at index 0 of every string, and an empty step/job name matches a bare
+    # `- name:` line vacuously, so an empty bound is no bound — the shape these helpers
+    # exist to remove. `str.split("", 1)` raised too; keep that floor across the family.
     if not marker:
-        raise ValueError("marker must not be empty")
+        raise ValueError(f"marker {marker!r} must not be empty")

--- a/tests/_workflow_steps.py
+++ b/tests/_workflow_steps.py
@@ -1,11 +1,17 @@
-"""Bound a workflow YAML "- name: <step>" block to that step's own body.
+"""Bound a document slice to its landmark, so a reworded landmark FAILS the test.
 
-Test-only helper shared by tests/test_issue2143_*.py: those suites assert
-against one named step's env/run text inside a `.github/workflows/*.yml` file.
-A plain ``str.split(marker, 1)[1]`` slices to end-of-file, so an assertion
-against the slice can accidentally match a LATER, unrelated step once anything
-is appended after the one under test. ``extract_step`` stops at the next
-sibling list item (`- ...`) at the SAME indentation instead.
+Test-only helpers for the contract suites that assert against one region of a
+`.github/workflows/*.yml`, a policy/skill Markdown file, or a `src/` source file.
+A plain ``str.split(marker, 1)[1]`` slices to end-of-file, so an assertion against
+the slice can accidentally match a LATER, unrelated step; and ``[0]`` on an absent
+terminator returns the WHOLE string, so the slice silently stops bounding anything
+the moment an ordinary documentation edit rewords the landmark (issue #2669; it hit
+PR #2663 for real). Every helper here makes the landmark load-bearing: a missing one
+raises ``ValueError`` naming it instead of quietly widening the region.
+
+``extract_after``/``extract_before``/``extract_between`` bound an arbitrary landmark
+pair; ``extract_step``/``extract_job`` know the workflow-YAML shapes and stop at the
+next sibling at the same indentation.
 """
 
 from __future__ import annotations
@@ -45,9 +51,40 @@ def extract_job(workflow: str, job_name: str) -> str:
     """
     marker = re.compile(rf"^  {re.escape(job_name)}:\n", re.MULTILINE)
     match = marker.search(workflow)
-    assert match is not None, f"job {job_name!r} not found in workflow"
+    if match is None:
+        raise ValueError(f"job {job_name!r} not found in workflow")
     start = match.end()
     sibling = re.compile(r"^  [A-Za-z0-9_-]+:\n", re.MULTILINE)
     next_match = sibling.search(workflow, start)
     end = next_match.start() if next_match else len(workflow)
     return workflow[start:end]
+
+
+def extract_after(text: str, marker: str) -> str:
+    """Return the part of ``text`` after the first ``marker``.
+
+    ``ValueError`` naming ``marker`` when it is absent — the ``split(marker, 1)[1]``
+    form raises a bare ``IndexError`` that names nothing.
+    """
+    start = text.find(marker)
+    if start < 0:
+        raise ValueError(f"marker {marker!r} not found in text")
+    return text[start + len(marker) :]
+
+
+def extract_before(text: str, marker: str) -> str:
+    """Return the part of ``text`` before the first ``marker``.
+
+    ``ValueError`` naming ``marker`` when it is absent — this is the silent case:
+    ``split(marker, 1)[0]`` returns the whole string and the slice stops bounding.
+    """
+    end = text.find(marker)
+    if end < 0:
+        raise ValueError(f"marker {marker!r} not found in text")
+    return text[:end]
+
+
+def extract_between(text: str, start_marker: str, end_marker: str) -> str:
+    """Return the region of ``text`` between ``start_marker`` and the next
+    ``end_marker`` after it; either one absent raises ``ValueError`` naming it."""
+    return extract_before(extract_after(text, start_marker), end_marker)

--- a/tests/smoke/ui/test_render_smoke.py
+++ b/tests/smoke/ui/test_render_smoke.py
@@ -38,6 +38,8 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+from tests._workflow_steps import extract_between
+
 from .. import helpers, pkg_identity
 from .render_oracle import PhpErrorLogGuard, evaluate_render
 from .test_category import _snapshot_node
@@ -3272,7 +3274,7 @@ def test_dnsbl_regex_save_uses_package_python_wrapper() -> None:
     """
     source_path = helpers.SMOKE_DIR.parent.parent / "src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php"
     source = source_path.read_text(encoding="utf-8")
-    block = source.split("// A usable validator always runs", 1)[1].split("// Validate DNSBL VIP address", 1)[0]
+    block = extract_between(source, "// A usable validator always runs", "// Validate DNSBL VIP address")
 
     assert "$pfb_regex_python = pfb_python_interpreter();" in block
     assert re.search(
@@ -3287,7 +3289,7 @@ def test_pfblockerng_tick_delegates_safesearch_to_due_ledger() -> None:
     source_path = helpers.SMOKE_DIR.parent.parent / "src/usr/local/www/pfblockerng/pfblockerng.php"
     source = source_path.read_text(encoding="utf-8")
 
-    tick_branch = source.split("elseif ($argv[1] == 'tick') {", 1)[1].split("elseif ($argv[1] == 'cron-tick') {", 1)[0]
+    tick_branch = extract_between(source, "elseif ($argv[1] == 'tick') {", "elseif ($argv[1] == 'cron-tick') {")
     assert tick_branch.count("pfblockerng_tick();") == 1
     assert "pfblockerng_ss_refresh" not in tick_branch
 

--- a/tests/test_agent_roles_check.py
+++ b/tests/test_agent_roles_check.py
@@ -19,6 +19,7 @@ import subprocess
 import sys
 from pathlib import Path
 
+from tests._workflow_steps import extract_after, extract_before, extract_between
 from tests.gitenv import scrubbed_git_env
 
 _TOOL = Path(__file__).resolve().parent.parent / "scripts" / "check_agent_roles.py"
@@ -175,8 +176,8 @@ def test_ci_workflow_paths_match_checker_triggers() -> None:
     # Compare each trigger block INDEPENDENTLY: the two hand-duplicated paths
     # lists drift exactly one-block-at-a-time, and a whole-file set comparison
     # cannot see an entry dropped from only one of them.
-    push_block, _, tail = text.partition("pull_request:")
-    pr_block = tail.partition("permissions:")[0]
+    push_block = extract_before(text, "pull_request:")
+    pr_block = extract_between(text, "pull_request:", "permissions:")
     for name, block in (("push", push_block), ("pull_request", pr_block)):
         listed = re.findall(r"^\s+- '([^']+)'\s*$", block, re.MULTILINE)
         assert len(listed) == len(expected), f"{name} paths list has duplicates or gaps: {sorted(listed)}"
@@ -187,7 +188,7 @@ def test_ci_workflow_runs_on_push() -> None:
     # Dev-only classes (skills, agent config, policy docs) land as direct pushes
     # to devel, so a pull_request-only gate never sees the dominant landing path.
     text = _workflow_text()
-    push_block = text.partition("pull_request:")[0]
+    push_block = extract_before(text, "pull_request:")
     assert "push:" in push_block, "dev-only surfaces land as direct pushes to devel"
     assert re.search(r"^\s+branches: \[main, devel\]$", push_block, re.MULTILINE), push_block
 
@@ -195,7 +196,7 @@ def test_ci_workflow_runs_on_push() -> None:
 def test_ci_workflow_runs_the_parity_gate() -> None:
     # Match the RUN step, not the guard's name anywhere: the name is also a trigger
     # path, so a bare substring assertion stays green with the step deleted.
-    steps = _workflow_text().partition("\njobs:")[2]
+    steps = extract_after(_workflow_text(), "\njobs:")
     assert re.search(rf"^\s+run: sh {re.escape(_PARITY_GUARD)}$", steps, re.MULTILINE), steps
 
 

--- a/tests/test_benchmarks_ci_deps.py
+++ b/tests/test_benchmarks_ci_deps.py
@@ -11,6 +11,8 @@ import re
 import tomllib
 from pathlib import Path
 
+from tests._workflow_steps import extract_after
+
 ROOT = Path(__file__).resolve().parents[1]
 
 # `pip` and `pip3` name the same installer, and both spellings are on a runner's PATH.
@@ -28,7 +30,7 @@ def _pinned_benchmark_packages() -> set[str]:
 
 def _benchmarks_job() -> str:
     """The `benchmarks` job of test.yml, sliced at the next job key."""
-    rest = (ROOT / ".github/workflows/test.yml").read_text(encoding="utf-8").split("\n  benchmarks:\n", 1)[1]
+    rest = extract_after((ROOT / ".github/workflows/test.yml").read_text(encoding="utf-8"), "\n  benchmarks:\n")
     end = re.search(r"^  [A-Za-z0-9_.-]+:\s*$", rest, re.MULTILINE)
     return rest[: end.start()] if end else rest
 

--- a/tests/test_ci_graphify_merge_driver.py
+++ b/tests/test_ci_graphify_merge_driver.py
@@ -236,7 +236,7 @@ def test_exhaustive_push_matrix_has_graphify_driver_before_each_mutation() -> No
         workflow = (WORKFLOWS / spec.workflow).read_text(encoding="utf-8")
         try:
             _assert_job_contract(extract_job(workflow, spec.job), spec)
-        except AssertionError as error:
+        except (AssertionError, ValueError) as error:
             failures.append(str(error))
     assert not failures, "\n" + "\n".join(failures)
 

--- a/tests/test_ci_tool_pins.py
+++ b/tests/test_ci_tool_pins.py
@@ -2,8 +2,6 @@ import re
 from collections.abc import Iterable
 from pathlib import Path
 
-from tests._workflow_steps import extract_between
-
 ROOT = Path(__file__).resolve().parents[1]
 
 SHELLCHECK_PIN = "v0.11.0"
@@ -103,10 +101,6 @@ def test_pin_scanner_reports_a_planted_disagreement() -> None:
 
 def _contributing() -> str:
     return (ROOT / "CONTRIBUTING.md").read_text(encoding="utf-8")
-
-
-def _job(workflow: str, name: str, next_name: str) -> str:
-    return extract_between(workflow, f"\n  {name}:\n", f"\n  {next_name}:\n")
 
 
 def test_ci_shellcheck_pin_matches_the_documented_local_version() -> None:

--- a/tests/test_ci_tool_pins.py
+++ b/tests/test_ci_tool_pins.py
@@ -2,6 +2,8 @@ import re
 from collections.abc import Iterable
 from pathlib import Path
 
+from tests._workflow_steps import extract_between
+
 ROOT = Path(__file__).resolve().parents[1]
 
 SHELLCHECK_PIN = "v0.11.0"
@@ -104,7 +106,7 @@ def _contributing() -> str:
 
 
 def _job(workflow: str, name: str, next_name: str) -> str:
-    return workflow.split(f"\n  {name}:\n", 1)[1].split(f"\n  {next_name}:\n", 1)[0]
+    return extract_between(workflow, f"\n  {name}:\n", f"\n  {next_name}:\n")
 
 
 def test_ci_shellcheck_pin_matches_the_documented_local_version() -> None:

--- a/tests/test_context_budget.py
+++ b/tests/test_context_budget.py
@@ -20,6 +20,7 @@ from pathlib import Path
 
 import pytest
 
+from tests._workflow_steps import extract_before, extract_between
 from tests.gitenv import scrubbed_git_env
 
 _TOOL = Path(__file__).resolve().parent.parent / "scripts" / "check_context_budget.py"
@@ -891,8 +892,8 @@ def test_ci_workflow_paths_match_checker_triggers() -> None:
     # lists drift exactly one-block-at-a-time, and a whole-file set comparison
     # cannot see an entry dropped from only one of them.
     assert "push:" in text, "md-only pushes straight to devel are the dominant re-accretion vector"
-    push_block, _, tail = text.partition("pull_request:")
-    pr_block = tail.partition("permissions:")[0]
+    push_block = extract_before(text, "pull_request:")
+    pr_block = extract_between(text, "pull_request:", "permissions:")
     for name, block in (("push", push_block), ("pull_request", pr_block)):
         listed = re.findall(r"^\s+- '([^']+)'\s*$", block, re.MULTILINE)
         assert len(listed) == len(expected), f"{name} paths list has duplicates or gaps: {sorted(listed)}"

--- a/tests/test_cross_agent_tooling.py
+++ b/tests/test_cross_agent_tooling.py
@@ -7,6 +7,8 @@ import json
 import subprocess
 from pathlib import Path
 
+from tests._workflow_steps import extract_between
+
 ROOT = Path(__file__).resolve().parent.parent
 REPO_SKILLS = {
     "coderabbit",
@@ -157,7 +159,7 @@ def test_repository_intelligence_routing_is_canonical_for_every_client() -> None
     bootstrap = (ROOT / "AGENTS.md").read_text(encoding="utf-8")
     heading = "## Repository intelligence routing"
     assert heading in bootstrap, "repository-intelligence routing must be vendor-neutral"
-    routing = bootstrap.split(heading, 1)[1].split("\n## ", 1)[0]
+    routing = extract_between(bootstrap, heading, "\n## ")
     for contract in (
         "scripts/agent/ensure-codegraph.sh",
         "codegraph_explore",

--- a/tests/test_image_refresh_plan_contract.py
+++ b/tests/test_image_refresh_plan_contract.py
@@ -57,8 +57,8 @@ def _run_plan(
     source = WORKFLOW.read_text(encoding="utf-8")
     step = extract_between(source, f"      - name: {STEP_NAME}\n", "\n      - name:")
     # The run-block body is every ≥10-space-indented line after `run: |`; the
-    # first shallower line ends it (this step is the last of its job, so a
-    # step-boundary split alone would leak the next job's YAML into the script).
+    # first shallower line ends it, because a step boundary alone can leak a later
+    # job's YAML in (the terminator matches the next `- name:` anywhere below).
     body: list[str] = []
     for line in extract_after(step, "        run: |\n").splitlines():
         if not line.strip():

--- a/tests/test_image_refresh_plan_contract.py
+++ b/tests/test_image_refresh_plan_contract.py
@@ -21,6 +21,8 @@ import subprocess
 from pathlib import Path
 from typing import Any
 
+from tests._workflow_steps import extract_after, extract_between
+
 ROOT = Path(__file__).resolve().parents[1]
 WORKFLOW = ROOT / ".github" / "workflows" / "image-refresh.yml"
 STEP_NAME = "Build refresh matrix from ci-metadata"
@@ -53,12 +55,12 @@ def _run_plan(
 ) -> dict[str, Any]:
     """Extract the plan step's run script and execute it against a fixture."""
     source = WORKFLOW.read_text(encoding="utf-8")
-    step = source.split(f"      - name: {STEP_NAME}\n", 1)[1].split("\n      - name:", 1)[0]
+    step = extract_between(source, f"      - name: {STEP_NAME}\n", "\n      - name:")
     # The run-block body is every ≥10-space-indented line after `run: |`; the
     # first shallower line ends it (this step is the last of its job, so a
     # step-boundary split alone would leak the next job's YAML into the script).
     body: list[str] = []
-    for line in step.split("        run: |\n", 1)[1].splitlines():
+    for line in extract_after(step, "        run: |\n").splitlines():
         if not line.strip():
             body.append("")
         elif line.startswith("          "):
@@ -350,9 +352,9 @@ class TestActivationPr:
         expect_failure: bool = False,
     ) -> tuple[str, str, Path]:
         source = WORKFLOW.read_text(encoding="utf-8")
-        step = source.split(f"      - name: {ACTIVATION_STEP}\n", 1)[1].split("\n      - name:", 1)[0]
+        step = extract_between(source, f"      - name: {ACTIVATION_STEP}\n", "\n      - name:")
         body: list[str] = []
-        for line in step.split("        run: |\n", 1)[1].splitlines():
+        for line in extract_after(step, "        run: |\n").splitlines():
             if not line.strip():
                 body.append("")
             elif line.startswith("          "):

--- a/tests/test_image_refresh_upgrade_contract.py
+++ b/tests/test_image_refresh_upgrade_contract.py
@@ -8,6 +8,8 @@ from pathlib import Path
 
 import pytest
 
+from tests._workflow_steps import extract_after
+
 ROOT = Path(__file__).resolve().parents[1]
 WORKFLOW = ROOT / ".github" / "workflows" / "image-refresh.yml"
 
@@ -20,7 +22,7 @@ def _upgrade_script() -> str:
     step_end = source.index("\n      - name:", step_id)
     step = source[step_start:step_end]
     body: list[str] = []
-    for line in step.split("        run: |\n", 1)[1].splitlines():
+    for line in extract_after(step, "        run: |\n").splitlines():
         if not line.strip():
             body.append("")
         elif line.startswith("          "):

--- a/tests/test_issue2143_adversarial_regressions.py
+++ b/tests/test_issue2143_adversarial_regressions.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import pytest
 
 from scripts.release_version import derive_destinations, derive_destinations_from_git
+from tests._workflow_steps import extract_between
 from tests.gitenv import scrubbed_git_env
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -82,7 +83,7 @@ def test_other_tags_ordered_or_branch_mapped_never_change_current_tag_destinatio
 
 
 def test_sync_ports_uses_only_exact_channel_recipe_paths() -> None:
-    sync = PUBLISHED.split("\n  sync-ports-fork:\n", 1)[1].split("\n  publish-pkg:\n", 1)[0]
+    sync = extract_between(PUBLISHED, "\n  sync-ports-fork:\n", "\n  publish-pkg:\n")
     assert '"stable") PORT_PATH="net/pfSense-pkg-pfBlockerNG"' in sync
     assert '"testing") PORT_PATH="net/pfSense-pkg-pfBlockerNG-testing"' in sync
     assert '"edge") PORT_PATH="net/pfSense-pkg-pfBlockerNG-edge"' in sync

--- a/tests/test_issue2143_callback_destinations.py
+++ b/tests/test_issue2143_callback_destinations.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from tests._workflow_steps import extract_after, extract_between
+
 ROOT = Path(__file__).resolve().parents[1]
 
 PUBLISHED = (ROOT / ".github/workflows/release-published.yml").read_text(encoding="utf-8")
@@ -32,18 +34,18 @@ def test_manual_callback_validates_published_release_and_derives_tuple() -> None
 
 
 def test_published_callback_uses_full_history_for_branch_ancestry() -> None:
-    checkout = PUBLISHED.split("uses: actions/checkout@v6", 1)[1].split("      - name: Classify", 1)[0]
+    checkout = extract_between(PUBLISHED, "uses: actions/checkout@v6", "      - name: Classify")
     assert "fetch-depth: 0" in checkout
 
 
 def test_tagged_callers_forward_live_smoke_secrets_through_both_reusable_hops() -> None:
     for workflow in (PUBLISHED, MANUAL):
-        publish_job = workflow.split("  publish-pkg:", 1)[1]
+        publish_job = extract_after(workflow, "  publish-pkg:")
         assert "secrets: inherit" in publish_job
         assert "PKG_GITHUB_APP_ID:" not in publish_job
         assert "PKG_GITHUB_APP_PRIVATE_KEY:" not in publish_job
 
-    live_gate_job = TAGGED_INGEST.split("  validate-live-pages-install:", 1)[1].split("\n  finalize-pkg:", 1)[0]
+    live_gate_job = extract_between(TAGGED_INGEST, "  validate-live-pages-install:", "\n  finalize-pkg:")
     assert "uses: ./.github/workflows/smoke-single.yml" in live_gate_job
     assert "secrets: inherit" in live_gate_job
     assert "SMOKE_SSH_PRIV_KEY" in SMOKE_SINGLE
@@ -51,17 +53,17 @@ def test_tagged_callers_forward_live_smoke_secrets_through_both_reusable_hops() 
 
 def test_every_pkg_mutation_orchestrator_keeps_queued_runs() -> None:
     for workflow in (PUBLISHED, MANUAL, NIGHTLY):
-        concurrency = workflow.split("concurrency:", 1)[1].split("\njobs:", 1)[0]
+        concurrency = extract_between(workflow, "concurrency:", "\njobs:")
         assert "group: pkg-repository-mutation" in concurrency
         assert "queue: max" in concurrency
         assert "cancel-in-progress: false" in concurrency
 
 
 def test_tagged_intermediate_preserves_package_read_for_nested_smoke() -> None:
-    permissions = TAGGED_INGEST.split("permissions:", 1)[1].split("\njobs:", 1)[0]
+    permissions = extract_between(TAGGED_INGEST, "permissions:", "\njobs:")
     assert "contents: read" in permissions
     assert "packages: read" in permissions
-    manual_permissions = MANUAL.split("permissions:", 1)[1].split("\nconcurrency:", 1)[0]
+    manual_permissions = extract_between(MANUAL, "permissions:", "\nconcurrency:")
     assert "packages: read" in manual_permissions
 
 
@@ -72,5 +74,5 @@ def test_live_pkg_publication_stays_disabled_until_owner_enables_it() -> None:
         (MANUAL, "publish-pkg"),
         (NIGHTLY, "publish-nightly-oci"),
     ):
-        job = workflow.split(f"  {job_name}:", 1)[1]
+        job = extract_after(workflow, f"  {job_name}:")
         assert gate in "\n".join(job.splitlines()[:5])

--- a/tests/test_issue2143_review_contract.py
+++ b/tests/test_issue2143_review_contract.py
@@ -8,7 +8,7 @@ import subprocess
 import textwrap
 from pathlib import Path
 
-from tests._workflow_steps import extract_after, extract_before, extract_between
+from tests._workflow_steps import extract_after, extract_between
 
 ROOT = Path(__file__).resolve().parents[1]
 RELEASE = (ROOT / ".github/workflows/release.yml").read_text(encoding="utf-8")
@@ -34,8 +34,9 @@ def test_release_build_outputs_keep_source_checkout_clean_and_native_identity() 
     assert 'export PFB_RUN_ROOT="$GITHUB_WORKSPACE/out"' not in RELEASE
     assert 'RENAMED="${PKG_DIR}/${BASE}-${VARIANT}-${PFSENSE_VERSION}.pkg"' in RELEASE
     assert 'RENAMED_DEP="${DEP_PKG_DIR}/${DEP_BASE}-${VARIANT}-${PFSENSE_VERSION}.pkg"' in RELEASE
-    record_step = extract_after(RELEASE, "name: Write the destination-bound build record")
-    record_step = extract_before(record_step, "name: Build the .pkg via build-leg.sh")
+    record_step = extract_between(
+        RELEASE, "name: Write the destination-bound build record", "name: Build the .pkg via build-leg.sh"
+    )
     assert '"destinations":' not in record_step
 
 

--- a/tests/test_issue2143_review_contract.py
+++ b/tests/test_issue2143_review_contract.py
@@ -8,6 +8,8 @@ import subprocess
 import textwrap
 from pathlib import Path
 
+from tests._workflow_steps import extract_after, extract_before, extract_between
+
 ROOT = Path(__file__).resolve().parents[1]
 RELEASE = (ROOT / ".github/workflows/release.yml").read_text(encoding="utf-8")
 REPUBLISH = (ROOT / ".github/workflows/pkg-republish.yml").read_text(encoding="utf-8")
@@ -32,8 +34,8 @@ def test_release_build_outputs_keep_source_checkout_clean_and_native_identity() 
     assert 'export PFB_RUN_ROOT="$GITHUB_WORKSPACE/out"' not in RELEASE
     assert 'RENAMED="${PKG_DIR}/${BASE}-${VARIANT}-${PFSENSE_VERSION}.pkg"' in RELEASE
     assert 'RENAMED_DEP="${DEP_PKG_DIR}/${DEP_BASE}-${VARIANT}-${PFSENSE_VERSION}.pkg"' in RELEASE
-    record_step = RELEASE.split("name: Write the destination-bound build record", 1)[1]
-    record_step = record_step.split("name: Build the .pkg via build-leg.sh", 1)[0]
+    record_step = extract_after(RELEASE, "name: Write the destination-bound build record")
+    record_step = extract_before(record_step, "name: Build the .pkg via build-leg.sh")
     assert '"destinations":' not in record_step
 
 
@@ -44,14 +46,14 @@ def test_manual_republish_inputs_are_individually_required() -> None:
 
 def test_release_build_leg_step_binds_variant_from_the_matrix_row() -> None:
     """The invocation test supplies VARIANT itself, so pin the step env that defines it."""
-    step = RELEASE.split("      - name: Build the .pkg via build-leg.sh", 1)[1].split("        run: |", 1)[0]
+    step = extract_between(RELEASE, "      - name: Build the .pkg via build-leg.sh", "        run: |")
     assert "VARIANT:" in step
-    assert "${{ matrix.variant }}" in step.split("VARIANT:", 1)[1].split("\n", 1)[0]
+    assert "${{ matrix.variant }}" in extract_after(step, "VARIANT:").split("\n", 1)[0]
 
 
 def test_release_build_leg_passes_variant_to_builder(tmp_path: Path) -> None:
     marker = '          PKG="$(sh scripts/build-leg.sh \\\n'
-    invocation = marker + RELEASE.split(marker, 1)[1].split("          PKG_DIR=", 1)[0]
+    invocation = marker + extract_between(RELEASE, marker, "          PKG_DIR=")
     fake_builder = tmp_path / "build-leg.sh"
     captured = tmp_path / "args"
     fake_builder.write_text(
@@ -101,8 +103,8 @@ def test_release_build_leg_passes_variant_to_builder(tmp_path: Path) -> None:
 
 
 def test_release_build_leg_places_generated_trees_outside_source(tmp_path: Path) -> None:
-    block = RELEASE.split("      - name: Build the .pkg via build-leg.sh", 1)[1]
-    invocation = textwrap.dedent(block.split("        run: |\n", 1)[1].split("          PKG_DIR=", 1)[0])
+    block = extract_after(RELEASE, "      - name: Build the .pkg via build-leg.sh")
+    invocation = textwrap.dedent(extract_between(block, "        run: |\n", "          PKG_DIR="))
     fake_dir = tmp_path / "fake scripts;safe"
     fake_dir.mkdir()
     fake_builder = fake_dir / "build-leg.sh"

--- a/tests/test_issue2143_review_round2.py
+++ b/tests/test_issue2143_review_round2.py
@@ -10,19 +10,21 @@ from pathlib import Path
 
 import pytest
 
+from tests._workflow_steps import extract_after, extract_between
+
 ROOT = Path(__file__).resolve().parents[1]
 RELEASE = (ROOT / ".github/workflows/release.yml").read_text(encoding="utf-8")
 REPUBLISH = (ROOT / ".github/workflows/pkg-republish.yml").read_text(encoding="utf-8")
 
 
 def _build_record_script() -> str:
-    block = RELEASE.split("      - name: Write the destination-bound build record", 1)[1]
-    return textwrap.dedent(block.split("        run: |\n", 1)[1].split("\n      - name:", 1)[0])
+    block = extract_after(RELEASE, "      - name: Write the destination-bound build record")
+    return textwrap.dedent(extract_between(block, "        run: |\n", "\n      - name:"))
 
 
 def _republish_validate_script() -> str:
-    block = REPUBLISH.split("      - name: Resolve exact immutable Release", 1)[1]
-    script = block.split("        run: |\n", 1)[1].split("\n          git fetch", 1)[0]
+    block = extract_after(REPUBLISH, "      - name: Resolve exact immutable Release")
+    script = extract_between(block, "        run: |\n", "\n          git fetch")
     return textwrap.dedent(script) + "\nexit 0\n"
 
 

--- a/tests/test_issue2143_workflow.py
+++ b/tests/test_issue2143_workflow.py
@@ -7,6 +7,8 @@ import subprocess
 import textwrap
 from pathlib import Path
 
+from tests._workflow_steps import extract_after, extract_between
+
 ROOT = Path(__file__).resolve().parents[1]
 
 RELEASE = (ROOT / ".github/workflows/release.yml").read_text(encoding="utf-8")
@@ -33,8 +35,8 @@ def test_published_callback_dispatches_exact_release_identity() -> None:
 
 
 def _republish_validate_script() -> str:
-    block = REPUBLISH.split("      - name: Resolve exact immutable Release", 1)[1]
-    script = block.split("        run: |\n", 1)[1].split("\n          git fetch", 1)[0]
+    block = extract_after(REPUBLISH, "      - name: Resolve exact immutable Release")
+    script = extract_between(block, "        run: |\n", "\n          git fetch")
     return textwrap.dedent(script) + "\nexit 0\n"
 
 

--- a/tests/test_issue2145_release_skills.py
+++ b/tests/test_issue2145_release_skills.py
@@ -13,6 +13,7 @@ from scripts.release_version import (
     primary_channel_for_tag,
     select_previous_release_tag,
 )
+from tests._workflow_steps import extract_after
 
 ROOT = Path(__file__).resolve().parents[1]
 RELEASE = ROOT / ".agents/skills/release/SKILL.md"
@@ -237,7 +238,7 @@ def test_workflow_propagates_trusted_release_contract_outputs() -> None:
 
 
 def test_draft_healthcheck_propagates_final_asset_handoff() -> None:
-    workflow = _text(WORKFLOW).split("  draft-healthcheck:", 1)[1]
+    workflow = extract_after(_text(WORKFLOW), "  draft-healthcheck:")
     for output in (
         "primary_kind:",
         "destination_tuple:",

--- a/tests/test_issue2347_short_nightly_sha.py
+++ b/tests/test_issue2347_short_nightly_sha.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import pytest
 
 from scripts import release_version as rv
+from tests._workflow_steps import extract_between
 
 ROOT = Path(__file__).resolve().parent.parent
 NIGHTLY_WORKFLOW = ROOT / ".github" / "workflows" / "nightly.yml"
@@ -30,7 +31,7 @@ def test_nightly_workflow_shortens_only_the_package_version_sha() -> None:
 
 def test_smoke_fixture_keeps_full_sha_annotation() -> None:
     workflow = SMOKE_WORKFLOW.read_text(encoding="utf-8")
-    nightly = workflow.split("- name: Build a nightly .pkg", 1)[1].split("\n      # ADR-24", 1)[0]
+    nightly = extract_between(workflow, "- name: Build a nightly .pkg", "\n      # ADR-24")
 
     assert 'SOURCE_SHORT_SHA="$(printf \'%.7s\' "$SOURCE_SHA")"' in nightly
     assert 'NIGHTLY_VERSION="$(date -u +%Y%m%d%H%M%S).${SOURCE_SHORT_SHA}"' in nightly

--- a/tests/test_issue2456_pkg_ownership.py
+++ b/tests/test_issue2456_pkg_ownership.py
@@ -6,7 +6,7 @@ import textwrap
 import unittest
 from pathlib import Path
 
-from tests._workflow_steps import extract_job, extract_step
+from tests._workflow_steps import extract_after, extract_before, extract_job, extract_step
 
 ROOT = Path(__file__).resolve().parents[1]
 WORKFLOWS = ROOT / ".github" / "workflows"
@@ -122,9 +122,9 @@ class SourcePublicationBoundaryTests(unittest.TestCase):
             finalize,
         )
         step = extract_step(finalize, "Promote a green stage or discard every other outcome")
-        script = textwrap.dedent(step.split("        run: |\n", 1)[1]).split(
-            "sh scripts/dispatch-pkg-publication.sh", 1
-        )[0]
+        script = extract_before(
+            textwrap.dedent(extract_after(step, "        run: |\n")), "sh scripts/dispatch-pkg-publication.sh"
+        )
         script += '\nprintf "%s\\n" "$PKG_OPERATION"\n'
         for gate_green, expected in (("true", "tagged-promote"), ("false", "tagged-discard")):
             completed = subprocess.run(

--- a/tests/test_issue2669_landmark_bounds.py
+++ b/tests/test_issue2669_landmark_bounds.py
@@ -3,13 +3,12 @@
 ``text.split(marker, 1)[0]`` returns the WHOLE string when ``marker`` is absent, so a
 slice bounded that way silently stops bounding anything the moment a documentation or
 workflow edit rewords the landmark: the slice grows to end-of-file and every assertion
-against it keeps passing. That is not hypothetical — PR #2663 reworded a doc phrase into
-the start of a sentence, the terminator vanished, the "recipe" slice grew from 655 to
-1363 characters, and the suite stayed green.
+against it keeps passing.
 
 These tests pin the replacement contract for the whole class: the landmark is
 load-bearing, an absent one raises ``ValueError`` naming it, and a present one yields
-byte-identically the same region the ``split`` form yielded.
+byte-identically the same region the ``split`` form yielded, bounding on the FIRST
+occurrence exactly as ``split(marker, 1)`` did.
 """
 
 from __future__ import annotations
@@ -78,10 +77,22 @@ def test_extract_between_raises_naming_the_absent_terminator() -> None:
     assert repr("MISSING-TERMINATOR") in str(excinfo.value)
 
 
-def test_extract_between_terminates_on_the_first_terminator_after_the_start_marker() -> None:
-    """A terminator that also appears BEFORE the start marker must not bound the slice."""
-    text = "END alpha START body END omega"
+def test_the_helpers_bound_on_the_first_occurrence_of_each_marker() -> None:
+    """Both markers repeat, and a terminator also sits BEFORE the start marker. Only
+    first-occurrence semantics — what ``split(marker, 1)`` gave — yields this region;
+    last-occurrence bounding widens it, which is the whole defect class."""
+    text = "END alpha START body END omega START again END tail"
+    assert extract_after(text, "START") == " body END omega START again END tail"
+    assert extract_before(text, "END") == ""
     assert extract_between(text, "START", "END") == " body "
+
+
+def test_an_empty_marker_raises_because_it_bounds_nothing() -> None:
+    """``"" in text`` is always true at index 0, so an empty marker is a bound that is
+    not there — the shape these helpers exist to remove. ``split("", 1)`` raised too."""
+    for helper in (extract_after, extract_before):
+        with pytest.raises(ValueError, match="must not be empty"):
+            helper(DOCUMENT, "")
 
 
 def test_extract_step_raises_naming_the_absent_step() -> None:
@@ -114,8 +125,7 @@ def test_reworded_landmark_in_a_real_document_raises_instead_of_widening(
     bounded = extract_between(document, start_marker, terminator)
     assert bounded == document.split(start_marker, 1)[1].split(terminator, 1)[0]
 
-    flipped = _reword(terminator)
-    reworded = document.replace(terminator, flipped, 1)
+    reworded = document.replace(terminator, terminator.swapcase())
     assert terminator not in reworded, f"reword did not remove {terminator!r}"
 
     widened = reworded.split(start_marker, 1)[1].split(terminator, 1)[0]
@@ -124,12 +134,3 @@ def test_reworded_landmark_in_a_real_document_raises_instead_of_widening(
     with pytest.raises(ValueError) as excinfo:
         extract_between(reworded, start_marker, terminator)
     assert repr(terminator) in str(excinfo.value)
-
-
-def _reword(marker: str) -> str:
-    """``marker`` with its first letter's case flipped — PR #2663's reword shape."""
-    for position, char in enumerate(marker):
-        if char.isalpha():
-            flipped = char.upper() if char.islower() else char.lower()
-            return marker[:position] + flipped + marker[position + 1 :]
-    raise AssertionError(f"marker {marker!r} carries no letter to reword")

--- a/tests/test_issue2669_landmark_bounds.py
+++ b/tests/test_issue2669_landmark_bounds.py
@@ -87,12 +87,23 @@ def test_the_helpers_bound_on_the_first_occurrence_of_each_marker() -> None:
     assert extract_between(text, "START", "END") == " body "
 
 
-def test_an_empty_marker_raises_because_it_bounds_nothing() -> None:
-    """``"" in text`` is always true at index 0, so an empty marker is a bound that is
-    not there — the shape these helpers exist to remove. ``split("", 1)`` raised too."""
-    for helper in (extract_after, extract_before):
+def test_an_empty_bound_raises_across_the_whole_family() -> None:
+    """``"" in text`` is true at index 0, and an empty step or job name matches a bare
+    ``- name:``/``  :`` line vacuously, so an empty bound is no bound at all — the shape
+    these helpers exist to remove. ``split("", 1)`` raised too. Every member owes it, or
+    the floor is only nearly total."""
+    vacuous = "jobs:\n  :\n    steps:\n      - name: \n        run: echo hi\n"
+    for helper, text in (
+        (extract_after, DOCUMENT),
+        (extract_before, DOCUMENT),
+        (extract_step, vacuous),
+        (extract_job, vacuous),
+    ):
         with pytest.raises(ValueError, match="must not be empty"):
-            helper(DOCUMENT, "")
+            helper(text, "")
+    for markers in (("", "END"), ("START", "")):
+        with pytest.raises(ValueError, match="must not be empty"):
+            extract_between(DOCUMENT, *markers)
 
 
 def test_extract_step_raises_naming_the_absent_step() -> None:

--- a/tests/test_issue2669_landmark_bounds.py
+++ b/tests/test_issue2669_landmark_bounds.py
@@ -1,0 +1,135 @@
+"""Issue #2669: a landmark that bounds a contract-test slice must be load-bearing.
+
+``text.split(marker, 1)[0]`` returns the WHOLE string when ``marker`` is absent, so a
+slice bounded that way silently stops bounding anything the moment a documentation or
+workflow edit rewords the landmark: the slice grows to end-of-file and every assertion
+against it keeps passing. That is not hypothetical — PR #2663 reworded a doc phrase into
+the start of a sentence, the terminator vanished, the "recipe" slice grew from 655 to
+1363 characters, and the suite stayed green.
+
+These tests pin the replacement contract for the whole class: the landmark is
+load-bearing, an absent one raises ``ValueError`` naming it, and a present one yields
+byte-identically the same region the ``split`` form yielded.
+"""
+
+from __future__ import annotations
+
+import pathlib
+
+import pytest
+
+from tests._workflow_steps import extract_after, extract_before, extract_between, extract_job, extract_step
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+DOCUMENT = "alpha START body-of-interest END omega"
+
+# One row per document flavour a converted call site slices, so the contract is pinned
+# against the real markers those sites use, not only against a synthetic fixture.
+REAL_DOCUMENTS = [
+    pytest.param(".github/workflows/release-published.yml", "\non:\n", "\npermissions:\n", id="workflow-yaml"),
+    pytest.param(".agents/policy/landing.md", "## Merge step", "## Post-merge", id="markdown-policy"),
+    pytest.param(
+        "src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php",
+        "// A usable validator always runs",
+        "// Validate DNSBL VIP address",
+        id="php-source",
+    ),
+]
+
+
+def test_extract_after_returns_the_region_the_split_form_returned() -> None:
+    """The conversion must not move the region: same marker in, same bytes out."""
+    assert extract_after(DOCUMENT, "START") == DOCUMENT.split("START", 1)[1]
+
+
+def test_extract_after_raises_naming_the_absent_marker() -> None:
+    with pytest.raises(ValueError) as excinfo:
+        extract_after(DOCUMENT, "MISSING-OPENER")
+    assert repr("MISSING-OPENER") in str(excinfo.value)
+
+
+def test_extract_before_returns_the_region_the_split_form_returned() -> None:
+    assert extract_before(DOCUMENT, "END") == DOCUMENT.split("END", 1)[0]
+
+
+def test_extract_before_raises_instead_of_widening_to_the_whole_string() -> None:
+    """Given a terminator that is gone, the ``split`` form widens silently; ``extract_before``
+    must raise instead. The before-state assertion is what makes green prove the flip."""
+    assert DOCUMENT.split("MISSING-TERMINATOR", 1)[0] == DOCUMENT  # the defect, unbounded
+    with pytest.raises(ValueError) as excinfo:
+        extract_before(DOCUMENT, "MISSING-TERMINATOR")
+    assert repr("MISSING-TERMINATOR") in str(excinfo.value)
+
+
+def test_extract_between_returns_the_region_the_chained_split_form_returned() -> None:
+    assert extract_between(DOCUMENT, "START", "END") == DOCUMENT.split("START", 1)[1].split("END", 1)[0]
+
+
+def test_extract_between_raises_naming_the_absent_start_marker() -> None:
+    with pytest.raises(ValueError) as excinfo:
+        extract_between(DOCUMENT, "MISSING-OPENER", "END")
+    assert repr("MISSING-OPENER") in str(excinfo.value)
+
+
+def test_extract_between_raises_naming_the_absent_terminator() -> None:
+    with pytest.raises(ValueError) as excinfo:
+        extract_between(DOCUMENT, "START", "MISSING-TERMINATOR")
+    assert repr("MISSING-TERMINATOR") in str(excinfo.value)
+
+
+def test_extract_between_terminates_on_the_first_terminator_after_the_start_marker() -> None:
+    """A terminator that also appears BEFORE the start marker must not bound the slice."""
+    text = "END alpha START body END omega"
+    assert extract_between(text, "START", "END") == " body "
+
+
+def test_extract_step_raises_naming_the_absent_step() -> None:
+    """The workflow-shape siblings owe the same named-`ValueError` contract: converted
+    sites bound a step or a job through them, so a silent miss there widens too."""
+    workflow = "jobs:\n  build:\n    steps:\n      - name: Present step\n        run: echo hi\n"
+    with pytest.raises(ValueError) as excinfo:
+        extract_step(workflow, "Absent step")
+    assert repr("Absent step") in str(excinfo.value)
+
+
+def test_extract_job_raises_naming_the_absent_job() -> None:
+    workflow = "jobs:\n  build:\n    steps:\n      - name: Present step\n        run: echo hi\n"
+    with pytest.raises(ValueError) as excinfo:
+        extract_job(workflow, "absent-job")
+    assert repr("absent-job") in str(excinfo.value)
+
+
+@pytest.mark.parametrize(("relative_path", "start_marker", "terminator"), REAL_DOCUMENTS)
+def test_reworded_landmark_in_a_real_document_raises_instead_of_widening(
+    relative_path: str, start_marker: str, terminator: str
+) -> None:
+    """Scenario: a real repository document whose landmark a future edit rewords.
+
+    Given the document as committed, when the terminator is case-flipped the way PR #2663's
+    reword flipped one, then the ``split`` form widens the slice and stays quiet while
+    ``extract_between`` raises naming the terminator that vanished.
+    """
+    document = (ROOT / relative_path).read_text(encoding="utf-8")
+    bounded = extract_between(document, start_marker, terminator)
+    assert bounded == document.split(start_marker, 1)[1].split(terminator, 1)[0]
+
+    flipped = _reword(terminator)
+    reworded = document.replace(terminator, flipped, 1)
+    assert terminator not in reworded, f"reword did not remove {terminator!r}"
+
+    widened = reworded.split(start_marker, 1)[1].split(terminator, 1)[0]
+    assert len(widened) > len(bounded), "the split form must be shown widening, or this proves nothing"
+
+    with pytest.raises(ValueError) as excinfo:
+        extract_between(reworded, start_marker, terminator)
+    assert repr(terminator) in str(excinfo.value)
+
+
+def _reword(marker: str) -> str:
+    """``marker`` with its first letter's case flipped — PR #2663's reword shape."""
+    for position, char in enumerate(marker):
+        if char.isalpha():
+            flipped = char.upper() if char.islower() else char.lower()
+            return marker[:position] + flipped + marker[position + 1 :]
+    raise AssertionError(f"marker {marker!r} carries no letter to reword")

--- a/tests/test_release_ci_path_consistency.py
+++ b/tests/test_release_ci_path_consistency.py
@@ -17,7 +17,7 @@ import yaml
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
-from _workflow_steps import extract_step
+from _workflow_steps import extract_after, extract_between, extract_step
 
 _JOB_HEADER_RE = re.compile(r"^  ([A-Za-z][A-Za-z0-9_-]*):[ \t]*$")
 
@@ -96,7 +96,7 @@ def test_issue_2388_ports_sync_runs_only_after_published_release_resolution() ->
     assert "sync-ports-fork" in published_jobs, "publishing must trigger the FreeBSD-ports bump"
     job_names = list(published_jobs)
     assert job_names.index("sync-ports-fork") == job_names.index("resolve") + 1
-    concurrency = published.split("\nconcurrency:\n", 1)[1].split("\njobs:\n", 1)[0]
+    concurrency = extract_between(published, "\nconcurrency:\n", "\njobs:\n")
     assert "  queue: max" in concurrency, "every published release must keep its queued ports bump"
 
     sync = "\n".join(published_jobs["sync-ports-fork"])
@@ -170,7 +170,7 @@ def test_issue_2387_pin_step_executes_against_exact_ci_metadata_sha(
 ) -> None:
     release = (ROOT / ".github/workflows/release.yml").read_text(encoding="utf-8")
     script = textwrap.dedent(
-        extract_step(release, "Pin ci-metadata, ROUTE, and Ports identities").split("run: |\n", 1)[1]
+        extract_after(extract_step(release, "Pin ci-metadata, ROUTE, and Ports identities"), "run: |\n")
     )
     fake_bin = tmp_path / "bin"
     fake_bin.mkdir()
@@ -304,7 +304,7 @@ def test_issue_2387_pin_step_executes_against_exact_ci_metadata_sha(
 
 def test_release_dependency_loop_executes_every_origin_with_locked_python(tmp_path: Path) -> None:
     release = (ROOT / ".github/workflows/release.yml").read_text(encoding="utf-8")
-    script = textwrap.dedent(extract_step(release, "Build the .pkg via build-leg.sh").split("run: |\n", 1)[1])
+    script = textwrap.dedent(extract_after(extract_step(release, "Build the .pkg via build-leg.sh"), "run: |\n"))
     lines = script.splitlines()
     start = next(index for index, line in enumerate(lines) if line.strip().startswith("DEP_PKG_DIR="))
     end = next(index for index, line in enumerate(lines[start:], start) if line.strip().startswith("for DEP_PKG in"))

--- a/tests/test_release_dry_run_gate.py
+++ b/tests/test_release_dry_run_gate.py
@@ -10,6 +10,8 @@ from pathlib import Path
 
 import pytest
 
+from tests._workflow_steps import extract_between
+
 ROOT = Path(__file__).resolve().parents[1]
 WORKFLOW = ROOT / ".github/workflows/release.yml"
 
@@ -234,8 +236,8 @@ def test_the_release_draft_step_is_gated_on_an_explicit_false() -> None:
 def test_dry_run_input_is_declared_boolean() -> None:
     """The dispatch form itself must only offer two values, not free-form text."""
     workflow_text = WORKFLOW.read_text(encoding="utf-8")
-    dispatch = workflow_text.split("\non:\n", 1)[1].split("\npermissions:\n", 1)[0]
-    dry_run_block = dispatch.split("      dry_run:\n", 1)[1].split("\n\n", 1)[0]
+    dispatch = extract_between(workflow_text, "\non:\n", "\npermissions:\n")
+    dry_run_block = extract_between(dispatch, "      dry_run:\n", "\n\n")
     assert re.search(r"^        type:\s*boolean\s*$", dry_run_block, re.MULTILINE), (
         f"dry_run input must declare `type: boolean`; block was:\n{dry_run_block}"
     )
@@ -248,8 +250,8 @@ def test_dry_run_input_defaults_to_the_safe_value() -> None:
     false and a dispatch that simply omits the input publishes for real.
     """
     workflow_text = WORKFLOW.read_text(encoding="utf-8")
-    dispatch = workflow_text.split("\non:\n", 1)[1].split("\npermissions:\n", 1)[0]
-    dry_run_block = dispatch.split("      dry_run:\n", 1)[1].split("\n\n", 1)[0]
+    dispatch = extract_between(workflow_text, "\non:\n", "\npermissions:\n")
+    dry_run_block = extract_between(dispatch, "      dry_run:\n", "\n\n")
     assert re.search(r"^        default:\s*(true|'true'|\"true\")\s*$", dry_run_block, re.MULTILINE), (
         f"dry_run input must default to true (a dry run); block was:\n{dry_run_block}"
     )
@@ -262,7 +264,7 @@ def test_metadata_step_rejects_non_boolean_dry_run() -> None:
     never reaches a downstream job/output at all.
     """
     workflow_text = WORKFLOW.read_text(encoding="utf-8")
-    meta_step = workflow_text.split("id: meta\n", 1)[1].split("\n      - name:", 1)[0]
+    meta_step = extract_between(workflow_text, "id: meta\n", "\n      - name:")
 
     guard_match = re.search(r'case "\$DRY_RUN" in\n(.*?)\n[ \t]*esac', meta_step, re.DOTALL)
     assert guard_match is not None, (

--- a/tests/test_release_skill_contract_details.py
+++ b/tests/test_release_skill_contract_details.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from tests._workflow_steps import extract_between
+
 ROOT = Path(__file__).resolve().parents[1]
 SKILLS = (
     ROOT / ".agents/skills/release/SKILL.md",
@@ -98,7 +100,7 @@ def test_channel_targets_are_explicit_and_nightly_is_not_branch_bound() -> None:
 
 def test_scripts_readme_nightly_contract_is_branch_independent() -> None:
     content = _text(ROOT / "scripts/README.md")
-    paragraph = content.split("## Release channel contract", 1)[1].split("## ", 1)[0]
+    paragraph = extract_between(content, "## Release channel contract", "## ")
     assert "Nightly is an independent untagged" in paragraph
     assert "pinned source SHA" in paragraph
     assert not any(branch in paragraph for branch in ("`devel`", "`main`", "release/X.Y"))

--- a/tests/test_release_tag_after_verify.py
+++ b/tests/test_release_tag_after_verify.py
@@ -37,6 +37,7 @@ from pathlib import Path
 
 import pytest
 
+from tests._workflow_steps import extract_after, extract_between
 from tests.gitenv import scrubbed_git_env
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -397,7 +398,7 @@ def test_downstream_publish_effects_do_not_run_in_the_draft_workflow() -> None:
 
 def test_the_published_workflow_triggers_on_a_published_release() -> None:
     text = PUBLISHED_WORKFLOW.read_text(encoding="utf-8")
-    on_block = text.split("\non:\n", 1)[1].split("\npermissions:\n", 1)[0]
+    on_block = extract_between(text, "\non:\n", "\npermissions:\n")
     assert "release:" in on_block, on_block
     assert "types: [published]" in on_block, on_block
 
@@ -674,11 +675,11 @@ def test_the_published_workflow_reads_the_tag_from_the_release_payload() -> None
 
 def test_release_dispatch_requires_explicit_channel_and_source() -> None:
     text = RELEASE_WORKFLOW.read_text(encoding="utf-8")
-    dispatch = text.split("\non:\n", 1)[1].split("\npermissions:\n", 1)[0]
-    channel = dispatch.split("      channel:\n", 1)[1].split("\n\n", 1)[0]
+    dispatch = extract_between(text, "\non:\n", "\npermissions:\n")
+    channel = extract_between(dispatch, "      channel:\n", "\n\n")
     assert re.search(r"^\s+type:\s*choice\s*$", channel, re.MULTILINE), channel
     assert re.search(r"^\s+options:\s*\[stable, testing, edge\]\s*$", channel, re.MULTILINE), channel
-    source = dispatch.split("      source:\n", 1)[1].split("\n\n", 1)[0]
+    source = extract_between(dispatch, "      source:\n", "\n\n")
     assert re.search(r"^\s+required:\s*true\s*$", source, re.MULTILINE), source
     assert "release/X.Y" in source, source
 
@@ -955,9 +956,9 @@ def test_release_33_decision_and_matrix_bindings_are_not_bypassed() -> None:
 
 def test_force_suites_input_is_declared_boolean_and_defaults_off() -> None:
     text = RELEASE_WORKFLOW.read_text(encoding="utf-8")
-    dispatch = text.split("\non:\n", 1)[1].split("\npermissions:\n", 1)[0]
+    dispatch = extract_between(text, "\non:\n", "\npermissions:\n")
     assert "force_suites:" in dispatch, "release.yml must offer a force_suites dispatch input"
-    block = dispatch.split("      force_suites:\n", 1)[1].split("\n\n", 1)[0]
+    block = extract_between(dispatch, "      force_suites:\n", "\n\n")
     assert re.search(r"^\s+type:\s*boolean\s*$", block, re.MULTILINE), block
     assert re.search(r"^\s+default:\s*false\s*$", block, re.MULTILINE), block
 
@@ -1129,9 +1130,9 @@ def test_tag_step_refuses_existing_tags_without_exact_channel_metadata(tmp_path:
 
 def test_retag_input_is_declared_boolean_and_defaults_off() -> None:
     text = RELEASE_WORKFLOW.read_text(encoding="utf-8")
-    dispatch = text.split("\non:\n", 1)[1].split("\npermissions:\n", 1)[0]
+    dispatch = extract_between(text, "\non:\n", "\npermissions:\n")
     assert "retag:" in dispatch, "release.yml must offer a retag dispatch input"
-    block = dispatch.split("      retag:\n", 1)[1].split("\n\n", 1)[0]
+    block = extract_between(dispatch, "      retag:\n", "\n\n")
     assert re.search(r"^\s+type:\s*boolean\s*$", block, re.MULTILINE), block
     assert re.search(r"^\s+default:\s*false\s*$", block, re.MULTILINE), block
 
@@ -1155,7 +1156,7 @@ def test_only_the_pin_job_may_delete_and_it_says_why() -> None:
     must be justified in place rather than silently widened."""
     body = "\n".join(_jobs()["prepare-release"])
     assert "contents: write" in body, body
-    assert "retag" in body.split("contents: write", 1)[1][:300], (
+    assert "retag" in extract_after(body, "contents: write")[:300], (
         "the write scope must name the retag deletion as its reason"
     )
     deleting_jobs = {name for name, lines in _jobs().items() if "gh release delete" in "\n".join(lines)}

--- a/tests/test_reproducible_source_archive.py
+++ b/tests/test_reproducible_source_archive.py
@@ -18,6 +18,8 @@ from typing import Any
 
 import pytest
 
+from tests._workflow_steps import extract_before, extract_between
+
 ROOT = Path(__file__).resolve().parents[1]
 BUILDER = ROOT / "scripts" / "build-source-archive.py"
 WORKFLOW = ROOT / ".github" / "workflows" / "release.yml"
@@ -400,7 +402,7 @@ def test_resolved_output_directory_replacement_uses_opened_identity(
 
 def _release_job() -> str:
     workflow = WORKFLOW.read_text(encoding="utf-8")
-    return workflow.split("  release:", 1)[1].split("\n  # ── 2b", 1)[0]
+    return extract_between(workflow, "  release:", "\n  # ── 2b")
 
 
 def _assert_archive_tool_pin_precedes_build(release_job: str) -> None:
@@ -408,7 +410,7 @@ def _assert_archive_tool_pin_precedes_build(release_job: str) -> None:
     archive_name = "      - name: Build source archive"
     pin_start = release_job.index(pin_name)
     archive_start = release_job.index(archive_name)
-    pin_step = release_job[pin_start:].split("\n      - name:", 1)[0]
+    pin_step = extract_before(release_job[pin_start:], "\n      - name:")
 
     assert "uses: actions/setup-python@v6" in pin_step
     assert 'python-version: "3.11.15"' in pin_step
@@ -417,7 +419,7 @@ def _assert_archive_tool_pin_precedes_build(release_job: str) -> None:
 
 def test_release_workflow_pins_and_uses_the_source_archive_builder() -> None:
     release_job = _release_job()
-    archive_step = release_job.split("      - name: Build source archive", 1)[1].split("\n      - name:", 1)[0]
+    archive_step = extract_between(release_job, "      - name: Build source archive", "\n      - name:")
 
     assert "runs-on: ubuntu-24.04" in release_job
     _assert_archive_tool_pin_precedes_build(release_job)

--- a/tests/test_shell_ci_routing.py
+++ b/tests/test_shell_ci_routing.py
@@ -7,6 +7,8 @@ from pathlib import Path
 
 import yaml
 
+from tests._workflow_steps import extract_after
+
 ROOT = Path(__file__).resolve().parents[1]
 
 
@@ -85,7 +87,7 @@ def test_the_shellspec_job_provides_the_locale_the_adr26_contract_needs() -> Non
     resolves, in the job itself, through commands that exit NONZERO when it does not:
     that it is listed at all, that LC_NUMERIC carries the decimal comma, and that awk
     — the interpreter the shard and module-duration specs probe through — reads it."""
-    rest = _read(".github/workflows/test.yml").split("\n  shell-tests:\n", 1)[1]
+    rest = extract_after(_read(".github/workflows/test.yml"), "\n  shell-tests:\n")
     end = re.search(r"^  [A-Za-z0-9_.-]+:\s*$", rest, re.MULTILINE)
     job = rest[: end.start()] if end else rest
     gaps = _locale_proof_gaps(job)

--- a/tests/test_smoke_ui_config_digest.py
+++ b/tests/test_smoke_ui_config_digest.py
@@ -28,6 +28,7 @@ from pathlib import Path
 
 import pytest
 
+from tests._workflow_steps import extract_after
 from tests.smoke import helpers
 
 _REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -360,7 +361,7 @@ def test_ui_job_budget_covers_live_vm_leg() -> None:
     smoke-single.yml already uses -- so a slow-but-healthy leg (setup alone ran
     ~23 of the observed 20m04s pass) isn't cancelled mid-run."""
     workflow = (_REPO_ROOT / ".github/workflows/ui-tests.yml").read_text(encoding="utf-8")
-    ui_job = workflow.split("\n  ui:\n", 1)[1]
+    ui_job = extract_after(workflow, "\n  ui:\n")
     match = re.search(r"^\s*timeout-minutes:\s*(\S+)\s*$", ui_job, re.MULTILINE)
     assert match, f"expected a timeout-minutes key under the `ui` job, found none in:\n{ui_job[:200]}"
 

--- a/tests/test_smoke_ui_config_digest.py
+++ b/tests/test_smoke_ui_config_digest.py
@@ -28,7 +28,7 @@ from pathlib import Path
 
 import pytest
 
-from tests._workflow_steps import extract_after
+from tests._workflow_steps import extract_job
 from tests.smoke import helpers
 
 _REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -361,7 +361,7 @@ def test_ui_job_budget_covers_live_vm_leg() -> None:
     smoke-single.yml already uses -- so a slow-but-healthy leg (setup alone ran
     ~23 of the observed 20m04s pass) isn't cancelled mid-run."""
     workflow = (_REPO_ROOT / ".github/workflows/ui-tests.yml").read_text(encoding="utf-8")
-    ui_job = extract_after(workflow, "\n  ui:\n")
+    ui_job = extract_job(workflow, "ui")
     match = re.search(r"^\s*timeout-minutes:\s*(\S+)\s*$", ui_job, re.MULTILINE)
     assert match, f"expected a timeout-minutes key under the `ui` job, found none in:\n{ui_job[:200]}"
 

--- a/tests/test_ui_release_gate_wiring.py
+++ b/tests/test_ui_release_gate_wiring.py
@@ -87,7 +87,7 @@ def _trigger_blocks(workflow: Path) -> tuple[str, str]:
     """Return (workflow_call inputs block, workflow_dispatch inputs block) as raw text,
     each spanning from its own `inputs:` header to the next top-level (2-space) key."""
     text = workflow.read_text(encoding="utf-8")
-    # Leading "\n" so the trigger split below (which requires a preceding
+    # Leading "\n" so the trigger marker below (which requires a preceding
     # newline) also matches the FIRST trigger key, not just later ones.
     on_section = "\n" + extract_between(text, "\non:\n", "\npermissions:\n")
 

--- a/tests/test_ui_release_gate_wiring.py
+++ b/tests/test_ui_release_gate_wiring.py
@@ -100,6 +100,15 @@ def _trigger_blocks(workflow: Path) -> tuple[str, str]:
     return _block("workflow_call"), _block("workflow_dispatch")
 
 
+def _input_block(trigger_block: str, name: str) -> str:
+    """The `name:` input's OWN sub-block, bounded at the next input key at the same
+    (6-space) indentation. A fixed-length suffix window instead reaches into a sibling
+    input, so an input that loses its own `default:` can pass on its neighbour's."""
+    body = extract_after(trigger_block, f"{name}:\n")
+    sibling = re.search(r"\n      [A-Za-z]", body)
+    return body[: sibling.start()] if sibling else body
+
+
 _JOB_KEY_RE = re.compile(r"^    [A-Za-z_-]+:")
 
 
@@ -148,9 +157,7 @@ def test_pkg_artifact_prefix_declared_in_both_trigger_blocks(workflow: Path) -> 
     call_block, dispatch_block = _trigger_blocks(workflow)
     for name, block in (("workflow_call", call_block), ("workflow_dispatch", dispatch_block)):
         assert "pkg_artifact_prefix:" in block, f"{workflow.name}: {name} is missing pkg_artifact_prefix"
-        # the input's own sub-block (description/required/type/default) ends well
-        # within a generous slice; scan that for the default line.
-        sub = extract_after(block, "pkg_artifact_prefix:\n")[:400]
+        sub = _input_block(block, "pkg_artifact_prefix")
         assert re.search(r"^\s*default:\s*\"\"\s*$", sub, re.MULTILINE), (
             f"{workflow.name}: {name}'s pkg_artifact_prefix must default to '' -- block was:\n{sub}"
         )
@@ -844,7 +851,7 @@ def test_checkout_ref_input_declared_in_both_trigger_blocks(workflow: Path) -> N
     call_block, dispatch_block = _trigger_blocks(workflow)
     for name, block in (("workflow_call", call_block), ("workflow_dispatch", dispatch_block)):
         assert "checkout_ref:" in block, f"{workflow.name}: {name} is missing checkout_ref"
-        sub = extract_after(block, "checkout_ref:\n")[:400]
+        sub = _input_block(block, "checkout_ref")
         assert re.search(r"^\s*default:\s*\"\"\s*$", sub, re.MULTILINE), (
             f"{workflow.name}: {name}'s checkout_ref must default to '' -- block was:\n{sub}"
         )
@@ -889,7 +896,7 @@ def test_release_gate_input_declared_in_both_trigger_blocks(workflow: Path) -> N
     call_block, dispatch_block = _trigger_blocks(workflow)
     for name, block in (("workflow_call", call_block), ("workflow_dispatch", dispatch_block)):
         assert "release_gate:" in block, f"{workflow.name}: {name} is missing release_gate"
-        sub = extract_after(block, "release_gate:\n")[:400]
+        sub = _input_block(block, "release_gate")
         assert re.search(r"^\s*default:\s*false\s*$", sub, re.MULTILINE), (
             f"{workflow.name}: {name}'s release_gate must default to false -- block was:\n{sub}"
         )

--- a/tests/test_ui_release_gate_wiring.py
+++ b/tests/test_ui_release_gate_wiring.py
@@ -25,6 +25,8 @@ from pathlib import Path
 import pytest
 import yaml
 
+from tests._workflow_steps import extract_after, extract_between
+
 ROOT = Path(__file__).resolve().parents[1]
 UI_WORKFLOW = ROOT / ".github/workflows/ui-tests.yml"
 SMOKE_WORKFLOW = ROOT / ".github/workflows/smoke.yml"
@@ -87,10 +89,10 @@ def _trigger_blocks(workflow: Path) -> tuple[str, str]:
     text = workflow.read_text(encoding="utf-8")
     # Leading "\n" so the trigger split below (which requires a preceding
     # newline) also matches the FIRST trigger key, not just later ones.
-    on_section = "\n" + text.split("\non:\n", 1)[1].split("\npermissions:\n", 1)[0]
+    on_section = "\n" + extract_between(text, "\non:\n", "\npermissions:\n")
 
     def _block(trigger: str) -> str:
-        after = on_section.split(f"\n  {trigger}:\n", 1)[1]
+        after = extract_after(on_section, f"\n  {trigger}:\n")
         # Ends at the next 2-space-indented key (another trigger, or the section end).
         m = re.search(r"\n  [A-Za-z]", after)
         return after[: m.start()] if m else after
@@ -148,7 +150,7 @@ def test_pkg_artifact_prefix_declared_in_both_trigger_blocks(workflow: Path) -> 
         assert "pkg_artifact_prefix:" in block, f"{workflow.name}: {name} is missing pkg_artifact_prefix"
         # the input's own sub-block (description/required/type/default) ends well
         # within a generous slice; scan that for the default line.
-        sub = block.split("pkg_artifact_prefix:\n", 1)[1][:400]
+        sub = extract_after(block, "pkg_artifact_prefix:\n")[:400]
         assert re.search(r"^\s*default:\s*\"\"\s*$", sub, re.MULTILINE), (
             f"{workflow.name}: {name}'s pkg_artifact_prefix must default to '' -- block was:\n{sub}"
         )
@@ -216,7 +218,7 @@ def test_ui_job_if_condition_shape() -> None:
     jobs = _jobs(UI_WORKFLOW)
     job_text = "\n".join(jobs["ui"])
     # The if: may be a folded multi-line block (`if: >-`); grab up to the `runs-on:` line.
-    if_block = job_text.split("if:", 1)[1].split("\n    runs-on:", 1)[0]
+    if_block = extract_between(job_text, "if:", "\n    runs-on:")
     assert "!cancelled()" in if_block
     assert "needs.prepare.result == 'success'" in if_block
     assert "needs.prepare.outputs.run == 'true'" in if_block
@@ -842,7 +844,7 @@ def test_checkout_ref_input_declared_in_both_trigger_blocks(workflow: Path) -> N
     call_block, dispatch_block = _trigger_blocks(workflow)
     for name, block in (("workflow_call", call_block), ("workflow_dispatch", dispatch_block)):
         assert "checkout_ref:" in block, f"{workflow.name}: {name} is missing checkout_ref"
-        sub = block.split("checkout_ref:\n", 1)[1][:400]
+        sub = extract_after(block, "checkout_ref:\n")[:400]
         assert re.search(r"^\s*default:\s*\"\"\s*$", sub, re.MULTILINE), (
             f"{workflow.name}: {name}'s checkout_ref must default to '' -- block was:\n{sub}"
         )
@@ -887,7 +889,7 @@ def test_release_gate_input_declared_in_both_trigger_blocks(workflow: Path) -> N
     call_block, dispatch_block = _trigger_blocks(workflow)
     for name, block in (("workflow_call", call_block), ("workflow_dispatch", dispatch_block)):
         assert "release_gate:" in block, f"{workflow.name}: {name} is missing release_gate"
-        sub = block.split("release_gate:\n", 1)[1][:400]
+        sub = extract_after(block, "release_gate:\n")[:400]
         assert re.search(r"^\s*default:\s*false\s*$", sub, re.MULTILINE), (
             f"{workflow.name}: {name}'s release_gate must default to false -- block was:\n{sub}"
         )
@@ -1127,14 +1129,14 @@ def test_release_channel_metadata_and_edge_following_do_not_start_a_second_relea
 
 def test_tagged_release_recipe_never_mutates_the_nightly_port() -> None:
     published = PUBLISHED_WORKFLOW.read_text(encoding="utf-8")
-    sync = published.split("\n  sync-ports-fork:\n", 1)[1].split("\n  publish-pkg:\n", 1)[0]
+    sync = extract_between(published, "\n  sync-ports-fork:\n", "\n  publish-pkg:\n")
     assert "pfSense-pkg-pfBlockerNG-nightly" not in sync, sync
     assert 'PORT_PATHS="net/pfSense-pkg-pfBlockerNG-devel net/pfSense-pkg-pfBlockerNG-nightly"' not in published
 
 
 def test_smoke_single_nightly_fixture_uses_utc_timestamp_and_source_sha() -> None:
     text = SMOKE_SINGLE_WORKFLOW.read_text(encoding="utf-8")
-    nightly = text.split("- name: Build a nightly .pkg", 1)[1].split("\n      # ADR-24", 1)[0]
+    nightly = extract_between(text, "- name: Build a nightly .pkg", "\n      # ADR-24")
     assert 'SOURCE_SHA="$(git rev-parse HEAD)"' in nightly, nightly
     assert 'SOURCE_SHORT_SHA="$(printf \'%.7s\' "$SOURCE_SHA")"' in nightly, nightly
     assert 'NIGHTLY_VERSION="$(date -u +%Y%m%d%H%M%S).${SOURCE_SHORT_SHA}"' in nightly, nightly

--- a/tests/test_version_tracker_reconcile_contract.py
+++ b/tests/test_version_tracker_reconcile_contract.py
@@ -23,6 +23,8 @@ import subprocess
 from pathlib import Path
 from typing import Any
 
+from tests._workflow_steps import extract_after, extract_between, extract_job, extract_step
+
 ROOT = Path(__file__).resolve().parents[1]
 WORKFLOW = ROOT / ".github" / "workflows" / "version-tracker.yml"
 
@@ -86,9 +88,9 @@ BETA_2607 = {
 
 def _step_script(step_name: str) -> str:
     source = WORKFLOW.read_text(encoding="utf-8")
-    step = source.split(f"      - name: {step_name}\n", 1)[1].split("\n      - name:", 1)[0]
+    step = extract_step(source, step_name)
     body: list[str] = []
-    for line in step.split("        run: |\n", 1)[1].splitlines():
+    for line in extract_after(step, "        run: |\n").splitlines():
         if not line.strip():
             body.append("")
         elif line.startswith("          "):
@@ -262,7 +264,7 @@ exit 0
         # Review F2: a wedged guest command must not hold a runner for the
         # 360-minute default
         source = WORKFLOW.read_text(encoding="utf-8")
-        job = source.split("\n  reconcile:\n", 1)[1].split("\n    steps:", 1)[0]
+        job = extract_between(source, "\n  reconcile:\n", "\n    steps:")
         assert "timeout-minutes:" in job
 
 
@@ -513,7 +515,7 @@ class TestReconcileMatrixSource:
     def test_reconcile_steps_consume_the_route_matrix(self) -> None:
         # Wiring pin: every reconcile step reads the never-deduped view.
         source = WORKFLOW.read_text(encoding="utf-8")
-        reconcile = source.split("\n  reconcile:\n", 1)[1]
+        reconcile = extract_after(source, "\n  reconcile:\n")
         assert "BUILD_MATRIX" not in reconcile
         assert reconcile.count("ROUTE_MATRIX:") >= 3
 
@@ -558,18 +560,18 @@ class TestReconcileMatrixSource:
         # would skip this job); and the resolve step must degrade like every
         # other data step in this best-effort job.
         source = WORKFLOW.read_text(encoding="utf-8")
-        reconcile = source.split("\n  reconcile:\n", 1)[1].split("\n  probe:", 1)[0]
+        reconcile = extract_job(source, "reconcile")
         assert "needs: read-matrix" not in reconcile
-        resolve = reconcile.split("- name: Resolve the route matrix", 1)[1].split("\n      - name:", 1)[0]
+        resolve = extract_between(reconcile, "- name: Resolve the route matrix", "\n      - name:")
         assert "continue-on-error: true" in resolve
 
     def test_reconcile_uploads_the_facts_tree(self) -> None:
         # issue #1848: an intermittent boot failure is undiagnosable once the
         # runner is gone — the facts must outlive it.
         source = WORKFLOW.read_text(encoding="utf-8")
-        reconcile = source.split("\n  reconcile:\n", 1)[1]
+        reconcile = extract_after(source, "\n  reconcile:\n")
         assert "actions/upload-artifact" in reconcile
-        upload = reconcile.split("actions/upload-artifact", 1)[1][:400]
+        upload = extract_after(reconcile, "actions/upload-artifact")[:400]
         assert "facts" in upload
         # the window an intermittent failure gets investigated in
         assert "retention-days: 14" in upload

--- a/tests/test_workflow_issue_dedup_contract.py
+++ b/tests/test_workflow_issue_dedup_contract.py
@@ -9,6 +9,8 @@ from pathlib import Path
 
 import pytest
 
+from tests._workflow_steps import extract_after
+
 ROOT = Path(__file__).resolve().parents[1]
 WORKFLOWS = ROOT / ".github" / "workflows"
 _LABEL = re.compile(r'--label "([^"]+)"')
@@ -33,7 +35,7 @@ def _issue_creation_steps(path: Path) -> list[str]:
 
 
 def _script(step: str) -> str:
-    return "\n".join(line[10:] for line in step.split("        run: |\n", 1)[1].splitlines())
+    return "\n".join(line[10:] for line in extract_after(step, "        run: |\n").splitlines())
 
 
 def _run_script(
@@ -46,7 +48,7 @@ def _run_script(
     extra_env: dict[str, str] | None = None,
 ) -> list[str]:
     source = path.read_text(encoding="utf-8")
-    tail = source.split(f"      - name: {step_name}\n", 1)[1]
+    tail = extract_after(source, f"      - name: {step_name}\n")
     step = re.split(r"\n(?:      - name:|  [a-z][a-z0-9_-]*:)", tail, maxsplit=1)[0]
     script = _script(step).replace("${{ steps.report.outputs.body_file }}", str(tmp_path / "body.md"))
     log = tmp_path / "gh.log"

--- a/tests/test_workflow_issue_recovery_order.py
+++ b/tests/test_workflow_issue_recovery_order.py
@@ -10,15 +10,17 @@ from pathlib import Path
 
 import pytest
 
+from tests._workflow_steps import extract_after
+
 ROOT = Path(__file__).resolve().parents[1]
 WORKFLOWS = ROOT / ".github" / "workflows"
 
 
 def _recovery_script(path: Path) -> str:
     source = path.read_text(encoding="utf-8")
-    tail = source.split("      - name: Close the recovered tracking issue\n", 1)[1]
+    tail = extract_after(source, "      - name: Close the recovered tracking issue\n")
     step = re.split(r"\n(?:      - name:|  [a-z][a-z0-9_-]*:)", tail, maxsplit=1)[0]
-    return "\n".join(line[10:] for line in step.split("        run: |\n", 1)[1].splitlines())
+    return "\n".join(line[10:] for line in extract_after(step, "        run: |\n").splitlines())
 
 
 def _run_recovery(

--- a/tests/test_worktrunk_config.py
+++ b/tests/test_worktrunk_config.py
@@ -3,6 +3,8 @@ from pathlib import Path
 
 import pytest
 
+from tests._workflow_steps import extract_between
+
 ROOT = Path(__file__).resolve().parents[1]
 PROJECT_CONFIG = ROOT / ".config" / "wt.toml"
 WORKTREE_DOCS = (
@@ -44,7 +46,7 @@ def test_worktrunk_creation_guard_rejects_the_legacy_command() -> None:
 
 def test_landing_fetches_before_json_cleanup_and_reports_branch_deletion() -> None:
     landing = LANDING_POLICY.read_text(encoding="utf-8")
-    merge_section = landing.split("## Merge step", 1)[1].split("## Post-merge", 1)[0]
+    merge_section = extract_between(landing, "## Merge step", "## Post-merge")
 
     merged = merge_section.index("PR's state must read `MERGED`")
     fetch = merge_section.index("Run `git fetch origin` after that verification", merged)


### PR DESCRIPTION
## What this fixes

`text.split(marker, 1)[0]` returns the **whole string** when `marker` is absent, so a
contract-test slice bounded that way silently stops bounding anything the moment an
ordinary documentation or workflow edit rewords the landmark: the region widens to
end-of-file and every assertion against it keeps passing. Reproduced on `devel` before
touching anything, by rewording one landmark in `.agents/policy/landing.md`:

```text
$ python3 -c "print('abc'.split('xyz', 1))"
['abc']                       # no exception, no bound

# reword '## Post-merge' -> '## Post-Merge' in .agents/policy/landing.md, then:
slice bounded by "## Merge step".."## Post-merge": 2690 chars -> 4111 chars
$ python3 -m pytest tests/test_worktrunk_config.py -q
....                                                                     [100%]
4 passed in 0.01s
```

Fixes #2669

## Enumeration (executed, from source)

The issue's own command, re-run on the base the branch was cut from (`1cbbe81c`; the branch
is now rebased onto `d936f3ce`, and every count below was re-derived there too):

```text
$ git grep -n 'split(' -- tests/ | grep -E '\.split\([^)]*, ?1\)\[[01]\]' | wc -l
     127
```

That regex misses multi-line forms and separators containing `)`, so the triage corpus is
an AST enumeration instead: every `.split(sep, 1)[<int>]` / `.rsplit(sep, 1)[<int>]`
subscript under `tests/`.

```text
209 subscripts across 59 test modules
  85  ordinary field split        (left alone)
 124  document/workflow landmark  (converted) -> 77 call sites across the 26 converted
                                                 modules, 25 of which carry one: the two in
                                                 test_ci_tool_pins.py left with its dead _job
```

Adjacent axes, each enumerated from source and each either converted or cleared:

| axis | hits | verdict |
| --- | --- | --- |
| `.split(sep, 1)[0\|1]` / `.rsplit(sep, 1)[0\|1]` subscripts | 209 | 124 landmark, converted |
| `str.partition(m)[0]` / `[2]`, `rpartition` subscripts | 8 | 4 landmark, converted (round 1 review) |
| `a, _, b = x.partition(m)` tuple unpacks | 17 | 2 landmark, converted (round 1 review) |
| `re.split(pat, text, maxsplit=1)[<int>]` (keyword form) | 5 | none landmark: each no-match case is the correct end-of-file region |
| `.split(sep)[0\|1]` with no `maxsplit` | 14 | none landmark; the one non-trivial site (`test_update_tld_lists.py:235`) carries a `not in` assertion, so widening is stricter |
| `text[:text.find(m)]` / `text[text.index(m):]` slices | 6 | none landmark: probe sentinels and diagnostics, or already `index()`-based and therefore raising |
| `.split(sep, 1)[-1]` / `.rsplit(sep, 1)[-1]` (negative index) | 27 | none landmark-bound *unguarded*: 24 carry a `/` or `.` separator, and the 3 that bound on the dated heading `'## Amendment — 2026-08-04'` (`tests/test_release_skill_contract_details.py:122,129,158`) are each preceded on the line above by `assert "## Amendment — 2026-08-04" in content`, so the landmark is already load-bearing |
| `rpartition` | 0 | — |

After the change the issue's grep reports **58** on this branch: 51 field-class or
docstring lines, plus 7 in the new suite, which compares against the legacy `split` form
on purpose.

### Triage rule

`field-split` when the separator is one the format itself guarantees, so its absence
cannot silently widen anything:

- a 1-2 character structural separator (`.` `:` `=` `/` `#` `-` `::` `^` `$` `?` `|` `\n` `' #'`);
- a probe sentinel the test's own command emits (`<<CFG>>`, `<<END>>`, `<<PFB1357>>`, ...);
- a per-line parse whose receiver an upstream `startswith()`/`assert` already filtered
  (`tests/test_release_tag_after_verify.py`'s `_needs` and `_job_contents_scope`;
  `tests/smoke/ui/test_render_smoke.py`'s `DNSBL category` row, guarded by
  `assert "DNSBL category" in body` on the line above);
- `rsplit`, whose last-separator semantics `extract_*` do not implement. All **20**
  `rsplit` subscripts carry a `/` or `.` separator, so the first rule already claims them.
- a `partition` whose absence an adjacent `assert` already makes loud:
  `tests/test_issue2212_hostile_path_gates.py:113` unpacks `body.partition("run: |\n")` and
  asserts on the separator it captured, so a reworded `run: |` fails by name rather than
  widening. Named here because `'run: |\n'` IS a converted literal elsewhere.

`landmark-bound` otherwise: the separator is a heading, phrase, YAML key, step/job name,
or source comment read out of a repository document, i.e. something a future edit rewords.

**Purely structural terminators were deliberately converted, not classed as field splits.**
Eight sites bound on `'\n\n'`, `'## '` or `'\n## '` — a blank line or the next heading.
Their absence widens exactly like a reworded phrase, so they are load-bearing now. The
trade is explicit: a formatting-only edit (deleting a blank line, or a section becoming
its document's last) now fails its contract test loudly by name, where before it silently
unbounded the assertion. A loud false failure is the outcome this issue asks for; a silent
true negative is the defect.

### Landmark-bound modules (converted)

| Module | landmark sites | field sites left alone |
| --- | --- | --- |
| `tests/smoke/ui/test_render_smoke.py` | 4 | 4 |
| `tests/test_agent_roles_check.py` | 4 (`partition`) | 0 |
| `tests/test_benchmarks_ci_deps.py` | 1 | 1 |
| `tests/test_ci_tool_pins.py` | 2 | 0 |
| `tests/test_context_budget.py` | 2 (`partition`) | 0 |
| `tests/test_cross_agent_tooling.py` | 2 | 0 |
| `tests/test_image_refresh_plan_contract.py` | 6 | 0 |
| `tests/test_image_refresh_upgrade_contract.py` | 1 | 0 |
| `tests/test_issue2143_adversarial_regressions.py` | 2 | 0 |
| `tests/test_issue2143_callback_destinations.py` | 12 | 0 |
| `tests/test_issue2143_review_contract.py` | 10 | 1 |
| `tests/test_issue2143_review_round2.py` | 6 | 0 |
| `tests/test_issue2143_workflow.py` | 3 | 0 |
| `tests/test_issue2145_release_skills.py` | 1 | 0 |
| `tests/test_issue2347_short_nightly_sha.py` | 2 | 0 |
| `tests/test_issue2456_pkg_ownership.py` | 2 | 0 |
| `tests/test_release_ci_path_consistency.py` | 4 | 0 |
| `tests/test_release_dry_run_gate.py` | 10 | 0 |
| `tests/test_release_skill_contract_details.py` | 2 | 0 |
| `tests/test_release_tag_after_verify.py` | 17 | 4 |
| `tests/test_reproducible_source_archive.py` | 5 | 0 |
| `tests/test_shell_ci_routing.py` | 1 | 0 |
| `tests/test_smoke_ui_config_digest.py` | 1 | 0 |
| `tests/test_ui_release_gate_wiring.py` | 12 | 0 |
| `tests/test_version_tracker_reconcile_contract.py` | 12 | 2 |
| `tests/test_workflow_issue_dedup_contract.py` | 2 | 0 |
| `tests/test_workflow_issue_recovery_order.py` | 2 | 0 |
| `tests/test_worktrunk_config.py` | 2 | 0 |

Two of those sites were **deleted rather than converted**: `_job` in
`tests/test_ci_tool_pins.py` was dead at the base and stayed dead once converted, so it
went instead of gaining a helper call.

The 33 remaining modules carrying hits are field-split only and untouched:
`tests/smoke/conftest.py`, `tests/smoke/helpers.py`, `tests/smoke/screendump.py`,
`tests/smoke/test_install_hook.py`, `tests/smoke/test_repo_install.py`,
`tests/smoke/test_schedule_runtime.py`, `tests/smoke/test_smoke_abp.py`,
`tests/smoke/test_smoke_autorule_immutable.py`,
`tests/smoke/test_smoke_dnsbl_ramdisk_reboot.py`, `tests/smoke/test_smoke_feeds.py`,
`tests/smoke/test_smoke_lan_rule_preserve.py`, `tests/smoke/test_smoke_matrix.py`,
`tests/smoke/test_top1m_fixed_file.py`, `tests/smoke/ui/conftest.py`,
`tests/smoke/ui/test_alerts.py`, `tests/smoke/ui/test_alerts_asn_csv.py`,
`tests/smoke/ui/test_alerts_bidi_control_render.py`,
`tests/smoke/ui/test_alerts_idn_exclusion_render.py`,
`tests/smoke/ui/test_alerts_render_verify.py`,
`tests/smoke/ui/test_alerts_stat_hostname_boundary.py`,
`tests/smoke/ui/test_alerts_stat_render.py`,
`tests/smoke/ui/test_alerts_total_event_count.py`, `tests/smoke/ui/test_xss_escaping.py`,
`tests/test_adr07_decision_spec.py`, `tests/test_adr07_php_boundary.py`,
`tests/test_adr08_confusable_matcher.py`, `tests/test_channel_install.py`,
`tests/test_check_skip_allowlist.py`, `tests/test_ci_graphify_merge_driver.py`,
`tests/test_issue2231_workflow_hygiene.py`,
`tests/test_nightly_failure_alert_coverage.py`, `tests/test_release_version.py`,
`tests/test_shard_union.py`.

## The fix

Three primitives beside the existing `extract_step`/`extract_job` in
`tests/_workflow_steps.py`, the module that already documented this failure mode verbatim:

```python
extract_after(text, marker)         # replaces .split(marker, 1)[1] and .partition(m)[2]
extract_before(text, marker)        # replaces .split(marker, 1)[0] and .partition(m)[0]
extract_between(text, start, end)   # replaces the chained pair
```

Each raises `ValueError` naming the missing marker, and every member of the family —
`extract_step` and `extract_job` included — rejects an empty bound. `""` is found at index 0
in every string, and an empty step or job name matches a bare `- name:` / `  :` line
*vacuously*, so an empty bound is no bound at all. Proven against the base helpers:

```text
BASE extract_step(vacuous, "")  -> '        run: echo hi\n'                        # silent region
BASE extract_job(vacuous, "")   -> '    steps:\n      - name: \n        run: echo hi\n'
HEAD both                       -> ValueError: marker '' must not be empty
```

**Marker literals are unchanged at every `extract_after`/`extract_before`/`extract_between`
site**, so each of those regions is byte-identical to what the `split`/`partition` form
returned while the markers are present: `extract_after` is `text[find(m) + len(m):]` and
`extract_before` is `text[:find(m)]`, the same indices `split(m, 1)` computes. Proven
mechanically twice in review — by inverting every helper call back to its `split` chain and
comparing ASTs against the base file (25 of 26 modules identical, the 26th's whole residual
delta being the two declared structural re-bounds), and by a runtime shadow that computed
both values at all 444 real invocations (0 divergences).

The two structural re-bounds below are the stated exception: `extract_step` includes the
boundary `"\n"` that `split("\n      - name:", 1)[0]` consumed, so its region is legacy + one
newline for four of `_step_script`'s five step names. The derived shell script is identical
for four and gains one trailing newline for the fifth, inert in a `bash -c` payload, because
the body loop breaks at the first line that is not 10-space indented.

`extract_job` raised `AssertionError`. Asserts vanish under `-O` and converted sites now
depend on it, so it joins the family's `ValueError` contract.

### `extract_step` was preferred, then rejected on evidence

The issue suggests reusing `extract_step`. For the `- name: X` .. `\n      - name:` sites
that would silently **re-scope** every converted region, so it was not used there:

```text
354 "      - name:" step bodies across .github/workflows/*.yml compared
330 differ between extract_step() and the legacy split form (315 by the boundary "\n" alone)
```

It IS used where the legacy bound was already broken, because there the region cannot be
preserved: it had already widened to end-of-file.

## Two landmarks were already gone on `devel`

Converting turned two pre-existing silent drifts into immediate failures, both in
`tests/test_version_tracker_reconcile_contract.py`:

| Site | Landmark it bounded with | Reality on `devel` |
| --- | --- | --- |
| `_step_script()` | `"\n      - name:"` after the named step | the matrix-PR step is the **last** of its job |
| `test_reconcile_job_is_independent_and_best_effort` | `"\n  probe:"` | `version-tracker.yml` has **no** `probe:` job |

Both are now bounded structurally (`extract_step` / `extract_job`), and both regions are
byte-identical to what the drifted splits actually returned:

```text
extract_job(version-tracker.yml, "reconcile")  == legacy tail   True  (21751 chars)
extract_step(..., "Open matrix PRs for planned actions") == legacy  True  ( 7212 chars)
```

Their new bounds are load-bearing on the step/job name instead:

```text
reworded step -> ValueError: step 'Open matrix PRs for planned actions' not found in workflow
    (the legacy opener form widened 7212 -> 34323 chars, with only a bare IndexError to lose)
reworded job  -> ValueError: job 'reconcile' not found in workflow
```

For `_step_script` the widened region was never *observable* — the dedent loop already
stopped at the first shallower line — so the drift there was latent, not active. The
job-level drift was active.

No assertion was weakened, removed, or re-scoped to make either pass.

## The `str.partition` arm (found by review round 1)

The first round of this PR defined the corpus as `.split`/`.rsplit` subscripts, which
missed `str.partition(marker)[0]` — identical silent semantics. Two modules bounded a
workflow trigger block with `permissions:`, the very literal already converted at eight
`.split` sites, and both stayed **fully green** with the bound gone. Both are now
load-bearing:

```text
reword 'permissions:' in .github/workflows/agent-config.yml
    tests/test_agent_roles_check.py    base: 62 passed  (exit 0)  ->  head: 1 failed, 61 passed
reword 'permissions:' in .github/workflows/context-budget.yml
    tests/test_context_budget.py       base: 119 passed (exit 0)  ->  head: 1 failed, 118 passed
```

## Frozen red -> green

`tests/test_issue2669_landmark_bounds.py`, authored and executed RED on unchanged
production code, byte-identical at both moments.

| | value |
| --- | --- |
| frozen test | `tests/test_issue2669_landmark_bounds.py` |
| `git hash-object` at RED | `e5f010150300119a2bb6af4d60bd748ee8e3ae1f` |
| `git hash-object` at GREEN | `e5f010150300119a2bb6af4d60bd748ee8e3ae1f` |
| RED exit | `2` |
| GREEN exit | `0` |

```text
$ python3 -m pytest tests/test_issue2669_landmark_bounds.py -q      # 30 paths reverted to base
tests/test_issue2669_landmark_bounds.py:21: in <module>
    from tests._workflow_steps import extract_after, extract_before, extract_between, extract_job, extract_step
E   ImportError: cannot import name 'extract_after' from 'tests._workflow_steps'
Interrupted: 1 error during collection
1 error in 0.07s                                                    # exit 2

$ python3 -m pytest tests/test_issue2669_landmark_bounds.py -q      # restored
..............                                                           [100%]
14 passed in 0.03s                                                  # exit 0
```

**A collection `ImportError` is a content-blind red** — a stub module with the same import
line and a single `pass` body produces the identical exit 2. Review proved that, so the
discriminating red is a per-helper mutant battery instead. Two of its mutants are literally
the `split` form being replaced (M1, M2), one is literally the code at the base commit (M6),
and the rest are the plausible regressions of the new contract. Every one is killed:

| # | mutant of `tests/_workflow_steps.py` | frozen suite |
| --- | --- | --- |
| M1 | `extract_before` -> `split(marker, 1)[0]` (the defect itself) | KILLED — 6 failed, 8 passed |
| M2 | `extract_after` -> `split(marker, 1)[1]` | KILLED — 3 failed, 11 passed |
| M3 | `extract_before` raises without naming the marker | KILLED — 5 failed, 9 passed |
| M4 | `extract_after` raises without naming the marker | KILLED — 2 failed, 12 passed |
| M5 | `extract_step` raises without naming the step | KILLED — 1 failed, 13 passed |
| M6 | `extract_job` reverted to the bare `assert` (the code at base) | KILLED — 1 failed, 13 passed |
| M7 | `extract_between` bounds on the LAST terminator | KILLED — 5 failed, 9 passed (this form also loses the raise; the *minimal* first-to-last mutant that keeps it dies 1 failed, 13 passed, killed by exactly the new first-occurrence test) |
| M8 | `extract_before` uses `rfind` | KILLED — 1 failed, 13 passed |
| M9 | `extract_after` uses `rfind` | KILLED — 1 failed, 13 passed |
| M10 | `extract_after` keeps the marker (region shifted by `len`) | KILLED — 6 failed, 8 passed |
| M11 | `extract_before` keeps one byte of the marker | KILLED — 6 failed, 8 passed |
| M12 | the empty-marker guard removed | KILLED — 1 failed, 13 passed |
| M13 | the guard applied to `extract_after` only | KILLED — 1 failed, 13 passed |
| M14 | the guard applied to `extract_before` only | KILLED — 1 failed, 13 passed |
| M15 | the guard dropped from `extract_step` | KILLED — 1 failed, 13 passed |
| M16 | the guard dropped from `extract_job` | KILLED — 1 failed, 13 passed |
| M17 | the empty-bound message reworded | KILLED — 1 failed, 13 passed |

`17/17` killed, `0` survivors, run with `PYTHONDONTWRITEBYTECODE=1 python3 -B` and
`tests/__pycache__` purged per mutant — two same-size mutants in the same clock second
otherwise share a stale `.pyc` and report the previous mutant's verdict. M7/M8/M9 survived
the first round's suite; the fixture now repeats both markers, which kills all three.

The suite's real-document rows prove the transition rather than only the end state: each
asserts the `split` form widens on the reworded document *before* asserting
`extract_between` raises, over three document flavours (workflow YAML, Markdown policy
text, PHP source).

## Verification

```text
$ sh scripts/agent/run-gates.sh --diff origin/devel
GATE PASS: python3 scripts/check_coverage_pairing.py --name-status-z
GATE PASS: uv run --locked pytest
GATE PASS: uv run --locked ruff check .
GATE PASS: uv run --locked ruff format --check .
GATE PASS: uv run --locked mypy tests/
GATES: PASS                                                          # exit 0

$ python3 -m pytest --collect-only -q                     base 5575 -> branch 5589   (+14)
$ python3 -m pytest --collect-only -q --override-ini=addopts=   base 6442 -> branch 6456   (+14)
#   the second form drops the default --ignore=tests/smoke, so it also collects the smoke tree;
#   the delta is +14 either way, and no existing test silently disappeared
```

`tests/smoke/` is `--ignore`d in the default run, so the two converted sites in
`tests/smoke/ui/test_render_smoke.py` were verified by running those two tests directly —
they are hermetic source-text tests needing no VM — and by the base-to-branch mutation flip:

```text
$ python3 -m pytest tests/smoke/ui/test_render_smoke.py -q --override-ini=addopts= \
      -k "dnsbl_regex_save_uses_package_python_wrapper or tick_delegates_safesearch"
2 passed

pfblockerng_dnsbl.php  region identical to the split form: True (807 chars)
    terminator reworded -> ValueError naming '// Validate DNSBL VIP address'
    the split form on the same input widened to 120419 chars, silently
pfblockerng.php        region identical to the split form: True (248 chars)
    terminator reworded -> ValueError naming the missing cron-tick marker
    the split form on the same input widened to  63990 chars, silently
```

A whole-corpus mutation sweep — reword each landmark in the document its module reads, run
that module, before and after the conversion, in two independent worktrees — is posted as a
comment, with its own accounting of which rows are discriminating and which are not.

## Not done, deliberately

No regrowth checker. The issue lists it as optional and requires any guard to be
mutation-proven rather than source-text-only. Every shape available here is a source-text
scan keyed on line numbers or literals, which drifts on the first unrelated edit and
guesses at the boundary the enumeration just established by hand. Review round 1 sharpened
the honest limit of the alternative argument: the landmark being load-bearing guards only
slices routed through the helpers, which is why the `str.partition` arm above had to be
enumerated and converted rather than assumed closed.

Two pre-existing near-duplicates of this helper family are tracked separately rather than
folded in here.

---
🤖 Generated by Oh My Pi and posted on behalf of @andrebrait.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved workflow text extraction with shared landmark-based helpers.
  - Added clear validation errors for missing or empty markers.
  - Expanded regression coverage for bounded extraction and renamed landmarks.
  - Updated workflow and UI validation tests to use consistent parsing, preserving existing assertions and behavior.
- **Refactor**
  - Replaced fragile, repeated string-splitting logic across test coverage with reusable extraction utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->