### PR TITLE
tests: pin the routing document's /graphify first build

### DIFF
--- a/tests/test_cross_agent_tooling.py
+++ b/tests/test_cross_agent_tooling.py
@@ -188,7 +188,10 @@ def test_repository_intelligence_initializes_each_worktree_directly() -> None:
         "scripts/agent/init-worktree-tools.sh",
         "scripts/agent/ensure-codegraph.sh",
         "graphify update",
-        "graphify extract",
+        # The initializer no longer builds the first graph: the routing document
+        # must direct that judgement call to a `/graphify` run instead.
+        "prints a notice and builds nothing",
+        "`/graphify` run",
         "serena project index",
         "OMP_CLI",
         "PI_CLI",


### PR DESCRIPTION
`devel` is red: `pytest / Python 3.11` fails on `devel` itself and on every PR based on it.

```
FAILED tests/test_cross_agent_tooling.py::test_repository_intelligence_initializes_each_worktree_directly
AssertionError: direct worktree initialization routing lost graphify extract
```

**Cause.** 59eb1762 ("agent: skip the automated first Graphify build") stopped the initializer from building the first graph and rewrote `.agents/context/repository-intelligence.md` to direct that judgement call to a `/graphify` run. The routing gate still required the document to name `graphify extract`, which now appears nowhere else on `devel`:

```
$ git grep -n "graphify extract" origin/devel -- ':!graphify-out'
origin/devel:tests/test_cross_agent_tooling.py:191:        "graphify extract",
```

**Fix.** Replace the stale row with the two contracts the document is now required to carry — `prints a notice and builds nothing` and `` `/graphify` run ``.

**Evidence.** RED is the CI failure above (run 33089359729). GREEN after the fix: `uv run --locked pytest` passes, `scripts/agent/run-gates.sh --diff origin/devel` → `GATES: PASS`. Both new rows were mutation-checked in the worktree — rewording either sentence in the routing document fails the gate by name (`routing lost prints a notice and builds nothing`, `routing lost \`/graphify\` run`), so neither row is coverage theater.

Fixes #2761