### PR TITLE
Execute the Software page's version-check save in tests instead of replaying it

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -5206,9 +5206,7 @@ function pfb_software_check_enabled(): bool {
  * default 'yes' included, canonicalises to the owner-ruled empty Off. The caller flushes
  * config.xml.
  *
- * issue #2525: this is a named function rather than an expression inside the page so the
- * persistence a test can execute IS the persistence the page runs. While it lived in the page
- * the only reachable coverage replayed it, and deleting the write left the suite green.
+ * issue #2525: named, so the persistence a test executes is the persistence the page runs.
  */
 function pfb_software_check_save(array $post): string {
 	$token = pfb_filter($post['pfb_software_check'] ?? '', PFB_FILTER_ON_OFF, 'software') ?: '';

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -5200,6 +5200,23 @@ function pfb_software_check_enabled(): bool {
 }
 
 /*
+ * Persist the "Check for new versions" token from a Software-page Save POST, and return the
+ * token that was stored. A checkbox is absent from the POST when unticked, and
+ * PFB_FILTER_ON_OFF accepts only 'on' and '' -- so every other token, pfSense's Form_Checkbox
+ * default 'yes' included, canonicalises to the owner-ruled empty Off. The caller flushes
+ * config.xml.
+ *
+ * issue #2525: this is a named function rather than an expression inside the page so the
+ * persistence a test can execute IS the persistence the page runs. While it lived in the page
+ * the only reachable coverage replayed it, and deleting the write left the suite green.
+ */
+function pfb_software_check_save(array $post): string {
+	$token = pfb_filter($post['pfb_software_check'] ?? '', PFB_FILTER_ON_OFF, 'software') ?: '';
+	PfbConfig::write('gen/pfb_software_check', $token);
+	return $token;
+}
+
+/*
  * The notify state machine: TRUE iff a `file_notice` should fire THIS tick.
  *
  * The single "Check for new versions" boolean ($enabled) gates notifications equally on every

--- a/src/usr/local/www/pfblockerng/pfblockerng_software.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_software.php
@@ -86,9 +86,7 @@ if ($_POST && !empty($_POST['pfb_sw_action'])) {
 $input_errors = array();
 
 // "Save" the settings (standard pfSense CSRF POST). pfb_software_check_save() owns the token
-// (a checkbox is absent from the POST when unticked, so it persists the owner-ruled empty Off
-// token; an absent config key defaults On) -- issue #2525: the page keeps only the decision to
-// save, the flush and the redirect, so what a test can drive is what this handler runs.
+// (issue #2525); this handler owns only the flush and the redirect.
 if ($_POST && isset($_POST['save'])) {
 	pfb_software_check_save($_POST);
 	write_config('[pfBlockerNG] save Software settings');

--- a/src/usr/local/www/pfblockerng/pfblockerng_software.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_software.php
@@ -85,10 +85,12 @@ if ($_POST && !empty($_POST['pfb_sw_action'])) {
 // without 'save'.
 $input_errors = array();
 
-// "Save" the settings (standard pfSense CSRF POST). A checkbox is absent from the POST when
-// unticked, so persist the owner-ruled empty Off token; an absent config key defaults On.
+// "Save" the settings (standard pfSense CSRF POST). pfb_software_check_save() owns the token
+// (a checkbox is absent from the POST when unticked, so it persists the owner-ruled empty Off
+// token; an absent config key defaults On) -- issue #2525: the page keeps only the decision to
+// save, the flush and the redirect, so what a test can drive is what this handler runs.
 if ($_POST && isset($_POST['save'])) {
-	PfbConfig::write('gen/pfb_software_check', pfb_filter($_POST['pfb_software_check'] ?? '', PFB_FILTER_ON_OFF, 'software') ?: '');
+	pfb_software_check_save($_POST);
 	write_config('[pfBlockerNG] save Software settings');
 	header('Location: /pfblockerng/pfblockerng_software.php');
 	exit;

--- a/tests/php/SoftwareCheckPostRoundTripTest.php
+++ b/tests/php/SoftwareCheckPostRoundTripTest.php
@@ -173,14 +173,19 @@ final class SoftwareCheckPostRoundTripTest extends TestCase
 	 * pfb_software_check_save() and only then flush config.xml, and the page must carry no
 	 * second, untested write of this field.
 	 *
-	 * The handler is pinned as ONE literal sequence, and each of its three lines is required
-	 * to occur exactly once on the page. Anything that resolves the handler's extent — a
-	 * scan for a closing brace, a brace-matching walk, an unbounded strpos from the opening
-	 * line — can select the wrong region and then pass against it, which is how review found
-	 * this assertion vacuous twice: an indented closing brace ran a literal scan past the
-	 * handler, and a '${' interpolation, whose closer is a plain '}' token, silently
-	 * shortened a brace-matching walk. A literal sequence has no extent to get wrong, and
-	 * the exactly-once counts leave the sequence nowhere else on the page to live.
+	 * LIMITATION, stated rather than implied: this is a source-text gate and cannot prove
+	 * executed behaviour. The page's top-level handler is not executable under the
+	 * page-loader harnesses (they eval() function definitions out of a page), which is why
+	 * #2525 chose extraction in the first place; the executable proof lives in the cases
+	 * above, which drive the extracted function itself.
+	 *
+	 * The branch is pinned as ONE literal sequence, with each of its three lines required to
+	 * occur exactly once on the page. Anything that resolves the handler's EXTENT — a scan
+	 * for a closing brace, a brace-matching walk — can select the wrong region and then pass
+	 * against it, which is how review found this assertion vacuous twice: an indented closing
+	 * brace ran a literal scan past the handler, and a '${' interpolation, whose closer is a
+	 * plain '}' token, silently shortened a brace-matching walk. A literal sequence has no
+	 * extent to get wrong.
 	 */
 	public function testPageSaveDelegatesToTheExtractedSave(): void
 	{

--- a/tests/php/SoftwareCheckPostRoundTripTest.php
+++ b/tests/php/SoftwareCheckPostRoundTripTest.php
@@ -21,18 +21,20 @@ use PHPUnit\Framework\TestCase;
  * of what the page renders: drop the explicit value again and the extraction falls back to
  * pfSense's 'yes' and these cases go red.
  *
- * issue #2525 — the persistence half is EXECUTED, never modelled. Every case below drives
- * pfb_software_check_save(), the function the page's Save handler calls, so deleting its
- * PfbConfig::write() turns cases red. The earlier version of this file replayed the save
- * instead: it called PfbConfig::write() itself with a filter constant scraped out of the
- * page by regex, which is what the page SHOULD do and never what it DID — deleting the
- * page's own write left the whole 5459-test suite green.
+ * issue #2525 — the persistence half is EXECUTED, never modelled: every case below drives
+ * pfb_software_check_save(), the function the page's Save handler calls, so deleting that
+ * function's PfbConfig::write() turns cases red.
  */
 #[CoversFunction('pfb_software_check_save')]
 #[CoversFunction('pfb_software_check_enabled')]
 final class SoftwareCheckPostRoundTripTest extends TestCase
 {
 	private const PAGE = __DIR__ . '/../../src/usr/local/www/pfblockerng/pfblockerng_software.php';
+
+	/** The Save handler's opening line, and the two statements it must carry, in order. */
+	private const SAVE_OPEN = "if (\$_POST && isset(\$_POST['save'])) {";
+	private const PERSIST   = 'pfb_software_check_save($_POST);';
+	private const FLUSH     = "write_config('[pfBlockerNG] save Software settings');";
 
 	/**
 	 * The value the rendered checkbox posts when ticked: the Form_Checkbox call's 5th
@@ -132,24 +134,17 @@ final class SoftwareCheckPostRoundTripTest extends TestCase
 	/**
 	 * The trap itself, named: the page must pass its checkbox value explicitly. Sibling
 	 * pages that pass 'on' (pfblockerng_sync.php) round-trip; one that relies on the
-	 * default posts 'yes' and cannot.
+	 * default posts 'yes' and cannot. The save oracle for that token lives in
+	 * testCheckedSavePersistsEnabled() — this case states only what the page must render.
 	 */
 	public function testCheckboxPostsATokenTheFilterAccepts(): void
 	{
-		$posted = $this->postedWhenChecked();
-
 		$this->assertNotSame(
 			'yes',
-			$posted,
+			$this->postedWhenChecked(),
 			"the checkbox must pass its value explicitly; pfSense's Form_Checkbox default 'yes' "
 			. 'is rejected by PFB_FILTER_ON_OFF'
 		);
-		$this->assertSame(
-			$posted,
-			pfb_software_check_save(['pfb_software_check' => $posted]),
-			'the posted token must survive the save path unchanged'
-		);
-		$this->assertTrue(pfb_software_check_enabled(), 'and must land as the enabled token');
 	}
 
 	/**
@@ -173,6 +168,39 @@ final class SoftwareCheckPostRoundTripTest extends TestCase
 	}
 
 	/**
+	 * The Save handler's block, resolved by matching its braces through PhpToken so the
+	 * bound cannot be moved by whitespace.
+	 *
+	 * Scanning for a literal "\n}\n" instead pins the closing brace's INDENTATION: indent
+	 * it and the scan runs on to the next unindented brace further down the page, silently
+	 * widening the block, and every assertion below then passes against the wrong region
+	 * (found reviewing #2525 — a mutant that indented this brace AND moved the flush out of
+	 * the handler stayed green). Braces are tokens here, so one inside a string or a comment
+	 * cannot be miscounted either.
+	 */
+	private function saveHandlerBlock(string $source): string
+	{
+		$open = strpos($source, self::SAVE_OPEN);
+		$this->assertNotFalse($open, 'the Software page must keep its Save handler');
+
+		$depth = 0;
+		foreach (PhpToken::tokenize($source) as $token) {
+			if ($token->pos < $open || ($token->text !== '{' && $token->text !== '}')) {
+				continue;
+			}
+			if ($token->text === '{') {
+				$depth++;
+				continue;
+			}
+			if (--$depth === 0) {
+				return substr($source, $open, $token->pos - $open);
+			}
+		}
+
+		$this->fail("the Save handler's block is never closed");
+	}
+
+	/**
 	 * The extraction is only worth anything while the function these cases drive is the one
 	 * the page runs (issue #2525). The Save handler must delegate to
 	 * pfb_software_check_save() and persist before it flushes config.xml, and the page must
@@ -181,17 +209,18 @@ final class SoftwareCheckPostRoundTripTest extends TestCase
 	public function testPageSaveDelegatesToTheExtractedSave(): void
 	{
 		$source = (string) file_get_contents(self::PAGE);
-		$start  = strpos($source, "if (\$_POST && isset(\$_POST['save'])) {");
-		$this->assertNotFalse($start, 'the Software page must keep its Save handler');
-		$end = strpos($source, "\n}\n", $start);
-		$this->assertNotFalse($end, "the Save handler's block must close at column 0");
-		$save = substr($source, $start, $end - $start);
+		$save   = $this->saveHandlerBlock($source);
 
-		$persist = strpos($save, 'pfb_software_check_save($_POST);');
-		$flush   = strpos($save, "write_config('[pfBlockerNG] save Software settings');");
+		// Exactly once each, so a second copy of either statement elsewhere on the page
+		// cannot stand in for the one this block is asserted to hold.
+		$this->assertSame(1, substr_count($source, self::PERSIST), 'the page must call the extracted save exactly once');
+		$this->assertSame(1, substr_count($source, self::FLUSH), 'the page must flush the Software settings exactly once');
+
+		$persist = strpos($save, self::PERSIST);
+		$flush   = strpos($save, self::FLUSH);
 		$this->assertNotFalse($persist, 'the Save handler must persist through pfb_software_check_save()');
 		$this->assertNotFalse($flush, 'the Save handler must flush config.xml');
-		$this->assertTrue($persist < $flush, 'the token must be persisted before the flush');
+		$this->assertLessThan($flush, $persist, 'the token must be persisted before the flush');
 
 		$this->assertStringNotContainsString(
 			"PfbConfig::write('gen/pfb_software_check'",

--- a/tests/php/SoftwareCheckPostRoundTripTest.php
+++ b/tests/php/SoftwareCheckPostRoundTripTest.php
@@ -7,7 +7,8 @@ use PHPUnit\Framework\TestCase;
 
 /**
  * The Software page's "New version check" checkbox has to POST a token its own save path
- * accepts (issue #2367).
+ * accepts (issue #2367), and that save path has to be the one the page actually runs
+ * (issue #2525).
  *
  * pfSense's Form_Checkbox posts 'yes' unless the caller passes a value:
  * ``__construct($name, $title, $description, $checked, $value = 'yes')``. The save path
@@ -17,9 +18,17 @@ use PHPUnit\Framework\TestCase;
  * and no UI path can turn the check back on.
  *
  * The posted token is read OUT OF THE PAGE here rather than assumed, so this stays a test
- * of what the page does: drop the explicit value again and the extraction falls back to
+ * of what the page renders: drop the explicit value again and the extraction falls back to
  * pfSense's 'yes' and these cases go red.
+ *
+ * issue #2525 — the persistence half is EXECUTED, never modelled. Every case below drives
+ * pfb_software_check_save(), the function the page's Save handler calls, so deleting its
+ * PfbConfig::write() turns cases red. The earlier version of this file replayed the save
+ * instead: it called PfbConfig::write() itself with a filter constant scraped out of the
+ * page by regex, which is what the page SHOULD do and never what it DID — deleting the
+ * page's own write left the whole 5459-test suite green.
  */
+#[CoversFunction('pfb_software_check_save')]
 #[CoversFunction('pfb_software_check_enabled')]
 final class SoftwareCheckPostRoundTripTest extends TestCase
 {
@@ -52,32 +61,6 @@ final class SoftwareCheckPostRoundTripTest extends TestCase
 		return trim($args[3], "'\"");
 	}
 
-	/**
-	 * The page's save filter, applied through the SAME constant the page names, so swapping
-	 * the page to another filter cannot leave this modelling the old one.
-	 */
-	private function saveFilter(string $posted): string
-	{
-		$source = php_strip_whitespace(self::PAGE);
-		$found  = preg_match(
-			"/pfb_filter\\(\\\$_POST\\['pfb_software_check'\\] \\?\\? '', (PFB_FILTER_[A-Z_]+), 'software'\\) \\?: ''/",
-			$source,
-			$m
-		);
-		$this->assertSame(1, $found, 'the modelled save expression no longer matches the page');
-		// Applied through the page's own constant so this cannot model a filter the page
-		// stopped using, AND pinned to the one that makes the round-trip meaningful: a save
-		// widened to accept a looser token set is a different contract, not a refactor.
-		$this->assertSame(
-			'PFB_FILTER_ON_OFF',
-			$m[1],
-			'the Save must keep filtering with PFB_FILTER_ON_OFF; a looser filter would accept tokens '
-			. 'that no longer round-trip through the toggle gateway'
-		);
-
-		return pfb_filter($posted, constant($m[1]), 'software') ?: '';
-	}
-
 	private bool $hadConfig = FALSE;
 	private mixed $originalConfig = NULL;
 
@@ -105,22 +88,29 @@ final class SoftwareCheckPostRoundTripTest extends TestCase
 
 	/**
 	 * Save with the box ticked persists ENABLED. This is the defect's direct oracle: with a
-	 * posted 'yes' the filter rejects the token, the page stores '', and the setting reads
+	 * posted 'yes' the filter rejects the token, the save stores '', and the setting reads
 	 * back disabled however many times it is saved.
 	 */
 	public function testCheckedSavePersistsEnabled(): void
 	{
 		// Before: an unticked Save has left the setting off, so a green below is this
-		// save's doing and not the registry's enabled-by-default.
-		PfbConfig::write('gen/pfb_software_check', $this->saveFilter(''));
+		// save's doing and not the registry's enabled-by-default. Asserting that BEFORE
+		// state is also what makes a save that persists nothing at all fail here: an
+		// absent key reads as the registered On default.
+		$this->assertSame('', pfb_software_check_save([]), 'an absent checkbox saves the empty Off token');
 		$this->assertFalse(pfb_software_check_enabled(), 'precondition: the check starts disabled');
 
-		PfbConfig::write('gen/pfb_software_check', $this->saveFilter($this->postedWhenChecked()));
+		$posted = $this->postedWhenChecked();
+		$this->assertSame(
+			$posted,
+			pfb_software_check_save(['pfb_software_check' => $posted]),
+			'the token the rendered checkbox posts must survive the save unchanged'
+		);
 
 		$this->assertTrue(
 			pfb_software_check_enabled(),
 			'a Save with the box ticked must persist the enabled token; the posted value was '
-			. var_export($this->postedWhenChecked(), TRUE)
+			. var_export($posted, TRUE)
 		);
 	}
 
@@ -130,11 +120,11 @@ final class SoftwareCheckPostRoundTripTest extends TestCase
 	 */
 	public function testUncheckedSavePersistsDisabled(): void
 	{
-		PfbConfig::write('gen/pfb_software_check', $this->saveFilter($this->postedWhenChecked()));
+		PfbConfig::write('gen/pfb_software_check', PfbToggle::On);
 		$this->assertTrue(pfb_software_check_enabled(), 'precondition: the check is enabled first');
 
-		// An absent POST key reaches the save path as ''.
-		PfbConfig::write('gen/pfb_software_check', $this->saveFilter(''));
+		// An absent POST key is exactly what a browser sends for an unticked checkbox.
+		$this->assertSame('', pfb_software_check_save([]), 'an unticked Save returns the empty Off token');
 
 		$this->assertFalse(pfb_software_check_enabled(), 'an unticked Save must persist the disabled token');
 	}
@@ -156,8 +146,57 @@ final class SoftwareCheckPostRoundTripTest extends TestCase
 		);
 		$this->assertSame(
 			$posted,
-			$this->saveFilter($posted),
-			'the posted token must survive the page\'s own save path unchanged'
+			pfb_software_check_save(['pfb_software_check' => $posted]),
+			'the posted token must survive the save path unchanged'
+		);
+		$this->assertTrue(pfb_software_check_enabled(), 'and must land as the enabled token');
+	}
+
+	/**
+	 * The save keeps rejecting every token the toggle gateway cannot round-trip, stated as
+	 * behaviour rather than as a regex over the source: widening the filter to accept
+	 * pfSense's 'yes' would be a different contract, not a refactor. 'yes' is the exact
+	 * token the checkbox posted for a release (issue #2367), so this is the input class
+	 * that actually reached the save in the field.
+	 */
+	public function testSaveRejectsATokenTheToggleGatewayCannotRoundTrip(): void
+	{
+		PfbConfig::write('gen/pfb_software_check', PfbToggle::On);
+		$this->assertTrue(pfb_software_check_enabled(), 'precondition: the check is enabled first');
+
+		$this->assertSame('', pfb_software_check_save(['pfb_software_check' => 'yes']));
+
+		$this->assertFalse(
+			pfb_software_check_enabled(),
+			"'yes' is not an accepted token: it must persist as the disabled token, never enable the check"
+		);
+	}
+
+	/**
+	 * The extraction is only worth anything while the function these cases drive is the one
+	 * the page runs (issue #2525). The Save handler must delegate to
+	 * pfb_software_check_save() and persist before it flushes config.xml, and the page must
+	 * carry no second, untested write of this field.
+	 */
+	public function testPageSaveDelegatesToTheExtractedSave(): void
+	{
+		$source = (string) file_get_contents(self::PAGE);
+		$start  = strpos($source, "if (\$_POST && isset(\$_POST['save'])) {");
+		$this->assertNotFalse($start, 'the Software page must keep its Save handler');
+		$end = strpos($source, "\n}\n", $start);
+		$this->assertNotFalse($end, "the Save handler's block must close at column 0");
+		$save = substr($source, $start, $end - $start);
+
+		$persist = strpos($save, 'pfb_software_check_save($_POST);');
+		$flush   = strpos($save, "write_config('[pfBlockerNG] save Software settings');");
+		$this->assertNotFalse($persist, 'the Save handler must persist through pfb_software_check_save()');
+		$this->assertNotFalse($flush, 'the Save handler must flush config.xml');
+		$this->assertTrue($persist < $flush, 'the token must be persisted before the flush');
+
+		$this->assertStringNotContainsString(
+			"PfbConfig::write('gen/pfb_software_check'",
+			$source,
+			'the page must not persist this field itself: an inline write is a path no test executes'
 		);
 	}
 }

--- a/tests/php/SoftwareCheckPostRoundTripTest.php
+++ b/tests/php/SoftwareCheckPostRoundTripTest.php
@@ -168,59 +168,33 @@ final class SoftwareCheckPostRoundTripTest extends TestCase
 	}
 
 	/**
-	 * The Save handler's block, resolved by matching its braces through PhpToken so the
-	 * bound cannot be moved by whitespace.
-	 *
-	 * Scanning for a literal "\n}\n" instead pins the closing brace's INDENTATION: indent
-	 * it and the scan runs on to the next unindented brace further down the page, silently
-	 * widening the block, and every assertion below then passes against the wrong region
-	 * (found reviewing #2525 — a mutant that indented this brace AND moved the flush out of
-	 * the handler stayed green). Braces are tokens here, so one inside a string or a comment
-	 * cannot be miscounted either.
-	 */
-	private function saveHandlerBlock(string $source): string
-	{
-		$open = strpos($source, self::SAVE_OPEN);
-		$this->assertNotFalse($open, 'the Software page must keep its Save handler');
-
-		$depth = 0;
-		foreach (PhpToken::tokenize($source) as $token) {
-			if ($token->pos < $open || ($token->text !== '{' && $token->text !== '}')) {
-				continue;
-			}
-			if ($token->text === '{') {
-				$depth++;
-				continue;
-			}
-			if (--$depth === 0) {
-				return substr($source, $open, $token->pos - $open);
-			}
-		}
-
-		$this->fail("the Save handler's block is never closed");
-	}
-
-	/**
 	 * The extraction is only worth anything while the function these cases drive is the one
-	 * the page runs (issue #2525). The Save handler must delegate to
-	 * pfb_software_check_save() and persist before it flushes config.xml, and the page must
-	 * carry no second, untested write of this field.
+	 * the page runs (issue #2525). The Save branch must persist through
+	 * pfb_software_check_save() and only then flush config.xml, and the page must carry no
+	 * second, untested write of this field.
+	 *
+	 * The handler is pinned as ONE literal sequence, and each of its three lines is required
+	 * to occur exactly once on the page. Anything that resolves the handler's extent — a
+	 * scan for a closing brace, a brace-matching walk, an unbounded strpos from the opening
+	 * line — can select the wrong region and then pass against it, which is how review found
+	 * this assertion vacuous twice: an indented closing brace ran a literal scan past the
+	 * handler, and a '${' interpolation, whose closer is a plain '}' token, silently
+	 * shortened a brace-matching walk. A literal sequence has no extent to get wrong, and
+	 * the exactly-once counts leave the sequence nowhere else on the page to live.
 	 */
 	public function testPageSaveDelegatesToTheExtractedSave(): void
 	{
 		$source = (string) file_get_contents(self::PAGE);
-		$save   = $this->saveHandlerBlock($source);
 
-		// Exactly once each, so a second copy of either statement elsewhere on the page
-		// cannot stand in for the one this block is asserted to hold.
+		$this->assertSame(1, substr_count($source, self::SAVE_OPEN), 'the page must open the Save branch exactly once');
 		$this->assertSame(1, substr_count($source, self::PERSIST), 'the page must call the extracted save exactly once');
 		$this->assertSame(1, substr_count($source, self::FLUSH), 'the page must flush the Software settings exactly once');
 
-		$persist = strpos($save, self::PERSIST);
-		$flush   = strpos($save, self::FLUSH);
-		$this->assertNotFalse($persist, 'the Save handler must persist through pfb_software_check_save()');
-		$this->assertNotFalse($flush, 'the Save handler must flush config.xml');
-		$this->assertLessThan($flush, $persist, 'the token must be persisted before the flush');
+		$this->assertStringContainsString(
+			self::SAVE_OPEN . "\n\t" . self::PERSIST . "\n\t" . self::FLUSH,
+			$source,
+			'the Save branch must persist through pfb_software_check_save() and then flush config.xml'
+		);
 
 		$this->assertStringNotContainsString(
 			"PfbConfig::write('gen/pfb_software_check'",

--- a/tests/php/SoftwareCheckPostRoundTripTest.php
+++ b/tests/php/SoftwareCheckPostRoundTripTest.php
@@ -188,12 +188,9 @@ final class SoftwareCheckPostRoundTripTest extends TestCase
 	 * shim for guiconfig.inc and what it pulls in is tracked separately.
 	 *
 	 * The branch is pinned as ONE literal sequence, with each of its three lines required to
-	 * occur exactly once on the page. Anything that resolves the handler's EXTENT -- a scan
-	 * for a closing brace, a brace-matching walk -- can select the wrong region and then pass
-	 * against it, which is how review found this assertion vacuous twice: an indented closing
-	 * brace ran a literal scan past the handler, and a '${' interpolation, whose closer is a
-	 * plain '}' token, silently shortened a brace-matching walk. A literal sequence has no
-	 * extent to get wrong.
+	 * occur exactly once on the page. Never reintroduce anything that resolves the handler's
+	 * EXTENT -- a closing-brace scan, a token walk: a wrong extent passes against the wrong
+	 * region, which happened twice here.
 	 */
 	public function testPageSaveDelegatesToTheExtractedSave(): void
 	{

--- a/tests/php/SoftwareCheckPostRoundTripTest.php
+++ b/tests/php/SoftwareCheckPostRoundTripTest.php
@@ -173,15 +173,23 @@ final class SoftwareCheckPostRoundTripTest extends TestCase
 	 * pfb_software_check_save() and only then flush config.xml, and the page must carry no
 	 * second, untested write of this field.
 	 *
-	 * LIMITATION, stated rather than implied: this is a source-text gate and cannot prove
-	 * executed behaviour. The page's top-level handler is not executable under the
-	 * page-loader harnesses (they eval() function definitions out of a page), which is why
-	 * #2525 chose extraction in the first place; the executable proof lives in the cases
-	 * above, which drive the extracted function itself.
+	 * LIMITATION, stated rather than implied: this proves the wiring TEXT and cannot prove
+	 * reachability. A handler behind an inverted condition is caught, because the branch's
+	 * opening line is part of the pinned sequence, but a rewrite that keeps the sequence and
+	 * makes it unreachable -- the whole branch inside a dead `if (FALSE)`, or in a function
+	 * nobody calls, or after an unconditional exit -- survives this test. The executable
+	 * proof for this field is the cases above, which drive the extracted function itself.
+	 *
+	 * There is no executable proof of the page's DECISION to call it, because the page's
+	 * top-level handler cannot be run under this harness: including the page after
+	 * tests/php/bootstrap.php exits 255 at its line 31, `require_once('guiconfig.inc')`,
+	 * before any page logic -- the bootstrap's include path carries tests/php/shims and the
+	 * system path, and no guiconfig.inc. That is why #2525 chose extraction, and a runtime
+	 * shim for guiconfig.inc and what it pulls in is tracked separately.
 	 *
 	 * The branch is pinned as ONE literal sequence, with each of its three lines required to
-	 * occur exactly once on the page. Anything that resolves the handler's EXTENT — a scan
-	 * for a closing brace, a brace-matching walk — can select the wrong region and then pass
+	 * occur exactly once on the page. Anything that resolves the handler's EXTENT -- a scan
+	 * for a closing brace, a brace-matching walk -- can select the wrong region and then pass
 	 * against it, which is how review found this assertion vacuous twice: an indented closing
 	 * brace ran a literal scan past the handler, and a '${' interpolation, whose closer is a
 	 * plain '}' token, silently shortened a brace-matching walk. A literal sequence has no

--- a/tests/php/fixtures/function_inventory.json
+++ b/tests/php/fixtures/function_inventory.json
@@ -10819,6 +10819,19 @@
         "returnType": "bool",
         "params": []
     },
+    "pfb_software_check_save": {
+        "returnsRef": false,
+        "returnType": "string",
+        "params": [
+            {
+                "name": "post",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            }
+        ]
+    },
     "pfb_software_is_our_build": {
         "returnsRef": false,
         "returnType": "bool",


### PR DESCRIPTION
## What this does

`tests/php/SoftwareCheckPostRoundTripTest.php` did not execute the Software page's Save handler. It called `PfbConfig::write()` itself, with the filter constant scraped out of the page's source by regex, and then asserted the value round-tripped — a replay of what the page *should* do, never a run of what it *does*. So `gen/pfb_software_check` had no PR-gating persistence coverage.

This extracts the save into `pfb_software_check_save()`, leaves the page with the presentation decision, and pins it with tests that drive that function directly.

## The hole, executed before it was fixed

The mutation is the one the issue names: the page evaluates its filter and throws the result away, so nothing persists. The filter expression is left in place so the old test's source-scrape still matches — deleting the whole line would have reddened that test through a source-shape assertion rather than through the missing persistence, which is not the same claim.

```diff
 if ($_POST && isset($_POST['save'])) {
-	PfbConfig::write('gen/pfb_software_check', pfb_filter($_POST['pfb_software_check'] ?? '', PFB_FILTER_ON_OFF, 'software') ?: '');
+	pfb_filter($_POST['pfb_software_check'] ?? '', PFB_FILTER_ON_OFF, 'software') ?: '';
 	write_config('[pfBlockerNG] save Software settings');
```

Focused:

```text
$ vendor/bin/phpunit --filter SoftwareCheckPostRoundTripTest
OK (3 tests, 20 assertions)
```

Whole suite, at `25554a7b`, both halves — the untouched base tree and the same tree with only that write deleted:

```text
base-25554a7b-unmutated:          Tests: 5459, Assertions: 30888, Failures: 1, Warnings: 29, Deprecations: 3, Notices: 1, Skipped: 3.
base-25554a7b-with-write-deleted: Tests: 5459, Assertions: 30888, Failures: 1, Warnings: 29, Deprecations: 3, Notices: 1, Skipped: 3.
```

Byte-identical, down to the assertion count; a `diff` of the two full logs with timestamps and temp-dir ids masked is empty. The single failure in both is pre-existing and host-only — `DownloadSizeCeilingTest::test_extract_cmd_ceiling_stops_a_child_that_writes_past_it`, "Darwin dd must surface RLIMIT_FSIZE as its EFBIG exit"; see "Gates" below. `25554a7b` is an ancestor of the current base and nothing between them touches `tests/php` or `phpunit.xml`, which the test-honesty leg checked before accepting the pair.

## The fix

`pfb_software_check_save()` lives in `pfblockerng.inc` beside `pfb_software_check_enabled()`, the accessor that reads the same field, and follows the shape #2523 established for `pfb_login_ca_consent_save()` (that surface was retired in `fd978e09`, so the precedent is history-only now):

```php
function pfb_software_check_save(array $post): string {
	$token = pfb_filter($post['pfb_software_check'] ?? '', PFB_FILTER_ON_OFF, 'software') ?: '';
	PfbConfig::write('gen/pfb_software_check', $token);
	return $token;
}
```

The page keeps the decision to save, the flush and the redirect:

```php
if ($_POST && isset($_POST['save'])) {
	pfb_software_check_save($_POST);
	write_config('[pfBlockerNG] save Software settings');
	header('Location: /pfblockerng/pfblockerng_software.php');
	exit;
}
```

Persistence still routes through `PfbConfig`, and authorization is unchanged. `PfbConfig::write()` re-asserts the field's `write_priv` at the write and not at the call site — "Authorization is a property of the WRITE, not the call site", `pfblockerng_extra.inc` — so the #485 `pkg_mgr_installed.php` override gates this field from the `.inc` exactly as it did from the page. A future no-web-session caller throws rather than writing silently; the correctness leg executed that path and got the documented `RuntimeException`.

`RequireConfigGatewaySniff` has two rules and this diff triggers neither: the raw registered-path rule (`processRawConfigPathCall()`) applies wherever a `config_*_path` call names a registered path, and only the `PfbConfig::*System()` rule is scoped to `/usr/local/www/`. The page makes no config call at all now, and the new function uses the authorization-checked `PfbConfig::write()`, not a `*System()` escape hatch.

## Tests

Three frozen moments, each with the test file byte-identical across its red and green runs:

| Frozen test | `git hash-object` | RED against | GREEN against |
| --- | --- | --- | --- |
| `tests/php/SoftwareCheckPostRoundTripTest.php` — the extraction | `011cf2fdce6dc2d05fdd0ea745d0ec74a413fb6b` | the pre-extraction tree | the post-extraction tree |
| same file — review round 2, brace-matched bound | `23fb7ad3be3411d0c6b67e6fc8b9a77dbb6829dd` | MUTANT V | the clean tree |
| same file — review round 3, literal sequence | `c4e8f5470cfc117d76021830dff2c8c7214aceeb` | 14 mutants below | the clean tree |
| same file — as shipped, with the limitation documented | `e1fb698bba787184f794ca17fd30052d1d56a1ba` | (comment-only since `c4e8f547`) | the clean tree |

RED for the extraction (production files at base, test file frozen):

```text
$ vendor/bin/phpunit --filter SoftwareCheckPostRoundTripTest
EEEEF                                                               5 / 5 (100%)

There were 4 errors:
1) SoftwareCheckPostRoundTripTest::testCheckedSavePersistsEnabled
Error: Call to undefined function pfb_software_check_save()
2) SoftwareCheckPostRoundTripTest::testUncheckedSavePersistsDisabled
3) SoftwareCheckPostRoundTripTest::testCheckboxPostsATokenTheFilterAccepts
4) SoftwareCheckPostRoundTripTest::testSaveRejectsATokenTheToggleGatewayCannotRoundTrip

There was 1 failure:
1) SoftwareCheckPostRoundTripTest::testPageSaveDelegatesToTheExtractedSave
the Save handler must persist through pfb_software_check_save()
Failed asserting that false is not false.

ERRORS!
Tests: 5, Assertions: 7, Errors: 4, Failures: 1.
```

GREEN after it, same hash: `OK (5 tests, 21 assertions)`. Both were replayed independently by the verifier and by the test-honesty leg in their own worktrees, at the same hash.

### Mutation matrix

Run at the head, with the tree checked out at that commit and every file restored from it — nothing copied in. Each mutant is an exact-string replacement whose anchor count is asserted to be 1 and whose `git diff` is asserted non-empty before the run, so a substitution that does not apply aborts instead of producing a false green. 18 rows, 0 mismatches, `git status` empty at the end.

| Mutant | Verdict | Cases turned RED |
| --- | --- | --- |
| delete `PfbConfig::write('gen/pfb_software_check', $token)` from the function | KILLED | `testCheckedSavePersistsEnabled`, `testUncheckedSavePersistsDisabled`, `testSaveRejectsATokenTheToggleGatewayCannotRoundTrip` |
| delete the page's `pfb_software_check_save($_POST);` call | KILLED | `testPageSaveDelegatesToTheExtractedSave` |
| store the raw posted token instead of the `PFB_FILTER_ON_OFF` result | KILLED | `testSaveRejectsATokenTheToggleGatewayCannotRoundTrip` |
| write the token to a different registered key (`gen/pfb_keep`) | KILLED | the same three persistence cases |
| keep the write, return the wrong token | KILLED | `testCheckedSavePersistsEnabled` |
| page flushes before it persists | KILLED | `testPageSaveDelegatesToTheExtractedSave` |
| page calls the save twice | KILLED | `testPageSaveDelegatesToTheExtractedSave` |
| `Form_Checkbox` drops its explicit `'on'` (issue #2367's original defect) | KILLED | `testCheckedSavePersistsEnabled`, `testCheckboxPostsATokenTheFilterAccepts` |
| reintroduce an inline `PfbConfig::write` on the page | KILLED | `testPageSaveDelegatesToTheExtractedSave` |
| MUTANT V: the Save no longer flushes (flush moved to a later block) **and** its closing brace is indented | KILLED | `testPageSaveDelegatesToTheExtractedSave` |
| `"${foo}"` interpolation inserted between the call and the flush | KILLED | `testPageSaveDelegatesToTheExtractedSave` |
| a decoy `if (FALSE)` block carrying the handler's opening literal, with the real handler emptied | KILLED | `testPageSaveDelegatesToTheExtractedSave` |
| the flush statement duplicated in a comment | KILLED | `testPageSaveDelegatesToTheExtractedSave` |
| the handler's opening literal duplicated in a comment | KILLED | `testPageSaveDelegatesToTheExtractedSave` |
| `"${foo}"` interpolation inserted **after** the flush | survives by design | — |
| the handler's closing brace indented | survives by design | — |
| a heredoc containing a lone `}` after the flush | survives by design | — |
| a `match` expression after the flush | survives by design | — |

The four survivors are the states the assertion must tolerate; each leaves the pinned sequence byte-identical, and a test that reddened on them would be pinning brace style rather than behaviour.

The first mutant's output, quoted, because it is the one the issue is about:

```text
FF.F.                                                               5 / 5 (100%)

There were 3 failures:

1) SoftwareCheckPostRoundTripTest::testCheckedSavePersistsEnabled
precondition: the check starts disabled
Failed asserting that true is false.

2) SoftwareCheckPostRoundTripTest::testUncheckedSavePersistsDisabled
an unticked Save must persist the disabled token
Failed asserting that true is false.

3) SoftwareCheckPostRoundTripTest::testSaveRejectsATokenTheToggleGatewayCannotRoundTrip
'yes' is not an accepted token: it must persist as the disabled token, never enable the check
Failed asserting that true is false.

FAILURES!
Tests: 5, Assertions: 18, Failures: 3.
```

Deleting the write is invisible unless the BEFORE state is asserted: with nothing stored, the field reads as its registered On default, so a test that only checks the end state of a save-to-on passes on a save that does nothing. Every case here asserts its before state.

### What the delegation assertion proves, and what it cannot

It proves the wiring TEXT. It cannot prove reachability, and that is stated in the test's own docblock rather than left to be rediscovered: an inverted branch condition is caught, because the branch's opening line is part of the pinned sequence, but a rewrite that keeps the sequence and makes it unreachable — the branch inside a dead `if (FALSE)`, in a function nobody calls, or after an unconditional `exit` — survives it. Each of those is a real defect, and no source-text check can tell them from the real thing.

The honest gate is not available here, established by execution rather than assumed:

```text
$ php -d display_errors=1 -r 'require "tests/php/bootstrap.php"; $_POST=["save"=>1,"pfb_software_check"=>"on"]; include "src/usr/local/www/pfblockerng/pfblockerng_software.php";'
exit 255
Fatal error: require_once(): Failed opening required 'guiconfig.inc' … pfblockerng_software.php on line 31
```

That is before any page logic. The bootstrap's include path carries `tests/php/shims` and the system path and has no `guiconfig.inc`, and `AlertsPageLoader`/`UpdatePageLoader` avoid top-level wiring by design — which is exactly why #2525 asked for extraction. The executable proof for this field is therefore the four cases that drive `pfb_software_check_save()` itself, where deleting the production write reddens three of them.

The harness gap is filed as **#2768** (it is the same wall #2518 and #2367 hit), including a working prototype: a driver that doubles the prologue functions, doubles `pfb_software_check_save()` and `write_config()` as recorders, drops the appliance-path `require_once` lines and evaluates the rest of the page verbatim, recording `PROVENANCE / PRIV pkg_mgr_installed.php / SAVE 'on' / FLUSH … / EXIT` for a ticked Save and `SAVE NULL` for an unticked one. It is not in this PR by owner ruling: harness work needs its own review, and this ticket's bar is already met.

### Why that assertion has no scanner

Review found the same idea vacuous twice, and the second time is the instructive one:

- **Round 1.** The handler was bounded by `strpos($source, "\n}\n", $start)`. That pins the closing brace's *indentation*: indent it and the scan runs past the handler to the next unindented brace, silently widening the block. MUTANT V — the indented brace plus the flush moved out of the handler, `php -l` clean — was green against that bound and red against its replacement.
- **Round 2.** The bound became a `PhpToken` brace-matching walk. `${` tokenises as `T_DOLLAR_OPEN_CURLY_BRACES`, whose text is `${`, so a walk counting `{` never counts the opener while its closer arrives as a plain `}`. The depth unbalances and the walk returns a silently *shortened* block: inserting `$interpolated = "${foo}";` after the flush left the test green while the resolved block ended mid-string. The leg also named a decoy block carrying the handler's opening literal, which would anchor the `strpos` while the real handler was emptied.

Counting `${` would have closed the first of those and left the second, so the mechanism went instead of getting a third patch. The branch is pinned as one literal sequence — its opening line, the call, the flush, in that order — with each of those three lines required to occur exactly once on the page. Nothing lexes anything, there is no extent to get wrong, and the exactly-once counts leave the sequence nowhere else on the page to live. It is 26 lines smaller than the walk it replaces, and the over-engineering leg's shorter alternative was measured weaker on four of nine mutants (see its round-3 audit comment).

### What changed in the test file

- The `saveFilter()` helper is gone with its regex. Its one load-bearing job — pinning `PFB_FILTER_ON_OFF` so a widened filter reads as a contract change rather than a refactor — is now a behavioural case: `'yes'`, the token the checkbox actually posted for a release (#2367), must persist as Off. That case is mutation-killed twice.
- `postedWhenChecked()` stays and still reads the rendered checkbox's posted value out of the page. That half genuinely lives on the page, and it is #2367's pin. `testCheckboxPostsATokenTheFilterAccepts` now carries only the assertion that is its own — that the rendered token is not pfSense's `'yes'` — because its save oracle duplicated `testCheckedSavePersistsEnabled`'s, which is where the rendered token's round trip is now asserted.
- `testPageSaveDelegatesToTheExtractedSave()` is new: the extraction is only worth anything while the function the tests drive is the one the page runs.

### Live tiers

no-test-needed: the `www/` half is a delegation of an expression already covered at every live tier, with no rendered or behavioural difference, and the tiers that would gate it already exist and are unchanged — Tier A `test_software_page_renders_when_override_forces_on` and `test_software_check_checkbox_posts_a_token_the_save_path_accepts` (`tests/smoke/ui/test_render_smoke.py`), Tier B `test_software_page_toggle_post_roundtrip` (`tests/smoke/ui/test_functional.py`), which drives this exact field off/on/off through a real POST and reads `config.xml` back. The test-honesty leg verified that justification independently, including that `git diff --quiet` over `tests/smoke/` between base and head is clean. Adding a smoke edit to satisfy the pairing gate would be the coverage theater `testing.md` forbids; the coverage this issue asked for is the hermetic PHP tier above, which is what a PR can actually gate on — the live UI fan-out reports `skipping` on PRs, which is why the hole survived.

`tests/php/fixtures/function_inventory.json` gains the one new signature, regenerated with `PFB_UPDATE_FUNCTION_INVENTORY=1` and re-verified green without it.

## Gates

`scripts/agent/run-gates.sh --diff origin/devel`: `php -l` (×3), `composer phpstan`, `composer phpcs`, and the Composer vendor checker all PASS.

Two local gates need a word, and CI is green on both:

- `vendor/bin/phpunit` reports FAIL on the sole pre-existing failure above — identical on a clean worktree of the base with no diff applied, deterministic across three runs, and reproducible straight from `sh` with the default `SIGXFSZ` disposition. It is a Darwin-only expectation pinned by #2685's fix to one of the two statuses a `RLIMIT_FSIZE` overrun can produce; filed as #2765. CI's `PHPUnit unit tests / PHP 8.3` and `/ PHP 8.5` are green.
- `check_coverage_pairing.py` fails locally because `run-gates.sh` does not pass `--warn-only`; CI reads the label live and does, and its `Coverage pairing (src/tests + www/ui)` check passes with the justification line above (#921/#969).

Fixes #2525

🤖 Generated by Oh My Pi and posted on behalf of @andrebrait.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the Software page’s “Check for new versions” setting so unchecked or invalid values are not incorrectly saved as enabled.
  * Improved consistency when saving the setting and applying configuration changes. 


<!-- end of auto-generated comment: release notes by coderabbit.ai -->