### PR TITLE
software: make a failed catalogue refresh observable

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -5200,6 +5200,40 @@ function pfb_software_uninstall_href(string $pkgname): string {
 }
 
 /*
+ * WHEN the most recent version check failed, or 0 when the page must show nothing (issue
+ * #2674). The Software page pairs this with "Last checked" — the last SUCCESSFUL read — so an
+ * admin can tell "checked, and you are up to date" from "the check failed and you are looking
+ * at a cached answer".
+ *
+ * $cache_current is the page's own pfb_software_cache_matches_install() verdict, so a failure
+ * recorded against a previous install is never shown against the current one. The cache is a
+ * JSON file on disk, so a non-numeric or non-scalar value names no time and shows nothing
+ * rather than rendering a 1970 timestamp or emitting a conversion warning (issue #2367).
+ */
+function pfb_software_failed_at(array $cache, bool $cache_current): int {
+	if (!$cache_current || !isset($cache['last_failed']) || !is_numeric($cache['last_failed'])) {
+		return 0;
+	}
+	$at = (int) $cache['last_failed'];
+	return ($at > 0) ? $at : 0;
+}
+
+/*
+ * Where "Check now" redirects after the check it forced (issue #2674).
+ *
+ * The handler POSTs, checks, and redirects, so before #2674 an admin who explicitly asked for
+ * a fresh answer was silently re-served the old page. A failed forced check carries a query
+ * token the page's render arm turns into a warning box; a successful one redirects clean, so a
+ * benign load never raises it. Same shape as pfb_general_schedule_save_redirect().
+ */
+function pfb_software_check_redirect(
+	bool $check_ok,
+	string $failure_redirect = '/pfblockerng/pfblockerng_software.php?check=failed'
+): string {
+	return $check_ok ? '/pfblockerng/pfblockerng_software.php' : $failure_redirect;
+}
+
+/*
  * TRUE when $latest is strictly newer than $installed, via pfSense pkg_version_compare()
  * (never a string compare — it returns '<' | '=' | '>'). Empty/invalid inputs -> FALSE
  * (no update): a missing installed or latest version is never "an update is available".
@@ -5457,6 +5491,19 @@ function pfb_pkg_newest_version(array $versions): string {
 }
 
 /*
+ * Did the live catalogue read just performed actually SUCCEED? (issue #2674)
+ *
+ * All three inputs matter, and the refresh one is the reason this rule exists. A non-zero
+ * `pkg update -f` means the catalogue was NOT refreshed, so any version rquery then prints
+ * came off the STALE local DB — reading it is a fallback, never a successful check. Before
+ * #2674 the refresh's return value was discarded at the call site, so a stale answer was
+ * indistinguishable from a fresh one and the page advanced "Last checked" for it.
+ */
+function pfb_pkg_read_ok(int $refresh_ret, int $rquery_ret, string $latest): bool {
+	return $refresh_ret === 0 && $rquery_ret === 0 && $latest !== '';
+}
+
+/*
  * The pfBlockerNG repo's latest version of $pkgname: `pkg update -f -r <repo>` (forced
  * refresh of just that repo's catalog DB) then `pkg rquery -r <repo> '%v' <pkgname>`.
  * Reads ONLY that repo ($reponame) — never -r pfSense / get_pkg_info (ADR-19 §2 "Read
@@ -5466,8 +5513,18 @@ function pfb_pkg_newest_version(array $versions): string {
  *   - the pkg subsystem is locked (is_subsystem_dirty('pkg')) — never fight a base update;
  *   - DNS is unavailable (get_dnsavailable()) — never stall on a network read;
  *   - the rquery yields nothing (repo/conf absent).
+ *
+ * $read_ok reports the OUTCOME to the caller, which an empty return alone cannot (issue
+ * #2674 — a failing check was indistinguishable from a successful one):
+ *   TRUE   the catalogue was refreshed and named a version;
+ *   FALSE  the read was attempted and FAILED (either pkg call exited non-zero, or the
+ *          catalogue named nothing) — the caller records that;
+ *   NULL   no read was attempted, because a guard above deliberately deferred it. A
+ *          deferral is not a failure: turning "pkg is busy" or "no DNS yet" into a failed
+ *          check is exactly the scary page #2674 asks us not to produce.
  */
-function pfb_pkg_latest(string $pkgname, string $reponame): string {
+function pfb_pkg_latest(string $pkgname, string $reponame, ?bool &$read_ok = null): string {
+	$read_ok = null;
 	if ($pkgname === '' || $reponame === '') {
 		return '';
 	}
@@ -5482,16 +5539,21 @@ function pfb_pkg_latest(string $pkgname, string $reponame): string {
 	// Bound both networked pkg calls with timeout(1) (same idiom as the hook runner) so a
 	// hung mirror can never stall the cron pass or the page's forced "Check now".
 	$tmo = '/usr/bin/timeout -s TERM -k 5 60 ';
-	// Forced catalog refresh of the pfBlockerNG repo only; ignore failures (stale DB still reads).
+	// Forced catalog refresh of the pfBlockerNG repo only. A failure is NOT fatal -- the
+	// stale DB still reads, which is #2379's fallback -- but its return value is CAPTURED
+	// and fed to pfb_pkg_read_ok() rather than discarded, so the caller can tell a refreshed
+	// answer from a stale one (issue #2674). stderr stays redirected on both calls: what is
+	// observable is a state, never a pkg diagnostic on the page.
 	// -f is required: Pages/file:// catalogs can keep an unchanged mtime/etag (issue #2379).
-	pfb_pkg_exec("{$tmo}{$bin} update -f -r {$repo} 2>/dev/null");
+	$refresh_out = array();
+	$refresh_ret = -1;
+	pfb_pkg_exec("{$tmo}{$bin} update -f -r {$repo} 2>/dev/null", $refresh_out, $refresh_ret);
 	$out = array();
 	$ret = -1;
 	pfb_pkg_exec("{$tmo}{$bin} rquery -r {$repo} '%v' " . escapeshellarg($pkgname) . ' 2>/dev/null', $out, $ret);
-	if ($ret !== 0 || $out === array()) {
-		return '';
-	}
-	return pfb_pkg_newest_version($out);
+	$latest = ($ret === 0) ? pfb_pkg_newest_version($out) : '';
+	$read_ok = pfb_pkg_read_ok($refresh_ret, $ret, $latest);
+	return $latest;
 }
 
 /*
@@ -5636,13 +5698,22 @@ function pfb_software_update_check(bool $force = FALSE, ?array $io = null): arra
 	$cache = pfb_software_read_cache();
 
 	// 3. Read latest from the installed repo; keep the cached value when the live read is
-	// unavailable. last_checked advances only on a successful live read (issue #2379).
+	// unavailable. last_checked advances only on a successful live read (issue #2379), and
+	// $read_ok — not merely a non-empty version — is what "successful" means (issue #2674):
+	// a version read off a catalogue whose refresh failed is a fallback, not a fresh check.
+	$read_ok = null;
 	if (array_key_exists('latest', $io)) {
 		$live_latest = (string) $io['latest'];
+		// Tests may pin the outcome independently of the value; absent, an empty injected
+		// latest means the same thing it means on the live path — the read produced nothing.
+		$read_ok = array_key_exists('read_ok', $io)
+			? (is_bool($io['read_ok']) ? $io['read_ok'] : null)
+			: ($live_latest !== '');
 	} else {
-		$live_latest = pfb_pkg_latest($pkgname, $repo);
+		$live_latest = pfb_pkg_latest($pkgname, $repo, $read_ok);
 	}
 	$live_ok = ($live_latest !== '');
+	$read_failed = ($read_ok === FALSE);
 	// Only reuse cached latest/last_notified when the cache belongs to the SAME install.
 	// pfb_software_cache_matches_install() is the whole question — name AND repo — and the
 	// Software page gates its DISPLAYED values on the identical call, so the two can never
@@ -5658,6 +5729,9 @@ function pfb_software_update_check(bool $force = FALSE, ?array $io = null): arra
 	$kept_checked = ($cache_matches_install && array_key_exists('last_checked', $cache))
 		? $cache['last_checked']
 		: null;
+	$kept_failed = ($cache_matches_install && array_key_exists('last_failed', $cache))
+		? $cache['last_failed']
+		: null;
 
 	// 4. Refresh the cache. last_notified is written from the scoped value so a cache left
 	// by a different install (a different package name OR a different catalogue) is reset
@@ -5668,12 +5742,23 @@ function pfb_software_update_check(bool $force = FALSE, ?array $io = null): arra
 	$cache['installed']     = $installed;
 	$cache['latest']        = $latest;
 	$cache['last_notified'] = $last_notified;
-	if ($live_ok) {
+	if ($live_ok && !$read_failed) {
 		$cache['last_checked'] = time();
 	} elseif ($kept_checked !== null) {
 		$cache['last_checked'] = $kept_checked;
 	} else {
 		unset($cache['last_checked']);
+	}
+	// last_failed is the record #2674 was missing: WHEN the most recent attempt failed, or
+	// absent when the last thing that happened was not a failure. Scoped exactly like
+	// last_checked, so a failure from a previous install is never shown against this one.
+	// A successful read supersedes it; a deliberate deferral leaves the failure that stands.
+	if ($read_failed) {
+		$cache['last_failed'] = time();
+	} elseif (!$live_ok && $kept_failed !== null) {
+		$cache['last_failed'] = $kept_failed;
+	} else {
+		unset($cache['last_failed']);
 	}
 
 	if (pfb_should_notify($installed, $latest, $last_notified, $enabled)) {

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -5207,15 +5207,26 @@ function pfb_software_uninstall_href(string $pkgname): string {
  *
  * $cache_current is the page's own pfb_software_cache_matches_install() verdict, so a failure
  * recorded against a previous install is never shown against the current one. The cache is a
- * JSON file on disk, so a non-numeric or non-scalar value names no time and shows nothing
- * rather than rendering a 1970 timestamp or emitting a conversion warning (issue #2367).
+ * JSON file on disk, so only a value this box could actually have RECORDED is accepted: an
+ * int, or its plain decimal string (json_decode hands back either). Everything else names no
+ * time and shows nothing. That exclusion is load-bearing, not defensive: a JSON integer too
+ * large for a PHP int decodes to a FLOAT, and casting one emits "not representable as an int"
+ * into php_error.log on every page load -- noise the UI tiers read as a page defect (issue
+ * #2367) -- while PHP_INT_MAX would render a year-292277 date in the Status section.
  */
 function pfb_software_failed_at(array $cache, bool $cache_current): int {
-	if (!$cache_current || !isset($cache['last_failed']) || !is_numeric($cache['last_failed'])) {
+	if (!$cache_current || !isset($cache['last_failed'])) {
 		return 0;
 	}
-	$at = (int) $cache['last_failed'];
-	return ($at > 0) ? $at : 0;
+	$raw = $cache['last_failed'];
+	if (!is_int($raw) && !(is_string($raw) && preg_match('/^\d+$/', $raw) === 1)) {
+		return 0;
+	}
+	// An oversized decimal string saturates to PHP_INT_MAX rather than warning, so the range
+	// check below is what refuses it. The day of slack absorbs a clock stepped backwards by
+	// NTP without letting a hand-edited or overflowed value through.
+	$at = (int) $raw;
+	return ($at > 0 && $at <= time() + 86400) ? $at : 0;
 }
 
 /*
@@ -5545,10 +5556,11 @@ function pfb_pkg_latest(string $pkgname, string $reponame, ?bool &$read_ok = nul
 	// answer from a stale one (issue #2674). stderr stays redirected on both calls: what is
 	// observable is a state, never a pkg diagnostic on the page.
 	// -f is required: Pages/file:// catalogs can keep an unchanged mtime/etag (issue #2379).
-	$refresh_out = array();
-	$refresh_ret = -1;
-	pfb_pkg_exec("{$tmo}{$bin} update -f -r {$repo} 2>/dev/null", $refresh_out, $refresh_ret);
+	// pfb_pkg_exec() clears its $out at entry, so the two calls share one buffer; only the
+	// two return codes have to be kept apart.
 	$out = array();
+	$refresh_ret = -1;
+	pfb_pkg_exec("{$tmo}{$bin} update -f -r {$repo} 2>/dev/null", $out, $refresh_ret);
 	$ret = -1;
 	pfb_pkg_exec("{$tmo}{$bin} rquery -r {$repo} '%v' " . escapeshellarg($pkgname) . ' 2>/dev/null', $out, $ret);
 	$latest = ($ret === 0) ? pfb_pkg_newest_version($out) : '';
@@ -5567,7 +5579,9 @@ function pfb_software_cache_file(): string {
 
 /*
  * Read the cache file as an assoc array (channel, installed, latest, last_checked,
- * last_notified); [] when absent/unreadable/corrupt.
+ * last_notified, last_failed); [] when absent/unreadable/corrupt. last_failed is present
+ * only while the most recent check ATTEMPT failed (issue #2674); its absence is the ordinary
+ * state and is what a successful check restores.
  */
 function pfb_software_read_cache(): array {
 	$file = pfb_software_cache_file();
@@ -5582,8 +5596,9 @@ function pfb_software_read_cache(): array {
 	if (!is_array($data)) {
 		return array();
 	}
-	// Every consumer reads these values through a (string) cast -- the orchestrator's
-	// latest/last_notified, the page's displayed fields, the install matcher. A non-scalar
+	// Consumers read these values through a (string) cast -- the orchestrator's
+	// latest/last_notified, the page's displayed fields, the install matcher -- or, for the
+	// timestamps, through a validating accessor (pfb_software_failed_at()). A non-scalar
 	// value (a hand-edit, a future writer) makes each of those casts emit "Array to string
 	// conversion" once per call, so it is dropped HERE rather than guarded at each site,
 	// where the next site added would be unguarded again (issue #2367). Every key the writer
@@ -5630,20 +5645,31 @@ function pfb_software_write_cache(array $cache): void {
  *      remains enabled from a prior our-repo install. Injectable via $io['provenance_ok']
  *      for off-box tests.
  *   3. Read latest from the repo the package was INSTALLED from (guarded inside
- *      pfb_pkg_latest()). An empty latest (pkg locked / no DNS / repo absent) preserves the
- *      cached latest so the page keeps showing the last-known value rather than regressing
- *      to ''. A failed live read does NOT advance last_checked (issue #2379).
+ *      pfb_pkg_latest()). A live read that did not SUCCEED preserves the cached latest so
+ *      the page keeps showing the last-known value rather than regressing to '', and does
+ *      NOT advance last_checked (issue #2379). "Succeeded" is pfb_pkg_latest()'s reported
+ *      outcome, not merely a non-empty return: a version rquery printed off a catalogue
+ *      whose refresh failed is a fallback, so promoting it would let the notice in step 4
+ *      announce an update nothing verified (issue #2674).
  *   4. Refresh the cache (pkgname/repo/channel/installed/latest; last_checked only on a
- *      successful live read) and, when pfb_should_notify() says so, raise a DE-DUPED
- *      file_notice and persist last_notified = latest (so repeated ticks at the same
- *      latest do not renotify).
+ *      successful live read, last_failed only while the last attempt failed) and, when
+ *      pfb_should_notify() says so, raise a DE-DUPED file_notice and persist
+ *      last_notified = latest (so repeated ticks at the same latest do not renotify).
+ *
+ * $read_ok reports THIS call's read outcome to the caller, with pfb_pkg_latest()'s meanings:
+ * TRUE succeeded, FALSE attempted and failed, NULL not attempted (a gate above returned
+ * early, or a guard deferred the read). The page's "Check now" keys its feedback on this
+ * rather than on the cache, because the cache deliberately KEEPS a failure across a later
+ * deferral — reading it there made an identical deferral report "failed" or "fine" depending
+ * only on what an earlier tick had recorded (issue #2674).
  *
  * Best-effort throughout: it returns the cache array and never throws, so wiring it into
  * the cron pass can never break a feed update. $force (the page's "Check now" button) bypasses
  * the "Check for new versions" enable-gate so a manual check always runs; it never bypasses the
  * provenance gate, and notifications still require the setting enabled.
  */
-function pfb_software_update_check(bool $force = FALSE, ?array $io = null): array {
+function pfb_software_update_check(bool $force = FALSE, ?array $io = null, ?bool &$read_ok = null): array {
+	$read_ok = null;
 	$io = is_array($io) ? $io : array();
 
 	$pkgname = array_key_exists('installed_name', $io)
@@ -5697,32 +5723,37 @@ function pfb_software_update_check(bool $force = FALSE, ?array $io = null): arra
 
 	$cache = pfb_software_read_cache();
 
-	// 3. Read latest from the installed repo; keep the cached value when the live read is
-	// unavailable. last_checked advances only on a successful live read (issue #2379), and
-	// $read_ok — not merely a non-empty version — is what "successful" means (issue #2674):
-	// a version read off a catalogue whose refresh failed is a fallback, not a fresh check.
-	$read_ok = null;
+	// 3. Read latest from the installed repo; keep the cached value when the live read did
+	// not succeed. $read_ok — not merely a non-empty version — is what "successful" means
+	// (issue #2674): a version rquery printed off a catalogue whose refresh failed came from
+	// a stale DB, so it is neither promoted nor notified from. The cache keeps the last
+	// version a SUCCESSFUL read produced (issue #2379's fallback), and last_checked keeps
+	// naming that read.
 	if (array_key_exists('latest', $io)) {
 		$live_latest = (string) $io['latest'];
-		// Tests may pin the outcome independently of the value; absent, an empty injected
-		// latest means the same thing it means on the live path — the read produced nothing.
+		// An explicitly injected outcome wins. A non-bool states none, and fails CLOSED:
+		// nothing is promoted, timestamped or notified on an outcome nobody named. Absent,
+		// an injected latest means what it means on the live path.
 		$read_ok = array_key_exists('read_ok', $io)
 			? (is_bool($io['read_ok']) ? $io['read_ok'] : null)
 			: ($live_latest !== '');
 	} else {
 		$live_latest = pfb_pkg_latest($pkgname, $repo, $read_ok);
 	}
-	$live_ok = ($live_latest !== '');
-	$read_failed = ($read_ok === FALSE);
+	// pfb_pkg_read_ok() already requires a non-empty version for TRUE on the live path; the
+	// second half closes the $io seam against a contradictory outcome/value pair.
+	$read_succeeded = ($read_ok === TRUE && $live_latest !== '');
 	// Only reuse cached latest/last_notified when the cache belongs to the SAME install.
 	// pfb_software_cache_matches_install() is the whole question — name AND repo — and the
 	// Software page gates its DISPLAYED values on the identical call, so the two can never
 	// disagree about which cache is current.
 	$cache_matches_install = pfb_software_cache_matches_install($cache, $pkgname, $repo);
-	if (!$live_ok && $cache_matches_install) {
+	if ($read_succeeded) {
+		$latest = $live_latest;
+	} elseif ($cache_matches_install) {
 		$latest = (string) ($cache['latest'] ?? '');
 	} else {
-		$latest = $live_latest;
+		$latest = '';
 	}
 
 	$last_notified = $cache_matches_install ? (string) ($cache['last_notified'] ?? '') : '';
@@ -5742,7 +5773,7 @@ function pfb_software_update_check(bool $force = FALSE, ?array $io = null): arra
 	$cache['installed']     = $installed;
 	$cache['latest']        = $latest;
 	$cache['last_notified'] = $last_notified;
-	if ($live_ok && !$read_failed) {
+	if ($read_succeeded) {
 		$cache['last_checked'] = time();
 	} elseif ($kept_checked !== null) {
 		$cache['last_checked'] = $kept_checked;
@@ -5753,9 +5784,9 @@ function pfb_software_update_check(bool $force = FALSE, ?array $io = null): arra
 	// absent when the last thing that happened was not a failure. Scoped exactly like
 	// last_checked, so a failure from a previous install is never shown against this one.
 	// A successful read supersedes it; a deliberate deferral leaves the failure that stands.
-	if ($read_failed) {
+	if ($read_ok === FALSE) {
 		$cache['last_failed'] = time();
-	} elseif (!$live_ok && $kept_failed !== null) {
+	} elseif (!$read_succeeded && $kept_failed !== null) {
 		$cache['last_failed'] = $kept_failed;
 	} else {
 		unset($cache['last_failed']);

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -5219,7 +5219,7 @@ function pfb_software_failed_at(array $cache, bool $cache_current): int {
 		return 0;
 	}
 	$raw = $cache['last_failed'];
-	if (!is_int($raw) && !(is_string($raw) && preg_match('/^\d+$/', $raw) === 1)) {
+	if (!is_int($raw) && !(is_string($raw) && ctype_digit($raw))) {
 		return 0;
 	}
 	// An oversized decimal string saturates to PHP_INT_MAX rather than warning, so the range

--- a/src/usr/local/www/pfblockerng/pfblockerng_software.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_software.php
@@ -124,8 +124,12 @@ if ($input_errors) {
 // sets this token, so a plain GET — including one served entirely off a stale cache (issue
 // #2379) — stays silent: this box says "the action you asked for failed", never "your cache is
 // old" (issue #2674). Fixed literal comparison, so a hostile or array-valued query is inert.
+//
+// It names the CONTROL the admin pressed, which both distinguishes it from the Status row's
+// standing-state help below and gives the UI tiers a phrase that matches this box alone: while
+// the two shared a sentence, the tiers' "a plain load stays silent" assertion tripped on the row.
 if (($_GET['check'] ?? '') === 'failed') {
-	print_info_box(gettext('The version check could not read the pfBlockerNG repository catalogue. The versions below are from the last check that succeeded.'), 'warning');
+	print_info_box(gettext('Check now could not read the pfBlockerNG repository catalogue. The versions below are from the last check that succeeded.'), 'warning');
 }
 
 // Tab bar (the Software tab is the active one here; gated like every page).

--- a/src/usr/local/www/pfblockerng/pfblockerng_software.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_software.php
@@ -97,12 +97,16 @@ if ($_POST && isset($_POST['save'])) {
 $pfb_sw_check	= pfb_software_check_enabled();
 
 // "Check now" — a manual, explicit cache refresh from the pfBlockerNG repo, then redisplay. $force=true
-// bypasses the "Check for new versions" enable-gate so a one-off check always works. The check's own
-// outcome is CAPTURED and routed through pfb_software_check_redirect(): a forced check whose catalogue
-// read failed redirects carrying feedback rather than silently re-serving the cached answer (#2674).
+// bypasses the "Check for new versions" enable-gate so a one-off check always works. The outcome of
+// THIS read is captured out-of-band and routed through pfb_software_check_redirect(): a forced check
+// whose catalogue read failed redirects carrying feedback rather than silently re-serving the cached
+// answer (#2674). It is deliberately not read off the returned cache, which KEEPS a failure across a
+// later deferral — that would make an identical deferral report "failed" or "fine" depending only on
+// what an earlier tick recorded. NULL (nothing was attempted) is not a failure.
 if ($pfb_sw_action === 'check') {
-	$pfb_sw_result = pfb_software_update_check(TRUE);
-	header('Location: ' . pfb_software_check_redirect(!isset($pfb_sw_result['last_failed'])));
+	$pfb_sw_read_ok = NULL;
+	pfb_software_update_check(TRUE, NULL, $pfb_sw_read_ok);
+	header('Location: ' . pfb_software_check_redirect($pfb_sw_read_ok !== FALSE));
 	exit;
 }
 

--- a/src/usr/local/www/pfblockerng/pfblockerng_software.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_software.php
@@ -97,10 +97,12 @@ if ($_POST && isset($_POST['save'])) {
 $pfb_sw_check	= pfb_software_check_enabled();
 
 // "Check now" — a manual, explicit cache refresh from the pfBlockerNG repo, then redisplay. $force=true
-// bypasses the "Check for new versions" enable-gate so a one-off check always works.
+// bypasses the "Check for new versions" enable-gate so a one-off check always works. The check's own
+// outcome is CAPTURED and routed through pfb_software_check_redirect(): a forced check whose catalogue
+// read failed redirects carrying feedback rather than silently re-serving the cached answer (#2674).
 if ($pfb_sw_action === 'check') {
-	pfb_software_update_check(TRUE);
-	header('Location: /pfblockerng/pfblockerng_software.php');
+	$pfb_sw_result = pfb_software_update_check(TRUE);
+	header('Location: ' . pfb_software_check_redirect(!isset($pfb_sw_result['last_failed'])));
 	exit;
 }
 
@@ -112,6 +114,14 @@ include_once('head.inc');
 
 if ($input_errors) {
 	print_input_errors($input_errors);
+}
+
+// Feedback for the forced check that just ran. Only the check handler's own failure redirect
+// sets this token, so a plain GET — including one served entirely off a stale cache (issue
+// #2379) — stays silent: this box says "the action you asked for failed", never "your cache is
+// old" (issue #2674). Fixed literal comparison, so a hostile or array-valued query is inert.
+if (($_GET['check'] ?? '') === 'failed') {
+	print_info_box(gettext('The version check could not read the pfBlockerNG repository catalogue. The versions below are from the last check that succeeded.'), 'warning');
 }
 
 // Tab bar (the Software tab is the active one here; gated like every page).
@@ -152,6 +162,10 @@ $disp_latest	= ($cached_latest !== '') ? $cached_latest : gettext('Not checked y
 $disp_checked	= ($cache_current && !empty($cache['last_checked']))
 			? date('Y-m-d H:i:s', (int) $cache['last_checked'])
 			: gettext('never');
+// issue #2674: WHEN the last attempt failed, or 0 for the ordinary case (the last thing that
+// happened was not a failure). Non-zero adds ONE row below; it never restyles the rest, so a
+// box serving a cached answer after a transient failure stays readable rather than alarming.
+$failed_at	= pfb_software_failed_at($cache, $cache_current);
 
 $update_available = pfb_update_available($installed_ver, $cached_latest);
 if ($update_available) {
@@ -184,8 +198,17 @@ $section->addInput(new Form_StaticText(
 ));
 $section->addInput(new Form_StaticText(
 	'Last checked',
-	htmlspecialchars((string) $disp_checked)
-));
+	'<span id="pfb-sw-checked">' . htmlspecialchars((string) $disp_checked) . '</span>'
+))->setHelp('When a version check last completed successfully.');
+if ($failed_at > 0) {
+	$section->addInput(new Form_StaticText(
+		'Last check failed',
+		'<span id="pfb-sw-check-failed" class="text-warning">'
+			. htmlspecialchars(date('Y-m-d H:i:s', $failed_at))
+			. '</span>'
+	))->setHelp('The most recent version check could not read the pfBlockerNG repository catalogue, '
+		. 'so the versions above are from the last check that succeeded.');
+}
 $form->add($section);
 
 $section = new Form_Section('Updates');

--- a/src/usr/local/www/pfblockerng/pfblockerng_software.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_software.php
@@ -125,9 +125,8 @@ if ($input_errors) {
 // #2379) — stays silent: this box says "the action you asked for failed", never "your cache is
 // old" (issue #2674). Fixed literal comparison, so a hostile or array-valued query is inert.
 //
-// It names the CONTROL the admin pressed, which both distinguishes it from the Status row's
-// standing-state help below and gives the UI tiers a phrase that matches this box alone: while
-// the two shared a sentence, the tiers' "a plain load stays silent" assertion tripped on the row.
+// It names the CONTROL the admin pressed, which distinguishes it from the Status row's
+// standing-state help below; the two must not share a sentence.
 if (($_GET['check'] ?? '') === 'failed') {
 	print_info_box(gettext('Check now could not read the pfBlockerNG repository catalogue. The versions below are from the last check that succeeded.'), 'warning');
 }

--- a/tests/php/SoftwareCacheReadNormalisationTest.php
+++ b/tests/php/SoftwareCacheReadNormalisationTest.php
@@ -79,8 +79,10 @@ final class SoftwareCacheReadNormalisationTest extends TestCase
 
 	/**
 	 * A non-scalar value is dropped, so a caller casting it never sees it. Asserted through
-	 * the cast every consumer performs, with warnings captured rather than converted — the
-	 * point is what the code EMITS, not merely what it returns.
+	 * the cast the string-valued consumers perform, with warnings captured rather than
+	 * converted — the point is what the code EMITS, not merely what it returns. The one
+	 * consumer that does not cast (``pfb_software_failed_at()``, which validates instead)
+	 * refuses the same values, pinned in SoftwareFailedCheckStateTest.
 	 */
 	public function testNonScalarValuesAreDroppedSoConsumerCastsAreSilent(): void
 	{

--- a/tests/php/SoftwareCacheReadNormalisationTest.php
+++ b/tests/php/SoftwareCacheReadNormalisationTest.php
@@ -6,10 +6,11 @@ use PHPUnit\Framework\Attributes\CoversFunction;
 use PHPUnit\Framework\TestCase;
 
 /**
- * Every consumer of the software-update cache reads its values with a ``(string)`` cast —
- * the cron orchestrator's latest/last_notified, the Software page's displayed fields, the
- * install matcher. A non-scalar value in the file therefore emits "Array to string
- * conversion" at EACH of those call sites, once per call (issue #2367).
+ * Consumers of the software-update cache read its values with a ``(string)`` cast — the cron
+ * orchestrator's latest/last_notified, the Software page's displayed fields, the install
+ * matcher — or, for a timestamp, through a validating accessor (``pfb_software_failed_at()``,
+ * issue #2674). A non-scalar value in the file therefore emits "Array to string conversion"
+ * at EACH casting call site, once per call (issue #2367).
  *
  * Guarding each site would leave the next one to be written unguarded, so the value is
  * dropped where the file becomes data: a key the reader cannot hand to a caster is a key no

--- a/tests/php/SoftwareFailedCheckStateTest.php
+++ b/tests/php/SoftwareFailedCheckStateTest.php
@@ -49,6 +49,9 @@ final class SoftwareFailedCheckStateTest extends TestCase
 	/** The shipped orchestrator + read helpers, read by the wiring case below. */
 	private const INC = __DIR__ . '/../../src/usr/local/pkg/pfblockerng/pfblockerng.inc';
 
+	/** The Tier-A module, read for the phrase both live tiers key on (issue #2674). */
+	private const TIER_A = __DIR__ . '/../smoke/ui/test_render_smoke.py';
+
 	private const NAME = 'pfSense-pkg-pfBlockerNG';
 	private const REPO = 'pfblockerng-nightly';
 
@@ -708,6 +711,64 @@ final class SoftwareFailedCheckStateTest extends TestCase
 			pfb_software_failed_at(['last_failed' => '1700000000'], TRUE),
 			'a decimal integer string is the same time (json_decode can hand back either)'
 		);
+	}
+
+	/**
+	 * The phrase the UI tiers key on must identify the Check-now feedback and NOTHING ELSE
+	 * on the page.
+	 *
+	 * The page says two things about a failed read: the info box is about the action the
+	 * admin just took, the Status row is about standing state. Both tiers assert "the plain
+	 * page does not carry the Check-now feedback" by searching the rendered HTML for one
+	 * phrase, so a phrase the Status row ALSO contains makes that assertion trip on the row
+	 * and report a defect that is not there.
+	 *
+	 * This reads the tier's own constant rather than a phrase of its own, because the
+	 * coupling is the whole point: it is the tier's chosen string that has to discriminate.
+	 * Executed here because this is exactly what reddened all four Tier-A legs on the
+	 * previous head, and a hermetic gate catches it in a second instead of a VM round trip.
+	 */
+	public function testTheUiTiersFeedbackPhraseMatchesOnlyTheCheckNowBox(): void
+	{
+		$tier = (string) file_get_contents(self::TIER_A);
+		$phrase = $this->pageString($tier, '_SOFTWARE_CHECK_FAILED_TEXT = "', '"');
+		$this->assertNotSame('', $phrase, 'the Tier-A module must define the feedback phrase');
+
+		$page = (string) file_get_contents(self::PAGE);
+		$this->assertSame(
+			1,
+			substr_count($page, $phrase),
+			"the tiers key on '{$phrase}', which must appear EXACTLY once in the page — the "
+				. 'Status row restating it makes the plain-load assertion trip on the row'
+		);
+
+		// And the one occurrence is the info box, not something else that happens to match.
+		$box = $this->pageString($page, "print_info_box(gettext('", "')");
+		$this->assertStringContainsString(
+			$phrase,
+			$box,
+			'the single occurrence must be the Check now info box itself'
+		);
+
+		$row = $this->pageString($page, "))->setHelp('The most recent version check", "');");
+		$this->assertNotSame('', $row, 'the failed-attempt row must still carry its own help text');
+		$this->assertStringNotContainsString(
+			$phrase,
+			$row,
+			'the failed-attempt row must say its own thing, not restate the Check-now feedback'
+		);
+	}
+
+	/** The literal between $open and the next $close in $src, or '' when absent. */
+	private function pageString(string $src, string $open, string $close): string
+	{
+		$at = strpos($src, $open);
+		if ($at === FALSE) {
+			return '';
+		}
+		$from = $at + strlen($open);
+		$end = strpos($src, $close, $from);
+		return ($end === FALSE) ? '' : substr($src, $from, $end - $from);
 	}
 
 	/**

--- a/tests/php/SoftwareFailedCheckStateTest.php
+++ b/tests/php/SoftwareFailedCheckStateTest.php
@@ -1,0 +1,524 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * issue #2674 — a catalogue refresh that FAILED must be distinguishable from one that
+ * succeeded, at the read layer, on the cache, and on the Software page.
+ *
+ * The defect: `pkg update -f -r <repo>` ran with its return value discarded, so
+ * pfb_pkg_latest() could not tell its caller whether the version it returned came from a
+ * catalogue it had just refreshed or from a stale local DB — and a live read that produced
+ * nothing left NO field on the cache document naming the failure. With the cron tick still
+ * writing a good cache from a context where `pkg` works, the page rendered a version, an
+ * "Up to date" verdict and a recent "Last checked" while its own forced check failed every
+ * time. Probe on the pre-fix tree: a failed forced check added zero keys to the cache and
+ * the page's display expressions were byte-identical to the success case.
+ *
+ * What must NOT change is issue #2379's fallback: a failed live read keeps the cached
+ * `latest` rather than regressing it to '', and a benign deferral (pkg locked, no DNS) is
+ * not a failure at all. Observability here is a STATE, never a raw `pkg` error dump.
+ *
+ * Branch map, so every side of every decision is pinned:
+ *   read rule      refresh ok / refresh failed x rquery ok / rquery failed x version / none
+ *   attempt state  succeeded (TRUE) / failed (FALSE) / not attempted (NULL)
+ *   cache          record a failure / clear one on success / keep one across a skip /
+ *                  never carry a foreign install's failure
+ *   page           show the failed-attempt row / hide it / Check-now feedback both ways
+ */
+#[CoversFunction('pfb_pkg_read_ok')]
+#[CoversFunction('pfb_pkg_latest')]
+#[CoversFunction('pfb_software_update_check')]
+#[CoversFunction('pfb_software_failed_at')]
+#[CoversFunction('pfb_software_check_redirect')]
+final class SoftwareFailedCheckStateTest extends TestCase
+{
+	/** The page whose handler + render wiring the reachability cases below read. */
+	private const PAGE = __DIR__ . '/../../src/usr/local/www/pfblockerng/pfblockerng_software.php';
+
+	/** The shipped orchestrator + read helpers, read by the wiring case below. */
+	private const INC = __DIR__ . '/../../src/usr/local/pkg/pfblockerng/pfblockerng.inc';
+
+	private const NAME = 'pfSense-pkg-pfBlockerNG';
+	private const REPO = 'pfblockerng-nightly';
+
+	/** Every key the software cache writer is allowed to store (issue #2674: a state, not a dump). */
+	private const CACHE_KEYS = [
+		'pkgname', 'repo', 'channel', 'installed', 'latest',
+		'last_notified', 'last_checked', 'last_failed',
+	];
+
+	private string $dbdir = '';
+
+	private bool $hadDbdir = FALSE;
+	private mixed $savedDbdir = NULL;
+	private bool $hadConfig = FALSE;
+	private mixed $savedConfig = NULL;
+
+	protected function setUp(): void
+	{
+		$this->dbdir = sys_get_temp_dir() . '/pfb_2674_' . uniqid('', TRUE);
+		mkdir($this->dbdir, 0755, TRUE);
+		$this->hadDbdir   = isset($GLOBALS['pfb']) && array_key_exists('dbdir', $GLOBALS['pfb']);
+		$this->savedDbdir = $GLOBALS['pfb']['dbdir'] ?? NULL;
+		$GLOBALS['pfb']['dbdir'] = $this->dbdir;
+
+		$GLOBALS['pfb_test_file_notices']   = [];
+		$GLOBALS['pfb_test_pkg_locked']     = FALSE;
+		$GLOBALS['pfb_test_dns_available']  = TRUE;
+
+		$this->hadConfig   = array_key_exists('config', $GLOBALS);
+		$this->savedConfig = $GLOBALS['config'] ?? NULL;
+		$GLOBALS['config'] = [
+			'installedpackages' => ['pfblockerng' => ['config' => [0 => ['pfb_software_check' => 'on']]]],
+		];
+	}
+
+	protected function tearDown(): void
+	{
+		$file = $this->dbdir . '/software_update.json';
+		if (is_file($file)) {
+			unlink($file);
+		}
+		if (is_dir($this->dbdir)) {
+			rmdir($this->dbdir);
+		}
+		unset(
+			$GLOBALS['pfb_test_file_notices'],
+			$GLOBALS['pfb_test_pkg_locked'],
+			$GLOBALS['pfb_test_dns_available']
+		);
+		if ($this->hadDbdir) {
+			$GLOBALS['pfb']['dbdir'] = $this->savedDbdir;
+		} else {
+			unset($GLOBALS['pfb']['dbdir']);
+		}
+		if ($this->hadConfig) {
+			$GLOBALS['config'] = $this->savedConfig;
+		} else {
+			unset($GLOBALS['config']);
+		}
+	}
+
+	private function readCache(): ?array
+	{
+		$file = $this->dbdir . '/software_update.json';
+		if (!is_file($file)) {
+			return NULL;
+		}
+		$data = json_decode((string) file_get_contents($file), TRUE);
+		return is_array($data) ? $data : NULL;
+	}
+
+	/**
+	 * A cache exactly as a cron tick with a WORKING pkg leaves it: a known latest and a
+	 * successful-check timestamp, no failure recorded. This is the state the field report
+	 * describes — the page looks healthy because some other producer keeps it warm.
+	 */
+	private function seedCronWarmedCache(int $checkedAt = 1000, string $latest = '3.3.2'): array
+	{
+		pfb_software_write_cache([
+			'pkgname'       => self::NAME,
+			'repo'          => self::REPO,
+			'channel'       => 'nightly',
+			'installed'     => '3.3.2',
+			'latest'        => $latest,
+			'last_checked'  => $checkedAt,
+			'last_notified' => '',
+		]);
+		$seeded = (array) $this->readCache();
+		$this->assertArrayNotHasKey(
+			'last_failed',
+			$seeded,
+			'before: a cron-warmed cache records no failed attempt'
+		);
+		return $seeded;
+	}
+
+	/** The orchestrator's documented $io seam, scoped to this install. */
+	private function io(string $latest, ?bool $readOk = NULL, bool $withReadOk = TRUE): array
+	{
+		$io = [
+			'installed_name' => self::NAME,
+			'installed'      => '3.3.2',
+			'installed_repo' => self::REPO,
+			'record_channel' => 'nightly',
+			'provenance_ok'  => TRUE,
+			'latest'         => $latest,
+		];
+		if ($withReadOk) {
+			$io['read_ok'] = $readOk;
+		}
+		return $io;
+	}
+
+	/*
+	 * ---- The read rule: the catalogue refresh's return value is load-bearing ----
+	 */
+
+	/**
+	 * The defect's direct oracle. `pkg update -f` exited non-zero, so the catalogue was
+	 * NOT refreshed — but the stale local DB still answers rquery, so a version comes back.
+	 * That version is the best value we have, and it is NOT a successful check: reporting it
+	 * as one is exactly how a stale answer got presented as a fresh one.
+	 *
+	 * Asserts the success side first, so green proves the refresh rc — not the version —
+	 * caused the verdict to flip.
+	 */
+	public function testAFailedRefreshIsNotASuccessfulReadEvenWhenTheStaleDbAnswers(): void
+	{
+		$this->assertTrue(
+			pfb_pkg_read_ok(0, 0, '3.3.2'),
+			'a refresh that succeeded and an rquery that named a version IS a successful read'
+		);
+		$this->assertFalse(
+			pfb_pkg_read_ok(1, 0, '3.3.2'),
+			'the SAME version off a catalogue that failed to refresh is NOT a successful read'
+		);
+	}
+
+	/**
+	 * The other two ways a live read fails, and the two versions of each: rquery itself
+	 * exiting non-zero, and rquery exiting clean but naming nothing (repo present, package
+	 * absent from the catalogue).
+	 */
+	public function testAFailedOrEmptyRqueryIsNotASuccessfulRead(): void
+	{
+		$this->assertFalse(pfb_pkg_read_ok(0, 1, ''), 'rquery failed and named nothing');
+		$this->assertFalse(pfb_pkg_read_ok(0, 1, '3.3.2'), 'rquery failed, so what it printed is not trusted');
+		$this->assertFalse(pfb_pkg_read_ok(0, 0, ''), 'rquery clean but the catalogue names no version');
+		$this->assertFalse(pfb_pkg_read_ok(1, 1, ''), 'both calls failed — the field report shape');
+	}
+
+	/**
+	 * pfb_pkg_latest() reports the outcome to its CALLER, which it previously could not:
+	 * off-appliance there is no /usr/local/sbin/pkg, so both calls exit non-zero and the
+	 * attempt is a recorded FAILURE rather than an indistinguishable empty string.
+	 */
+	public function testPkgLatestReportsAFailedAttemptToItsCaller(): void
+	{
+		$readOk = NULL;
+		$latest = pfb_pkg_latest(self::NAME, self::REPO, $readOk);
+
+		$this->assertSame('', $latest, 'no pkg binary here, so no version can be read');
+		$this->assertFalse($readOk, 'and the caller is TOLD the attempt failed, not just handed an empty string');
+	}
+
+	/**
+	 * The benign side, which #2379 established and #2674 must not turn into a scary page:
+	 * a deliberate deferral is NOT a failed attempt. pkg locked (never fight a base update),
+	 * no DNS (never stall on a network read) and an unnamed package/repo all leave the
+	 * outcome UNDECIDED (NULL) so nothing is recorded against them.
+	 */
+	public function testADeliberateDeferralIsNotAFailedAttempt(): void
+	{
+		$GLOBALS['pfb_test_pkg_locked'] = TRUE;
+		$readOk = TRUE;
+		$this->assertSame('', pfb_pkg_latest(self::NAME, self::REPO, $readOk), 'locked: no read');
+		$this->assertNull($readOk, 'pkg locked is a deferral, not a failure');
+
+		$GLOBALS['pfb_test_pkg_locked'] = FALSE;
+		$GLOBALS['pfb_test_dns_available'] = FALSE;
+		$readOk = TRUE;
+		$this->assertSame('', pfb_pkg_latest(self::NAME, self::REPO, $readOk), 'no DNS: no read');
+		$this->assertNull($readOk, 'no DNS is a deferral, not a failure');
+
+		$GLOBALS['pfb_test_dns_available'] = TRUE;
+		$readOk = TRUE;
+		$this->assertSame('', pfb_pkg_latest('', self::REPO, $readOk), 'no package name: no read');
+		$this->assertNull($readOk, 'an unnamed package was never attempted');
+	}
+
+	/**
+	 * The wiring the off-appliance case above cannot isolate: pfb_pkg_latest() must CAPTURE
+	 * the refresh return value and feed it to the read rule, and both `pkg` calls must keep
+	 * their stderr redirected so no `pkg` diagnostic can ever reach the page (issue #2674:
+	 * observability is a state, not an error dump).
+	 */
+	public function testPkgLatestCapturesBothReturnValuesAndKeepsPkgStderrOffThePage(): void
+	{
+		$src = (string) file_get_contents(self::INC);
+		$start = strpos($src, 'function pfb_pkg_latest(');
+		$this->assertNotFalse($start, 'pfb_pkg_latest must exist');
+		$body = substr($src, $start, (int) strpos($src, "\n}\n", $start) - $start);
+
+		$this->assertMatchesRegularExpression(
+			'/update -f -r \{\$repo\} 2>\/dev\/null",\s*\$refresh_out,\s*\$refresh_ret\)/',
+			$body,
+			'the catalogue refresh must capture its return value, not discard it'
+		);
+		$this->assertStringContainsString(
+			'pfb_pkg_read_ok($refresh_ret, $ret, $latest)',
+			$body,
+			'both captured return values must reach the read rule'
+		);
+		$this->assertSame(
+			2,
+			substr_count($body, '2>/dev/null'),
+			'both pkg calls keep stderr redirected — no pkg diagnostic may reach the page'
+		);
+	}
+
+	/*
+	 * ---- The cache records the outcome of the last attempt ----
+	 */
+
+	/**
+	 * Scenario: the field report. A cron tick from a context where `pkg` works left a good
+	 * cache; the page's forced Check now runs in a context where it does not.
+	 *
+	 * Given a cron-warmed cache with a known latest and a successful-check time,
+	 * When a forced check's live read fails,
+	 * Then the cache records the failed attempt, keeps the cached latest (#2379), and does
+	 *      NOT advance the successful-check time.
+	 */
+	public function testAFailedCheckRecordsTheFailedAttemptOnTheCache(): void
+	{
+		$this->seedCronWarmedCache();
+
+		$before = time();
+		$cache = pfb_software_update_check(TRUE, $this->io('', FALSE));
+
+		$this->assertArrayHasKey('last_failed', $cache, 'after: the failed attempt must be recorded');
+		$this->assertGreaterThanOrEqual($before, (int) $cache['last_failed'], 'recorded at attempt time');
+		$this->assertSame('3.3.2', $cache['latest'], 'the last-known latest must not regress (issue #2379)');
+		$this->assertSame(1000, $cache['last_checked'], 'a failed attempt is not a successful check');
+		$this->assertSame($cache, $this->readCache(), 'the state reached disk, not just the return value');
+	}
+
+	/**
+	 * The stale-catalogue near-miss, at the orchestrator: the refresh failed but the stale
+	 * DB named a version. The version is adopted (it is newer information than the cache),
+	 * and the successful-check time still does not move — otherwise the page reports
+	 * "Last checked: just now" beside an answer nothing refreshed.
+	 */
+	public function testAStaleCatalogueReadDoesNotAdvanceTheSuccessfulCheckTime(): void
+	{
+		$this->seedCronWarmedCache(1000, '3.3.2');
+
+		$cache = pfb_software_update_check(TRUE, $this->io('3.3.4', FALSE));
+
+		$this->assertSame('3.3.4', $cache['latest'], 'the version that was read is still reported');
+		$this->assertSame(1000, $cache['last_checked'], 'but a failed refresh is not a successful check');
+		$this->assertArrayHasKey('last_failed', $cache, 'and the failed attempt is recorded');
+	}
+
+	/**
+	 * Transition: a recorded failure is transient state, not a sticky label. Asserts the
+	 * failure is present FIRST, so green proves the successful check cleared it.
+	 */
+	public function testASuccessfulCheckClearsARecordedFailure(): void
+	{
+		$this->seedCronWarmedCache();
+		$failed = pfb_software_update_check(TRUE, $this->io('', FALSE));
+		$this->assertArrayHasKey('last_failed', $failed, 'before: a failure is on the cache');
+
+		$before = time();
+		$cache = pfb_software_update_check(TRUE, $this->io('3.3.2', TRUE));
+
+		$this->assertArrayNotHasKey('last_failed', $cache, 'after: a successful check clears the failure');
+		$this->assertGreaterThanOrEqual($before, (int) $cache['last_checked'], 'and advances the successful-check time');
+		$this->assertSame($cache, $this->readCache(), 'the cleared state reached disk');
+	}
+
+	/**
+	 * A deferral neither invents a failure nor erases the one that stands. pkg locked is
+	 * the real short-circuit (no injected latest), so this drives the shipped
+	 * pfb_pkg_latest() guard rather than the $io seam.
+	 */
+	public function testADeferredTickNeitherInventsNorErasesAFailure(): void
+	{
+		$this->seedCronWarmedCache();
+
+		// A deferral on a clean cache records nothing.
+		$GLOBALS['pfb_test_pkg_locked'] = TRUE;
+		$clean = pfb_software_update_check(FALSE, [
+			'installed_name' => self::NAME,
+			'installed'      => '3.3.2',
+			'installed_repo' => self::REPO,
+			'record_channel' => 'nightly',
+			'provenance_ok'  => TRUE,
+		]);
+		$this->assertArrayNotHasKey('last_failed', $clean, 'a deferral is not a failure');
+		$this->assertSame(1000, $clean['last_checked'], 'and does not advance the successful-check time');
+
+		// A real failure, then a deferral: the failure that stands is preserved.
+		$GLOBALS['pfb_test_pkg_locked'] = FALSE;
+		$failed = pfb_software_update_check(TRUE, $this->io('', FALSE));
+		$recorded = (int) $failed['last_failed'];
+		$this->assertGreaterThan(0, $recorded, 'before: a failure is recorded');
+
+		$GLOBALS['pfb_test_pkg_locked'] = TRUE;
+		$deferred = pfb_software_update_check(FALSE, [
+			'installed_name' => self::NAME,
+			'installed'      => '3.3.2',
+			'installed_repo' => self::REPO,
+			'record_channel' => 'nightly',
+			'provenance_ok'  => TRUE,
+		]);
+		$this->assertSame($recorded, (int) $deferred['last_failed'], 'after: the standing failure is kept, not rewritten');
+	}
+
+	/**
+	 * A failure belongs to the install it happened on. The Software page trusts cache values
+	 * only while they describe the CURRENT install, and the orchestrator rescopes the cache
+	 * on a change — so a failure left by a previous catalogue must not be carried into the
+	 * rescoped document and shown against the new one (the issue #2148 rule, applied to the
+	 * new field).
+	 */
+	public function testAFailureFromAnotherInstallIsNotCarriedForward(): void
+	{
+		pfb_software_write_cache([
+			'pkgname'      => self::NAME,
+			'repo'         => 'pfblockerng-stable',
+			'channel'      => 'stable',
+			'installed'    => '3.3.0',
+			'latest'       => '3.3.0',
+			'last_checked' => 500,
+			'last_failed'  => 600,
+		]);
+		$this->assertSame(600, $this->readCache()['last_failed'], 'before: the stable install recorded a failure');
+
+		// Same package name, now on the nightly catalogue, and this tick is DEFERRED, so
+		// nothing about this install failed yet.
+		$GLOBALS['pfb_test_pkg_locked'] = TRUE;
+		$cache = pfb_software_update_check(FALSE, [
+			'installed_name' => self::NAME,
+			'installed'      => '3.3.2',
+			'installed_repo' => self::REPO,
+			'record_channel' => 'nightly',
+			'provenance_ok'  => TRUE,
+		]);
+
+		$this->assertSame(self::REPO, $cache['repo'], 'the cache is rescoped to the current install');
+		$this->assertArrayNotHasKey(
+			'last_failed',
+			$cache,
+			"the previous catalogue's failure must not be shown against this install"
+		);
+	}
+
+	/**
+	 * Observability is a STATE, never a raw `pkg` error dump: the document a failed attempt
+	 * leaves carries only known scalar fields, so no captured stderr or command output can
+	 * ride to the page inside the cache.
+	 */
+	public function testAFailedAttemptWritesAStateNotAnErrorDump(): void
+	{
+		$this->seedCronWarmedCache();
+		$cache = pfb_software_update_check(TRUE, $this->io('', FALSE));
+
+		$this->assertArrayHasKey('last_failed', $cache, 'the failure is recorded as a timestamp field');
+		$this->assertSame(
+			[],
+			array_diff(array_keys($cache), self::CACHE_KEYS),
+			'a failed attempt introduces no field outside the known cache shape'
+		);
+		foreach ($cache as $key => $value) {
+			$this->assertIsScalar($value, "cache field '{$key}' must be a scalar state, not captured output");
+		}
+	}
+
+	/*
+	 * ---- The Software page: the state the admin sees ----
+	 */
+
+	/**
+	 * The page's failed-attempt gate. A recorded failure surfaces only while the cache
+	 * describes the install the box carries now, and a garbage or absent value shows
+	 * nothing rather than a 1970 timestamp.
+	 */
+	public function testTheFailedAttemptRowIsGatedOnTheCurrentInstall(): void
+	{
+		$this->assertSame(1700000000, pfb_software_failed_at(['last_failed' => 1700000000], TRUE));
+		$this->assertSame(0, pfb_software_failed_at(['last_failed' => 1700000000], FALSE), 'a foreign cache shows nothing');
+		$this->assertSame(0, pfb_software_failed_at([], TRUE), 'no recorded failure, no row');
+		$this->assertSame(0, pfb_software_failed_at(['last_failed' => ''], TRUE), 'an empty value is not a failure');
+		$this->assertSame(0, pfb_software_failed_at(['last_failed' => 'yesterday'], TRUE), 'a non-numeric value shows nothing');
+		$this->assertSame(0, pfb_software_failed_at(['last_failed' => ['x']], TRUE), 'a non-scalar value shows nothing');
+		$this->assertSame(0, pfb_software_failed_at(['last_failed' => 0], TRUE), 'a zero timestamp is not a failure');
+	}
+
+	/**
+	 * Check now must not redirect an admin who explicitly asked for a fresh answer back to
+	 * an unchanged page. Both branches, plus the round trip: the query the failure redirect
+	 * carries is the one the page's render arm reads, so a rename on either side is caught.
+	 */
+	public function testCheckNowReportsAForcedRefreshThatFailed(): void
+	{
+		$this->assertSame(
+			'/pfblockerng/pfblockerng_software.php',
+			pfb_software_check_redirect(TRUE),
+			'a check that worked redirects to the plain page'
+		);
+
+		$failed = pfb_software_check_redirect(FALSE);
+		$this->assertSame(
+			'/pfblockerng/pfblockerng_software.php?check=failed',
+			$failed,
+			'a check that failed redirects carrying feedback'
+		);
+
+		$query = [];
+		parse_str((string) parse_url($failed, PHP_URL_QUERY), $query);
+		$page = (string) file_get_contents(self::PAGE);
+		$this->assertStringContainsString(
+			"(\$_GET['check'] ?? '') === '" . $query['check'] . "'",
+			$page,
+			'the page must read back the exact token its own failure redirect writes'
+		);
+	}
+
+	/**
+	 * The page wiring, read out of the page rather than assumed.
+	 *
+	 * LIMITATION, established by execution and shared with issue #2525: the page's top level
+	 * cannot run under this harness at all — including it after tests/php/bootstrap.php exits
+	 * 255 at require_once('guiconfig.inc'), before any page logic, and the sibling page
+	 * loaders sidestep that deliberately by eval()ing function definitions only. So these
+	 * assertions prove the wiring TEXT, not its reachability: an inverted condition is caught
+	 * because the branch's opening line is pinned, but a rewrite that keeps the sequence and
+	 * makes it unreachable (inside a dead `if (FALSE)`, after an unconditional exit) survives
+	 * them. Harness work to close that gap is issue #2768. The executable proof for this
+	 * behaviour is the four cases above, which drive the functions the page calls; the LIVE
+	 * proof is tests/smoke/ui (Tier A renders the failed-attempt row off a seeded cache;
+	 * Tier B drives the ?check=failed feedback in a browser).
+	 */
+	public function testThePageDrivesTheExtractedHelpers(): void
+	{
+		$page = (string) file_get_contents(self::PAGE);
+
+		$handler = strpos($page, "if (\$pfb_sw_action === 'check') {");
+		$this->assertNotFalse($handler, 'the Check now handler must still be the page entry point');
+		$block = substr($page, $handler, (int) strpos($page, 'exit;', $handler) - $handler);
+		$this->assertStringContainsString(
+			'pfb_software_update_check(TRUE)',
+			$block,
+			'Check now still forces the check'
+		);
+		$this->assertStringContainsString(
+			'pfb_software_check_redirect(',
+			$block,
+			'and routes its outcome through the redirect helper instead of discarding it'
+		);
+
+		$this->assertStringContainsString(
+			'pfb_software_failed_at(',
+			$page,
+			'the Status section must gate the failed-attempt row on the shared helper'
+		);
+		$this->assertMatchesRegularExpression(
+			'/print_info_box\(\s*gettext\(/',
+			$page,
+			'the Check now feedback renders through the house warning box'
+		);
+		$this->assertStringContainsString(
+			"'warning'",
+			$page,
+			'a failed forced check is a warning, not a silent redisplay'
+		);
+	}
+}

--- a/tests/php/SoftwareFailedCheckStateTest.php
+++ b/tests/php/SoftwareFailedCheckStateTest.php
@@ -381,6 +381,18 @@ final class SoftwareFailedCheckStateTest extends TestCase
 		]);
 
 		$this->assertSame('3.3.2', $cache['latest'], 'the verified version is what is reported');
+		// A notice MUST fire here, or the loop below would assert nothing: installed 3.3.0 is
+		// older than the cached 3.3.2 and nothing has been notified yet.
+		$this->assertCount(
+			1,
+			$GLOBALS['pfb_test_file_notices'],
+			'the un-notified update from the last successful read is still announced'
+		);
+		$this->assertStringContainsString(
+			'3.3.2 available',
+			$GLOBALS['pfb_test_file_notices'][0]['notice'],
+			'and it names the version a successful read produced'
+		);
 		foreach ($GLOBALS['pfb_test_file_notices'] as $notice) {
 			$this->assertStringNotContainsString(
 				'3.3.4',
@@ -467,6 +479,44 @@ final class SoftwareFailedCheckStateTest extends TestCase
 			pfb_software_check_redirect($failed_ok !== FALSE),
 			'and Check now says so'
 		);
+	}
+
+	/**
+	 * The reported outcome is reset at ENTRY, so a caller reusing a by-ref variable can never
+	 * read a previous call's answer. Two gates return before any catalogue read — a build that
+	 * cannot show the page, and background checking switched off without a force — and on both
+	 * of those paths nothing was attempted, which is NULL rather than whatever the caller
+	 * happened to be holding. Each arm pre-sets the variable TRUE so the reset has to do work.
+	 */
+	public function testAGateThatRefusesBeforeAnyReadReportsNoOutcome(): void
+	{
+		$io = [
+			'installed_name' => self::NAME,
+			'installed'      => '3.3.2',
+			'installed_repo' => self::REPO,
+			'record_channel' => 'nightly',
+			'provenance_ok'  => FALSE,
+			'latest'         => '3.3.4',
+			'read_ok'        => TRUE,
+		];
+		$read_ok = TRUE;
+		pfb_software_update_check(TRUE, $io, $read_ok);
+		$this->assertNull($read_ok, 'a build that cannot show the page attempted no read');
+
+		// The other early return: checking disabled and not forced.
+		$GLOBALS['config'] = [
+			'installedpackages' => ['pfblockerng' => ['config' => [0 => ['pfb_software_check' => '']]]],
+		];
+		$io['provenance_ok'] = TRUE;
+		$read_ok = TRUE;
+		pfb_software_update_check(FALSE, $io, $read_ok);
+		$this->assertNull($read_ok, 'a disabled background check attempted no read');
+
+		// And the control: with both gates open the same call DOES report an outcome, so the
+		// two assertions above are about the gates and not about an out-param nobody writes.
+		$read_ok = NULL;
+		pfb_software_update_check(TRUE, $io, $read_ok);
+		$this->assertTrue($read_ok, 'with the gates open the read outcome is reported');
 	}
 
 	/**
@@ -629,6 +679,10 @@ final class SoftwareFailedCheckStateTest extends TestCase
 			'a negative decimal string'     => '-1',
 			'a fractional string'           => '1700000000.5',
 			'a whitespace-padded number'    => ' 1700000000 ',
+			// PCRE's $ matches before a final newline, so a regex-based digit test accepts
+			// this; the house ctype_digit() convention does not.
+			'a trailing newline'            => "1700000000\n",
+			'an oversized decimal string'   => '99999999999999999999999999',
 			'a boolean'                     => TRUE,
 		];
 

--- a/tests/php/SoftwareFailedCheckStateTest.php
+++ b/tests/php/SoftwareFailedCheckStateTest.php
@@ -205,11 +205,22 @@ final class SoftwareFailedCheckStateTest extends TestCase
 
 	/**
 	 * pfb_pkg_latest() reports the outcome to its CALLER, which it previously could not:
-	 * off-appliance there is no /usr/local/sbin/pkg, so both calls exit non-zero and the
-	 * attempt is a recorded FAILURE rather than an indistinguishable empty string.
+	 * with no pkg(8) to run, both calls exit non-zero and the attempt is a recorded FAILURE
+	 * rather than an indistinguishable empty string.
+	 *
+	 * This drives the real shellout, so it asserts a fixed outcome only where that shellout
+	 * cannot succeed. On a host that carries the port binary the result depends on that
+	 * host's repository configuration, which is not this case's subject: it skips there
+	 * rather than reporting a red for an environment difference.
 	 */
 	public function testPkgLatestReportsAFailedAttemptToItsCaller(): void
 	{
+		if (is_executable(PFB_PKG_BIN)) {
+			$this->markTestSkipped(
+				'host carries ' . PFB_PKG_BIN . ' — the live read outcome is then repository state, not this rule'
+			);
+		}
+
 		$readOk = NULL;
 		$latest = pfb_pkg_latest(self::NAME, self::REPO, $readOk);
 
@@ -724,9 +735,8 @@ final class SoftwareFailedCheckStateTest extends TestCase
 	 * and report a defect that is not there.
 	 *
 	 * This reads the tier's own constant rather than a phrase of its own, because the
-	 * coupling is the whole point: it is the tier's chosen string that has to discriminate.
-	 * Executed here because this is exactly what reddened all four Tier-A legs on the
-	 * previous head, and a hermetic gate catches it in a second instead of a VM round trip.
+	 * coupling is the whole point: it is the tier's chosen string that has to discriminate,
+	 * and a hermetic gate settles it without a live-VM round trip.
 	 */
 	public function testTheUiTiersFeedbackPhraseMatchesOnlyTheCheckNowBox(): void
 	{
@@ -851,14 +861,21 @@ final class SoftwareFailedCheckStateTest extends TestCase
 			$page,
 			'and gate the row on it — a gate rewritten to a constant renders the row never'
 		);
+		// Scoped to the feedback arm, not searched page-wide: the page happens to carry
+		// exactly one print_info_box and one 'warning' today, so a page-wide search still
+		// fails on a regression -- but it would go quietly vacuous the moment a second
+		// info box is added anywhere on the page.
+		$feedback_at = strpos($page, "(\$_GET['check'] ?? '') === 'failed'");
+		$this->assertNotFalse($feedback_at, 'the failure token must gate the feedback box');
+		$feedback = substr($page, $feedback_at, (int) strpos($page, "\n}\n", $feedback_at) - $feedback_at);
 		$this->assertMatchesRegularExpression(
 			'/print_info_box\(\s*gettext\(/',
-			$page,
+			$feedback,
 			'the Check now feedback renders through the house warning box'
 		);
 		$this->assertStringContainsString(
 			"'warning'",
-			$page,
+			$feedback,
 			'a failed forced check is a warning, not a silent redisplay'
 		);
 	}

--- a/tests/php/SoftwareFailedCheckStateTest.php
+++ b/tests/php/SoftwareFailedCheckStateTest.php
@@ -20,14 +20,21 @@ use PHPUnit\Framework\TestCase;
  *
  * What must NOT change is issue #2379's fallback: a failed live read keeps the cached
  * `latest` rather than regressing it to '', and a benign deferral (pkg locked, no DNS) is
- * not a failure at all. Observability here is a STATE, never a raw `pkg` error dump.
+ * not a failure at all. Observability here is a STATE, never a raw `pkg` error dump. And a
+ * read that FAILED contributes no version at all: promoting the stale catalogue's answer
+ * would let the cron notice announce an update off a catalogue nothing refreshed.
  *
  * Branch map, so every side of every decision is pinned:
  *   read rule      refresh ok / refresh failed x rquery ok / rquery failed x version / none
- *   attempt state  succeeded (TRUE) / failed (FALSE) / not attempted (NULL)
+ *   attempt state  succeeded (TRUE) / failed (FALSE) / not attempted (NULL) / uninterpretable
+ *   version        promoted only on a successful read; cached kept otherwise; never a
+ *                  stale-catalogue answer, and never a notice naming one
  *   cache          record a failure / clear one on success / keep one across a skip /
  *                  never carry a foreign install's failure
- *   page           show the failed-attempt row / hide it / Check-now feedback both ways
+ *   timestamps     a plain epoch renders; negative, future, oversized, non-finite and
+ *                  non-decimal values render nothing, silently
+ *   page           show the failed-attempt row / hide it / Check-now feedback keyed on THIS
+ *                  attempt's outcome, both ways, never on the cache's history
  */
 #[CoversFunction('pfb_pkg_read_ok')]
 #[CoversFunction('pfb_pkg_latest')]
@@ -245,8 +252,11 @@ final class SoftwareFailedCheckStateTest extends TestCase
 		$this->assertNotFalse($start, 'pfb_pkg_latest must exist');
 		$body = substr($src, $start, (int) strpos($src, "\n}\n", $start) - $start);
 
+		// The rc variable is pinned; the output buffer is not, because the two calls may
+		// legitimately share one (pfb_pkg_exec() clears it at entry) and its name is not
+		// the thing that has to hold.
 		$this->assertMatchesRegularExpression(
-			'/update -f -r \{\$repo\} 2>\/dev\/null",\s*\$refresh_out,\s*\$refresh_ret\)/',
+			'/update -f -r \{\$repo\} 2>\/dev\/null",\s*\$\w+,\s*\$refresh_ret\)/',
 			$body,
 			'the catalogue refresh must capture its return value, not discard it'
 		);
@@ -291,9 +301,8 @@ final class SoftwareFailedCheckStateTest extends TestCase
 
 	/**
 	 * The stale-catalogue near-miss, at the orchestrator: the refresh failed but the stale
-	 * DB named a version. The version is adopted (it is newer information than the cache),
-	 * and the successful-check time still does not move — otherwise the page reports
-	 * "Last checked: just now" beside an answer nothing refreshed.
+	 * DB named a version. The successful-check time does not move, and the version is NOT
+	 * adopted — a catalogue nothing refreshed cannot produce a new "latest".
 	 */
 	public function testAStaleCatalogueReadDoesNotAdvanceTheSuccessfulCheckTime(): void
 	{
@@ -301,9 +310,163 @@ final class SoftwareFailedCheckStateTest extends TestCase
 
 		$cache = pfb_software_update_check(TRUE, $this->io('3.3.4', FALSE));
 
-		$this->assertSame('3.3.4', $cache['latest'], 'the version that was read is still reported');
-		$this->assertSame(1000, $cache['last_checked'], 'but a failed refresh is not a successful check');
+		$this->assertSame('3.3.2', $cache['latest'], 'the last SUCCESSFULLY read version still stands');
+		$this->assertSame(1000, $cache['last_checked'], 'a failed refresh is not a successful check');
 		$this->assertArrayHasKey('last_failed', $cache, 'and the failed attempt is recorded');
+	}
+
+	/**
+	 * Scenario: the field report's near-miss, followed all the way to the notice.
+	 *
+	 * `pkg update -f` exits non-zero, the stale catalogue DB still answers rquery, and what
+	 * it answers is NEWER than the last version a successful read produced. Promoting that
+	 * would make the page announce — and the cron file_notice ANNOUNCE BY EMAIL — an update
+	 * read off a catalogue nothing refreshed. A read that failed contributes no version.
+	 *
+	 * Given a cache holding the last successfully read latest, already notified,
+	 * When a forced check's refresh fails but the stale DB names a newer version,
+	 * Then the cached latest and de-dupe state both stand, and NO notice fires.
+	 */
+	public function testAFailedRefreshNeverPromotesAStaleCatalogueVersion(): void
+	{
+		pfb_software_write_cache([
+			'pkgname'       => self::NAME,
+			'repo'          => self::REPO,
+			'channel'       => 'nightly',
+			'installed'     => '3.3.2',
+			'latest'        => '3.3.2',
+			'last_checked'  => 1000,
+			'last_notified' => '3.3.2',
+		]);
+		$this->assertSame([], $GLOBALS['pfb_test_file_notices'], 'before: no notice raised');
+
+		$cache = pfb_software_update_check(TRUE, $this->io('3.3.4', FALSE));
+
+		$this->assertSame('3.3.2', $cache['latest'], 'a version off an unrefreshed catalogue is not promoted');
+		$this->assertSame('3.3.2', $cache['last_notified'], 'and cannot rewrite the de-dupe state');
+		$this->assertSame(
+			[],
+			$GLOBALS['pfb_test_file_notices'],
+			'after: a failed refresh must never announce a version it could not verify'
+		);
+		$this->assertSame(1000, $cache['last_checked'], 'and is not a successful check');
+		$this->assertArrayHasKey('last_failed', $cache, 'the failure itself is what gets recorded');
+	}
+
+	/**
+	 * The same rule where the update is genuinely un-notified: the notice may still fire for
+	 * the last SUCCESSFULLY read version, but never for the stale one. Asserts the notice
+	 * text, so a promotion that slipped through would be visible rather than merely counted.
+	 */
+	public function testANoticeAfterAFailedRefreshNamesOnlyTheVerifiedVersion(): void
+	{
+		pfb_software_write_cache([
+			'pkgname'       => self::NAME,
+			'repo'          => self::REPO,
+			'channel'       => 'nightly',
+			'installed'     => '3.3.0',
+			'latest'        => '3.3.2',
+			'last_checked'  => 1000,
+			'last_notified' => '',
+		]);
+
+		$cache = pfb_software_update_check(TRUE, [
+			'installed_name' => self::NAME,
+			'installed'      => '3.3.0',
+			'installed_repo' => self::REPO,
+			'record_channel' => 'nightly',
+			'provenance_ok'  => TRUE,
+			'latest'         => '3.3.4',
+			'read_ok'        => FALSE,
+		]);
+
+		$this->assertSame('3.3.2', $cache['latest'], 'the verified version is what is reported');
+		foreach ($GLOBALS['pfb_test_file_notices'] as $notice) {
+			$this->assertStringNotContainsString(
+				'3.3.4',
+				$notice['notice'],
+				'no notice may name a version read off a catalogue that failed to refresh'
+			);
+		}
+	}
+
+	/**
+	 * A contradictory injected outcome fails CLOSED. The $io seam takes an explicit outcome;
+	 * anything that is not a bool names no outcome, and a version paired with no outcome
+	 * must not be promoted, timestamped or notified as if the read had succeeded.
+	 */
+	public function testAnUninterpretableInjectedOutcomeFailsClosed(): void
+	{
+		foreach ([['x'], 'false', 0, 1.0] as $bogus) {
+			$this->seedCronWarmedCache(1000, '3.3.2');
+			$cache = pfb_software_update_check(TRUE, [
+				'installed_name' => self::NAME,
+				'installed'      => '3.3.2',
+				'installed_repo' => self::REPO,
+				'record_channel' => 'nightly',
+				'provenance_ok'  => TRUE,
+				'latest'         => '3.3.4',
+				'read_ok'        => $bogus,
+			]);
+			$label = gettype($bogus);
+			$this->assertSame('3.3.2', $cache['latest'], "{$label}: no promotion without a stated outcome");
+			$this->assertSame(1000, $cache['last_checked'], "{$label}: and no successful-check time");
+			$this->assertSame([], $GLOBALS['pfb_test_file_notices'], "{$label}: and no notice");
+			@unlink($this->dbdir . '/software_update.json');
+		}
+	}
+
+	/**
+	 * Check now's feedback describes THIS attempt, never the cache's history.
+	 *
+	 * The cache deliberately keeps a standing failure across a deferral, so reading the
+	 * feedback off the cache made an identical deferral report "failed" or "fine" depending
+	 * only on what a previous tick had recorded. The outcome of the attempt just made is a
+	 * separate value.
+	 *
+	 * Given a cache that already records a failure,
+	 * When a forced check DEFERS (pkg locked — nothing failed now),
+	 * Then Check now redirects clean;
+	 * And when a forced check actually fails,
+	 * Then it redirects carrying feedback.
+	 */
+	public function testCheckNowFeedbackFollowsThisAttemptNotTheCachedHistory(): void
+	{
+		$this->seedCronWarmedCache();
+		pfb_software_update_check(TRUE, $this->io('', FALSE));
+		$this->assertArrayHasKey(
+			'last_failed',
+			(array) $this->readCache(),
+			'before: a failure from an earlier tick stands on the cache'
+		);
+
+		// A deferral now: the standing failure is preserved, but nothing failed THIS time.
+		$GLOBALS['pfb_test_pkg_locked'] = TRUE;
+		$deferred_ok = TRUE;
+		pfb_software_update_check(TRUE, [
+			'installed_name' => self::NAME,
+			'installed'      => '3.3.2',
+			'installed_repo' => self::REPO,
+			'record_channel' => 'nightly',
+			'provenance_ok'  => TRUE,
+		], $deferred_ok);
+		$this->assertNull($deferred_ok, 'a deferred check reports no outcome');
+		$this->assertSame(
+			'/pfblockerng/pfblockerng_software.php',
+			pfb_software_check_redirect($deferred_ok !== FALSE),
+			'so Check now must not claim the check failed'
+		);
+
+		// A real failure now: the same call reports it, and the redirect carries feedback.
+		$GLOBALS['pfb_test_pkg_locked'] = FALSE;
+		$failed_ok = TRUE;
+		pfb_software_update_check(TRUE, $this->io('', FALSE), $failed_ok);
+		$this->assertFalse($failed_ok, 'a failed check reports its outcome');
+		$this->assertSame(
+			'/pfblockerng/pfblockerng_software.php?check=failed',
+			pfb_software_check_redirect($failed_ok !== FALSE),
+			'and Check now says so'
+		);
 	}
 
 	/**
@@ -443,6 +606,57 @@ final class SoftwareFailedCheckStateTest extends TestCase
 	}
 
 	/**
+	 * A timestamp this box cannot have recorded shows nothing, and says nothing doing it.
+	 *
+	 * The cache is a JSON file, so `last_failed` can arrive as a hand-edited negative, a
+	 * scientific-notation string, or an integer too large for a PHP int — which json_decode
+	 * hands back as a FLOAT. Casting one of those emits "not representable as an int" into
+	 * php_error.log (which the UI tiers read as a page defect, issue #2367) and PHP_INT_MAX
+	 * renders a year-292277 date in the Status section. Warnings are CAPTURED rather than
+	 * converted, so the assertion is about what the helper emitted and not merely that it
+	 * did not throw.
+	 */
+	public function testTheFailedAttemptRowRefusesATimeThisBoxCannotHaveRecorded(): void
+	{
+		$cases = [
+			'a negative timestamp'          => -1,
+			'the integer ceiling'           => PHP_INT_MAX,
+			'a far-future time'             => time() + 86400 * 365,
+			'an oversized JSON integer'     => 1.0e54,
+			'a non-finite float'            => NAN,
+			'an infinite float'             => INF,
+			'scientific notation'           => '1e5',
+			'a negative decimal string'     => '-1',
+			'a fractional string'           => '1700000000.5',
+			'a whitespace-padded number'    => ' 1700000000 ',
+			'a boolean'                     => TRUE,
+		];
+
+		foreach ($cases as $label => $value) {
+			$seen = [];
+			set_error_handler(static function (int $errno, string $msg) use (&$seen): bool {
+				$seen[] = $msg;
+				return TRUE;
+			});
+			try {
+				$at = pfb_software_failed_at(['last_failed' => $value], TRUE);
+			} finally {
+				restore_error_handler();
+			}
+			$this->assertSame(0, $at, "{$label} must show no failed-attempt row");
+			$this->assertSame([], $seen, "{$label} must reach that verdict silently");
+		}
+
+		// The branch that must keep working: a plain epoch this box could have recorded.
+		$this->assertSame(1700000000, pfb_software_failed_at(['last_failed' => 1700000000], TRUE));
+		$this->assertSame(
+			1700000000,
+			pfb_software_failed_at(['last_failed' => '1700000000'], TRUE),
+			'a decimal integer string is the same time (json_decode can hand back either)'
+		);
+	}
+
+	/**
 	 * Check now must not redirect an admin who explicitly asked for a fresh answer back to
 	 * an unchanged page. Both branches, plus the round trip: the query the failure redirect
 	 * carries is the one the page's render arm reads, so a rename on either side is caught.
@@ -479,13 +693,15 @@ final class SoftwareFailedCheckStateTest extends TestCase
 	 * cannot run under this harness at all — including it after tests/php/bootstrap.php exits
 	 * 255 at require_once('guiconfig.inc'), before any page logic, and the sibling page
 	 * loaders sidestep that deliberately by eval()ing function definitions only. So these
-	 * assertions prove the wiring TEXT, not its reachability: an inverted condition is caught
-	 * because the branch's opening line is pinned, but a rewrite that keeps the sequence and
-	 * makes it unreachable (inside a dead `if (FALSE)`, after an unconditional exit) survives
-	 * them. Harness work to close that gap is issue #2768. The executable proof for this
-	 * behaviour is the four cases above, which drive the functions the page calls; the LIVE
-	 * proof is tests/smoke/ui (Tier A renders the failed-attempt row off a seeded cache;
-	 * Tier B drives the ?check=failed feedback in a browser).
+	 * assertions prove the wiring TEXT, not its reachability. Precisely: every branch below
+	 * has its OPENING LINE pinned, so inverting one of those conditions is caught; a rewrite
+	 * that keeps the whole sequence and makes it unreachable — inside a dead `if (FALSE)`,
+	 * after an unconditional exit — is NOT, and neither is a row that renders the wrong
+	 * value. Harness work to close that gap is issue #2768. The executable proof for this
+	 * behaviour is the cases above, which drive the functions the page calls; the LIVE proof
+	 * is tests/smoke/ui — Tier A renders the failed-attempt row off a seeded cache and
+	 * asserts its time differs from the last successful check's (which catches the
+	 * wrong-value class), Tier B drives the ?check=failed feedback in a browser.
 	 */
 	public function testThePageDrivesTheExtractedHelpers(): void
 	{
@@ -495,7 +711,7 @@ final class SoftwareFailedCheckStateTest extends TestCase
 		$this->assertNotFalse($handler, 'the Check now handler must still be the page entry point');
 		$block = substr($page, $handler, (int) strpos($page, 'exit;', $handler) - $handler);
 		$this->assertStringContainsString(
-			'pfb_software_update_check(TRUE)',
+			'pfb_software_update_check(TRUE',
 			$block,
 			'Check now still forces the check'
 		);
@@ -504,11 +720,21 @@ final class SoftwareFailedCheckStateTest extends TestCase
 			$block,
 			'and routes its outcome through the redirect helper instead of discarding it'
 		);
+		$this->assertStringContainsString(
+			'$pfb_sw_read_ok',
+			$block,
+			"and the outcome it routes is THIS attempt's, not the cache's history"
+		);
 
 		$this->assertStringContainsString(
-			'pfb_software_failed_at(',
+			'$failed_at	= pfb_software_failed_at($cache, $cache_current);',
 			$page,
-			'the Status section must gate the failed-attempt row on the shared helper'
+			'the Status section must derive the failed-attempt time from the shared helper'
+		);
+		$this->assertStringContainsString(
+			'if ($failed_at > 0) {',
+			$page,
+			'and gate the row on it — a gate rewritten to a constant renders the row never'
 		);
 		$this->assertMatchesRegularExpression(
 			'/print_info_box\(\s*gettext\(/',

--- a/tests/php/fixtures/function_inventory.json
+++ b/tests/php/fixtures/function_inventory.json
@@ -10999,6 +10999,13 @@
                 "variadic": false,
                 "type": "?array",
                 "default": "NULL"
+            },
+            {
+                "name": "read_ok",
+                "byRef": true,
+                "variadic": false,
+                "type": "?bool",
+                "default": "NULL"
             }
         ]
     },

--- a/tests/php/fixtures/function_inventory.json
+++ b/tests/php/fixtures/function_inventory.json
@@ -9140,6 +9140,13 @@
                 "variadic": false,
                 "type": "string",
                 "default": null
+            },
+            {
+                "name": "read_ok",
+                "byRef": true,
+                "variadic": false,
+                "type": "?bool",
+                "default": "NULL"
             }
         ]
     },
@@ -9173,6 +9180,33 @@
         "returnsRef": false,
         "returnType": "string",
         "params": []
+    },
+    "pfb_pkg_read_ok": {
+        "returnsRef": false,
+        "returnType": "bool",
+        "params": [
+            {
+                "name": "refresh_ret",
+                "byRef": false,
+                "variadic": false,
+                "type": "int",
+                "default": null
+            },
+            {
+                "name": "rquery_ret",
+                "byRef": false,
+                "variadic": false,
+                "type": "int",
+                "default": null
+            },
+            {
+                "name": "latest",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
     },
     "pfb_pkg_ver": {
         "returnsRef": false,
@@ -10846,6 +10880,26 @@
         "returnType": "bool",
         "params": []
     },
+    "pfb_software_check_redirect": {
+        "returnsRef": false,
+        "returnType": "string",
+        "params": [
+            {
+                "name": "check_ok",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
+                "default": null
+            },
+            {
+                "name": "failure_redirect",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": "'/pfblockerng/pfblockerng_software.php?check=failed'"
+            }
+        ]
+    },
     "pfb_software_check_save": {
         "returnsRef": false,
         "returnType": "string",
@@ -10855,6 +10909,26 @@
                 "byRef": false,
                 "variadic": false,
                 "type": "array",
+                "default": null
+            }
+        ]
+    },
+    "pfb_software_failed_at": {
+        "returnsRef": false,
+        "returnType": "int",
+        "params": [
+            {
+                "name": "cache",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            },
+            {
+                "name": "cache_current",
+                "byRef": false,
+                "variadic": false,
+                "type": "bool",
                 "default": null
             }
         ]

--- a/tests/skip-allowlist.txt
+++ b/tests/skip-allowlist.txt
@@ -45,3 +45,8 @@ pytest:tests.test_build_pkg_origins::test_print_build_origins_includes_expected_
 pytest:tests.test_build_pkg_origins::test_sparse_build_byte_identical_to_full_build  # FreeBSD-ports checkout not present on the runner
 pytest:tests.test_build_pkg_portable::test_output_macos_os_alias_is_allowed[/tmp-/private/tmp]  # macOS-only alias case; the runner is Linux
 pytest:tests.test_build_pkg_portable::test_output_macos_os_alias_is_allowed[/var-/private/var]  # macOS-only alias case; the runner is Linux
+
+# ui -- observed on the live-VM Tier-B browser legs. The `ui-tests` label gates that fan-out,
+# so it runs seldom and this data-dependent skip had never been observed by the gate before;
+# the skip itself predates the PR that first surfaced it (it landed in 5792d6fb).
+ui:tests.smoke.ui.test_browser_misc::test_feeds_alt_radio_submit_wiring  # whether any pre-defined feed exposes an Alternate-URL radio is feed-data dependent; the case skips cleanly when none render

--- a/tests/skip-allowlist.txt
+++ b/tests/skip-allowlist.txt
@@ -46,7 +46,10 @@ pytest:tests.test_build_pkg_origins::test_sparse_build_byte_identical_to_full_bu
 pytest:tests.test_build_pkg_portable::test_output_macos_os_alias_is_allowed[/tmp-/private/tmp]  # macOS-only alias case; the runner is Linux
 pytest:tests.test_build_pkg_portable::test_output_macos_os_alias_is_allowed[/var-/private/var]  # macOS-only alias case; the runner is Linux
 
-# ui -- observed on the live-VM Tier-B browser legs. The `ui-tests` label gates that fan-out,
-# so it runs seldom and this data-dependent skip had never been observed by the gate before;
-# the skip itself predates the PR that first surfaced it (it landed in 5792d6fb).
-ui:tests.smoke.ui.test_browser_misc::test_feeds_alt_radio_submit_wiring  # whether any pre-defined feed exposes an Alternate-URL radio is feed-data dependent; the case skips cleanly when none render
+# ui -- the live-VM Tier-B browser legs. Whether any pre-defined feed exposes an
+# Alternate-URL radio is feed-data dependent, so the case has always skipped cleanly when
+# none render; the `ui-tests` label gates that fan-out, so the gate had not observed it.
+ui:tests.smoke.ui.test_browser_misc::test_feeds_alt_radio_submit_wiring  # no pre-defined feed exposes an Alternate-URL radio on this box
+
+# phpunit -- only on a host that carries the pkg(8) port binary (a FreeBSD/pfSense dev box).
+phpunit:SoftwareFailedCheckStateTest::testPkgLatestReportsAFailedAttemptToItsCaller  # drives the real pkg shellout; its outcome is host repository state where /usr/local/sbin/pkg exists

--- a/tests/smoke/ui/test_browser_misc.py
+++ b/tests/smoke/ui/test_browser_misc.py
@@ -57,6 +57,7 @@ from .. import helpers
 from .conftest import mask_page_identity
 from .test_render_smoke import (
     _SOFTWARE_CHECK_FAILED_QUERY,
+    _SOFTWARE_CHECK_FAILED_TEXT,
     _SOFTWARE_CHECKED_MARKER,
     _seed_vm_file,
     software_panel_forced,
@@ -79,6 +80,7 @@ SOFTWARE_PAGE = "/pfblockerng/pfblockerng_software.php"
 SOFTWARE_PANEL_MARKER = "pfb-software-panel"
 SOFTWARE_CHECKED_MARKER = _SOFTWARE_CHECKED_MARKER
 SOFTWARE_CHECK_FAILED_QUERY = _SOFTWARE_CHECK_FAILED_QUERY
+SOFTWARE_CHECK_FAILED_TEXT = _SOFTWARE_CHECK_FAILED_TEXT
 
 pytestmark = pytest.mark.ui_browser
 
@@ -340,18 +342,23 @@ def test_software_failed_check_feedback_is_visible(
     Scenario:
       Given the hidden override forcing the provenance gate on,
       When the Software page is opened plainly,
-      Then no warning box is visible (a benign load stays calm — issue #2379);
+      Then this feedback's warning box is absent (a benign load stays calm — issue #2379);
       And when it is opened with the feedback query Check now redirects with,
-      Then the warning box IS visible and names the catalogue read that failed.
+      Then the warning box IS visible, names the catalogue read that failed, and sits beside
+          the last-successful-check row rather than replacing it.
+
+    The locator is scoped to this message, never to ``.alert-warning`` alone: pfBlockerNG's
+    pending-changes banner is also an alert-warning and whatever ran before this case may have
+    left it set, so a bare class assertion would be about that banner instead of this feedback.
     """
+    failed_box = f".alert-warning:has-text('{SOFTWARE_CHECK_FAILED_TEXT}')"
     with software_panel_forced(smoke_vm, "on"):
         _open(browser_page, webui, SOFTWARE_PAGE)
         assert SOFTWARE_PANEL_MARKER in browser_page.content(), "Software panel marker absent when forced on"
-        expect(browser_page.locator(".alert-warning")).to_have_count(0, timeout=JS_TIMEOUT_MS)
+        expect(browser_page.locator(failed_box)).to_have_count(0, timeout=JS_TIMEOUT_MS)
 
         _open(browser_page, webui, SOFTWARE_PAGE + SOFTWARE_CHECK_FAILED_QUERY)
-        expect(browser_page.locator(".alert-warning")).to_be_visible(timeout=JS_TIMEOUT_MS)
-        expect(browser_page.get_by_text("could not read", exact=False)).to_be_visible(timeout=JS_TIMEOUT_MS)
+        expect(browser_page.locator(failed_box)).to_be_visible(timeout=JS_TIMEOUT_MS)
         expect(browser_page.locator(f"#{SOFTWARE_CHECKED_MARKER}")).to_be_visible(timeout=JS_TIMEOUT_MS)
         _shot(browser_page, screenshot_dir, "software_check_failed_feedback")
 

--- a/tests/smoke/ui/test_browser_misc.py
+++ b/tests/smoke/ui/test_browser_misc.py
@@ -56,6 +56,8 @@ import pytest
 from .. import helpers
 from .conftest import mask_page_identity
 from .test_render_smoke import (
+    _SOFTWARE_CHECK_FAILED_QUERY,
+    _SOFTWARE_CHECKED_MARKER,
     _seed_vm_file,
     software_panel_forced,
 )
@@ -71,9 +73,12 @@ if TYPE_CHECKING:
     from ..conftest import SmokeVM
     from .webui import WebUI
 
-# The provenance-gated Software (version/upgrades) page + its panel marker (ADR-19).
+# The provenance-gated Software (version/upgrades) page + its panel marker (ADR-19). The
+# failed-check markers/query are imported from Tier A so both tiers assert the same strings.
 SOFTWARE_PAGE = "/pfblockerng/pfblockerng_software.php"
 SOFTWARE_PANEL_MARKER = "pfb-software-panel"
+SOFTWARE_CHECKED_MARKER = _SOFTWARE_CHECKED_MARKER
+SOFTWARE_CHECK_FAILED_QUERY = _SOFTWARE_CHECK_FAILED_QUERY
 
 pytestmark = pytest.mark.ui_browser
 
@@ -316,6 +321,39 @@ def test_software_panel_screenshot_when_enabled(
         _open(browser_page, webui, SOFTWARE_PAGE)
         assert SOFTWARE_PANEL_MARKER in browser_page.content(), "Software panel marker absent when forced on"
         _shot(browser_page, screenshot_dir, "software_panel_enabled")
+
+
+def test_software_failed_check_feedback_is_visible(
+    smoke_vm: SmokeVM,
+    browser_page: Page,
+    webui: WebUI,
+    screenshot_dir: Path,
+) -> None:
+    """A forced check that failed says so in the browser, and a plain load does not (#2674).
+
+    Check now POSTs, runs the check and redirects, so before #2674 an admin who explicitly
+    asked for a fresh answer was silently re-served the old one. The handler now redirects
+    carrying ``?check=failed`` when the refresh it forced did not work, which is the state
+    this tier renders. Driving the query directly keeps the case deterministic: clicking the
+    button on a live guest runs a real ``pkg update`` whose outcome is not ours to fix.
+
+    Scenario:
+      Given the hidden override forcing the provenance gate on,
+      When the Software page is opened plainly,
+      Then no warning box is visible (a benign load stays calm — issue #2379);
+      And when it is opened with the feedback query Check now redirects with,
+      Then the warning box IS visible and names the catalogue read that failed.
+    """
+    with software_panel_forced(smoke_vm, "on"):
+        _open(browser_page, webui, SOFTWARE_PAGE)
+        assert SOFTWARE_PANEL_MARKER in browser_page.content(), "Software panel marker absent when forced on"
+        expect(browser_page.locator(".alert-warning")).to_have_count(0, timeout=JS_TIMEOUT_MS)
+
+        _open(browser_page, webui, SOFTWARE_PAGE + SOFTWARE_CHECK_FAILED_QUERY)
+        expect(browser_page.locator(".alert-warning")).to_be_visible(timeout=JS_TIMEOUT_MS)
+        expect(browser_page.get_by_text("could not read", exact=False)).to_be_visible(timeout=JS_TIMEOUT_MS)
+        expect(browser_page.locator(f"#{SOFTWARE_CHECKED_MARKER}")).to_be_visible(timeout=JS_TIMEOUT_MS)
+        _shot(browser_page, screenshot_dir, "software_check_failed_feedback")
 
 
 @pytest.mark.ui_browser

--- a/tests/smoke/ui/test_browser_misc.py
+++ b/tests/smoke/ui/test_browser_misc.py
@@ -348,8 +348,8 @@ def test_software_failed_check_feedback_is_visible(
           the last-successful-check row rather than replacing it.
 
     The locator is scoped to this message, never to ``.alert-warning`` alone: pfBlockerNG's
-    pending-changes banner is also an alert-warning and whatever ran before this case may have
-    left it set, so a bare class assertion would be about that banner instead of this feedback.
+    pending-changes banner is also an alert-warning and may be set, so a bare class assertion
+    would be about that banner instead of this feedback.
     """
     failed_box = f".alert-warning:has-text('{SOFTWARE_CHECK_FAILED_TEXT}')"
     with software_panel_forced(smoke_vm, "on"):

--- a/tests/smoke/ui/test_render_smoke.py
+++ b/tests/smoke/ui/test_render_smoke.py
@@ -2960,6 +2960,131 @@ def test_software_actions_link_to_package_manager(
             smoke_vm.ssh("/bin/rm", "-f", software_cache)
 
 
+# The two Status-section spans issue #2674 asks the page to keep apart: the last SUCCESSFUL
+# catalogue read, and the last attempt that failed. Plus the query token Check now redirects
+# with when the refresh it forced did not work.
+_SOFTWARE_CHECKED_MARKER = "pfb-sw-checked"
+_SOFTWARE_FAILED_MARKER = "pfb-sw-check-failed"
+_SOFTWARE_CHECK_FAILED_QUERY = "?check=failed"
+
+
+def test_software_page_shows_a_failed_catalogue_check(
+    smoke_vm: SmokeVM, webui: WebUI, php_error_log_guard: PhpErrorLogGuard
+) -> None:
+    """A failed catalogue refresh is visible on the page, and a successful one is not (#2674).
+
+    On a box whose webConfigurator ``pkg`` cannot reach our repository, the page reported a
+    version, an "Up to date" verdict and a recent "Last checked" while every check it ran
+    failed -- the cron tick kept the cache warm from a context where ``pkg`` works, and a
+    failed read left no field on the cache naming the failure. So the state worth rendering
+    is the one the cache now records, and this is the tier that proves it REACHES the page.
+
+    Scenario:
+      Given the hidden override forcing the provenance gate on,
+      And a cache scoped to this install that records a SUCCESSFUL check and no failure
+          (the before-state -- the page must stay calm, which is issue #2379's fallback),
+      When the Software page is GET,
+      Then the failed-attempt marker is ABSENT and the render oracle is clean;
+      And when the same cache additionally records a failed attempt,
+      Then the failed-attempt row renders its own time, distinct from the last successful
+          check's, and the page still renders clean (a state, never a ``pkg`` error dump);
+      And Check now's feedback query renders a warning, while a plain GET stays silent.
+
+    Fail-before/pass-after: on the pre-#2674 page the marker is absent in both states,
+    because nothing recorded or rendered the failure.
+    """
+    software_cache = "/var/db/pfblockerng/software_update.json"
+    pkgname = pkg_identity.branch_pkg_name(os.environ.get("SMOKE_PKG"))
+    repo_probe = smoke_vm.ssh("/usr/local/sbin/pkg", "query", "%R", pkgname)
+    installed_repo = repo_probe.stdout.strip() if repo_probe.returncode == 0 else ""
+
+    checked_at = 1735689600  # 2025-01-01 00:00:00 UTC — a fixed, recognisable success time
+    failed_at = 1767225600  # 2026-01-01 00:00:00 UTC — strictly later, so ordering is visible
+
+    def _seed(extra: dict[str, object]) -> None:
+        smoke_vm.ssh("/bin/rm", "-f", software_cache)
+        _seed_vm_file(
+            smoke_vm,
+            software_cache,
+            json.dumps(
+                {
+                    "pkgname": pkgname,
+                    "repo": installed_repo,
+                    "latest": "99.0.0",
+                    "last_checked": checked_at,
+                    **extra,
+                }
+            ),
+        )
+
+    try:
+        with software_panel_forced(smoke_vm, "on"):
+            # BEFORE: a successful check and nothing else — no failure surface at all.
+            _seed({})
+            resp = webui.get(_SOFTWARE_PAGE)
+            result = evaluate_render(_SOFTWARE_PAGE, resp.status_code, resp.text, (_SOFTWARE_PANEL_MARKER,))
+            assert result.ok, f"Software page render oracle failed on the clean cache: {result.detail}"
+            assert _SOFTWARE_FAILED_MARKER not in resp.text, (
+                "a cache recording only a successful check must render NO failed-attempt row "
+                "(issue #2379: a benign stale read is not a scary page)"
+            )
+
+            # AFTER: the same cache, now also recording that the last attempt failed.
+            _seed({"last_failed": failed_at})
+            resp = webui.get(_SOFTWARE_PAGE)
+            result = evaluate_render(_SOFTWARE_PAGE, resp.status_code, resp.text, (_SOFTWARE_PANEL_MARKER,))
+            assert result.ok, f"Software page render oracle failed on the failed-attempt cache: {result.detail}"
+            body = resp.text
+            assert _SOFTWARE_FAILED_MARKER in body, (
+                f"the Software page must render the {_SOFTWARE_FAILED_MARKER!r} row once the cache "
+                "records a failed catalogue read (issue #2674)"
+            )
+            failure = re.search(rf'id="{_SOFTWARE_FAILED_MARKER}"[^>]*>([^<]*)<', body)
+            assert failure is not None, f"the {_SOFTWARE_FAILED_MARKER} span is absent from the body"
+            checked = re.search(rf'id="{_SOFTWARE_CHECKED_MARKER}"[^>]*>([^<]*)<', body)
+            assert checked is not None, (
+                f"the {_SOFTWARE_CHECKED_MARKER!r} span must carry the last SUCCESSFUL check time — "
+                "without it the page cannot distinguish the two (issue #2674)"
+            )
+            # Both are rendered by the guest's own date() with the guest's timezone, so the
+            # assertion is that the page names TWO DIFFERENT times, not what either formats to.
+            rendered_failure = failure.group(1).strip()
+            rendered_checked = checked.group(1).strip()
+            assert rendered_failure != "", "the failed-attempt row rendered no time at all"
+            assert rendered_checked != "", "the last-checked row rendered no time at all"
+            assert rendered_failure != rendered_checked, (
+                "the failed attempt and the last successful check must render as DIFFERENT times "
+                f"— that distinction is the whole of issue #2674; both read {rendered_failure!r}"
+            )
+            assert rendered_checked != "never", (
+                "before-state broken: the seeded successful-check time did not reach the page, so a "
+                "failed attempt could not be told apart from 'never checked' here"
+            )
+
+            # Check now's own feedback, on its reachable GET: the query token the page's
+            # failure redirect carries renders a warning an admin can actually see.
+            resp = webui.get(_SOFTWARE_PAGE + _SOFTWARE_CHECK_FAILED_QUERY)
+            result = evaluate_render(
+                _SOFTWARE_PAGE + _SOFTWARE_CHECK_FAILED_QUERY,
+                resp.status_code,
+                resp.text,
+                (_SOFTWARE_PANEL_MARKER,),
+            )
+            assert result.ok, f"Software page render oracle failed on the check-failed query: {result.detail}"
+            assert "alert-warning" in resp.text, (
+                "a forced check that failed must redisplay with a warning box, not an unchanged page"
+            )
+            assert "could not read" in resp.text, (
+                "the Check now feedback must say the catalogue could not be read (issue #2674)"
+            )
+            # And it stays feedback about THIS action: a plain GET is silent.
+            assert "alert-warning" not in webui.get(_SOFTWARE_PAGE).text, (
+                "a plain GET must not raise the Check now warning — only the forced check that failed does"
+            )
+    finally:
+        smoke_vm.ssh("/bin/rm", "-f", software_cache)
+
+
 def _pfb_output_value(body: str) -> str:
     """Return the rendered value (text between the tags) of the ``pfb_output`` textarea."""
     match = re.search(r'<textarea\b[^>]*name="pfb_output"[^>]*>(.*?)</textarea>', body, re.DOTALL)

--- a/tests/smoke/ui/test_render_smoke.py
+++ b/tests/smoke/ui/test_render_smoke.py
@@ -2962,10 +2962,12 @@ def test_software_actions_link_to_package_manager(
 
 # The two Status-section spans issue #2674 asks the page to keep apart: the last SUCCESSFUL
 # catalogue read, and the last attempt that failed. Plus the query token Check now redirects
-# with when the refresh it forced did not work.
+# with when the refresh it forced did not work, and the message that token renders -- both
+# tiers assert the same strings, so the page and the tests cannot drift apart.
 _SOFTWARE_CHECKED_MARKER = "pfb-sw-checked"
 _SOFTWARE_FAILED_MARKER = "pfb-sw-check-failed"
 _SOFTWARE_CHECK_FAILED_QUERY = "?check=failed"
+_SOFTWARE_CHECK_FAILED_TEXT = "could not read the pfBlockerNG repository catalogue"
 
 
 def test_software_page_shows_a_failed_catalogue_check(
@@ -3063,6 +3065,13 @@ def test_software_page_shows_a_failed_catalogue_check(
 
             # Check now's own feedback, on its reachable GET: the query token the page's
             # failure redirect carries renders a warning an admin can actually see.
+            #
+            # Keyed on the MESSAGE, never on the ``alert-warning`` class: pfBlockerNG's
+            # pending-changes banner is also an alert-warning, and whatever ran before this
+            # case may have left it set, so a class-level absence assertion would be about
+            # that banner rather than about this feedback. The warning STYLING is pinned by
+            # SoftwareFailedCheckStateTest's page-wiring case and asserted visually by the
+            # Tier-B case, which scopes its locator to this same text.
             resp = webui.get(_SOFTWARE_PAGE + _SOFTWARE_CHECK_FAILED_QUERY)
             result = evaluate_render(
                 _SOFTWARE_PAGE + _SOFTWARE_CHECK_FAILED_QUERY,
@@ -3071,14 +3080,12 @@ def test_software_page_shows_a_failed_catalogue_check(
                 (_SOFTWARE_PANEL_MARKER,),
             )
             assert result.ok, f"Software page render oracle failed on the check-failed query: {result.detail}"
-            assert "alert-warning" in resp.text, (
-                "a forced check that failed must redisplay with a warning box, not an unchanged page"
-            )
-            assert "could not read" in resp.text, (
-                "the Check now feedback must say the catalogue could not be read (issue #2674)"
+            assert _SOFTWARE_CHECK_FAILED_TEXT in resp.text, (
+                "a forced check that failed must say so on the redisplay, not re-serve an "
+                f"unchanged page (looked for {_SOFTWARE_CHECK_FAILED_TEXT!r})"
             )
             # And it stays feedback about THIS action: a plain GET is silent.
-            assert "alert-warning" not in webui.get(_SOFTWARE_PAGE).text, (
+            assert _SOFTWARE_CHECK_FAILED_TEXT not in webui.get(_SOFTWARE_PAGE).text, (
                 "a plain GET must not raise the Check now warning — only the forced check that failed does"
             )
     finally:

--- a/tests/smoke/ui/test_render_smoke.py
+++ b/tests/smoke/ui/test_render_smoke.py
@@ -2967,7 +2967,10 @@ def test_software_actions_link_to_package_manager(
 _SOFTWARE_CHECKED_MARKER = "pfb-sw-checked"
 _SOFTWARE_FAILED_MARKER = "pfb-sw-check-failed"
 _SOFTWARE_CHECK_FAILED_QUERY = "?check=failed"
-_SOFTWARE_CHECK_FAILED_TEXT = "could not read the pfBlockerNG repository catalogue"
+# Matches the Check-now info box ALONE: the Status row's help text also says "could not read
+# the pfBlockerNG repository catalogue", so keying on that sentence made the "a plain load
+# stays silent" assertion trip on the row. SoftwareFailedCheckStateTest pins the uniqueness.
+_SOFTWARE_CHECK_FAILED_TEXT = "Check now could not read"
 
 
 def test_software_page_shows_a_failed_catalogue_check(

--- a/tests/smoke/ui/test_render_smoke.py
+++ b/tests/smoke/ui/test_render_smoke.py
@@ -2967,9 +2967,8 @@ def test_software_actions_link_to_package_manager(
 _SOFTWARE_CHECKED_MARKER = "pfb-sw-checked"
 _SOFTWARE_FAILED_MARKER = "pfb-sw-check-failed"
 _SOFTWARE_CHECK_FAILED_QUERY = "?check=failed"
-# Matches the Check-now info box ALONE: the Status row's help text also says "could not read
-# the pfBlockerNG repository catalogue", so keying on that sentence made the "a plain load
-# stays silent" assertion trip on the row. SoftwareFailedCheckStateTest pins the uniqueness.
+# Must match the Check-now info box ALONE -- the Status row's help text speaks about the same
+# failure, so a phrase both carry cannot support the "a plain load stays silent" assertion.
 _SOFTWARE_CHECK_FAILED_TEXT = "Check now could not read"
 
 
@@ -2995,8 +2994,8 @@ def test_software_page_shows_a_failed_catalogue_check(
           check's, and the page still renders clean (a state, never a ``pkg`` error dump);
       And Check now's feedback query renders a warning, while a plain GET stays silent.
 
-    Fail-before/pass-after: on the pre-#2674 page the marker is absent in both states,
-    because nothing recorded or rendered the failure.
+    Fail-before/pass-after: without the fix the marker is absent in both states, because
+    nothing records or renders the failure.
     """
     software_cache = "/var/db/pfblockerng/software_update.json"
     pkgname = pkg_identity.branch_pkg_name(os.environ.get("SMOKE_PKG"))
@@ -3070,11 +3069,8 @@ def test_software_page_shows_a_failed_catalogue_check(
             # failure redirect carries renders a warning an admin can actually see.
             #
             # Keyed on the MESSAGE, never on the ``alert-warning`` class: pfBlockerNG's
-            # pending-changes banner is also an alert-warning, and whatever ran before this
-            # case may have left it set, so a class-level absence assertion would be about
-            # that banner rather than about this feedback. The warning STYLING is pinned by
-            # SoftwareFailedCheckStateTest's page-wiring case and asserted visually by the
-            # Tier-B case, which scopes its locator to this same text.
+            # pending-changes banner is also an alert-warning and may be set, so a class-level
+            # absence assertion would be about that banner rather than about this feedback.
             resp = webui.get(_SOFTWARE_PAGE + _SOFTWARE_CHECK_FAILED_QUERY)
             result = evaluate_render(
                 _SOFTWARE_PAGE + _SOFTWARE_CHECK_FAILED_QUERY,

--- a/tests/test_check_skip_allowlist.py
+++ b/tests/test_check_skip_allowlist.py
@@ -632,10 +632,8 @@ def test_canary_fixture_is_never_on_the_real_allowlist(suite: str, capsys: pytes
 # --------------------------------------------------------------------------- #
 
 
-# Suite prefixes the allowlist may legitimately carry. Enumerated from the invocations, not
-# from memory: run-gates.sh passes --suite pytest/phpunit/shellspec, and ui-tests.yml passes
-# --suite ui (pinned twice by tests/test_ui_release_gate_wiring.py). `ui` was missing here,
-# so the first live-VM leg to observe a conditional UI skip could not be allowlisted at all.
+# Suite prefixes the allowlist may legitimately carry, one per --suite value the gates pass:
+# run-gates.sh uses pytest/phpunit/shellspec and ui-tests.yml uses ui.
 _ALLOWLIST_SUITES = ("pytest", "phpunit", "shellspec", "ui")
 
 

--- a/tests/test_check_skip_allowlist.py
+++ b/tests/test_check_skip_allowlist.py
@@ -632,10 +632,17 @@ def test_canary_fixture_is_never_on_the_real_allowlist(suite: str, capsys: pytes
 # --------------------------------------------------------------------------- #
 
 
+# Suite prefixes the allowlist may legitimately carry. Enumerated from the invocations, not
+# from memory: run-gates.sh passes --suite pytest/phpunit/shellspec, and ui-tests.yml passes
+# --suite ui (pinned twice by tests/test_ui_release_gate_wiring.py). `ui` was missing here,
+# so the first live-VM leg to observe a conditional UI skip could not be allowlisted at all.
+_ALLOWLIST_SUITES = ("pytest", "phpunit", "shellspec", "ui")
+
+
 def test_real_allowlist_file_parses_cleanly() -> None:
     root = Path(__file__).resolve().parents[1]
     allow = root / "tests/skip-allowlist.txt"
     entries = csa.parse_allowlist(allow)
     assert entries, "tests/skip-allowlist.txt must seed at least the known PHPUnit/pytest skips"
     for entry_id in entries:
-        assert entry_id.split(":", 1)[0] in ("pytest", "phpunit", "shellspec"), entry_id
+        assert entry_id.split(":", 1)[0] in _ALLOWLIST_SUITES, entry_id


### PR DESCRIPTION
Fixes #2674

## What was wrong

A failed catalogue refresh was invisible, so the Software page presented a cached version as a fresh check.

Two mechanisms, both confirmed by probe on untouched `devel` (`60d16bd8`) before any edit:

- **`pfb_pkg_latest()` discarded the refresh's return value.** `pfb_pkg_exec("… update -f -r <repo> 2>/dev/null")` was called with no `$out`/`$ret` arguments at all, and the function's signature was `(string, string): string` — so the rc could not reach the caller even in principle.
- **A failed live read left no record on the cache.** `pfb_software_update_check()` kept the cached `latest` and did not advance `last_checked` (correct, #2379) but wrote nothing naming the failure. With the cron tick still writing a good cache from a context where `pkg` works, the page looked healthy while its own forced check failed every time.

## Probe evidence (pre-fix, untouched tree)

```
=== PROBE A — H2: does a FAILED forced check leave any record on the cache? ===
  cron-warmed cache      : {"channel":"nightly", … "last_checked":1000, …}
  after a FAILED check   : {"channel":"nightly", … "last_checked":1000, …}
  keys the failed check ADDED: (none)
  page after cron success: {"Latest version":"20260824030000.abc1234","Status":"Up to date","Last checked":"1970-01-01 00:16:40"}
  page after failed check: {"Latest version":"20260824030000.abc1234","Status":"Up to date","Last checked":"1970-01-01 00:16:40"}
  VERDICT H2: page rendering identical? YES -> the failure is INVISIBLE

=== PROBE B — can the CALLER of pfb_pkg_latest() observe the refresh rc? ===
  signature: pfb_pkg_latest(string $pkgname, string $reponame): string
  refresh call site:	pfb_pkg_exec("{$tmo}{$bin} update -f -r {$repo} 2>/dev/null");
  VERDICT H1: refresh rc reaches the caller? NO -> string-only return, rc DISCARDED

=== PROBE C — refresh FAILS but the stale catalog DB still reads a version ===
  after stale-DB read    : { … "last_checked":1787855240, "latest":"20260820030000.dead999", … }
  last_checked advanced past the cron value (1000)? YES -> a stale answer is presented as a fresh check
```

Both hypotheses held, and they compose: PROBE B's discarded rc is what makes PROBE C possible; PROBE A is the total-failure case.

## What changed

**`pfb_pkg_read_ok(int $refresh_ret, int $rquery_ret, string $latest): bool`** (new) — the rule that was missing. A non-zero refresh means the catalogue was **not** refreshed, so any version `rquery` then prints came off the stale local DB: a fallback, never a successful check.

**`pfb_pkg_latest(…, ?bool &$read_ok = null)`** — captures the refresh rc and reports the outcome as a tri-state the caller can act on:

| `$read_ok` | meaning |
|---|---|
| `TRUE` | the catalogue was refreshed and named a version |
| `FALSE` | the read was attempted and **failed** (either `pkg` call non-zero, or nothing named) |
| `NULL` | **not attempted** — a guard deliberately deferred it |

`NULL` is load-bearing: `pkg` locked, no DNS and an unnamed package are deferrals, not failures. Turning "pkg is busy" into a failed check is exactly the scary page #2674 rules out.

**`pfb_software_update_check()`** — records `last_failed` when the attempt failed, clears it on a successful read, keeps the standing one across a deferral. Scoped exactly like `last_checked`, so a previous install's failure is never shown against the current one (#2148's rule applied to the new field). `last_checked` now advances only on a read that actually succeeded.

**The page** — `Last checked` (last **successful** read, now `id="pfb-sw-checked"`) is paired with a `Last check failed` row gated on **`pfb_software_failed_at()`**, and **Check now** routes its own outcome through **`pfb_software_check_redirect()`** so a forced check that failed redisplays with a warning instead of silently re-serving the old answer. Only that redirect's token raises the box, so a plain GET off a stale cache stays calm. Same shape as the existing `pfb_general_schedule_save_redirect()` / `?schcache=failed` pattern.

`pkg` stderr stays redirected on both calls, and the cache's key set is asserted **closed** so no captured output can ride to the page inside the cache. Observability here is a state, not an error dump.

## #2379's fallback is intact — re-verified post-fix

```
=== 2. issue #2379's fallback still holds ===
  PASS  the last-known latest did not regress to empty -> 20260824030000.abc1234
  PASS  a failed live read did not advance last_checked -> 1000
  PASS  no notice fired on the failed read
  PASS  no pkg output/stderr field rides in the cache -> channel,installed,last_checked,last_failed,last_notified,latest,pkgname,repo

=== 3. The BENIGN paths are unchanged (no scary page) ===
  successful-check page: {"Latest version":"…","Status":"Up to date","Last checked":"2026-08-27 18:43:35"}
  PASS  a successful check records no failure
  PASS  and renders no failed-attempt row
  PASS  and no warning box on a plain GET
  stale-cache page:      {"Latest version":"…","Status":"Up to date","Last checked":"1970-01-01 00:16:40"}
  PASS  a deferred tick records no failure
  PASS  the stale page renders exactly as before the change
  fresh-box page:        {"Latest version":"Not checked yet","Status":"Not checked yet","Last checked":"never"}
  PASS  a box that never checked shows no failure
  PASS  and still reads "Not checked yet"
```

The stale-cache page renders **byte-identically** to the pre-change success view. A benign stale read did not become a scary page.

## Test-first: frozen RED → GREEN at identical hashes

Frozen at the red run, byte-identical at the green run:

| file | `git hash-object` (red **and** green) |
|---|---|
| `tests/php/SoftwareFailedCheckStateTest.php` | `b93e7bab4f927c4b3be7659e8e7b8ed269723eeb` |
| `tests/smoke/ui/test_render_smoke.py` | `1002ee95eb19aeba34b7d322ebdc8c5371dbfeb1` |
| `tests/smoke/ui/test_browser_misc.py` | `762f3118dcaded019a31065691b03454e08d1fd1` |

**RED**, before the production edit — all 14 cases:

```
Tests: 14, Assertions: 25, Errors: 4, Failures: 10, Warnings: 1.

Errors:   testAFailedRefreshIsNotASuccessfulReadEvenWhenTheStaleDbAnswers  (undefined pfb_pkg_read_ok)
          testAFailedOrEmptyRqueryIsNotASuccessfulRead                     (undefined pfb_pkg_read_ok)
          testTheFailedAttemptRowIsGatedOnTheCurrentInstall                (undefined pfb_software_failed_at)
          testCheckNowReportsAForcedRefreshThatFailed                      (undefined pfb_software_check_redirect)
Failures: testPkgLatestReportsAFailedAttemptToItsCaller                    (asserting that null is false)
          testADeliberateDeferralIsNotAFailedAttempt
          testPkgLatestCapturesBothReturnValuesAndKeepsPkgStderrOffThePage
          testAFailedCheckRecordsTheFailedAttemptOnTheCache                (array has no key 'last_failed')
          testAStaleCatalogueReadDoesNotAdvanceTheSuccessfulCheckTime      (1787855424 is not 1000)
          testASuccessfulCheckClearsARecordedFailure
          testADeferredTickNeitherInventsNorErasesAFailure
          testAFailureFromAnotherInstallIsNotCarriedForward
          testAFailedAttemptWritesAStateNotAnErrorDump
          testThePageDrivesTheExtractedHelpers                             (page discards the outcome)
```

**GREEN**, same files, zero edits:

```
..............                                                    14 / 14 (100%)
OK (14 tests, 70 assertions)
```

## Mutation kills — every one executed

| # | mutant | named test(s) turned RED |
|---|---|---|
| M1 | drop the captured catalogue-refresh return value (`pfb_pkg_read_ok` ignores `$refresh_ret`) | `testAFailedRefreshIsNotASuccessfulReadEvenWhenTheStaleDbAnswers` |
| M2 | drop the failed-attempt state from the cache | `testAFailedCheckRecordsTheFailedAttemptOnTheCache`, `testAStaleCatalogueReadDoesNotAdvanceTheSuccessfulCheckTime`, `testASuccessfulCheckClearsARecordedFailure`, `testADeferredTickNeitherInventsNorErasesAFailure`, `testAFailedAttemptWritesAStateNotAnErrorDump` |
| M3 | drop the Check-now failure feedback (`pfb_software_check_redirect` always returns the bare path) | `testCheckNowReportsAForcedRefreshThatFailed` |
| M4 | let a failed attempt advance `last_checked` (`if ($live_ok)`) | `testAStaleCatalogueReadDoesNotAdvanceTheSuccessfulCheckTime` |
| M5 | page discards the forced check's outcome (the pre-#2674 handler, verbatim) | `testThePageDrivesTheExtractedHelpers` |
| M6 | page drops the Check-now warning box | `testCheckNowReportsAForcedRefreshThatFailed`, `testThePageDrivesTheExtractedHelpers` |
| M7 | page drops the failed-attempt row | `testThePageDrivesTheExtractedHelpers` |

All seven applied to the real source, executed, and reverted; the tree is byte-restored (`git status` clean apart from the intended diff).

## What the UI gate proves, and what it does not

**Proves, executed here (PHPUnit, host toolchain PHP 8.5.9):** the four functions the page calls behave correctly across every branch — the read rule's truth table, the attempt tri-state, the cache's record/clear/keep/rescope, and both arms of the Check-now redirect including a round trip from the redirect's own query token back to the token the page reads.

**Proves, in CI's smoke tier (not runnable on this workstation — no VM; Tier B additionally needs Playwright, which `pytest.importorskip` skips here):**
- Tier A `ui_render`, `test_software_page_shows_a_failed_catalogue_check` — seeds `software_update.json` on the guest and GETs the real page: the failed-attempt row is **absent** on a success-only cache and **present** with its own distinct time once a failure is recorded, `pfb-sw-checked` still carries the last successful read, `?check=failed` renders a warning, and a plain GET does not. Render oracle clean (200, no Fatal/Warning/Notice) in every state.
- Tier B `ui_browser`, `test_software_failed_check_feedback_is_visible` — drives the same feedback in headless Chromium (`.alert-warning` visible with the token, count 0 without), mirroring the established `?schcache=failed` browser case.

**Does NOT prove:** the page-source assertions in `testThePageDrivesTheExtractedHelpers` pin the wiring **text**, not its reachability. The page's top level cannot execute under the PHPUnit harness at all — `require_once('guiconfig.inc')` exits 255 before any page logic, which is why #2525 chose extraction. An inverted branch condition is caught (the branch's opening line is part of the pinned sequence); a rewrite that keeps the sequence and makes it unreachable — inside a dead `if (FALSE)`, after an unconditional `exit` — survives it. That gap is tracked in #2768; it is not grown into this PR. The Tier A/B cases above are the reachability proof, and they run in CI, not here.

## Out of scope

Why the webConfigurator's `pkg` lacks `SSL_CA_CERT_PATH` on pfSense Plus. That is its own defect; this change stands either way.

## Files

- `src/usr/local/pkg/pfblockerng/pfblockerng.inc` — confined to the software/cache functions; no download-family function touched, no neighbouring reformat.
- `src/usr/local/www/pfblockerng/pfblockerng_software.php`
- `tests/php/SoftwareFailedCheckStateTest.php` (new)
- `tests/php/fixtures/function_inventory.json` — regenerated for the three new symbols and `pfb_pkg_latest`'s new by-ref parameter, via the documented `PFB_UPDATE_FUNCTION_INVENTORY=1` path.
- `tests/smoke/ui/test_render_smoke.py`, `tests/smoke/ui/test_browser_misc.py`

No registered config field is added, so no `PfbConfig` surface changes; the cache is a JSON document, never `config.xml`.

Known pre-existing local failure, not chased: `DownloadSizeCeilingTest::test_extract_cmd_ceiling_stops_a_child_that_writes_past_it` (Darwin-only, #2765).

🤖 Generated by Oh My Pi and posted on behalf of @andrebrait.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Software update checks now distinguish failed, successful, and deferred repository reads.
  - Failed checks no longer overwrite the last successful check time or promote stale versions.
  - Failure status is recorded and cleared appropriately.

- **User Interface**
  - The Software page displays a “Last check failed” status when applicable.
  - “Check now” reports current-attempt failures with clear feedback.

- **Tests**
  - Added coverage for failure tracking, cache handling, redirects, notifications, and page feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->