### PR TITLE
pfblockerng: share Blacklist tar empty-tree finalize

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -4303,6 +4303,30 @@ function pfb_download_initial_retval(): int {
 }
 
 /**
+ * After a Blacklist tar extract, keep only staged category files.
+ * glob('*domains') matches directories; an empty file list must not publish.
+ */
+function pfb_blacklist_tar_finalize_staged(string $staged, string $filename, int $retval): int {
+	if (!pfb_download_extraction_succeeded($retval)) {
+		return $retval;
+	}
+	$list = glob("{$staged}/{$filename}*");
+	if (!is_array($list)) {
+		$list = array();
+	}
+	$list = array_values(array_filter($list, 'is_file'));
+	if (empty($list)) {
+		return pfb_download_initial_retval();
+	}
+	foreach ($list as $verify) {
+		if (strpos(basename($verify), '-') !== FALSE) {
+			rename($verify, dirname($verify) . '/' . str_replace('-', '_', basename($verify)));
+		}
+	}
+	return $retval;
+}
+
+/**
  * Publish an extraction atomically. $extract writes to a staged path beside $target and
  * returns its exit code; $target is replaced only once that code reports success, so a
  * failed extraction leaves the publication already in service untouched.
@@ -14456,27 +14480,7 @@ function pfb_download(PfbDownloadRequest $request): PfbDownloadResult {
 					if (!pfb_stage_publish_dir("{$pfb['dbdir']}/{$filename}",
 					    static function (string $staged) use ($file_dwn, $filename, $cmd, &$output, &$retval): int {
 						exec(pfb_extract_cmd("/usr/bin/tar -xf " . escapeshellarg("{$file_dwn}") . " {$cmd} -C " . escapeshellarg("{$staged}/") . " >/dev/null 2>&1"), $output, $retval);
-						if (!pfb_download_extraction_succeeded($retval)) {
-							return $retval;
-						}
-
-						// Rename any Category files with dashes
-						$list = glob("{$staged}/{$filename}*");
-						if (!is_array($list)) {
-							$list = array();
-						}
-						$list = array_values(array_filter($list, 'is_file'));
-						if (empty($list)) {
-							// issue #2638: tar exit 0 with no category file must not
-							// publish an empty tree over live categories.
-							return pfb_download_initial_retval();
-						}
-						foreach ($list as $verify) {
-							if (strpos(basename($verify), '-') !== FALSE) {
-								rename($verify, dirname($verify) . '/' . str_replace('-', '_', basename($verify)));
-							}
-						}
-						return $retval;
+						return pfb_blacklist_tar_finalize_staged($staged, $filename, $retval);
 					})) {
 						pfb_logger("\n[pfb_download] blacklist extraction failed (tar exit {$retval})" . pfb_extract_cap_note($retval), 2);
 						return PfbDownloadResult::failure();
@@ -15003,23 +15007,7 @@ function pfb_download(PfbDownloadRequest $request): PfbDownloadResult {
 					if (!pfb_stage_publish_dir("{$pfb['dbdir']}/{$filename}",
 					    static function (string $staged) use ($file_dwn, $filename, $cmd, &$output, &$retval): int {
 						exec(pfb_extract_cmd("/usr/bin/tar -xf " . escapeshellarg("{$file_dwn}") . " {$cmd} -C " . escapeshellarg("{$staged}/") . " >/dev/null 2>&1"), $output, $retval);
-						if (!pfb_download_extraction_succeeded($retval)) {
-							return $retval;
-						}
-						$list = glob("{$staged}/{$filename}*");
-						if (!is_array($list)) {
-							$list = array();
-						}
-						$list = array_values(array_filter($list, 'is_file'));
-						if (empty($list)) {
-							return pfb_download_initial_retval();
-						}
-						foreach ($list as $verify) {
-							if (strpos(basename($verify), '-') !== FALSE) {
-								rename($verify, dirname($verify) . '/' . str_replace('-', '_', basename($verify)));
-							}
-						}
-						return $retval;
+						return pfb_blacklist_tar_finalize_staged($staged, $filename, $retval);
 					})) {
 						pfb_logger("\n[pfb_download] blacklist extraction failed (tar exit {$retval})" . pfb_extract_cap_note($retval), 2);
 						return PfbDownloadResult::failure();

--- a/tests/php/DownloadExtractionExitCodeTest.php
+++ b/tests/php/DownloadExtractionExitCodeTest.php
@@ -171,6 +171,7 @@ final class DownloadExtractionExitCodeTest extends TestCase
 		$this->assertNotFalse($end);
 		$scope = substr(self::$source, $blacklist, $end - $blacklist);
 		$this->assertMatchesRegularExpression('/exec\(pfb_extract_cmd\(".*tar -xf .*\\$output, \\$retval\);/', $scope);
+		$this->assertStringContainsString('pfb_archive_unsafe_member', $scope);
 		$this->assertStringContainsString(
 			'pfb_blacklist_tar_finalize_staged($staged, $filename, $retval)',
 			$scope

--- a/tests/php/DownloadExtractionExitCodeTest.php
+++ b/tests/php/DownloadExtractionExitCodeTest.php
@@ -171,7 +171,10 @@ final class DownloadExtractionExitCodeTest extends TestCase
 		$this->assertNotFalse($end);
 		$scope = substr(self::$source, $blacklist, $end - $blacklist);
 		$this->assertMatchesRegularExpression('/exec\(pfb_extract_cmd\(".*tar -xf .*\\$output, \\$retval\);/', $scope);
-		$this->assertStringContainsString('pfb_download_extraction_succeeded($retval)', $scope);
+		$this->assertStringContainsString(
+			'pfb_blacklist_tar_finalize_staged($staged, $filename, $retval)',
+			$scope
+		);
 		// issue #2735: success return is immediately after the update marker (not a
 		// decoy elsewhere in the 1710-byte scope).
 		$this->assertMatchesRegularExpression(
@@ -372,17 +375,75 @@ final class DownloadExtractionExitCodeTest extends TestCase
 	}
 
 	/**
-	 * Issue #2638 B9 — glob() matches directories, so a *domains directory
-	 * satisfies an empty($list) guard. Category publish must count files.
+	 * Issue #2764 — gzip inner-tar extract (generic/IP) must stdout-extract
+	 * (`tar -xOf -`) and only when the inner MIME is x-tar. Mutations (c)
+	 * drop `-O` and (e) invert the comparison stay green without this pin.
 	 * Comments/docblocks cannot define this scope.
+	 */
+	public function testGzipInnerTarExtractIsStdoutAndTypeGated(): void
+	{
+		$gzip = strpos(self::$source, "if (\$file_type == 'application/x-gzip' || \$file_type == 'application/gzip')");
+		$blacklist = strpos(self::$source, "elseif (\$type == 'blacklist') {", $gzip === FALSE ? 0 : $gzip);
+		$inner = strpos(self::$source, 'else { $reject_detail = array();', $blacklist === FALSE ? 0 : $blacklist);
+		$bzip = strpos(self::$source, "elseif (\$file_type == 'application/x-bzip2')", $inner === FALSE ? 0 : $inner);
+		$this->assertNotFalse($gzip);
+		$this->assertNotFalse($inner);
+		$this->assertNotFalse($bzip);
+		$scope = substr(self::$source, $inner, $bzip - $inner);
+		$this->assertStringContainsString(
+			'$extract_tar = ($inner_type == \'application/x-tar\')',
+			$scope,
+			'inner tar extract must be gated on application/x-tar'
+		);
+		$this->assertStringContainsString(
+			'tar -xOf -',
+			$scope,
+			'gzip inner tar must stdout-extract (-O); dropping it writes a tar archive as a feed'
+		);
+	}
+
+	/**
+	 * Issue #2764 — both Blacklist tar staging sites share one helper that
+	 * drops directory glob hits. A site-count of 2 breaks when the arms
+	 * unify. Comments/docblocks cannot define this scope.
 	 */
 	public function testBlacklistEmptyTreeGuardCountsFilesNotDirectories(): void
 	{
-		$this->assertSame(
-			2,
-			substr_count(self::$source, "array_filter(\$list, 'is_file')"),
-			'both Blacklist staging sites must drop directory glob hits'
+		$this->assertTrue(
+			function_exists('pfb_blacklist_tar_finalize_staged'),
+			'Blacklist tar staging must share pfb_blacklist_tar_finalize_staged'
 		);
+		$this->assertGreaterThanOrEqual(
+			2,
+			substr_count(self::$source, 'pfb_blacklist_tar_finalize_staged($staged'),
+			'gzip and uncompressed Blacklist tar arms must both call the helper'
+		);
+		$this->assertStringContainsString(
+			"array_filter(\$list, 'is_file')",
+			self::$source,
+			'helper must still drop directory glob hits'
+		);
+	}
+
+	/**
+	 * Issue #2764 — a *domains directory in the staged tree is not a
+	 * category file. The helper returns the empty-tree sentinel.
+	 */
+	public function testBlacklistTarFinalizeTreatsDirectoryOnlyTreeAsEmpty(): void
+	{
+		$this->assertTrue(function_exists('pfb_blacklist_tar_finalize_staged'));
+		$staged = sys_get_temp_dir() . '/pfb2764_' . (string) getmypid();
+		@mkdir($staged, 0700, TRUE);
+		@mkdir($staged . '/feed_cat', 0700);
+		try {
+			$this->assertSame(
+				pfb_download_initial_retval(),
+				pfb_blacklist_tar_finalize_staged($staged, 'feed', 0)
+			);
+		} finally {
+			@rmdir($staged . '/feed_cat');
+			@rmdir($staged);
+		}
 	}
 
 	/**

--- a/tests/php/fixtures/function_inventory.json
+++ b/tests/php/fixtures/function_inventory.json
@@ -707,6 +707,33 @@
             }
         ]
     },
+    "pfb_blacklist_tar_finalize_staged": {
+        "returnsRef": false,
+        "returnType": "int",
+        "params": [
+            {
+                "name": "staged",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "filename",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "retval",
+                "byRef": false,
+                "variadic": false,
+                "type": "int",
+                "default": null
+            }
+        ]
+    },
     "pfb_build_aggregate_aliases": {
         "returnsRef": false,
         "returnType": null,


### PR DESCRIPTION
## Summary

#2743 round 3 recorded duplicated Blacklist tar staging (gzip + uncompressed) and a hard-coded `assertSame(2, substr_count(... is_file))`. This PR extracts `pfb_blacklist_tar_finalize_staged()` so both arms call one helper: glob, `is_file` filter, empty-tree sentinel, dash-to-underscore rename.

Also pins the gzip inner-tar generic/IP path: stdout extract (`tar -xOf -`) gated on `$inner_type == 'application/x-tar'`. Mutations (c) drop `-O` and (e) invert the comparison now fail `testGzipInnerTarExtractIsStdoutAndTypeGated`.

Not #2638 / #2743. Does not drop pipefail. UTC stamp arithmetic is #2770, not this PR.

## Verification

PHPUnit `DownloadExtractionExitCodeTest` 20 tests / 125 assertions (PHP 8.5.9). Helper directory-only tree returns `pfb_download_initial_retval()`. Dropping `-O` from gzip inner tar: RED (`tar -xOf -` missing). Inverting `==` to `!=`: RED (gate string missing). Restored.

| Frozen RED test | git hash-object | RED run tail |
| --- | --- | --- |
| `tests/php/DownloadExtractionExitCodeTest.php` | `282d83ed99fc5b2bf30a5087eca285719e7222ac` | helper missing / gzip inner `-O` / inverted `==` |

Blacklist staging helper only. Geoip x-tar extract arms are **not** unified here; #2764 stays open for that remainder.

Refs #2764

🤖 Generated by Grok and posted on behalf of @BBcan177.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved blacklist archive extraction reliability.
  * Prevented empty or directory-only extractions from being published.
  * Improved handling of staged files and filenames containing dashes.
  * Ensured extraction failures retain their original status.

* **Tests**
  * Added coverage for gzip and tar extraction validation.
  * Added checks for empty staged extraction results and consistent finalization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->