### PR TITLE
pfblockerng: stamp the due-ledger document the writer authors

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -4393,13 +4393,9 @@ function pfb_due_ledger_document_valid(mixed $document): bool
 /**
  * Read-modify-write one job row, stamping the document for the cache reader.
  *
- * pfb_due_ledger_cache_valid() requires `_meta`, so a document authored only here has
- * to carry it or pfb_due_ledger_read_cache() rejects this writer's own output (issue
- * #2598). An existing stamp is left alone: it names the generation the rows were
- * computed for, and refreshing it would make a stale cache look current. With no
- * resolvable generation there is nothing to stamp, so the row is published unstamped
- * as before -- the same model is needed to produce the hash a reader would read with,
- * so no reader can be looking, and the schedule refresh restores the stamp.
+ * issue #2598: pfb_due_ledger_cache_valid() requires `_meta`, so stamp the current
+ * resolvable generation when the document carries none; preserve any existing stamp, so
+ * a stale generation stays detectable. No resolvable generation, no stamp.
  */
 function pfb_due_ledger_update_entry(
 	string $job_key,

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -4390,6 +4390,17 @@ function pfb_due_ledger_document_valid(mixed $document): bool
 	return TRUE;
 }
 
+/**
+ * Read-modify-write one job row, stamping the document for the cache reader.
+ *
+ * pfb_due_ledger_cache_valid() requires `_meta`, so a document authored only here has
+ * to carry it or pfb_due_ledger_read_cache() rejects this writer's own output (issue
+ * #2598). An existing stamp is left alone: it names the generation the rows were
+ * computed for, and refreshing it would make a stale cache look current. With no
+ * resolvable generation there is nothing to stamp, so the row is published unstamped
+ * as before -- the same model is needed to produce the hash a reader would read with,
+ * so no reader can be looking, and the schedule refresh restores the stamp.
+ */
 function pfb_due_ledger_update_entry(
 	string $job_key,
 	callable $update,
@@ -4420,6 +4431,12 @@ function pfb_due_ledger_update_entry(
 				}
 			}
 			$data[$job_key] = $update($current);
+			if (!array_key_exists('_meta', $data)) {
+				$config_hash = pfb_schedule_runtime_config()['config_hash'] ?? NULL;
+				if (is_string($config_hash)) {
+					$data = ['_meta' => ['schema' => 1, 'config_hash' => $config_hash]] + $data;
+				}
+			}
 			return $data;
 		},
 		static fn (mixed $value): bool => pfb_due_ledger_document_valid($value),

--- a/tests/php/DueLedgerPublicationTest.php
+++ b/tests/php/DueLedgerPublicationTest.php
@@ -31,9 +31,16 @@ final class DueLedgerPublicationTest extends TestCase
 		], $this->dir);
 
 		$this->assertTrue($result, 'a valid ledger entry must report successful publication');
+		$model = pfb_schedule_runtime_config();
+		$this->assertIsArray($model,
+			'harness: the writer needs a resolvable config generation to stamp against');
 		$this->assertSame(
-			['dcc' => ['last_run' => 100, 'next_due' => 200, 'jitter' => 0]],
-			json_decode((string) file_get_contents($this->dir . '/pfb_due_ledger.json'), TRUE)
+			[
+				'_meta' => ['schema' => 1, 'config_hash' => $model['config_hash']],
+				'dcc' => ['last_run' => 100, 'next_due' => 200, 'jitter' => 0],
+			],
+			json_decode((string) file_get_contents($this->dir . '/pfb_due_ledger.json'), TRUE),
+			'the published document must carry the row plus the stamp its own cache reader requires'
 		);
 	}
 

--- a/tests/php/DueLedgerWriterMetaTest.php
+++ b/tests/php/DueLedgerWriterMetaTest.php
@@ -1,0 +1,260 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The due-ledger writer must author a document its own cache reader accepts.
+ *
+ * pfb_due_ledger_cache_valid() requires a `_meta` stamp carrying the schema and the
+ * config-generation hash. pfb_due_ledger_write_entry()/pfb_due_ledger_update_entry()
+ * are the other sanctioned authors of pfb_due_ledger.json, so a document they produce
+ * from scratch has to satisfy that same gate -- otherwise the writer's own reader
+ * returns NULL and the tick suppresses cron selection (issue #2598).
+ *
+ * The stamp is written only when the document does not already carry one: an existing
+ * stamp identifies the generation the rows were computed for, and refreshing it would
+ * make a stale cache look current.
+ */
+final class DueLedgerWriterMetaTest extends TestCase
+{
+	/** A row shape pfb_due_ledger_entry_valid() accepts. */
+	private const ENTRY = ['last_run' => 100, 'next_due' => 200, 'jitter' => 0];
+
+	/** A well-formed hash that is deliberately not this fixture's generation. */
+	private const OTHER_GENERATION_HASH =
+		'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+
+	private string $dir = '';
+	private string $path = '';
+	private mixed $originalConfig = NULL;
+	private string $configHash = '';
+
+	protected function setUp(): void
+	{
+		$this->originalConfig = $GLOBALS['config'] ?? NULL;
+		$this->configureSchedule('3', '4', '15');
+
+		$this->dir = sys_get_temp_dir() . '/pfb_due_writer_meta_' . getmypid() . '_' . uniqid();
+		mkdir($this->dir, 0755, TRUE);
+		$this->path = $this->dir . '/pfb_due_ledger.json';
+	}
+
+	protected function tearDown(): void
+	{
+		$GLOBALS['config'] = $this->originalConfig;
+		foreach (glob($this->dir . '/*') ?: [] as $artifact) {
+			@unlink($artifact);
+		}
+		@rmdir($this->dir);
+	}
+
+	/**
+	 * Stand up a self-contained schedule configuration and record its generation hash.
+	 *
+	 * Written per test rather than inherited from whatever ran earlier in the process,
+	 * so the generation this fixture asserts against is the one it set.
+	 */
+	private function configureSchedule(string $weekday, string $hour, string $minute): void
+	{
+		$GLOBALS['config'] = [];
+		config_set_path('installedpackages/pfblockerng/config/0/pfb_scheduled_feed_updates', 'on');
+		config_set_path('installedpackages/pfblockerng/config/0/pfb_schedule_weekday', $weekday);
+		config_set_path('installedpackages/pfblockerng/config/0/pfb_schedule_hour', $hour);
+		config_set_path('installedpackages/pfblockerng/config/0/pfb_schedule_minute', $minute);
+		config_set_path('installedpackages/pfblockernglistsv4/config', []);
+		config_set_path('installedpackages/pfblockernglistsv6/config', []);
+		config_set_path('installedpackages/pfblockerngdnsbl/config', []);
+		$model = pfb_schedule_runtime_config();
+		$this->configHash = is_array($model) ? (string) $model['config_hash'] : '';
+	}
+
+	/** Decoded pfb_due_ledger.json, or NULL when nothing is on disk. */
+	private function document(): ?array
+	{
+		if (!is_file($this->path)) {
+			return NULL;
+		}
+		$decoded = json_decode((string) file_get_contents($this->path), TRUE);
+		return is_array($decoded) ? $decoded : NULL;
+	}
+
+	private function report(string $what): string
+	{
+		return $what . '; document=' . var_export($this->document(), TRUE)
+			. '; generation=' . $this->configHash;
+	}
+
+	/**
+	 * Scenario: the ledger is authored from scratch by pfb_due_ledger_write_entry() alone.
+	 *
+	 * Given no pfb_due_ledger.json exists, so the cache reader has nothing to accept,
+	 * When the writer publishes one row and nothing else touches the file,
+	 * Then the cache reader accepts that document for the current generation.
+	 */
+	public function testFromScratchWriteEntryRoundTripsThroughTheCacheReader(): void
+	{
+		$this->assertMatchesRegularExpression('/^[0-9a-f]{64}$/D', $this->configHash,
+			'harness: the fixture must resolve a config generation to stamp against');
+		$this->assertFileDoesNotExist($this->path, 'precondition: no prior author');
+		$this->assertNull(pfb_due_ledger_read_cache($this->dir, $this->configHash),
+			'precondition: an absent ledger must read back as no cache');
+
+		$this->assertTrue(pfb_due_ledger_write_entry('cron', self::ENTRY, $this->dir),
+			'the writer must report a successful publication');
+
+		$cache = pfb_due_ledger_read_cache($this->dir, $this->configHash);
+		$this->assertIsArray($cache, $this->report(
+			'a ledger authored only through pfb_due_ledger_write_entry() must round-trip '
+			. 'through pfb_due_ledger_read_cache(), expected an array, got NULL'
+		));
+		$this->assertSame(['schema' => 1, 'config_hash' => $this->configHash], $cache['_meta'] ?? NULL,
+			$this->report('the writer must stamp the current generation, not a placeholder'));
+		$this->assertSame(self::ENTRY, $cache['cron'] ?? NULL,
+			$this->report('the published row must survive the stamp'));
+	}
+
+	/**
+	 * Scenario: the ledger is authored from scratch through the read-modify-write entry point.
+	 *
+	 * pfb_due_ledger_update_entry() is called directly by callers that need the previous
+	 * row (pfb_due_ledger_set_pending, the schedule-runtime harness), so the stamp cannot
+	 * live in the pfb_due_ledger_write_entry() wrapper alone.
+	 */
+	public function testFromScratchUpdateEntryRoundTripsThroughTheCacheReader(): void
+	{
+		$this->assertNull(pfb_due_ledger_read_cache($this->dir, $this->configHash),
+			'precondition: an absent ledger must read back as no cache');
+
+		$this->assertTrue(pfb_due_ledger_update_entry(
+			'ss_refresh',
+			static fn (?array $current): array => $current ?? self::ENTRY,
+			$this->dir
+		), 'the read-modify-write entry point must report a successful publication');
+
+		$cache = pfb_due_ledger_read_cache($this->dir, $this->configHash);
+		$this->assertIsArray($cache, $this->report(
+			'a ledger authored only through pfb_due_ledger_update_entry() must round-trip '
+			. 'through pfb_due_ledger_read_cache(), expected an array, got NULL'
+		));
+		$this->assertSame(['schema' => 1, 'config_hash' => $this->configHash], $cache['_meta'] ?? NULL,
+			$this->report('the read-modify-write entry point must stamp the current generation'));
+		$this->assertSame(self::ENTRY, $cache['ss_refresh'] ?? NULL,
+			$this->report('the published row must survive the stamp'));
+	}
+
+	/**
+	 * Scenario: a ledger written before this contract existed gets a row appended.
+	 *
+	 * Given an unstamped document on disk -- what an upgraded appliance carries until the
+	 * first schedule refresh, and what an older writer left behind,
+	 * When the writer appends a row,
+	 * Then the document the writer leaves behind is readable, not still rejected.
+	 */
+	public function testAnUnstampedDocumentOnDiskIsStampedByTheNextWrite(): void
+	{
+		file_put_contents($this->path, json_encode(['dcc' => self::ENTRY]));
+		$this->assertTrue(pfb_due_ledger_document_valid($this->document()),
+			'precondition: the unstamped document must be a valid legacy ledger');
+		$this->assertNull(pfb_due_ledger_read_cache($this->dir, $this->configHash),
+			'precondition: an unstamped document must not read back as a cache');
+
+		$this->assertTrue(pfb_due_ledger_write_entry('cron', self::ENTRY, $this->dir),
+			'appending to an unstamped document must still publish');
+
+		$cache = pfb_due_ledger_read_cache($this->dir, $this->configHash);
+		$this->assertIsArray($cache, $this->report(
+			'a write into an unstamped document must leave it readable, expected an array, got NULL'
+		));
+		$this->assertSame(self::ENTRY, $cache['dcc'] ?? NULL,
+			$this->report('the pre-existing row must be preserved'));
+		$this->assertSame(self::ENTRY, $cache['cron'] ?? NULL,
+			$this->report('the appended row must be present'));
+	}
+
+	/**
+	 * Scenario: an unstamped document has one of its existing rows rewritten.
+	 *
+	 * The stamp belongs to the document, not to the row: overwriting a row that was
+	 * already there has to leave the document readable just as adding a new one does.
+	 */
+	public function testRewritingAnExistingRowStampsAnUnstampedDocument(): void
+	{
+		file_put_contents($this->path, json_encode(['cron' => self::ENTRY]));
+		$this->assertSame(self::ENTRY, pfb_due_ledger_read_entry('cron', $this->dir),
+			'precondition: the row to be rewritten must already be on disk');
+		$this->assertNull(pfb_due_ledger_read_cache($this->dir, $this->configHash),
+			'precondition: an unstamped document must not read back as a cache');
+
+		$replacement = ['last_run' => 300, 'next_due' => 400, 'jitter' => 0];
+		$this->assertTrue(pfb_due_ledger_write_entry('cron', $replacement, $this->dir),
+			'rewriting a row in an unstamped document must still publish');
+
+		$cache = pfb_due_ledger_read_cache($this->dir, $this->configHash);
+		$this->assertIsArray($cache, $this->report(
+			'rewriting an existing row must leave the document readable, expected an array, got NULL'
+		));
+		$this->assertSame($replacement, $cache['cron'] ?? NULL,
+			$this->report('the rewritten row must be the published one'));
+	}
+
+	/**
+	 * Scenario: the writer touches a document stamped for a different generation.
+	 *
+	 * Given a document stamped for a generation that is not the current one -- the exact
+	 * state the generation check exists to detect,
+	 * When the writer publishes a row into it,
+	 * Then the stamp is left as it was, so the stale cache is still rejected for the
+	 * current generation instead of being adopted by it.
+	 */
+	public function testAStampFromAnotherGenerationIsPreservedNotRefreshed(): void
+	{
+		$this->assertNotSame(self::OTHER_GENERATION_HASH, $this->configHash,
+			'harness: the fixture stamp must differ from the current generation');
+		$this->assertTrue(pfb_due_ledger_write_cache(
+			['dcc' => self::ENTRY],
+			self::OTHER_GENERATION_HASH,
+			$this->dir
+		), 'precondition: the stale-generation document must publish');
+		$this->assertIsArray(pfb_due_ledger_read_cache($this->dir, self::OTHER_GENERATION_HASH),
+			'precondition: it must read back under its own generation');
+
+		$this->assertTrue(pfb_due_ledger_write_entry('cron', self::ENTRY, $this->dir),
+			'the writer must publish into a stamped document');
+
+		$this->assertSame(
+			['schema' => 1, 'config_hash' => self::OTHER_GENERATION_HASH],
+			$this->document()['_meta'] ?? NULL,
+			$this->report('an existing stamp must be preserved verbatim')
+		);
+		$this->assertNull(pfb_due_ledger_read_cache($this->dir, $this->configHash),
+			$this->report('a stale document must not be adopted by the current generation'));
+		$this->assertIsArray(pfb_due_ledger_read_cache($this->dir, self::OTHER_GENERATION_HASH),
+			$this->report('the stale document must still read back under its own generation'));
+	}
+
+	/**
+	 * Scenario: the schedule configuration cannot be built, so there is no generation to stamp.
+	 *
+	 * The writer is on the tick's failure path (pfb_due_ledger_set_pending after a failed
+	 * apply), so an unresolvable generation must not cost the caller its row. The document
+	 * stays unstamped -- and unreadable as a cache -- which is what the schedule refresh
+	 * repairs; nothing reads the cache in this state anyway, because the tick needs the
+	 * same model to produce the hash it would read with.
+	 */
+	public function testAnUnresolvableGenerationStillPublishesTheRow(): void
+	{
+		$this->configureSchedule('3', '99', '15');
+		$this->assertNull(pfb_schedule_runtime_config(),
+			'precondition: the fixture must make the runtime model unbuildable');
+
+		$this->assertTrue(pfb_due_ledger_write_entry('cron', self::ENTRY, $this->dir),
+			'an unresolvable generation must not cost the caller its row');
+
+		$this->assertSame(self::ENTRY, pfb_due_ledger_read_entry('cron', $this->dir),
+			$this->report('the row must be readable through the per-entry reader'));
+		$this->assertArrayNotHasKey('_meta', (array) $this->document(),
+			$this->report('no generation is known, so nothing may be stamped'));
+	}
+}

--- a/tests/php/TickScheduleRuntimeTest.php
+++ b/tests/php/TickScheduleRuntimeTest.php
@@ -532,6 +532,48 @@ final class TickScheduleRuntimeTest extends TestCase
 		);
 	}
 
+	/**
+	 * Scenario: the tick meets a ledger authored only by the due-ledger writer.
+	 *
+	 * Given the refresh-authored cache is gone and the rows are re-published solely
+	 *   through pfb_due_ledger_write_entry(),
+	 * When the fixed tick reads the ledger to decide what is due,
+	 * Then it does not declare the scheduled feed runtime unavailable -- the writer's
+	 *   own output has to be acceptable to the cache reader it shares (issue #2598).
+	 *
+	 * The feed pass is only a positive control that the tick ran to completion: it
+	 * dispatches on either side of this contract (an unusable cache still reaches the
+	 * dispatch block to regenerate one), so the notice is the sole discriminator.
+	 * Its presence is pinned from the other side by
+	 * testCachePublicationFailureSuppressesCronAndPreservesBytes.
+	 */
+	public function testWriterAuthoredLedgerDoesNotSuppressCronSelection(): void
+	{
+		$suppressed = 'Tick: scheduled feed runtime unavailable; cron selection suppressed.';
+		$now = time();
+		$dormant = ['last_run' => $now - 1, 'next_due' => $now + 86400, 'jitter' => 0];
+		$overdue = ['last_run' => $now - 86400, 'next_due' => $now - 1, 'jitter' => 0];
+		$this->assertTrue(unlink($this->dir . '/pfb_due_ledger.json'),
+			'precondition: the refresh-authored cache must be gone');
+		$this->assertTrue(pfb_due_ledger_write_entry('extra:dcc', $dormant, $this->dir));
+		$this->assertTrue(pfb_due_ledger_write_entry('cron', $overdue, $this->dir));
+		$this->assertSame($dormant, pfb_due_ledger_read_entry('extra:dcc', $this->dir),
+			'precondition: the writer alone must have authored the document');
+		$GLOBALS['pfb_test_logger_calls'] = [];
+
+		$this->tick();
+
+		$this->assertNotContains(
+			$suppressed,
+			array_column($GLOBALS['pfb_test_logger_calls'] ?? [], 'message'),
+			'a ledger authored through pfb_due_ledger_write_entry() must not read as an '
+			. 'unavailable runtime; logged='
+			. var_export(array_column($GLOBALS['pfb_test_logger_calls'] ?? [], 'message'), TRUE)
+		);
+		$this->assertSame(1, $this->feedRuns,
+			'positive control: the tick must have reached the scheduled feed dispatch');
+	}
+
 	private function recorder(): string
 	{
 		$path = $this->dir . '/php-recorder';


### PR DESCRIPTION
Fixes #2598

## What

`pfb_due_ledger_write_entry()` authored a due-ledger document that `pfb_due_ledger_read_cache()` always rejected. The writer is now symmetric with its reader: `pfb_due_ledger_update_entry()` — which `pfb_due_ledger_write_entry()` delegates to — stamps `_meta` with the config generation `pfb_schedule_runtime_config()` already computes for the refresh path.

## Disposition, and why

The issue offered three dispositions and called it a judgment call. Taken: **make the writer symmetric with the reader.**

- **Reader deliberately not loosened.** `pfb_due_ledger_cache_valid()` and `pfb_due_ledger_read_cache()` are byte-unchanged. `_meta.config_hash` is the generation gate: it is how the tick notices that the configuration moved and the derived cache is stale (`TickScheduleRuntimeTest::testStaleCacheHashIsReplacedFromCurrentRuntimeConfig` pins that). Accepting a `_meta`-less document as "degraded but usable" would weaken that gate to paper over a writer bug, and would leave the appliance dispatching on rows computed for a configuration that no longer exists.
- **Documenting the asymmetry and keeping it** was rejected for the reason the issue itself gives: a writer whose output its own reader rejects is a trap for any caller, and it is still reachable from production (`pfb_due_ledger_set_pending()` on the tick's apply-failure path, `pfb_due_ledger_mark_ran()`), not only from the harness.
- **No new coupling was needed.** The hash source is the same helper the refresh already uses, in the same file; the writer just calls it. It is called lazily — only when the document has no stamp — so the steady-state path pays nothing.

Two properties keep the change conservative:

- **An existing stamp is preserved, never refreshed.** Restamping would adopt a stale cache into the current generation and hide exactly what the gate exists to catch.
- **An unresolvable model leaves the row unstamped, as before.** With no model there is no hash to stamp — and no reader either, because the tick needs the same model to produce the hash it would read with. The row still publishes, so the tick's failure path cannot lose its pending marker; the next `pfb_schedule_cache_refresh()` restores the stamp.

## Probe — two hypotheses, one discriminator

- **H1** — the writer authors a `_meta`-less document and `pfb_due_ledger_cache_valid()` hard-requires `_meta`, so `read_cache()` returns `NULL`.
- **H2** — `read_cache()` rejects for some other reason (the 64-hex hash-argument guard, entry-shape validation, the shared-lock budget), in which case a stamp would not help.

Discriminator, run on untouched `devel` @ `0579efc0`: author a ledger from scratch through the writer only, read it back, then hand-stamp `_meta` with the **same** hash onto the **same** entries and read again. H1 predicts `NULL` then non-`NULL`; H2 predicts `NULL` twice.

```
=== step 1: author a from-scratch ledger through pfb_due_ledger_write_entry() only
write_entry returned: true
document on disk:
{
    "cron": { "last_run": 100, "next_due": 200, "jitter": 0 }
}
=== step 2: read it back through pfb_due_ledger_read_cache()
read_cache returned: NULL
cache_valid(document, hash): false
document_valid(document):    true
=== step 3: hand-stamp _meta with the SAME hash onto the SAME entries, read again
read_cache returned: array ( '_meta' => array ( 'schema' => 1, 'config_hash' => 'aaaa…aaaa' ),
  'cron' => array ( 'last_run' => 100, 'next_due' => 200, 'jitter' => 0 ) )
=== step 4: is the current config hash obtainable at write time?
pfb_schedule_runtime_config() config_hash: 'e97f78f57733c19ea9ed98de1cffbaf0eaa5b7f9aa20158a9b7320a6d7bc85d3'
```

H1 confirmed, H2 refuted. `document_valid` accepting the same bytes `cache_valid` rejects is the asymmetry in one line. Step 4 answers the issue's parenthetical ("requires knowing the current config hash at write time"): the model builds off-appliance from the bare bootstrap, so the hash is available where the writer runs.

## Tests

Frozen reproduction set, written and executed RED before the production edit.

| File | `git hash-object` at RED | GREEN at same hash |
| --- | --- | --- |
| `tests/php/DueLedgerWriterMetaTest.php` (5 cases) | `a1b0b5fe2f71484c55bef8bbb17ec3c3ba9ba406` | yes |
| `tests/php/TickScheduleRuntimeTest.php` | `1300ebc75bb9ac0bbdb902ce68cfb3331134e39a` | yes |

`tests/php/TickScheduleRuntimeTest.php` is still byte-identical at that hash on the pushed head. `DueLedgerWriterMetaTest.php` gained one further case *after* the green run — `testRewritingAnExistingRowStampsAnUnstampedDocument`, which closes the "stamp new rows only" mutant (M4 below); the file now hashes `499498637206f9650d7556efbeee0e3e011467ef`. Its own red proof is the base replay and M4, both quoted here.

RED — untouched base `devel` @ `0579efc0`, in a separate checkout with its own `composer install`:

```
=== RED replay on base 0579efc0 ===
Failed asserting that null is of type array.
/private/tmp/pfb2598_base/tests/php/DueLedgerWriterMetaTest.php:195
FAILURES!
Tests: 6, Assertions: 27, Failures: 4.

Failed asserting that an array does not contain 'Tick: scheduled feed runtime unavailable; cron selection suppressed.'.
/private/tmp/pfb2598_base/tests/php/TickScheduleRuntimeTest.php:566
FAILURES!
Tests: 1, Assertions: 7, Failures: 1.
```

The tick case reproduces the issue's exact notice. The two cases that pass on base are the regression guards, not reproductions: the existing-stamp preservation case and the unresolvable-generation case both pin behaviour that must *not* change.

GREEN — this branch, at the frozen hashes, immediately after the production edit:

```
a1b0b5fe2f71484c55bef8bbb17ec3c3ba9ba406
1300ebc75bb9ac0bbdb902ce68cfb3331134e39a
OK (5 tests, 29 assertions)
=== tick ===
OK (22 tests, 131 assertions)
```

And on the pushed head `ff415d53`: `OK (6 tests, 34 assertions)` / `OK (22 tests, 131 assertions)` / `OK (4 tests, 24 assertions)`.

### Mutation kills

Every mutant is an exact-string replacement in `pfblockerng_extra.inc` with an asserted occurrence count and an asserted non-empty `git diff`, so a mutant that no-ops fails the driver instead of scoring a fake kill; each is reverted with `git checkout --` and the tree re-asserted clean before the next.

| # | Mutant | Killed by | Failure |
| --- | --- | --- | --- |
| M1 | drop the `_meta` stamp (the pre-fix writer) | `DueLedgerWriterMetaTest::testFromScratchWriteEntryRoundTripsThroughTheCacheReader`, `…::testFromScratchUpdateEntryRoundTripsThroughTheCacheReader`, `…::testAnUnstampedDocumentOnDiskIsStampedByTheNextWrite`, `…::testRewritingAnExistingRowStampsAnUnstampedDocument`, `DueLedgerPublicationTest::testValidEntryPublishesAndReturnsTrue`, `TickScheduleRuntimeTest::testWriterAuthoredLedgerDoesNotSuppressCronSelection` | `Failed asserting that null is of type array.` (×4), `Failed asserting that two arrays are identical.`, `Failed asserting that an array does not contain 'Tick: scheduled feed runtime unavailable; cron selection suppressed.'` |
| M2 | stamp a wrong generation (`str_repeat('c', 64)`) | `…::testFromScratchWriteEntryRoundTripsThroughTheCacheReader`, `…::testFromScratchUpdateEntryRoundTripsThroughTheCacheReader`, `DueLedgerPublicationTest::testValidEntryPublishesAndReturnsTrue`, `TickScheduleRuntimeTest::testWriterAuthoredLedgerDoesNotSuppressCronSelection` | `Failed asserting that null is of type array.` (×2), `Failed asserting that two arrays are identical.`, `…does not contain 'Tick: scheduled feed runtime unavailable…'` |
| M3 | stamp on create only — `!array_key_exists('_meta', $data)` → `!is_file($path)` | `…::testAnUnstampedDocumentOnDiskIsStampedByTheNextWrite`, `…::testRewritingAnExistingRowStampsAnUnstampedDocument` | `Failed asserting that null is of type array.` (×2) |
| M4 | stamp new rows only — `… && $current === NULL` | `…::testRewritingAnExistingRowStampsAnUnstampedDocument` | `Failed asserting that null is of type array.` |
| M5 | restamp unconditionally — `if (TRUE) { unset($data['_meta']);` | `…::testAStampFromAnotherGenerationIsPreservedNotRefreshed` | `Failed asserting that two arrays are identical.` |
| M6 | drop the resolvable-generation guard (`is_string($config_hash)`) | `…::testAnUnresolvableGenerationStillPublishesTheRow` | `Failed asserting that false is true.` |

Driver's closing line: `tree clean for src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc: yes`.

### Steady state and self-heal

- `TickScheduleRuntimeTest` — all 22 cases green, including `testMissingCacheIsRegeneratedBeforeRuntimeDispatch` and `testStaleCacheHashIsReplacedFromCurrentRuntimeConfig` (the `pfb_schedule_cache_refresh` self-heal), and `testCachePublicationFailureSuppressesCronAndPreservesBytes`, which pins the suppression notice from the *other* side so the new case's `assertNotContains` cannot be vacuous.
- `testAStampFromAnotherGenerationIsPreservedNotRefreshed` proves an existing `_meta`-bearing document keeps its stamp verbatim and is still rejected for the current generation.
- The four smoke `pfb_due_ledger_write_entry()` call sites are untouched and unaffected: a stamped document is strictly more acceptable than an unstamped one to every reader in the tree, and the only key added is `_meta`, which `pfb_schedule_cache_refresh()`'s document builder already skips and `pfb_due_ledger_read_entry()` never looks at.

### Changed-contract test

`DueLedgerPublicationTest::testValidEntryPublishesAndReturnsTrue` asserted the exact from-scratch document as the row alone. That assertion *is* the bug, so it now asserts the row plus the stamp, resolving the generation from `pfb_schedule_runtime_config()` rather than a literal, with an explicit harness assertion if the model cannot be built. It was the only test in the tree asserting a whole writer-authored document; `git grep` over `tests/php` for exact-document assertions against `pfb_due_ledger.json` found no others.

## Gates

`scripts/agent/run-gates.sh --diff origin/devel`:

```
GATE PASS: python3 scripts/check_coverage_pairing.py --name-status-z
GATE PASS: uv run --locked python scripts/check_composer_vendor.py
GATE PASS: php -l src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
GATE PASS: php -l tests/php/DueLedgerPublicationTest.php
GATE PASS: php -l tests/php/DueLedgerWriterMetaTest.php
GATE PASS: php -l tests/php/TickScheduleRuntimeTest.php
GATE FAIL: vendor/bin/phpunit
GATE PASS: composer phpstan
GATE PASS: composer phpcs -- --standard=phpcs.xml.dist src/
GATES: FAIL
```

The single PHPUnit failure is `DownloadSizeCeilingTest::test_extract_cmd_ceiling_stops_a_child_that_writes_past_it` — the Darwin-only `RLIMIT_FSIZE`/`dd` divergence tracked in #2765. Measured on untouched base `0579efc0` and on this branch in the same session, same host toolchain (PHP 8.5.9, macOS arm64):

| | base `0579efc0` | this branch |
| --- | --- | --- |
| Tests | 5467 | 5474 |
| Failures | 1 (`DownloadSizeCeilingTest`) | 1 (`DownloadSizeCeilingTest`) |
| Warnings / Deprecations / Notices / Skipped | 29 / 3 / 1 / 4 | 29 / 3 / 1 / 4 |

Same single failure, same test, same message, identical warning and skip counts. CI grades on Linux and is the authoritative verdict.

## Review

Four adversarial legs reviewed `16bc86cc`; findings ledger in the orchestrator comment below.

| Leg | Verdict |
| --- | --- |
| Contract conformance | 0 blocking, 0 nitpicks |
| Correctness + hostile inputs | 0 blocking, 1 nitpick, 1 outside-diff |
| Test honesty | 0 blocking, 0 nitpicks (nine mutants applied, nine killed) |
| Over-engineering | 0 blocking, 3 nitpicks |

One fix applied, batched into a single follow-up commit `ff415d53`: the docblock was cut from 11 lines to 4, flagged independently by both the correctness and over-engineering legs against `coding.md`'s ≤3-line comment budget. Comment-only; no behaviour change. The one outside-diff finding — the ADR-43 section of `docs/misc/architecture-notes.md` predating the generation-stamped derived cache, blame-anchored to pre-PR `5792d6fb` — is deferred and tracked in #2773.

Notable executed corroborations from the legs, all reproducible:

- The reader is byte-identical to base: `pfb_due_ledger_cache_valid` 820 bytes, `pfb_due_ledger_read_cache` 678 bytes, IDENTICAL both sides.
- The five-case reconstruction of `DueLedgerWriterMetaTest.php` hashes `a1b0b5fe2f71484c55bef8bbb17ec3c3ba9ba406` — the claimed frozen hash, reproduced independently.
- No deadlock: the writer completes in 1 ms under a 3-second `SIGALRM` with a 0.25 s lock budget; the config path reaches only in-memory `config_get_path()` reads, no lock, no re-entry.
- The apply-failure path never loses its marker: across every hostile config probed, `pfb_due_ledger_set_pending('cron', …)` returned `true` and persisted `pending_apply: true` on head and base alike.
- The lazy gate is real: first meta-less publication does 8 config reads; a second write, `mark_ran`, `mark_ran_anchored`, and `set_pending` each do **0**.
- Malformed `_meta` on disk is refused identically to base (`write:false`, `bytes_preserved:true`) and repaired by the refresh (`cache_after_refresh:true`) — no new stuck state.

🤖 Generated by Oh My Pi and posted on behalf of @andrebrait.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Due-ledger files now include metadata needed for reliable cache validation.
  * Existing ledger metadata is preserved during updates, including legacy documents and entries from previous configuration generations.
  * Ledger entries can now be published safely even when runtime configuration details are unavailable.
  * Scheduled cron processing no longer gets incorrectly suppressed when using a ledger written through the standard update workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->