### PR TITLE
pfblockerng: share geoip tar extract and Blacklist update tails

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -4327,6 +4327,49 @@ function pfb_blacklist_tar_finalize_staged(string $staged, string $filename, int
 }
 
 /**
+ * After a successful Blacklist tar publish, drop leftover orig/hash sidecars
+ * and write the category update marker. Gzip and uncompressed x-tar share this.
+ */
+function pfb_blacklist_tar_mark_updated(string $file_dwn, string $filename): PfbDownloadResult {
+	global $pfb;
+
+	foreach (array("{$file_dwn}.orig", "{$file_dwn}.xxhash128", "{$file_dwn}.md5") as $blacklist_stale) {
+		unlink_if_exists($blacklist_stale);
+	}
+	touch("{$pfb['dbdir']}/{$filename}/{$filename}.update");
+	return PfbDownloadResult::success();
+}
+
+/**
+ * Disk-writing GeoIP tar extract into geoipshare. Gzip and uncompressed x-tar
+ * share this path; -C must be the share directory, never a .mmdb file.
+ */
+function pfb_geoip_extract_tar_to_share(
+	string $header,
+	string $file_download,
+	string $file_dwn_esc,
+	int &$retval
+): PfbDownloadResult {
+	global $pfb;
+
+	$unsafe_member = pfb_archive_unsafe_member(pfb_archive_member_names($file_download));
+	if ($unsafe_member !== NULL) {
+		pfb_validate_log($header, 'member', 'unsafe_member_name', $unsafe_member);
+		unlink_if_exists($file_download);
+		return PfbDownloadResult::failure();
+	}
+	$output = array();
+	$retval = pfb_download_initial_retval();
+	exec(pfb_extract_cmd("/usr/bin/tar -xf {$file_dwn_esc} --strip=1 -C {$pfb['geoipshare']} >/dev/null 2>&1"), $output, $retval);
+	unlink_if_exists($file_download);
+	if (!pfb_download_extraction_succeeded($retval)) {
+		pfb_logger("\n[pfb_download] geoip extraction failed (tar exit {$retval})" . pfb_extract_cap_note($retval), 2);
+		return PfbDownloadResult::failure();
+	}
+	return PfbDownloadResult::success();
+}
+
+/**
  * Publish an extraction atomically. $extract writes to a staged path beside $target and
  * returns its exit code; $target is replaced only once that code reports success, so a
  * failed extraction leaves the publication already in service untouched.
@@ -14447,21 +14490,7 @@ function pfb_download(PfbDownloadRequest $request): PfbDownloadResult {
 			}
 			if ($type == 'geoip') {
 				// Extras - MaxMind downloads
-				// ADR-46: disk-writing extraction -- reject hostile member names first
-				// (a NULL member list = unlistable archive rejects too, fail-closed).
-				$unsafe_member = pfb_archive_unsafe_member(pfb_archive_member_names($file_download));
-				if ($unsafe_member !== NULL) {
-					pfb_validate_log($header, 'member', 'unsafe_member_name', $unsafe_member);
-					unlink_if_exists($file_download);
-					return PfbDownloadResult::failure();
-				}
-				exec(pfb_extract_cmd("/usr/bin/tar -xf {$file_dwn_esc} --strip=1 -C {$pfb['geoipshare']} >/dev/null 2>&1"), $output, $retval);
-				unlink_if_exists($file_download);
-				if (!pfb_download_extraction_succeeded($retval)) {
-					pfb_logger("\n[pfb_download] geoip extraction failed (tar exit {$retval})" . pfb_extract_cap_note($retval), 2);
-					return PfbDownloadResult::failure();
-				}
-				return PfbDownloadResult::success();
+				return pfb_geoip_extract_tar_to_share($header, $file_download, $file_dwn_esc, $retval);
 			}
 			elseif ($type == 'asn') {
 				$retval = pfb_download_initial_retval();
@@ -14603,14 +14632,7 @@ function pfb_download(PfbDownloadRequest $request): PfbDownloadResult {
 					}
 
 					// issue #2738: unlink leftover orig/hash sidecars — Blacklist has no consumer.
-					foreach (array("{$file_dwn}.orig", "{$file_dwn}.xxhash128", "{$file_dwn}.md5") as $blacklist_stale) {
-						unlink_if_exists($blacklist_stale);
-					}
-
-					// Create update file indicator for update process
-					touch("{$pfb['dbdir']}/{$filename}/{$filename}.update");
-					// issue #2735: do not fall through into @touch($orig_download).
-					return PfbDownloadResult::success();
+					return pfb_blacklist_tar_mark_updated($file_dwn, $filename);
 				}
 				else {
 					pfb_logger("\n Invalid filename [{$filename}]", 1);
@@ -14950,19 +14972,7 @@ function pfb_download(PfbDownloadRequest $request): PfbDownloadResult {
 					}
 					$retval = pfb_download_initial_retval();
 					if ($type == 'geoip') {
-						$unsafe_member = pfb_archive_unsafe_member(pfb_archive_member_names($file_download));
-						if ($unsafe_member !== NULL) {
-							pfb_validate_log($header, 'member', 'unsafe_member_name', $unsafe_member);
-							unlink_if_exists($file_download);
-							return PfbDownloadResult::failure();
-						}
-						exec(pfb_extract_cmd("/usr/bin/tar -xf {$file_dwn_esc} --strip=1 -C {$pfb['geoipshare']} >/dev/null 2>&1"), $output, $retval);
-						unlink_if_exists($file_download);
-						if (!pfb_download_extraction_succeeded($retval)) {
-							pfb_logger("\n[pfb_download] {$type} tar extraction failed (tar exit {$retval})" . pfb_extract_cap_note($retval), 2);
-							return PfbDownloadResult::failure();
-						}
-						return PfbDownloadResult::success();
+						return pfb_geoip_extract_tar_to_share($header, $file_download, $file_dwn_esc, $retval);
 					}
 					if (!pfb_stage_publish($head_download,
 					    static function (string $staged) use ($file_dwn_esc, &$output, &$retval): int {
@@ -15128,11 +15138,7 @@ function pfb_download(PfbDownloadRequest $request): PfbDownloadResult {
 						pfb_logger("\n[pfb_download] blacklist extraction failed (tar exit {$retval})" . pfb_extract_cap_note($retval), 2);
 						return PfbDownloadResult::failure();
 					}
-					foreach (array("{$file_dwn}.orig", "{$file_dwn}.xxhash128", "{$file_dwn}.md5") as $blacklist_stale) {
-						unlink_if_exists($blacklist_stale);
-					}
-					touch("{$pfb['dbdir']}/{$filename}/{$filename}.update");
-					return PfbDownloadResult::success();
+					return pfb_blacklist_tar_mark_updated($file_dwn, $filename);
 				}
 				// issue #2635: a MIME-allowlisted non-archive body is not a
 				// successful Blacklist update — leave category files untouched.

--- a/tests/php/DownloadExtractionExitCodeTest.php
+++ b/tests/php/DownloadExtractionExitCodeTest.php
@@ -57,10 +57,10 @@ final class DownloadExtractionExitCodeTest extends TestCase
 		$this->assertNotFalse($asn);
 		$scope = substr(self::$source, $geoip, $asn - $geoip);
 		// issue #2638: bsdtar auto-detects compression; -xf serves gzip and plain tar.
-		$this->assertMatchesRegularExpression('/exec\(pfb_extract_cmd\(".*tar -xf .*\\$output, \\$retval\);/', $scope);
-		$this->assertStringContainsString('-C {$pfb[\'geoipshare\']}', $scope);
-		$this->assertStringContainsString('pfb_archive_unsafe_member', $scope);
-		$this->assertStringContainsString('pfb_download_extraction_succeeded($retval)', $scope);
+		$this->assertStringContainsString(
+			'pfb_geoip_extract_tar_to_share($header, $file_download, $file_dwn_esc, $retval)',
+			$scope
+		);
 	}
 
 	/**
@@ -176,10 +176,8 @@ final class DownloadExtractionExitCodeTest extends TestCase
 			'pfb_blacklist_tar_finalize_staged($staged, $filename, $retval)',
 			$scope
 		);
-		// issue #2735: success return is immediately after the update marker (not a
-		// decoy elsewhere in the 1710-byte scope).
-		$this->assertMatchesRegularExpression(
-			'/touch\("\{\$pfb\[.dbdir.\]\}\/\{\$filename\}\/\{\$filename\}\.update"\);\s*return PfbDownloadResult::success\(\);/',
+		$this->assertStringContainsString(
+			'pfb_blacklist_tar_mark_updated($file_dwn, $filename)',
 			$scope
 		);
 	}
@@ -201,8 +199,8 @@ final class DownloadExtractionExitCodeTest extends TestCase
 		$this->assertNotFalse($blacklist);
 		$this->assertNotFalse($end);
 		$scope = substr(self::$source, $blacklist, $end - $blacklist);
-		$this->assertMatchesRegularExpression(
-			'/foreach \(array\("\{\$file_dwn\}\.orig", "\{\$file_dwn\}\.xxhash128", "\{\$file_dwn\}\.md5"\) as \$blacklist_stale\) \{\s*unlink_if_exists\(\$blacklist_stale\);\s*\}\s*touch\("\{\$pfb\[.dbdir.\]\}\/\{\$filename\}\/\{\$filename\}\.update"\);\s*return PfbDownloadResult::success\(\);/',
+		$this->assertStringContainsString(
+			'pfb_blacklist_tar_mark_updated($file_dwn, $filename)',
 			$scope
 		);
 	}
@@ -274,6 +272,10 @@ final class DownloadExtractionExitCodeTest extends TestCase
 		$this->assertNotFalse($reject);
 		$this->assertNotFalse($tar);
 		$this->assertLessThan($reject, $tar, 'x-tar extract must run before the non-archive reject');
+		$this->assertStringContainsString(
+			'pfb_blacklist_tar_mark_updated($file_dwn, $filename)',
+			$scope
+		);
 	}
 
 	/**
@@ -373,6 +375,15 @@ final class DownloadExtractionExitCodeTest extends TestCase
 			$scope,
 			'geoip tar -C must be geoipshare, not $header (.mmdb file)'
 		);
+		$geoip = strpos($scope, "if (\$type == 'geoip') {");
+		$this->assertNotFalse($geoip);
+		$brace = strpos($scope, '{', $geoip);
+		$this->assertNotFalse($brace);
+		$geoip_scope = substr($scope, $geoip, self::closingBraceExclusive($scope, $brace) - $geoip);
+		$this->assertStringContainsString(
+			'pfb_geoip_extract_tar_to_share($header, $file_download, $file_dwn_esc, $retval)',
+			$geoip_scope
+		);
 	}
 
 	/**
@@ -419,6 +430,16 @@ final class DownloadExtractionExitCodeTest extends TestCase
 			substr_count(self::$source, 'pfb_blacklist_tar_finalize_staged($staged'),
 			'gzip and uncompressed Blacklist tar arms must both call the helper'
 		);
+		$this->assertGreaterThanOrEqual(
+			2,
+			substr_count(self::$source, 'pfb_blacklist_tar_mark_updated($file_dwn, $filename)'),
+			'gzip and uncompressed Blacklist tar arms must both mark updated via the helper'
+		);
+		$this->assertGreaterThanOrEqual(
+			2,
+			substr_count(self::$source, 'pfb_geoip_extract_tar_to_share($header, $file_download, $file_dwn_esc, $retval)'),
+			'gzip and uncompressed geoip tar arms must both call the share helper'
+		);
 		$this->assertStringContainsString(
 			"array_filter(\$list, 'is_file')",
 			self::$source,
@@ -445,6 +466,45 @@ final class DownloadExtractionExitCodeTest extends TestCase
 			@rmdir($staged . '/feed_cat');
 			@rmdir($staged);
 		}
+	}
+
+	/**
+	 * Issue #2764 F2 — sidecar purge and .update live in one helper so gzip/x-tar
+	 * cannot drift. Comments/docblocks cannot define this scope.
+	 */
+	public function testBlacklistTarMarkUpdatedUnlinksSidecarsAndTouchesUpdate(): void
+	{
+		$start = strpos(self::$source, 'function pfb_blacklist_tar_mark_updated(');
+		$this->assertNotFalse($start);
+		$brace = strpos(self::$source, '{', $start);
+		$this->assertNotFalse($brace);
+		$body = substr(self::$source, $start, self::closingBraceExclusive(self::$source, $brace) - $start);
+		$this->assertMatchesRegularExpression(
+			'/foreach \(array\("\{\$file_dwn\}\.orig", "\{\$file_dwn\}\.xxhash128", "\{\$file_dwn\}\.md5"\) as \$blacklist_stale\) \{\s*unlink_if_exists\(\$blacklist_stale\);\s*\}/',
+			$body
+		);
+		$this->assertStringContainsString(
+			'touch("{$pfb[\'dbdir\']}/{$filename}/{$filename}.update")',
+			$body
+		);
+	}
+
+	/**
+	 * Issue #2764 F3 — geoip tar -C is geoipshare with ADR-46, in one helper.
+	 * Comments/docblocks cannot define this scope.
+	 */
+	public function testGeoipTarExtractHelperWritesShareNotHeader(): void
+	{
+		$start = strpos(self::$source, 'function pfb_geoip_extract_tar_to_share(');
+		$this->assertNotFalse($start);
+		$brace = strpos(self::$source, '{', $start);
+		$this->assertNotFalse($brace);
+		$body = substr(self::$source, $start, self::closingBraceExclusive(self::$source, $brace) - $start);
+		$this->assertStringContainsString('-C {$pfb[\'geoipshare\']}', $body);
+		$this->assertStringNotContainsString('-C {$header_esc}', $body);
+		$this->assertStringContainsString('pfb_archive_unsafe_member', $body);
+		$this->assertMatchesRegularExpression('/exec\(pfb_extract_cmd\(".*tar -xf .*\\$output, \\$retval\);/', $body);
+		$this->assertStringContainsString('pfb_download_extraction_succeeded($retval)', $body);
 	}
 
 	/**

--- a/tests/php/DownloadExtractionExitCodeTest.php
+++ b/tests/php/DownloadExtractionExitCodeTest.php
@@ -487,6 +487,11 @@ final class DownloadExtractionExitCodeTest extends TestCase
 			'touch("{$pfb[\'dbdir\']}/{$filename}/{$filename}.update")',
 			$body
 		);
+		// issue #2735: success return is immediately after the update marker.
+		$this->assertMatchesRegularExpression(
+			'/touch\("\{\$pfb\[.dbdir.\]\}\/\{\$filename\}\/\{\$filename\}\.update"\);\s*return PfbDownloadResult::success\(\);/',
+			$body
+		);
 	}
 
 	/**

--- a/tests/php/fixtures/function_inventory.json
+++ b/tests/php/fixtures/function_inventory.json
@@ -734,6 +734,26 @@
             }
         ]
     },
+    "pfb_blacklist_tar_mark_updated": {
+        "returnsRef": false,
+        "returnType": "PfbDownloadResult",
+        "params": [
+            {
+                "name": "file_dwn",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "filename",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
     "pfb_build_aggregate_aliases": {
         "returnsRef": false,
         "returnType": null,
@@ -5056,6 +5076,40 @@
         "returnsRef": false,
         "returnType": "string",
         "params": []
+    },
+    "pfb_geoip_extract_tar_to_share": {
+        "returnsRef": false,
+        "returnType": "PfbDownloadResult",
+        "params": [
+            {
+                "name": "header",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "file_download",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "file_dwn_esc",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "retval",
+                "byRef": true,
+                "variadic": false,
+                "type": "int",
+                "default": null
+            }
+        ]
     },
     "pfb_geoip_generation_publication_lock": {
         "returnsRef": false,


### PR DESCRIPTION
## Summary

Finishes #2764 after #2771's Blacklist finalize helper.

- **F2:** gzip and uncompressed x-tar Blacklist success tails (`#2738` sidecar purge + `#2735` `.update` marker) now share `pfb_blacklist_tar_mark_updated()`. g6/g8 survived at #2771 head because only the gzip copies were pinned.
- **F3:** gzip (~14332) and uncompressed x-tar (~14836) geoip extract arms now share `pfb_geoip_extract_tar_to_share()`. Both `-C` targets were already `geoipshare` (the B2 class is not hiding a live difference).

## Test plan

- `DownloadExtractionExitCodeTest` pins helper calls on both arms and helper bodies (sidecar foreach, `.update`, `tar -xf` + `geoipshare` + ADR-46).
- Deleting the helper `.update` touch is RED; both-arm call counts are `>= 2`.
- `FunctionInventoryParityTest` golden includes the new signatures.

Fixes #2764

🤖 Generated by Grok and posted on behalf of @BBcan177.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GeoIP archive extraction with consistent safety checks, cleanup, and failure handling.
  * Improved Blacklist archive processing, including sidecar cleanup, update marking, and success reporting.

* **Tests**
  * Expanded coverage for GeoIP and Blacklist archive processing.
  * Added validation for archive safety behavior and update-marker handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->