### PR TITLE
install-pkg.sh: fail closed when pkg POST-INSTALL fails

### DIFF
--- a/scripts/install-pkg.sh
+++ b/scripts/install-pkg.sh
@@ -127,7 +127,25 @@ pkg_add_lock_retry() {
         fi
         _out=$(ssh_t "printf 'PFB_PKG_CONTEXT utc='; date -u '+%Y-%m-%dT%H:%M:%SZ'; printf 'PFB_PKG_CONTEXT absolute_abi='; /usr/local/sbin/pkg config ABI 2>&1 || true; printf 'PFB_PKG_CONTEXT path_pkg='; command -v pkg 2>&1 || true; printf 'PFB_PKG_CONTEXT path_abi='; pkg config ABI 2>&1 || true; printf 'PFB_PKG_CONTEXT boot_pkg_processes='; ps axww -o pid= -o comm= -o args= 2>&1 | awk '((\$2 == \"sh\" && \$3 == \"/bin/sh\" && (\$4 == \"/etc/rc.update_pkg_metadata\" || \$4 == \"/usr/local/sbin/pfSense-upgrade\" || \$4 == \"/usr/local/libexec/pfSense-upgrade\")) || (\$2 == \"lockf\" && \$0 ~ /\/tmp\/pfSense-upgrade\.lock/) || \$2 == \"pkg\" || \$2 == \"pkg-static\") { found=1; print } END { if (!found) print \"none\" }'; env ASSUME_ALWAYS_YES=yes ${_pkg_add} '${_pkg_remote}'" 2>&1) || _rc=$?
         if [ -n "$_out" ]; then printf '%s\n' "$_out"; fi
-        if [ "$_rc" -eq 0 ]; then return 0; fi
+        # pkg(8) can exit 0 after POST-INSTALL/DEINSTALL still failed — files are
+        # already extracted (issue #2575). Smoke 20260827T005125Z-smoke then printed
+        # "==> Installed" and helpers.deploy treated rc=0 as PASSED. Same matcher
+        # as install.sh, including the glued ``thrown</pre>pkg: POST-INSTALL script failed``.
+        if [ "$_rc" -eq 0 ]; then
+            _script_failed=0
+            while IFS= read -r _line || [ -n "${_line:-}" ]; do
+                case "$_line" in
+                    *'pkg: '*' script failed'*) _script_failed=1; break ;;
+                esac
+            done <<EOF
+${_out}
+EOF
+            if [ "$_script_failed" -eq 1 ]; then
+                echo "install-pkg: pkg reported a package-script failure — POST-INSTALL can fail while pkg still exits 0 (issue #2575)" >&2
+                return 1
+            fi
+            return 0
+        fi
         case "$_out" in
             *'Cannot get an exclusive lock on a database'* | *'Package database is busy'*) ;;
             *) return "$_rc" ;;

--- a/tests/shell/install_pkg_spec.sh
+++ b/tests/shell/install_pkg_spec.sh
@@ -18,7 +18,7 @@ Describe 'install-pkg.sh'
 
   setup() {
     scrub_git_env
-    unset SMOKE_DEP_PKGS SMOKE_ABI FAIL_PKG_ADD_MATCH EXEC_REMOTE_PKG_CONTEXT PFB_FAKE_PS_OUTPUT
+    unset SMOKE_DEP_PKGS SMOKE_ABI FAIL_PKG_ADD_MATCH EXEC_REMOTE_PKG_CONTEXT PFB_FAKE_PS_OUTPUT POSTINSTALL_FAIL
     WORK="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/instpkgspec.XXXXXX")"
     FAKE_BIN="${WORK}/bin"
     mkdir -p "$FAKE_BIN"
@@ -63,6 +63,20 @@ case "$_a" in
                 echo "pkg: Cannot get an exclusive lock on a database, it is locked by another process" >&2
                 exit 1
             fi
+        fi
+        ;;
+esac
+# pkg(8) can exit 0 after POST-INSTALL fails (files already extracted).
+# The stub reproduces that: rc=0 plus the pkg: * script failed line.
+case "$_a" in
+    *"pkg add"*)
+        if [ -n "${POSTINSTALL_FAIL:-}" ]; then
+            case "$POSTINSTALL_FAIL" in
+                glued) printf '%s\n' 'thrown</pre>pkg: POST-INSTALL script failed' ;;
+                noise) printf '%s\n' 'the POST-INSTALL script failed to mention foo' ;;
+                *) printf '%s\n' 'pkg: POST-INSTALL script failed' ;;
+            esac
+            exit 0
         fi
         ;;
 esac
@@ -305,5 +319,39 @@ Installing pfBlockerNG-devel.pkg...'
     The status should be failure
     # A missing-dependency-style failure is not a lock: exactly one attempt.
     The result of function pkg_add_count should equal 1
+  End
+
+  # pkg(8) can exit 0 after POST-INSTALL still failed (issue #2575 class).
+  # 20260827T005125Z-smoke shard-0.log:144-147 printed "Installed" and
+  # helpers.deploy treated rc=0 as PASSED. Fail closed; do not print Installed.
+
+  It 'fails closed when pkg add exits 0 after POST-INSTALL script failed'
+    POSTINSTALL_FAIL=1
+    export POSTINSTALL_FAIL
+    When run sh "$SCRIPT" root@dummy --pkg "$PKGFILE" --port 2222
+    The status should be failure
+    The stdout should include 'pkg: POST-INSTALL script failed'
+    The stdout should not include '==> Installed'
+    The stderr should include 'package-script failure'
+    The result of function pkg_add_count should equal 1
+  End
+
+  It 'fails closed when POST-INSTALL failed is glued to hook stdout'
+    POSTINSTALL_FAIL=glued
+    export POSTINSTALL_FAIL
+    When run sh "$SCRIPT" root@dummy --pkg "$PKGFILE" --port 2222
+    The status should be failure
+    The stdout should include 'pkg: POST-INSTALL script failed'
+    The stdout should not include '==> Installed'
+    The result of function pkg_add_count should equal 1
+  End
+
+  It 'does not treat a coincidental script-failed substring as a hook failure'
+    POSTINSTALL_FAIL=noise
+    export POSTINSTALL_FAIL
+    When run sh "$SCRIPT" root@dummy --pkg "$PKGFILE" --port 2222
+    The status should be success
+    The stdout should include 'the POST-INSTALL script failed to mention foo'
+    The stdout should include '==> Installed'
   End
 End


### PR DESCRIPTION
## Summary

`pkg add` can exit 0 after POST-INSTALL still failed (files already extracted; same class as #2575). Smoke `20260827T005125Z` then printed `==> Installed` and `helpers.deploy` treated rc=0 as PASSED, so a 3.3-bridge throw looked like 85 passed / 1 failed for eight days.

`install-pkg.sh` now uses install.sh's #2575 matcher (`pkg: * script failed`, including glued `thrown</pre>pkg: POST-INSTALL script failed`) and returns 1 without printing Installed. `helpers.deploy` already raises on non-zero; no helpers.py change.

Refs #2754. Item 4 of that issue is not in this PR.

## Verification

Frozen RED (new spec examples over `origin/devel` `install-pkg.sh`):

| blob | git hash-object |
|---|---|
| tests/shell/install_pkg_spec.sh | `b33733a16020d43b30361ff2c12de48eba9ebd6a` |

RED: 19 examples, 2 failures (`status success` + `==> Installed` after `pkg: POST-INSTALL script failed`).
GREEN: 19 examples, 0 failures (`sh` and `dash`).
Healthy-path pin unchanged: coincidental `the POST-INSTALL script failed to mention foo` still succeeds.

## Handback

A deploy that fails closed will turn some currently-green smoke tiers red if POST-INSTALL is still throwing. That is the point. 20260827T220841Z-smoke on devel was healthy (`Recording default settings... done.`, 1 passed) and must stay green.
