### PR TITLE
download: give processet() an exit contract so an aborted ET pass cannot read as a successful ingest

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -15211,7 +15211,15 @@ function pfb_download(PfbDownloadRequest $request): PfbDownloadResult {
 
 			// Process Emerging Threats IQRisk if required
 			if (strpos($list_url, 'iprepdata.txt') !== FALSE) {
-				exec("{$pfb['script']} et {$header_esc} x x x x x {$pfb['etblock']} {$pfb['etmatch']} {$elog}");
+				// issue #2683: gated on processet()'s exit status -- which is what lets
+				// issue #2658's ceiling ride along here. A helper killed at the ceiling
+				// exits non-zero and the feed is refused instead of republished from a
+				// truncated category split.
+				exec(pfb_extract_cmd("{$pfb['script']} et {$header_esc} x x x x x {$pfb['etblock']} {$pfb['etmatch']} {$elog}"), $output, $retval);
+				if (!pfb_download_extraction_succeeded($retval)) {
+					pfb_logger("\n[pfb_download] et processing failed (script exit {$retval})" . pfb_extract_cap_note($retval), 2);
+					return PfbDownloadResult::failure();
+				}
 			}
 				return PfbDownloadResult::success();
 		}

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -15212,12 +15212,18 @@ function pfb_download(PfbDownloadRequest $request): PfbDownloadResult {
 			// Process Emerging Threats IQRisk if required
 			if (strpos($list_url, 'iprepdata.txt') !== FALSE) {
 				// issue #2683: gated on processet()'s exit status -- which is what lets
-				// issue #2658's ceiling ride along here. A helper killed at the ceiling
-				// exits non-zero and the feed is refused instead of republished from a
-				// truncated category split.
+				// issue #2658's ceiling ride along here.
 				exec(pfb_extract_cmd("{$pfb['script']} et {$header_esc} x x x x x {$pfb['etblock']} {$pfb['etmatch']} {$elog}"), $output, $retval);
 				if (!pfb_download_extraction_succeeded($retval)) {
 					pfb_logger("\n[pfb_download] et processing failed (script exit {$retval})" . pfb_extract_cap_note($retval), 2);
+					// The '.orig' this pass published is the raw ET CSV (processet() rewrites
+					// it in place), which the apply loop's fail-marker fallback would parse.
+					// Both sidecar families go too (pfb_force_clear_validators()' suffix set)
+					// or a remote feed answers the next pass with a 304 and never re-fetches.
+					foreach (array('', '.xxhash128', '.md5', '.etag', '.lastmod') as $et_sfx) {
+						unlink_if_exists("{$orig_download}{$et_sfx}");
+					}
+					unlink_if_exists($file_download);
 					return PfbDownloadResult::failure();
 				}
 			}

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -15216,10 +15216,9 @@ function pfb_download(PfbDownloadRequest $request): PfbDownloadResult {
 				exec(pfb_extract_cmd("{$pfb['script']} et {$header_esc} x x x x x {$pfb['etblock']} {$pfb['etmatch']} {$elog}"), $output, $retval);
 				if (!pfb_download_extraction_succeeded($retval)) {
 					pfb_logger("\n[pfb_download] et processing failed (script exit {$retval})" . pfb_extract_cap_note($retval), 2);
-					// The '.orig' this pass published is the raw ET CSV (processet() rewrites
-					// it in place), which the apply loop's fail-marker fallback would parse.
-					// Both sidecar families go too (pfb_force_clear_validators()' suffix set)
-					// or a remote feed answers the next pass with a 304 and never re-fetches.
+					// The '.orig' this pass published is the raw ET CSV (processet() rewrites it
+					// in place), which the apply loop's fail-marker fallback would parse. Both sidecar
+					// families go (pfb_force_clear_validators()' set) or a surviving ETag 304s the next pass.
 					foreach (array('', '.xxhash128', '.md5', '.etag', '.lastmod') as $et_sfx) {
 						unlink_if_exists("{$orig_download}{$et_sfx}");
 					}

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.sh
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.sh
@@ -1980,8 +1980,7 @@ processet() {
 					# The pipeline's status is `cut`'s, never grep's: a category with
 					# no rows makes grep exit 1 and is entirely normal, while a failed
 					# WRITE must abort instead of publishing a truncated split.
-					grep ",${category}," "${pfborig}${alias}.orig" | cut -d',' -f1 > "${etdir}/${file}.txt" ||
-						{ etrc=$?; pfb_et_abort "the ${file} split" "${etrc}"; return "${etrc}"; }
+					grep ",${category}," "${pfborig}${alias}.orig" | cut -d',' -f1 > "${etdir}/${file}.txt" || { etrc=$?; pfb_et_abort "the ${file} split" "${etrc}"; return "${etrc}"; }
 					;;
 			esac
 			category="$((category + 1))"
@@ -2003,27 +2002,25 @@ processet() {
 					printf "%-10s %-25s\n" '  Block: ' "${list}"
 					# issue #1263: awk 1 supplies a record terminator cat doesn't --
 					# a category file no longer welds onto the next one accumulated.
-					awk 1 "${etdir}/${list}.txt" >> "${tempfile}" ||
-						{ etrc=$?; pfb_et_abort "the ${list} block accumulation" "${etrc}"; return "${etrc}"; }
+					# Both accumulations stay on ONE line: pfblockerng_cat_weld_more_spec.sh
+					# extracts each statement by line number and evals it.
+					awk 1 "${etdir}/${list}.txt" >> "${tempfile}" || { etrc=$?; pfb_et_abort "the ${list} block accumulation" "${etrc}"; return "${etrc}"; }
 					;;
 			esac
 			case ", ${etmatch}, " in
 				*", ${list}, "*)
 					printf "%-10s %-25s\n" '  Match: ' "${list}"
-					awk 1 "${etdir}/${list}.txt" >> "${tempfile2}" ||
-						{ etrc=$?; pfb_et_abort "the ${list} match accumulation" "${etrc}"; return "${etrc}"; }
+					awk 1 "${etdir}/${list}.txt" >> "${tempfile2}" || { etrc=$?; pfb_et_abort "the ${list} match accumulation" "${etrc}"; return "${etrc}"; }
 					;;
 			esac
 		done
 		echo '-------------------------------------------'
 
 		if [ -f "${tempfile}" ]; then
-			mv -f "${tempfile}" "${pfborig}${alias}.orig" ||
-				{ etrc=$?; pfb_et_abort 'the block publish' "${etrc}"; return "${etrc}"; }
+			mv -f "${tempfile}" "${pfborig}${alias}.orig" || { etrc=$?; pfb_et_abort 'the block publish' "${etrc}"; return "${etrc}"; }
 		fi
 		if [ "${etmatch}" != 'x' ]; then
-			mv -f "${tempfile2}" "${pfbmatchgen}pfB_Match_ET_v4.txt" ||
-				{ etrc=$?; pfb_et_abort 'the match publish' "${etrc}"; return "${etrc}"; }
+			mv -f "${tempfile2}" "${pfbmatchgen}pfB_Match_ET_v4.txt" || { etrc=$?; pfb_et_abort 'the match publish' "${etrc}"; return "${etrc}"; }
 		fi
 		# issue #1263: awk 1 supplies a record terminator cat doesn't -- an
 		# unterminated ET_* file no longer welds its last row onto the next file's first.
@@ -2247,8 +2244,8 @@ case "${1}" in
 		reputation_pmax
 		;;
 	et)
-		# issue #2683: the tail's bare `exitnow` defaults to 0, so the status has to
-		# be threaded through here (as `recompute` does).
+		# issue #2683: same wiring as the `xlsx` arm below -- the tail's bare
+		# `exitnow` defaults to 0.
 		processet
 		exitnow "$?"
 		;;

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.sh
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.sh
@@ -1936,7 +1936,19 @@ EOF
 }
 
 
+# One failure exit for every writing step of an ET pass: $1 names the step, so an
+# operator reads which one failed rather than a bare status. $2 is that status.
+pfb_et_abort() {
+	echo 'ET processing failed'
+	echo " [ ${alias} ] ET processing failed at ${1}, exit ${2}; aborting ET processing [ ${now} ]" >> "${errorlog}"
+}
+
+
 # Function to split ET Pro IPREP into category files and compile selected blocked categories into outfile.
+#
+# issue #2683: the exit contract pfb_download() gates on. A failing status is
+# returned verbatim rather than collapsed to 1, so a child killed at issue
+# #2658's extraction ceiling reaches the caller as the 153 that names it.
 processet() {
 	if [ -s "${pfborig}${alias}.orig" ]; then
 		# Remove previous ET IPRep files
@@ -1944,7 +1956,7 @@ processet() {
 		if ! true > "${tempfile}" || ! true > "${tempfile2}"; then
 			log="processet [ ${alias} ]: cannot create ET scratch file(s); aborting ET processing."
 			echo "${log}" | tee -a "${errorlog}"
-			return
+			return 1
 		fi
 
 		# ET CSV format (IP, Category, Score)
@@ -1965,7 +1977,11 @@ processet() {
 					# Some ET categories are not in use (For future use)
 					;;
 				*)
-					grep ",${category}," "${pfborig}${alias}.orig" | cut -d',' -f1 > "${etdir}/${file}.txt"
+					# The pipeline's status is `cut`'s, never grep's: a category with
+					# no rows makes grep exit 1 and is entirely normal, while a failed
+					# WRITE must abort instead of publishing a truncated split.
+					grep ",${category}," "${pfborig}${alias}.orig" | cut -d',' -f1 > "${etdir}/${file}.txt" ||
+						{ etrc=$?; pfb_et_abort "the ${file} split" "${etrc}"; return "${etrc}"; }
 					;;
 			esac
 			category="$((category + 1))"
@@ -1987,26 +2003,37 @@ processet() {
 					printf "%-10s %-25s\n" '  Block: ' "${list}"
 					# issue #1263: awk 1 supplies a record terminator cat doesn't --
 					# a category file no longer welds onto the next one accumulated.
-					awk 1 "${etdir}/${list}.txt" >> "${tempfile}"
+					awk 1 "${etdir}/${list}.txt" >> "${tempfile}" ||
+						{ etrc=$?; pfb_et_abort "the ${list} block accumulation" "${etrc}"; return "${etrc}"; }
 					;;
 			esac
 			case ", ${etmatch}, " in
 				*", ${list}, "*)
 					printf "%-10s %-25s\n" '  Match: ' "${list}"
-					awk 1 "${etdir}/${list}.txt" >> "${tempfile2}"
+					awk 1 "${etdir}/${list}.txt" >> "${tempfile2}" ||
+						{ etrc=$?; pfb_et_abort "the ${list} match accumulation" "${etrc}"; return "${etrc}"; }
 					;;
 			esac
 		done
 		echo '-------------------------------------------'
 
-		if [ -f "${tempfile}" ]; then mv -f "${tempfile}" "${pfborig}${alias}.orig"; fi
-		if [ "${etmatch}" != 'x' ]; then mv -f "${tempfile2}" "${pfbmatchgen}pfB_Match_ET_v4.txt"; fi
+		if [ -f "${tempfile}" ]; then
+			mv -f "${tempfile}" "${pfborig}${alias}.orig" ||
+				{ etrc=$?; pfb_et_abort 'the block publish' "${etrc}"; return "${etrc}"; }
+		fi
+		if [ "${etmatch}" != 'x' ]; then
+			mv -f "${tempfile2}" "${pfbmatchgen}pfB_Match_ET_v4.txt" ||
+				{ etrc=$?; pfb_et_abort 'the match publish' "${etrc}"; return "${etrc}"; }
+		fi
 		# issue #1263: awk 1 supplies a record terminator cat doesn't -- an
 		# unterminated ET_* file no longer welds its last row onto the next file's first.
 		counto="$(awk 1 "${etdir}"/ET_* | grep -cv '^#\|^$')"; countf="$(grep -cv "^${ip_placeholder2}$" "${pfborig}${alias}.orig")"
 		echo; echo "All ET Folder count [ ${counto} ]  Final count [ ${countf} ]"
+		return 0
 	else
 		echo; echo 'No ET .orig File Found!'
+		echo " [ ${alias} ] No ET .orig file found; aborting ET processing [ ${now} ]" >> "${errorlog}"
+		return 1
 	fi
 }
 
@@ -2220,7 +2247,10 @@ case "${1}" in
 		reputation_pmax
 		;;
 	et)
+		# issue #2683: the tail's bare `exitnow` defaults to 0, so the status has to
+		# be threaded through here (as `recompute` does).
 		processet
+		exitnow "$?"
 		;;
 	xlsx)
 		# issue #2666: the tail's bare `exitnow` defaults to 0, so the status has to

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.sh
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.sh
@@ -2244,8 +2244,7 @@ case "${1}" in
 		reputation_pmax
 		;;
 	et)
-		# issue #2683: same wiring as the `xlsx` arm below -- the tail's bare
-		# `exitnow` defaults to 0.
+		# issue #2683: same wiring as the `xlsx` arm below.
 		processet
 		exitnow "$?"
 		;;

--- a/tests/php/DownloadExtractionExitCodeTest.php
+++ b/tests/php/DownloadExtractionExitCodeTest.php
@@ -554,6 +554,28 @@ final class DownloadExtractionExitCodeTest extends TestCase
 		$this->assertStringNotContainsString('unlink_if_exists("{$orig_download}")', $scope);
 	}
 
+	/**
+	 * pfb_download() hands the ET IQRisk feed to the shell helper, which splits it
+	 * into per-category files and republishes the feed from the selected ones;
+	 * issue #2683 gave that helper an exit contract, so this branch is pinned like
+	 * its siblings — captured exec, nonzero-exit gate, and the ceiling wrap that
+	 * only an exit gate makes safe. Without the gate an aborted pass reached
+	 * PfbDownloadResult::success() with the unfiltered CSV still published.
+	 */
+	public function testEtBodyCapturesAndChecksHelperExit(): void
+	{
+		$start = strpos(self::$source, "if (strpos(\$list_url, 'iprepdata.txt') !== FALSE) {");
+		$this->assertNotFalse($start, 'the ET branch must still be in pfb_download()');
+		$brace = strpos(self::$source, '{', $start);
+		$this->assertNotFalse($brace);
+		$scope = substr(self::$source, $start, self::closingBraceExclusive(self::$source, $brace) - $start);
+		$this->assertStringContainsString(
+			'exec(pfb_extract_cmd("{$pfb[\'script\']} et {$header_esc} x x x x x '
+			. '{$pfb[\'etblock\']} {$pfb[\'etmatch\']} {$elog}"), $output, $retval);', $scope);
+		$this->assertStringContainsString('pfb_download_extraction_succeeded($retval)', $scope);
+		$this->assertStringContainsString('return PfbDownloadResult::failure();', $scope);
+	}
+
 	/** Exclusive end index of the brace block whose `{` is at `$openBrace`. */
 	private static function closingBraceExclusive(string $source, int $openBrace): int
 	{

--- a/tests/php/DownloadExtractionExitCodeTest.php
+++ b/tests/php/DownloadExtractionExitCodeTest.php
@@ -562,13 +562,10 @@ final class DownloadExtractionExitCodeTest extends TestCase
 	 * only an exit gate makes safe. Without the gate an aborted pass reached
 	 * PfbDownloadResult::success() with the unfiltered CSV still published.
 	 *
-	 * The refusal also has to DROP that publication. processet() rewrites the
-	 * '.orig' in place rather than staging, so at the moment the helper fails the
-	 * '.orig' this pass just published is the raw ET CSV — and the apply loop's
-	 * fail-marker fallback parses a '.orig' that is still there. It goes with BOTH
-	 * sidecar families — the content hashes and the conditional-GET validators —
-	 * because a remote feed whose ETag survives answers the next pass with a 304
-	 * and never re-fetches, leaving the list dropped until the feed itself changes.
+	 * The refusal also has to DROP that publication: processet() rewrites the
+	 * '.orig' in place, so what it published is the raw ET CSV the apply loop's
+	 * fail-marker fallback parses — and a surviving ETag would 304 the next pass,
+	 * so both sidecar families go with it.
 	 */
 	public function testEtBodyCapturesAndChecksHelperExit(): void
 	{
@@ -580,23 +577,18 @@ final class DownloadExtractionExitCodeTest extends TestCase
 		$this->assertStringContainsString(
 			'exec(pfb_extract_cmd("{$pfb[\'script\']} et {$header_esc} x x x x x '
 			. '{$pfb[\'etblock\']} {$pfb[\'etmatch\']} {$elog}"), $output, $retval);', $scope);
-		$this->assertStringContainsString('pfb_download_extraction_succeeded($retval)', $scope);
 		$this->assertStringContainsString('return PfbDownloadResult::failure();', $scope);
 		$fail = strpos($scope, 'if (!pfb_download_extraction_succeeded($retval)) {');
 		$this->assertNotFalse($fail, 'the ET branch must gate on the helper exit status');
 		$refusal = substr($scope, $fail);
 		$this->assertStringContainsString('unlink_if_exists("{$orig_download}', $refusal);
-		// The whole suffix SET, not four of five: the empty member is the one that
-		// drops the raw publication itself, which is the invariant the apply loop's
-		// fail-marker fallback turns on. Compared as a set, so reordering the list
-		// -- behaviour-neutral -- cannot fail this.
-		$this->assertSame(1, preg_match('/foreach \(array\((.*?)\) as \$et_sfx\)/', $refusal, $m),
-			'the refusal must sweep a suffix list over the published .orig');
-		$this->assertEqualsCanonicalizing(
-			array('', '.xxhash128', '.md5', '.etag', '.lastmod'),
-			array_map(static fn (string $s): string => trim(trim($s), "'"), explode(',', $m[1])),
-			"the refusal must drop the '.orig' itself and BOTH sidecar families — the content"
-			. ' hashes and the conditional-GET validators');
+		// The whole suffix SET, not four of five: the empty member is what drops the
+		// raw publication the fail-marker fallback would parse. Parsed and compared
+		// canonically so a behaviour-neutral reordering of the literal cannot fail it.
+		preg_match('/foreach \(array\((.*?)\) as \$et_sfx\)/', $refusal, $m);
+		$this->assertEqualsCanonicalizing(array('', '.xxhash128', '.md5', '.etag', '.lastmod'),
+			array_map(static fn (string $s): string => trim(trim($s), "'"), explode(',', $m[1] ?? '')),
+			"the refusal must drop the '.orig' itself and BOTH sidecar families");
 		$this->assertStringContainsString('unlink_if_exists($file_download);', $refusal);
 	}
 

--- a/tests/php/DownloadExtractionExitCodeTest.php
+++ b/tests/php/DownloadExtractionExitCodeTest.php
@@ -561,6 +561,14 @@ final class DownloadExtractionExitCodeTest extends TestCase
 	 * its siblings — captured exec, nonzero-exit gate, and the ceiling wrap that
 	 * only an exit gate makes safe. Without the gate an aborted pass reached
 	 * PfbDownloadResult::success() with the unfiltered CSV still published.
+	 *
+	 * The refusal also has to DROP that publication. processet() rewrites the
+	 * '.orig' in place rather than staging, so at the moment the helper fails the
+	 * '.orig' this pass just published is the raw ET CSV — and the apply loop's
+	 * fail-marker fallback parses a '.orig' that is still there. It goes with BOTH
+	 * sidecar families — the content hashes and the conditional-GET validators —
+	 * because a remote feed whose ETag survives answers the next pass with a 304
+	 * and never re-fetches, leaving the list dropped until the feed itself changes.
 	 */
 	public function testEtBodyCapturesAndChecksHelperExit(): void
 	{
@@ -574,6 +582,15 @@ final class DownloadExtractionExitCodeTest extends TestCase
 			. '{$pfb[\'etblock\']} {$pfb[\'etmatch\']} {$elog}"), $output, $retval);', $scope);
 		$this->assertStringContainsString('pfb_download_extraction_succeeded($retval)', $scope);
 		$this->assertStringContainsString('return PfbDownloadResult::failure();', $scope);
+		$fail = strpos($scope, 'if (!pfb_download_extraction_succeeded($retval)) {');
+		$this->assertNotFalse($fail, 'the ET branch must gate on the helper exit status');
+		$refusal = substr($scope, $fail);
+		$this->assertStringContainsString('unlink_if_exists("{$orig_download}', $refusal);
+		foreach (array('.xxhash128', '.md5', '.etag', '.lastmod') as $sidecar) {
+			$this->assertStringContainsString("'{$sidecar}'", $refusal,
+				"the refusal must drop the {$sidecar} sidecar, or the next pass reuses this one's baseline");
+		}
+		$this->assertStringContainsString('unlink_if_exists($file_download);', $refusal);
 	}
 
 	/** Exclusive end index of the brace block whose `{` is at `$openBrace`. */

--- a/tests/php/DownloadExtractionExitCodeTest.php
+++ b/tests/php/DownloadExtractionExitCodeTest.php
@@ -586,10 +586,17 @@ final class DownloadExtractionExitCodeTest extends TestCase
 		$this->assertNotFalse($fail, 'the ET branch must gate on the helper exit status');
 		$refusal = substr($scope, $fail);
 		$this->assertStringContainsString('unlink_if_exists("{$orig_download}', $refusal);
-		foreach (array('.xxhash128', '.md5', '.etag', '.lastmod') as $sidecar) {
-			$this->assertStringContainsString("'{$sidecar}'", $refusal,
-				"the refusal must drop the {$sidecar} sidecar, or the next pass reuses this one's baseline");
-		}
+		// The whole suffix SET, not four of five: the empty member is the one that
+		// drops the raw publication itself, which is the invariant the apply loop's
+		// fail-marker fallback turns on. Compared as a set, so reordering the list
+		// -- behaviour-neutral -- cannot fail this.
+		$this->assertSame(1, preg_match('/foreach \(array\((.*?)\) as \$et_sfx\)/', $refusal, $m),
+			'the refusal must sweep a suffix list over the published .orig');
+		$this->assertEqualsCanonicalizing(
+			array('', '.xxhash128', '.md5', '.etag', '.lastmod'),
+			array_map(static fn (string $s): string => trim(trim($s), "'"), explode(',', $m[1])),
+			"the refusal must drop the '.orig' itself and BOTH sidecar families — the content"
+			. ' hashes and the conditional-GET validators');
 		$this->assertStringContainsString('unlink_if_exists($file_download);', $refusal);
 	}
 

--- a/tests/php/DownloadSizeCeilingTest.php
+++ b/tests/php/DownloadSizeCeilingTest.php
@@ -291,7 +291,7 @@ final class DownloadSizeCeilingTest extends TestCase
 	 *
 	 * The allow-list holds each exempt call's WHOLE statement, terminator included,
 	 * not a prefix of it. A prefix would exempt everything that merely starts the
-	 * same way, so `exec("{$pfb['script']} et" . $anything)` -- a genuinely
+	 * same way, so `exec("{$pfb['script']} asn_table" . $anything)` -- a genuinely
 	 * unguarded extraction wearing an exempt call's opening -- would pass. Changing
 	 * an exempt call means updating its entry here, which is the point: the
 	 * exemption is for that call as written, not for its first few characters.
@@ -302,11 +302,10 @@ final class DownloadSizeCeilingTest extends TestCase
 			// Helper-script calls that post-process an ALREADY-extracted text feed.
 			'exec("{$pfb[\'script\']} whoisconvert {$header_esc} {$vtype} {$list_url_esc} {$elog}");',
 			'exec("{$pfb[\'script\']} asn_table {$elog}");',
-			'exec("{$pfb[\'script\']} et {$header_esc} x x x x x {$pfb[\'etblock\']} {$pfb[\'etmatch\']} {$elog}");',
 			// Lists an archive; extracts nothing.
 			'exec("/usr/bin/tar -tf {$file_dwn_esc}");',
-			// Capped. This one stays a prefix: it covers ten call sites with ten
-			// different argument lists. So a command concatenated onto a capped call
+			// Capped. This one stays a prefix: it covers every capped call site, each
+			// with its own argument list. So a command concatenated onto a capped call
 			// is invisible HERE -- but not uncapped: ulimit is process-scoped, so the
 			// prefix pfb_extract_cmd() returns still bounds whatever follows it in the
 			// same exec(). Probed with a real over-ceiling tar appended to a wrapped

--- a/tests/shell/pfblockerng_processet_exit_spec.sh
+++ b/tests/shell/pfblockerng_processet_exit_spec.sh
@@ -9,7 +9,7 @@
 #
 # These examples pin the contract the caller now gates on: every abort reports
 # non-zero, a failing status comes back VERBATIM (so a child killed at issue
-# #2658's extraction ceiling reaches the caller as the 153 that names it), and a
+# #2658's extraction ceiling reaches the caller as the status that names it), and a
 # failed pass leaves the live pfB_Match_ET_v4.txt publication byte-unchanged.
 #
 # Fixture shape: the feed's ".orig" is the raw ET IQRisk CSV ("IP,category,
@@ -28,6 +28,10 @@ Describe 'processet() exit contract (issue #2683)'
 		errorlog="${work}/error.log"
 		runner="${work}/run.sh"
 		mkdir -p "${orig}" "${match}" "${etdir}" "${scratch}"
+
+		# The downloaded ET feed, verbatim: two Block categories (1, 2) and one
+		# Match (3), as "IP,category,score" rows.
+		et_csv="$(printf '%s\n' '192.0.2.10,1,127' '198.51.100.20,2,88' '203.0.113.30,3,50')"
 
 		# `ls` sorts the category files, so the selected Block categories
 		# accumulate in ALPHABETICAL order (ET_Bot, category 2, before ET_Cnc,
@@ -72,10 +76,8 @@ RUNNER
 	Before 'setup'
 	After 'cleanup'
 
-	# The downloaded ET feed: two Block categories (1, 2) and one Match (3).
 	plant_et_orig() {
-		printf '%s\n' '192.0.2.10,1,127' '198.51.100.20,2,88' '203.0.113.30,3,50' \
-			> "${orig}${alias}.orig"
+		printf '%s\n' "${et_csv}" > "${orig}${alias}.orig"
 	}
 
 	# A live match publication left by a previous, successful pass.
@@ -83,8 +85,12 @@ RUNNER
 		printf '%s\n' "${prior_match}" > "${match}pfB_Match_ET_v4.txt"
 	}
 
-	# A child killed the way issue #2658's ceiling kills one: SIGXFSZ, which the
-	# shell reports as 128 + 25.
+	# A child killed the way the appliance's ceiling kills one: SIGXFSZ, which a
+	# shell reports as 128 + 25. The shim stands in for the signal because a real
+	# RLIMIT_FSIZE overrun does not report 153 everywhere -- Darwin's awk catches
+	# the write error and exits 2 -- while the status this pins is the one
+	# pfb_extract_cap_note() keys on. The real ceiling gets its own example below,
+	# asserting refusal rather than a particular status.
 	plant_killed_awk() {
 		mkdir -p "${work}/shim"
 		printf '#!/bin/sh\nexit 153\n' > "${work}/shim/awk"
@@ -144,11 +150,16 @@ RUNNER
 		Before 'plant_prior_match'
 		Before 'plant_readonly_etdir'
 
-		It 'fails and keeps the live match publication byte-unchanged'
+		It 'fails and leaves both the feed and the live match publication untouched'
 			When run sh "${runner}"
 			The status should be failure
 			The output should include 'ET processing failed'
 			The contents of file "${match}pfB_Match_ET_v4.txt" should equal "${prior_match}"
+			# The abort must not half-write the publication either. processet()
+			# rewrites the ".orig" in place, so this is the raw CSV the download
+			# left -- what pfb_download()'s refusal then has to drop, since the
+			# parser would otherwise read the unfiltered feed.
+			The contents of file "${orig}${alias}.orig" should equal "${et_csv}"
 			The stderr should be present
 		End
 	End

--- a/tests/shell/pfblockerng_processet_exit_spec.sh
+++ b/tests/shell/pfblockerng_processet_exit_spec.sh
@@ -1,0 +1,269 @@
+#shellcheck shell=sh
+# issue #2683: processet() reported no exit status. Its scratch-file abort used a
+# bare `return`, so the function handed back whatever the preceding command had
+# left behind, and the steps that WRITE -- the per-category splits, the two
+# accumulations and the two publishes -- had no status read at all. The `et)`
+# dispatch arm then fell through to the script tail's bare `exitnow`, which
+# defaults to 0, so an aborted ET pass exited the process 0 and pfb_download()
+# could not tell it from a completed one.
+#
+# These examples pin the contract the caller now gates on: every abort reports
+# non-zero, a failing status comes back VERBATIM (so a child killed at issue
+# #2658's extraction ceiling reaches the caller as the 153 that names it), and a
+# failed pass leaves the live pfB_Match_ET_v4.txt publication byte-unchanged.
+#
+# Fixture shape: the feed's ".orig" is the raw ET IQRisk CSV ("IP,category,
+# score"). processet() splits it into one file per category, accumulates the
+# selected Block categories onto the ".orig" and the selected Match categories
+# onto pfB_Match_ET_v4.txt.
+
+Describe 'processet() exit contract (issue #2683)'
+	setup() {
+		work="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/etexit.XXXXXX")"
+		orig="${work}/orig/"
+		match="${work}/match/"
+		etdir="${work}/etdir"
+		scratch="${work}/scratch"
+		alias='EtFeed'
+		errorlog="${work}/error.log"
+		runner="${work}/run.sh"
+		mkdir -p "${orig}" "${match}" "${etdir}" "${scratch}"
+
+		# `ls` sorts the category files, so the selected Block categories
+		# accumulate in ALPHABETICAL order (ET_Bot, category 2, before ET_Cnc,
+		# category 1) rather than in category-number order.
+		expected="$(printf '%s\n' '198.51.100.20' '192.0.2.10')"
+		expected_match='203.0.113.30'
+		# What a live match publication looks like before a failed refresh: a
+		# failure must leave exactly this behind.
+		prior_match='PRIOR-MATCH-MARKER'
+
+		# processet() reads its inputs from the top-level init's globals, which
+		# never resolve off-appliance. Source the script as a library, point those
+		# globals at the fixture, and call the function -- from a real child
+		# process, so an example may impose an RLIMIT_FSIZE without the shellspec
+		# harness itself then writing under it, and so the child's exit status IS
+		# the function's. $1/$2 override the selected Block/Match categories.
+		cat > "${runner}" <<RUNNER
+#!/bin/sh
+PFB_SOURCED=1
+. "${PFB_PKGDIR}/pfblockerng.sh"
+pfborig="${orig}"
+alias="${alias}"
+etdir="${etdir}"
+pfbmatchgen="${match}"
+errorlog="${errorlog}"
+tempfile="${scratch}/et.tmp"
+tempfile2="${scratch}/et2.tmp"
+etblock="\${1:-ET_Cnc, ET_Bot}"
+etmatch="\${2:-ET_Spam}"
+now='2026-01-01 00:00:00'
+ip_placeholder2='127\.1\.7\.7'
+processet
+RUNNER
+		chmod +x "${runner}"
+	}
+	# A context that revokes write permission to force a failure has to hand it
+	# back, or the tree cannot be removed.
+	cleanup() {
+		chmod -R u+w "${work}" 2>/dev/null
+		rm -rf "${work}"
+	}
+	Before 'setup'
+	After 'cleanup'
+
+	# The downloaded ET feed: two Block categories (1, 2) and one Match (3).
+	plant_et_orig() {
+		printf '%s\n' '192.0.2.10,1,127' '198.51.100.20,2,88' '203.0.113.30,3,50' \
+			> "${orig}${alias}.orig"
+	}
+
+	# A live match publication left by a previous, successful pass.
+	plant_prior_match() {
+		printf '%s\n' "${prior_match}" > "${match}pfB_Match_ET_v4.txt"
+	}
+
+	# A child killed the way issue #2658's ceiling kills one: SIGXFSZ, which the
+	# shell reports as 128 + 25.
+	plant_killed_awk() {
+		mkdir -p "${work}/shim"
+		printf '#!/bin/sh\nexit 153\n' > "${work}/shim/awk"
+		chmod +x "${work}/shim/awk"
+	}
+
+	Context 'on a healthy ET feed'
+		Before 'plant_et_orig'
+		Before 'plant_prior_match'
+
+		It 'publishes both artifacts and reports success'
+			When run sh "${runner}"
+			The status should be success
+			The contents of file "${orig}${alias}.orig" should equal "${expected}"
+			The contents of file "${match}pfB_Match_ET_v4.txt" should equal "${expected_match}"
+			The output should include 'Final count'
+		End
+	End
+
+	Context 'when the ET scratch files cannot be created'
+		# The abort issue #2683 names by hand. It printed its message and then
+		# handed back the status of the `tee` that printed it -- 0.
+		plant_readonly_scratch() { chmod 555 "${scratch}"; }
+		Before 'plant_et_orig'
+		Before 'plant_prior_match'
+		Before 'plant_readonly_scratch'
+
+		It 'fails and keeps the live match publication byte-unchanged'
+			When run sh "${runner}"
+			The status should be failure
+			The output should include 'cannot create ET scratch file'
+			The contents of file "${match}pfB_Match_ET_v4.txt" should equal "${prior_match}"
+			The stderr should be present
+		End
+	End
+
+	Context 'when no ET .orig file is present'
+		# The other abort: the function fell off the end of its `else` branch, so
+		# its status was the closing `echo`'s.
+		Before 'plant_prior_match'
+
+		It 'fails instead of reporting a pass that processed nothing'
+			When run sh "${runner}"
+			The status should be failure
+			The output should include 'No ET .orig File Found!'
+			The contents of file "${match}pfB_Match_ET_v4.txt" should equal "${prior_match}"
+			The contents of file "${errorlog}" should include 'No ET .orig file'
+		End
+	End
+
+	Context 'when a category split cannot be written'
+		# The split is a pipeline, so its status is `cut`'s, not `grep`'s: a
+		# category with no rows makes grep exit 1 and is entirely normal, while a
+		# failed WRITE has to abort rather than publish a truncated block list.
+		plant_readonly_etdir() { chmod 555 "${etdir}"; }
+		Before 'plant_et_orig'
+		Before 'plant_prior_match'
+		Before 'plant_readonly_etdir'
+
+		It 'fails and keeps the live match publication byte-unchanged'
+			When run sh "${runner}"
+			The status should be failure
+			The output should include 'ET processing failed'
+			The contents of file "${match}pfB_Match_ET_v4.txt" should equal "${prior_match}"
+			The stderr should be present
+		End
+	End
+
+	Context 'when the block accumulation is killed'
+		# The status has to come back VERBATIM, because pfb_extract_cap_note() reads
+		# exactly 153 to tell the operator "too large" instead of printing a bare
+		# exit code.
+		#
+		# The shim breaks every `awk` in the pass, so the two accumulations get one
+		# example each with only their own categories selected -- otherwise whichever
+		# runs first covers for the other and neither check is isolated.
+		Before 'plant_et_orig'
+		Before 'plant_prior_match'
+		Before 'plant_killed_awk'
+
+		It 'returns the kill status verbatim and publishes nothing'
+			When run sh -c "PATH='${work}/shim:${PATH}' sh '${runner}' 'ET_Cnc, ET_Bot' x"
+			The status should equal 153
+			The contents of file "${match}pfB_Match_ET_v4.txt" should equal "${prior_match}"
+			The output should include 'ET processing failed'
+			The contents of file "${errorlog}" should include 'exit 153'
+		End
+	End
+
+	Context 'when the match accumulation is killed'
+		Before 'plant_et_orig'
+		Before 'plant_prior_match'
+		Before 'plant_killed_awk'
+
+		It 'returns the kill status verbatim and keeps the live match publication'
+			When run sh -c "PATH='${work}/shim:${PATH}' sh '${runner}' x ET_Spam"
+			The status should equal 153
+			The contents of file "${match}pfB_Match_ET_v4.txt" should equal "${prior_match}"
+			The output should include 'ET processing failed'
+			The contents of file "${errorlog}" should include 'exit 153'
+		End
+	End
+
+	Context 'when the block publication cannot be moved into place'
+		# The publish is a `mv` off the private temp directory, which is a separate
+		# filesystem from /var on a default use_mfs_tmpvar install -- so it copies
+		# rather than renames, and can fail on its own.
+		plant_readonly_origdir() { chmod 555 "${orig}"; }
+		Before 'plant_et_orig'
+		Before 'plant_prior_match'
+		Before 'plant_readonly_origdir'
+
+		It 'fails and keeps the live match publication byte-unchanged'
+			When run sh "${runner}"
+			The status should be failure
+			The output should include 'ET processing failed'
+			The contents of file "${match}pfB_Match_ET_v4.txt" should equal "${prior_match}"
+			The stderr should be present
+		End
+	End
+
+	Context 'when the match publication cannot be moved into place'
+		# The last write of the pass, and the only failure context that gets past
+		# the block publish -- so this is where the pfB_Match_ET_v4.txt artifact
+		# the issue names is the one left byte-unchanged by the failure itself.
+		plant_readonly_matchdir() { chmod 555 "${match}"; }
+		Before 'plant_et_orig'
+		Before 'plant_prior_match'
+		Before 'plant_readonly_matchdir'
+
+		It 'fails and keeps the live match publication byte-unchanged'
+			When run sh "${runner}"
+			The status should be failure
+			The output should include 'ET processing failed'
+			The contents of file "${match}pfB_Match_ET_v4.txt" should equal "${prior_match}"
+			The stderr should be present
+		End
+	End
+
+	Context 'when the extraction ceiling fires'
+		# issue #2658's ceiling (pfb_extract_cmd() -> `ulimit -f`) is what the
+		# caller now wraps this helper in: RLIMIT_FSIZE is inherited by every
+		# descendant, so a write past the ceiling kills whichever child is doing
+		# it. One 512-byte block is far below this feed's ET_Cnc split, so a child
+		# is guaranteed to be killed. The fixture carries Match rows too, so a pass
+		# that got through would REPLACE the prior match publication -- the prior
+		# surviving is therefore evidence of the refusal, not of an empty feed.
+		plant_large_et_orig() {
+			awk 'BEGIN { for (i = 1; i < 4000; i++) printf "192.0.2.%d,1,90\n203.0.113.%d,3,40\n", i % 254 + 1, i % 254 + 1 }' \
+				> "${orig}${alias}.orig"
+		}
+		Before 'plant_large_et_orig'
+		Before 'plant_prior_match'
+
+		It 'refuses the feed instead of publishing the truncated remains of one'
+			When run sh -c "ulimit -f 1 || exit 1; sh '${runner}' >/dev/null 2>&1"
+			The status should be failure
+			The contents of file "${match}pfB_Match_ET_v4.txt" should equal "${prior_match}"
+		End
+	End
+End
+
+Describe 'pfblockerng.sh et dispatch arm (issue #2683)'
+	# The script tail's bare `exitnow` defaults to 0, so processet()'s status
+	# would be discarded at the process boundary even once the function reports
+	# one -- the same wiring bug the `recompute` arm fixed in issue #1084. Runs
+	# the REAL entrypoint, because the propagation lives in the dispatch rather
+	# than in the function.
+	It 'exits non-zero when the feed has no ET .orig file'
+		# Off-appliance /var/db/pfblockerng/original/ holds nothing, so the
+		# no-.orig abort is the one reached, before any appliance-only tool is
+		# needed. Argument order mirrors pfb_download()'s exec():
+		# et <header> x x x x x <etblock> <etmatch> <elog>.
+		When run sh "${PFB_PKGDIR}/pfblockerng.sh" et NoSuchEtFeed x x x x x ET_Cnc x
+		The status should be failure
+		The stdout should include 'No ET .orig File Found!'
+		# The top-level init spews unrelated noise off-appliance (missing
+		# read_xml_tag.sh, /cf/conf/config.xml, unwritable /var/db) -- real but
+		# incidental here, so only asserted as present.
+		The stderr should not equal ''
+	End
+End

--- a/tests/shell/pfblockerng_processet_exit_spec.sh
+++ b/tests/shell/pfblockerng_processet_exit_spec.sh
@@ -29,8 +29,7 @@ Describe 'processet() exit contract (issue #2683)'
 		runner="${work}/run.sh"
 		mkdir -p "${orig}" "${match}" "${etdir}" "${scratch}"
 
-		# The downloaded ET feed, verbatim: two Block categories (1, 2) and one
-		# Match (3), as "IP,category,score" rows.
+		# The downloaded ET feed: two Block categories (1, 2) and one Match (3).
 		et_csv="$(printf '%s\n' '192.0.2.10,1,127' '198.51.100.20,2,88' '203.0.113.30,3,50')"
 
 		# `ls` sorts the category files, so the selected Block categories
@@ -86,11 +85,9 @@ RUNNER
 	}
 
 	# A child killed the way the appliance's ceiling kills one: SIGXFSZ, which a
-	# shell reports as 128 + 25. The shim stands in for the signal because a real
-	# RLIMIT_FSIZE overrun does not report 153 everywhere -- Darwin's awk catches
-	# the write error and exits 2 -- while the status this pins is the one
-	# pfb_extract_cap_note() keys on. The real ceiling gets its own example below,
-	# asserting refusal rather than a particular status.
+	# shell reports as 128 + 25. The shim stands in for the signal: a real
+	# RLIMIT_FSIZE overrun does not report 153 everywhere (Darwin's awk exits 2),
+	# while 153 is the status pfb_extract_cap_note() keys on.
 	plant_killed_awk() {
 		mkdir -p "${work}/shim"
 		printf '#!/bin/sh\nexit 153\n' > "${work}/shim/awk"
@@ -155,10 +152,8 @@ RUNNER
 			The status should be failure
 			The output should include 'ET processing failed'
 			The contents of file "${match}pfB_Match_ET_v4.txt" should equal "${prior_match}"
-			# The abort must not half-write the publication either. processet()
-			# rewrites the ".orig" in place, so this is the raw CSV the download
-			# left -- what pfb_download()'s refusal then has to drop, since the
-			# parser would otherwise read the unfiltered feed.
+			# processet() rewrites the ".orig" in place, so this is the raw CSV the
+			# download left -- the state pfb_download()'s refusal then has to drop.
 			The contents of file "${orig}${alias}.orig" should equal "${et_csv}"
 			The stderr should be present
 		End


### PR DESCRIPTION
## What this changes

`processet()` reported no exit status. Its scratch-file abort used a bare `return`,
so the function handed back whatever the preceding command had left behind (the
`tee` that printed the message — 0); its `else` branch fell off the end on an
`echo`; and the steps that actually *write* — the 33 per-category splits, the two
accumulations, and the two publishes — had no status read at all. The `et)`
dispatch arm then fell through to the script tail's bare `exitnow`, which defaults
to 0 (the issue #1084 wiring bug), and its caller in `pfb_download()` ran
`exec("{$pfb['script']} et …")` with no `$output`/`$retval` and no gate. So an
aborted ET pass exited the process 0 and reported a successful ingest.

Same three-part fix as PR #2680, same shape:

1. **The shell function reports.** Every abort returns a real status, and every
   writing step carries its own. A failing status is returned **verbatim** rather
   than collapsed to 1, so a child killed at issue #2658's ceiling still reaches
   the caller as the 153 `pfb_extract_cap_note()` reads. The category split is
   checked on the **pipeline's** status, which is `cut`'s, not `grep`'s: a category
   with no rows makes `grep` exit 1 and is entirely normal, while a failed write
   must abort instead of republishing the feed from a truncated split.
2. **The dispatch arm threads it through.** `exitnow "$?"` on the `et)` arm, the
   way `recompute` and `xlsx` already do.
3. **The caller gates on the status.** `pfb_download()` runs the helper under
   `pfb_extract_cmd()`, captures `$output`/`$retval`, and refuses the feed on a
   non-zero exit — logging the ceiling by name via `pfb_extract_cap_note()`. The
   ET site therefore stops being an allow-list entry in
   `DownloadSizeCeilingTest::test_every_extraction_exec_runs_under_the_ceiling`.

`pfb_et_abort()` exists because there are five failure exits, not one: it names
*which* step failed in the error log, which a bare status cannot.

And one property that came out of review, because a status nobody read decides
nothing while a status somebody reads has to leave a coherent state behind:

4. **The refusal has to hold.** `processet()` rewrites the `.orig` **in place**
   rather than staging, so at the moment the helper fails, the `.orig` this pass
   just published is the raw ET CSV — and the apply loop's fail-marker fallback
   parses a `.orig` that is still there, publishing the unfiltered feed including
   categories the operator never selected. The refusal therefore drops that
   publication together with **both** sidecar families, `pfb_force_clear_validators()`'
   suffix set: the content hashes *and* the conditional-GET validators, because a
   remote feed whose ETag survived would answer the next pass with a 304 and never
   re-fetch. That bad publication is pre-existing byte-for-byte on `devel` — where
   the same aborted pass reports *success* — so it is not a regression; but a gate
   that returns `failure()` and leaves the CSV where the parser reads it is not a
   refusal, so it is closed here rather than deferred.

Nothing else moved. The publish is still `mv -f` off the private temp directory —
that already was a staged publish, which is why this needed no `.orig.tmp` staging
of its own the way `processxlsx()` did.

### Two hypotheses, and the probe that separated them

**H1** — the defect as filed: the aborts report 0, the arm's fall-through to the
bare `exitnow` discards whatever they do report, and the uncaptured `exec()` cannot
see it. **H2** — something already gates it: `exitnow` picks up `$?` implicitly, or
`pfb_download()` re-checks the publication downstream the way the XLSX branch used
to check `file_exists()`.

Discriminating probe (`sh probe.sh <tree>`, sourced-library runner in a real child
process plus the real entrypoint), run on `devel` and then on this branch with the
same driver:

```text
                                  devel     this branch
ABORT_SCRATCH_RC                  0         1
ABORT_SCRATCH_SAW_MESSAGE         1         1
ABORT_SCRATCH_MATCH_PUBLICATION   [PRIOR-MATCH-MARKER|]   [PRIOR-MATCH-MARKER|]
ARM_NO_ORIG_RC                    0         1
ARM_NO_ORIG_SAW_MESSAGE           1         1
SUCCESS_RC                        0         0
SUCCESS_ORIG                      [198.51.100.20|192.0.2.10|]   (unchanged)
SUCCESS_MATCH                     [203.0.113.30|]               (unchanged)
```

`ABORT_SCRATCH_RC=0` **with** the message printed is the issue's own black-box
reproduction: the `cannot create ET scratch file(s)` branch was genuinely taken and
the process still exited 0. `ARM_NO_ORIG_RC=0` is the same thing through the real
entrypoint, so the arm swallows it too. H2 is refuted twice from source in the same
run — `exitnow` is `rc="${1:-0}"`, so there is no implicit `$?`, and the
`pfb_download()` call site was a bare `exec()` with nothing after it but
`return PfbDownloadResult::success();`.

### The success path is unregressed, and now runs under the ceiling

Same probe: `SUCCESS_RC` stays 0 and both published artifacts are byte-identical
before and after. Under the **real** ceiling `pfb_extract_cmd()` imposes
(`PFB_EXTRACT_MAX_BLOCKS`, read from source rather than restated), a realistic feed
ingests untouched:

```text
CEILING_BLOCKS=4194304
FEED_BYTES=2486172
SUCCESS_UNDER_CEILING_RC=0
PUBLISHED_ORIG_ROWS=100000
PUBLISHED_MATCH_ROWS=50000
MATCH_REPLACED_PRIOR=0
FINAL_COUNT_LINE=[All ET Folder count [ 150000 ]  Final count [ 100000 ]]
ERRORLOG_PRESENT=no
```

## Tests

`tests/shell/pfblockerng_processet_exit_spec.sh` (new) pins the contract end to
end. A healthy feed publishes both artifacts and reports success; the scratch-file
abort, an absent `.orig`, an unwritable category split, a killed block
accumulation, a killed match accumulation, an unwritable block publish, an
unwritable match publish, and a run under `ulimit -f 1` each fail and leave the
live `pfB_Match_ET_v4.txt` byte-unchanged; the split example additionally pins the
feed's own `.orig` byte-unchanged, which is the state item 4's refusal then has to
drop. A second `Describe` runs the real entrypoint to pin the arm's propagation.

The two accumulations get **one example each with only their own categories
selected**. The `awk` shim breaks every `awk` in the pass, so a single combined
example let whichever accumulation ran first cover for the other — measured: the
first cut of this spec had one combined example and the block-accumulation mutant
survived it 10/10 green. Splitting them is what makes both checks isolated.

The shim exits 153 rather than raising a real `SIGXFSZ`, and the spec says so: a
real `RLIMIT_FSIZE` overrun does **not** report 153 everywhere — Darwin's `awk`
catches the write error and exits 2 — while 153 is the status
`pfb_extract_cap_note()` keys on. The real-ceiling example is separate and asserts
refusal rather than a particular status.

`tests/php/DownloadExtractionExitCodeTest::testEtBodyCapturesAndChecksHelperExit`
pins the branch beside the eight sibling extraction branches already pinned there
(the placement PR #2680's contract leg asked for), including one assertion per
dropped sidecar suffix.
`tests/php/DownloadSizeCeilingTest.php` drops the ET allow-list entry, moves the
docblock's prefix-attack example off `et` (now capped) onto `asn_table`, and stops
naming a call-site count next to the `exec(pfb_extract_cmd(` entry — it read
"ten call sites" against 17 in the tree today, and this change makes 18.

### Red → green

Test-first, re-executed at `924b66b2` with the two production files checked out at
the base SHA `18c66eaf` and the committed test files untouched. Their
`git hash-object` is identical across both runs:

```text
tests/shell/pfblockerng_processet_exit_spec.sh  e072d2348dd9be7841a2a772d96b6c4c8c6ff7e3
tests/php/DownloadSizeCeilingTest.php          11c8f821796f8d46eb52d7d187245c8d1ba69504
tests/php/DownloadExtractionExitCodeTest.php   8c12d83baf00a7c3c8f2fdc59bedd4ceb60dc43f
```

RED — `git checkout 18c66eaf -- src/usr/local/pkg/pfblockerng/pfblockerng.{sh,inc}`:

```text
$ shellspec --shell "$(command -v dash)" tests/shell/pfblockerng_processet_exit_spec.sh
10 examples, 9 failures
$ vendor/bin/phpunit --filter 'DownloadSizeCeilingTest|DownloadExtractionExitCodeTest'
1) DownloadExtractionExitCodeTest::testEtBodyCapturesAndChecksHelperExit
2) DownloadSizeCeilingTest::test_every_extraction_exec_runs_under_the_ceiling
```

The one example green at red is `on a healthy ET feed` — it is the success-path
pin, not a reproduction. GREEN — production restored, same test bytes:

```text
$ shellspec --shell "$(command -v dash)" tests/shell/pfblockerng_processet_exit_spec.sh
10 examples, 0 failures
$ vendor/bin/phpunit --filter 'DownloadSizeCeilingTest|DownloadExtractionExitCodeTest'
OK (38 tests, 230 assertions)
```

**Executed-example count:** `10 examples` in the ShellSpec run, from a file that
declares 10 `It` blocks — the examples ran, they are not merely written (the issue
#2749 lesson), and the run reports no skip. The mutation driver's baseline line,
printed from the same unmutated tree, says the same: `shellspec: 10 examples, 0 failures`.

### Mutation table

Every mutant applied one at a time by a self-contained POSIX `sh` driver in an
isolated clone it owns, each with an **asserted single-occurrence** needle block
and an **asserted non-empty `git diff`** so no mutant can silently no-op, reverted
between runs (`FINAL_TREE_CLEAN_LINES=0`).

| # | Mutation | Killed by |
| --- | --- | --- |
| M1 | scratch-file abort back to a bare `return` | spec — `when the ET scratch files cannot be created` |
| M2 | `exitnow "$?"` dropped from the `et)` arm | spec — `et dispatch arm … exits non-zero when the feed has no ET .orig file` |
| M3 | `$output`/`$retval` capture dropped from the caller | `testEtBodyCapturesAndChecksHelperExit` |
| M4 | caller's exit gate neutralised (`if (FALSE)`) | `testEtBodyCapturesAndChecksHelperExit` |
| M5 | allow-list entry kept | `test_every_extraction_exec_runs_under_the_ceiling` |
| M6 | category-split status check dropped | spec — `when a category split cannot be written` |
| M7 | block-accumulation status check dropped | spec — `when the block accumulation is killed` |
| M8 | match-accumulation status check dropped | spec — `when the match accumulation is killed` |
| M9 | block-publish status check dropped | spec — `when the block publication cannot be moved into place` |
| M10 | match-publish status check dropped | spec — `when the match publication cannot be moved into place` |
| M11 | no-`.orig` abort returns 0 | spec — `when no ET .orig file is present` **and** the dispatch-arm example |
| M12 | failing status collapsed to `1` instead of verbatim | spec — `when the block accumulation is killed` |
| M13 | refusal no longer drops the raw `.orig` it just published | `testEtBodyCapturesAndChecksHelperExit` |
| M14 | refusal drops the hashes but keeps the conditional-GET validators | `testEtBodyCapturesAndChecksHelperExit` |
| M15 | refusal keeps the downloaded `.raw` | `testEtBodyCapturesAndChecksHelperExit` |

The driver passes `--colors=never` to PHPUnit. `phpunit.xml` forces ANSI on, so an
anchored `^OK (` match silently never fired and a surviving PHP mutant would have
printed nothing — indistinguishable from PHPUnit not running. Caught by the
independent verifier, fixed, and every PHP mutant above now shows both its
`Failures: 1` line and an affirmative kill.

### Review

Four adversarial legs, two rounds. Two `blocking` findings were raised and fixed:
the refusal that did not hold (correctness leg, plus its conditional-GET follow-up)
and a surviving mutant on the refusal's own new assertion — four of its five suffix
members were pinned, and the missing one was the empty member that drops the raw
`.orig` (test-honesty leg). One dead assertion was removed (over-engineering leg):
the gate needle added beside it contains it as a substring, so it could never fail.
Two findings are deferred with tracking issues — #2776 and #2778 — and the
over-engineering leg's eight remaining cuts (−15 lines) are applied. Per-leg audit
comments carry the executed evidence and the accept/skip reasoning.

### One CI catch worth recording

CI's shellspec leg went red on a **pre-existing** spec, not on the new one:
`pfblockerng_cat_weld_more_spec.sh` extracts each accumulation statement from the
committed file **by line number** and `eval`s it, so splitting a statement across a
`||` continuation left it evaluating an incomplete command
(`eval: Syntax error: end of file unexpected`). Every status check is on one line
now, and the constraint is recorded at the site a reformat would break.

## Deferred

- **#2776** — `pfblockerng_apply.inc`'s reuse path calls the same `et` arm and still
  discards the status. Out of scope here because closing it changes
  `pfb_apply_gunzip_orig_pipeline()`'s shared `$consumer` contract (declared
  `void`, and the helper's own `bool` return is `FALSE` on exactly that path), which
  `GunzipTrailingNewlineWiringTest` pins in seven places. Found by enumerating the
  arm's callers from `git grep`, not from memory.
- **#2778** — the category split reads `cut`'s status, which is right for `grep`'s
  no-match 1 and also masks its hard errors: a NUL-bearing `.orig` makes `grep`
  print `Binary file … matches` on stdout, which `cut` publishes as list content.
  Exact base parity, measured on all five rows. Closing it needs the split
  restructured so `grep`'s own status is readable at all (POSIX pipeline status
  cannot express it) plus a content-sanity gate, which overlaps #2682.
- **The normalize-stage digest baseline** (`.norm.src.xxhash128`) deliberately
  survives the refusal. Probed rather than assumed: after the drop, a re-download of
  *changed* bytes reports changed and re-normalizes, and a re-download of
  byte-identical bytes reuses staging that was produced by the last **successful**
  pass — the failed pass never normalized, because the apply loop takes its
  unconditional `continue` once the `.orig` is gone.

Fixes #2683

🤖 Generated by Oh My Pi and posted on behalf of @andrebrait.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Emerging Threats feed processing to detect download and extraction failures.
  - Prevented incomplete or corrupted threat data from being published when processing fails.
  - Automatically cleans up failed downloads and associated temporary files.
  - Preserved existing published data when an update cannot be completed.
  - Added clearer error reporting, including the failed processing step and exit status.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->