### PR TITLE
smoke: capture pkg ABI/repos in the diag bundle

### DIFF
--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -48,6 +48,8 @@ import shlex
 import shutil
 import subprocess
 import sys
+import tarfile
+import tempfile
 import time
 import uuid
 from collections.abc import Callable, Iterable, Sequence
@@ -5285,6 +5287,32 @@ _PKG_TOKEN_QUERY_RE = re.compile(
     re.IGNORECASE,
 )
 
+# Guest capture uses BSD sed (no I flag). Spell every letter so ?TOKEN= redacts.
+_PKG_URL_GUEST_SED_USERINFO = r"s#(https?://)[^/@:]+(:[^/@]*)?@#\1REDACTED@#g"
+_PKG_URL_GUEST_SED_QUERY = (
+    r"s#([?&]("
+    r"[Tt][Oo][Kk][Ee][Nn]|"
+    r"[Kk][Ee][Yy]|"
+    r"[Ss][Ee][Cc][Rr][Ee][Tt]|"
+    r"[Pp][Aa][Ss][Ss][Ww][Oo][Rr][Dd]|"
+    r"[Aa][Uu][Tt][Hh]"
+    r")=)[^&[:space:]]+#\1REDACTED#g"
+)
+
+
+def apply_guest_pkg_url_sed(text: str) -> str:
+    """The on-box capture redactor (sed ERE). Host tests drive this same program."""
+    result = subprocess.run(
+        ["sed", "-E", "-e", _PKG_URL_GUEST_SED_USERINFO, "-e", _PKG_URL_GUEST_SED_QUERY],
+        input=text,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        return text
+    return result.stdout
+
 
 def redact_pkg_urls(text: str) -> str:
     """Strip userinfo and token-shaped query values from pkg dump text.
@@ -5295,6 +5323,35 @@ def redact_pkg_urls(text: str) -> str:
     """
     out = _PKG_USERINFO_RE.sub(r"\1REDACTED@", text)
     return _PKG_TOKEN_QUERY_RE.sub(r"\1REDACTED", out)
+
+
+def redact_pkg_tarball(tgz_path: str) -> None:
+    """Host-side second pass over a pulled diag tarball's ``pkg/`` files.
+
+    The guest sed has no case-insensitive flag; this IGNORECASE pass is the
+    belt. No-op when the archive is missing or has no pkg dump.
+    """
+    if not os.path.isfile(tgz_path):
+        return
+    with tempfile.TemporaryDirectory() as tmp:
+        with tarfile.open(tgz_path, "r:gz") as tar:
+            tar.extractall(tmp, filter="data")
+        pkg_root = os.path.join(tmp, "pfb_smoke_diag", "pkg")
+        if os.path.isdir(pkg_root):
+            for dirpath, _, files in os.walk(pkg_root):
+                for name in files:
+                    path = os.path.join(dirpath, name)
+                    try:
+                        raw = Path(path).read_text(encoding="utf-8", errors="surrogateescape")
+                    except OSError:
+                        continue
+                    new = redact_pkg_urls(raw)
+                    if new != raw:
+                        Path(path).write_text(new, encoding="utf-8", errors="surrogateescape")
+        tmp_out = tgz_path + ".redact"
+        with tarfile.open(tmp_out, "w:gz") as tar:
+            tar.add(os.path.join(tmp, "pfb_smoke_diag"), arcname="pfb_smoke_diag")
+        os.replace(tmp_out, tgz_path)
 
 
 def redact_values(text: str, values: Iterable[str]) -> str:
@@ -5435,8 +5492,8 @@ def collect_host_diagnostics(vm: SmokeVM, dest_dir: str = "smoke-diag", *, timeo
         'find "$D/pkg" -type f 2>/dev/null | while IFS= read -r _pfb_pkg_f; do '
         'LC_ALL=C grep -Iq . "$_pfb_pkg_f" 2>/dev/null || continue; '
         "sed -i '' -E "
-        r"-e 's#(https?://)[^/@:]+(:[^/@]*)?@#\1REDACTED@#g' "
-        r"-e 's#([?&]([Tt]oken|[Kk]ey|[Ss]ecret|[Pp]assword|[Aa]uth)=)[^&[:space:]]+#\1REDACTED#g' "
+        f"-e '{_PKG_URL_GUEST_SED_USERINFO}' "
+        f"-e '{_PKG_URL_GUEST_SED_QUERY}' "
         '"$_pfb_pkg_f"; '
         "done; "
         # Scrub secrets from config.xml BEFORE it leaves the box.
@@ -5469,6 +5526,7 @@ def collect_host_diagnostics(vm: SmokeVM, dest_dir: str = "smoke-diag", *, timeo
         result = subprocess.run(scp_argv, capture_output=True, text=True, timeout=timeout, check=False)
         if result.returncode == 0:
             print(f"[smoke] collected full guest diagnostics -> {dest_dir}/pfb_smoke_diag.tgz")
+            redact_pkg_tarball(os.path.join(dest_dir, "pfb_smoke_diag.tgz"))
         else:
             print(f"[smoke] guest-diagnostics scp failed (non-fatal): {result.stderr!r}")
         # Surface the VM SERIAL CONSOLE in the uploaded artifact. boot_vm.sh runs

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -5279,6 +5279,24 @@ def _sed_escape_literal(value: str) -> str:
     return out
 
 
+_PKG_USERINFO_RE = re.compile(r"(https?://)[^/@:]+(?::[^/@]*)?@", re.IGNORECASE)
+_PKG_TOKEN_QUERY_RE = re.compile(
+    r"([?&](?:token|key|secret|password|auth)=)[^&\s]+",
+    re.IGNORECASE,
+)
+
+
+def redact_pkg_urls(text: str) -> str:
+    """Strip userinfo and token-shaped query values from pkg dump text.
+
+    ``pkg -vv`` and ``/usr/local/etc/pkg/repos/*`` can embed credentials.
+    Capture-time redaction (issue #2754) so the diag tarball never holds them.
+    ABI / ALTABI / ``uname -mr`` have no URLs and are unchanged.
+    """
+    out = _PKG_USERINFO_RE.sub(r"\1REDACTED@", text)
+    return _PKG_TOKEN_QUERY_RE.sub(r"\1REDACTED", out)
+
+
 def redact_values(text: str, values: Iterable[str]) -> str:
     """Replace every non-empty ``value`` (matched LITERALLY, not as a regex, and
     CASE-INSENSITIVELY) in ``text`` with ``REDACTED``.
@@ -5405,6 +5423,22 @@ def collect_host_diagnostics(vm: SmokeVM, dest_dir: str = "smoke-diag", *, timeo
         'tar czf "$D/var_db_pfblockerng.tgz" -C /var/db pfblockerng 2>/dev/null; '
         'tar czf "$D/var_db_aliastables.tgz" -C /var/db aliastables 2>/dev/null; '
         '/bin/ps auxww > "$D/ps.txt" 2>&1; '
+        # pkg ABI / repos (issue #2754): ABI drift is otherwise invisible after
+        # teardown. pkg -vv and repo confs can carry credentials — redact
+        # userinfo and token-shaped query parameters before the tarball.
+        'mkdir -p "$D/pkg"; '
+        'pkg config ABI > "$D/pkg/abi.txt" 2>&1; '
+        'pkg config ALTABI > "$D/pkg/altabi.txt" 2>&1; '
+        'uname -mr > "$D/pkg/uname_mr.txt" 2>&1; '
+        'pkg -vv > "$D/pkg/pkg_vv.txt" 2>&1; '
+        'cp -a /usr/local/etc/pkg/repos "$D/pkg/repos" 2>/dev/null; '
+        'find "$D/pkg" -type f 2>/dev/null | while IFS= read -r _pfb_pkg_f; do '
+        'LC_ALL=C grep -Iq . "$_pfb_pkg_f" 2>/dev/null || continue; '
+        "sed -i '' -E "
+        r"-e 's#(https?://)[^/@:]+(:[^/@]*)?@#\1REDACTED@#g' "
+        r"-e 's#([?&]([Tt]oken|[Kk]ey|[Ss]ecret|[Pp]assword|[Aa]uth)=)[^&[:space:]]+#\1REDACTED#g' "
+        '"$_pfb_pkg_f"; '
+        "done; "
         # Scrub secrets from config.xml BEFORE it leaves the box.
         + config_scrub
         # ADR-24: value-redact the Plus secret identity across the WHOLE bundle

--- a/tests/test_smoke_diag_pkg_abi.py
+++ b/tests/test_smoke_diag_pkg_abi.py
@@ -61,6 +61,31 @@ def test_redact_pkg_urls_strips_token_query() -> None:
     assert "abi=FreeBSD:15:amd64" in out
 
 
+def test_redact_pkg_urls_strips_uppercase_token_query() -> None:
+    """Given ?TOKEN= (all-caps keyword)
+    When the Python redactor runs
+    Then the secret is gone.
+    """
+    raw = "url: https://pkg.example.com/repo?TOKEN=SEKRIT&abi=FreeBSD:15:amd64\n"
+    out = helpers.redact_pkg_urls(raw)
+    assert "SEKRIT" not in out
+    assert "TOKEN=REDACTED" in out
+
+
+def test_guest_sed_redacts_uppercase_token_query() -> None:
+    """Given the on-box sed program
+    When it sees ?TOKEN= and ?KEY=
+    Then those secrets are gone (BSD sed has no I flag; every letter is spelled).
+    """
+    raw = "?token=seklower\n?Token=sekmixed\n?TOKEN=SEKRIT\n?KEY=KEYSECRET\n?tOkEn=weird\n"
+    out = helpers.apply_guest_pkg_url_sed(raw)
+    assert "seklower" not in out
+    assert "sekmixed" not in out
+    assert "SEKRIT" not in out
+    assert "KEYSECRET" not in out
+    assert "weird" not in out
+
+
 def test_redact_pkg_urls_leaves_clean_urls_intact() -> None:
     """Given a URL with no userinfo and no token query
     When capture-time redaction runs
@@ -73,7 +98,35 @@ def test_redact_pkg_urls_leaves_clean_urls_intact() -> None:
 def test_collect_host_diagnostics_redacts_pkg_urls_at_capture() -> None:
     """Given the guest snapshot script
     When it captures pkg -vv and repo confs
-    Then it redacts URLs before the tarball is built.
+    Then the live on-box sed is the tested program, and the host second pass runs.
     """
     src = inspect.getsource(helpers.collect_host_diagnostics)
-    assert "redact_pkg_urls" in src or "REDACTED@" in src
+    assert "_PKG_URL_GUEST_SED_QUERY" in src
+    assert "redact_pkg_tarball(" in src
+
+
+def test_redact_pkg_tarball_strips_uppercase_token() -> None:
+    """Given a pulled diag tarball whose pkg dump still has ?TOKEN=
+    When the host second pass runs
+    Then the secret is gone from the retarred bundle.
+    """
+    import tarfile
+    import tempfile
+    from pathlib import Path
+
+    secret = "url: https://pkg.example.com/repo?TOKEN=SEKRIT\n"
+    with tempfile.TemporaryDirectory() as tmp:
+        inner = Path(tmp) / "pkg"
+        inner.mkdir()
+        (inner / "repos.conf").write_text(secret, encoding="utf-8")
+        tgz = Path(tmp) / "pfb_smoke_diag.tgz"
+        with tarfile.open(tgz, "w:gz") as tar:
+            tar.add(inner, arcname="pfb_smoke_diag/pkg")
+        helpers.redact_pkg_tarball(str(tgz))
+        with tarfile.open(tgz, "r:gz") as tar:
+            member = tar.getmember("pfb_smoke_diag/pkg/repos.conf")
+            data = tar.extractfile(member)
+            assert data is not None
+            out = data.read().decode("utf-8")
+        assert "SEKRIT" not in out
+        assert "TOKEN=REDACTED" in out

--- a/tests/test_smoke_diag_pkg_abi.py
+++ b/tests/test_smoke_diag_pkg_abi.py
@@ -1,0 +1,79 @@
+"""Smoke diag bundle must capture pkg ABI/repos with URL redaction (issue #2754).
+
+A #2242 drift (guest pkg ABI FreeBSD:16 vs expected 15) produced 155 setup
+errors. The collector had no pkg config ABI, no pkg -vv, no repo confs, so
+the forced-ABI path stayed unproven after the guest was torn down.
+
+pkg -vv and repo confs can carry credentials. Redact userinfo and token-shaped
+query parameters at capture time.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+from tests.smoke import helpers
+
+
+def test_collect_host_diagnostics_captures_pkg_abi_and_uname() -> None:
+    """Given collect_host_diagnostics
+    When it builds the guest snapshot script
+    Then it records pkg ABI, ALTABI, and uname -mr.
+    """
+    src = inspect.getsource(helpers.collect_host_diagnostics)
+    assert "pkg config ABI" in src
+    assert "pkg config ALTABI" in src
+    assert "uname -mr" in src
+
+
+def test_collect_host_diagnostics_captures_pkg_vv_and_repo_confs() -> None:
+    """Given collect_host_diagnostics
+    When it snapshots pkg configuration
+    Then pkg -vv and /usr/local/etc/pkg/repos are in the bundle.
+    """
+    src = inspect.getsource(helpers.collect_host_diagnostics)
+    assert "pkg -vv" in src
+    assert "/usr/local/etc/pkg/repos" in src
+
+
+def test_redact_pkg_urls_strips_userinfo() -> None:
+    """Given a repo URL with user:pass@
+    When capture-time redaction runs
+    Then the userinfo is gone and the rest of the URL remains.
+    """
+    raw = "url: https://ci-token:s3cret@pkg.example.com/nightly/ce-2.8\n"
+    out = helpers.redact_pkg_urls(raw)
+    assert "s3cret" not in out
+    assert "ci-token" not in out
+    assert "pkg.example.com/nightly/ce-2.8" in out
+    assert "REDACTED@" in out
+
+
+def test_redact_pkg_urls_strips_token_query() -> None:
+    """Given a URL with a token-shaped query parameter
+    When capture-time redaction runs
+    Then the parameter value is REDACTED and neighbouring params remain.
+    """
+    raw = "https://pkg.example.com/repo?token=ghp_abc123&abi=FreeBSD:15:amd64\n"
+    out = helpers.redact_pkg_urls(raw)
+    assert "ghp_abc123" not in out
+    assert "token=REDACTED" in out
+    assert "abi=FreeBSD:15:amd64" in out
+
+
+def test_redact_pkg_urls_leaves_clean_urls_intact() -> None:
+    """Given a URL with no userinfo and no token query
+    When capture-time redaction runs
+    Then the text is unchanged.
+    """
+    raw = "url: http://pkg.pfblockerng.com/nightly/ce-2.8/\nABI: FreeBSD:15:amd64\n"
+    assert helpers.redact_pkg_urls(raw) == raw
+
+
+def test_collect_host_diagnostics_redacts_pkg_urls_at_capture() -> None:
+    """Given the guest snapshot script
+    When it captures pkg -vv and repo confs
+    Then it redacts URLs before the tarball is built.
+    """
+    src = inspect.getsource(helpers.collect_host_diagnostics)
+    assert "redact_pkg_urls" in src or "REDACTED@" in src


### PR DESCRIPTION
## Summary

A #2242 ABI drift (`FreeBSD:16` vs expected 15) produced 155 setup errors. The diag bundle had no `pkg config ABI`, no `pkg -vv`, no repo confs, so the forced-ABI path stayed unproven after the guest was torn down.

Always capture ABI, ALTABI, `uname -mr`, `pkg -vv`, and `/usr/local/etc/pkg/repos` into `pfb_smoke_diag.tgz`. Redact URL userinfo and token-shaped query parameters at capture time (`pkg -vv` and repo confs can embed credentials).

Refs #2754. This is item 4 of that issue.

## Verification

Frozen RED (new tests over `origin/devel` `helpers.py`): 6 failed (no `pkg config ABI` / `redact_pkg_urls`).
GREEN: 6 passed.

| blob | git hash-object |
|---|---|
| tests/test_smoke_diag_pkg_abi.py | `3a872453cfb6ec6e2fb95fbb4050f3b724ec279d` |
| tests/smoke/helpers.py | `f1eb076ce96f6a449fa5586a455123f54b37ea12` |

No live-VM re-run: the drifted guest is gone. Hermetic pin of the collector only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved diagnostic collection to include package configuration, ABI details, system information, and repository configuration.
  * Automatically removes credentials and token-like query parameters from captured package URLs.
  * Applies redaction both during collection and to the resulting diagnostics archive for safer sharing.

* **Tests**
  * Added coverage for credential removal across URL formats, guest capture, and diagnostic archives.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->