### PR TITLE
local-smoke: reject a missing or abbreviated ref before leasing

### DIFF
--- a/scripts/local-smoke.sh
+++ b/scripts/local-smoke.sh
@@ -57,6 +57,11 @@
 # Test-only (env):
 #   PFB_SELECT_BOX  override the select-box.sh path (default: scripts/select-box.sh).
 #                   Used by tests/shell/local_smoke_spec.sh to inject a fake.
+#   PFB_REF_PREFLIGHT  set to 0 to skip the branch/tag ls-remote check
+#                   (issue #2780). SHA expansion still runs. Spec rows that
+#                   use --ref dummy set this; production never does.
+#   PFB_LS_REMOTE   override the `git ls-remote` binary (same argv:
+#                   --exit-code <remote> <ref>). Spec injects a fake.
 #
 # The leased box runs scripts/smoke-on-box.sh, which:
 #   - checks out the requested ref
@@ -181,6 +186,46 @@ if [ -z "$_REF" ]; then
 fi
 
 _REF="${_REF#origin/}"
+
+# issue #2780: fail before select-box.sh when the box's git fetch cannot
+# succeed. An abbreviated SHA is not a fetch refspec (rc=128 in ~2s, zero
+# tests); a branch that exists only on this clone is the same class.
+_ref_is_hex() {
+    case "$1" in
+        *[!0-9a-fA-F]*|'') return 1 ;;
+        *) return 0 ;;
+    esac
+}
+_ref_len=${#_REF}
+if _ref_is_hex "$_REF" && [ "$_ref_len" -ge 4 ] && [ "$_ref_len" -le 39 ]; then
+    if _full="$(git -C "$REPO_ROOT" rev-parse --verify "${_REF}^{commit}" 2>/dev/null)"; then
+        _REF=$_full
+    else
+        printf 'local-smoke: abbreviated SHA %s is not in this clone; pass a full 40-character SHA or a branch that exists on %s\n' \
+            "$_REF" "$_GIT_REMOTE" >&2
+        exit 2
+    fi
+fi
+_ref_len=${#_REF}
+_skip_ls=0
+if _ref_is_hex "$_REF" && [ "$_ref_len" -eq 40 ]; then
+    # loose objects are not advertised; the box fetch of a full SHA is the
+    # check. ls-remote here would reject reachable SHAs that are not tips.
+    _skip_ls=1
+fi
+if [ "${PFB_REF_PREFLIGHT:-1}" != 0 ] && [ "$_skip_ls" -eq 0 ]; then
+    _ls_rc=0
+    if [ -n "${PFB_LS_REMOTE:-}" ]; then
+        "$PFB_LS_REMOTE" --exit-code "$_GIT_REMOTE" "$_REF" || _ls_rc=$?
+    else
+        git ls-remote --exit-code "$_GIT_REMOTE" "$_REF" >/dev/null 2>&1 || _ls_rc=$?
+    fi
+    if [ "$_ls_rc" -ne 0 ]; then
+        printf 'local-smoke: ref %s is not on %s; not leasing a box\n' \
+            "$_REF" "$_GIT_REMOTE" >&2
+        exit 2
+    fi
+fi
 
 _sq() { printf '%s' "$1" | sed "s/'/'\\\\''/g"; }
 

--- a/scripts/local-smoke.sh
+++ b/scripts/local-smoke.sh
@@ -57,9 +57,10 @@
 # Test-only (env):
 #   PFB_SELECT_BOX  override the select-box.sh path (default: scripts/select-box.sh).
 #                   Used by tests/shell/local_smoke_spec.sh to inject a fake.
-#   PFB_REF_PREFLIGHT  set to 0 to skip the branch/tag ls-remote check
-#                   (issue #2780). SHA expansion still runs. Spec rows that
-#                   use --ref dummy set this; production never does.
+#   PFB_REF_PREFLIGHT  1 = ls-remote check on; 0 = skip it (SHA expansion
+#                   still runs). Unset + PFB_SELECT_BOX set also skips, so
+#                   hermetic --ref dummy specs keep working. Production
+#                   never sets either, so the check stays on.
 #   PFB_LS_REMOTE   override the `git ls-remote` binary (same argv:
 #                   --exit-code <remote> <ref>). Spec injects a fake.
 #
@@ -213,7 +214,14 @@ if _ref_is_hex "$_REF" && [ "$_ref_len" -eq 40 ]; then
     # check. ls-remote here would reject reachable SHAs that are not tips.
     _skip_ls=1
 fi
-if [ "${PFB_REF_PREFLIGHT:-1}" != 0 ] && [ "$_skip_ls" -eq 0 ]; then
+# Production: preflight ON. Hermetic specs inject PFB_SELECT_BOX and pass
+# --ref dummy; skip ls-remote unless they opted in with PFB_REF_PREFLIGHT=1.
+if [ "${PFB_REF_PREFLIGHT:-}" = 0 ]; then
+    _skip_ls=1
+elif [ -z "${PFB_REF_PREFLIGHT+x}" ] && [ -n "${PFB_SELECT_BOX:-}" ]; then
+    _skip_ls=1
+fi
+if [ "$_skip_ls" -eq 0 ]; then
     _ls_rc=0
     if [ -n "${PFB_LS_REMOTE:-}" ]; then
         "$PFB_LS_REMOTE" --exit-code "$_GIT_REMOTE" "$_REF" || _ls_rc=$?

--- a/tests/shell/local_smoke_spec.sh
+++ b/tests/shell/local_smoke_spec.sh
@@ -53,7 +53,11 @@ FAKEEOF
 
     PFB_SELECT_BOX="$FAKE_SELECT_BOX"
     PFB_BOXES="dummy@dummy"
-    export PFB_SELECT_BOX PFB_BOXES WORK CALLS_DIR TMPDIR
+    # issue #2780: existing --ref dummy rows are not on any remote; skip the
+    # ls-remote preflight. SHA expansion still runs (dummy is not hex).
+    PFB_REF_PREFLIGHT=0
+    unset PFB_LS_REMOTE
+    export PFB_SELECT_BOX PFB_BOXES WORK CALLS_DIR TMPDIR PFB_REF_PREFLIGHT
   }
 
   teardown() {
@@ -325,4 +329,132 @@ FAKEEOF
     End
   End
 
+End
+
+# issue #2780: a missing or abbreviated ref used to lease a box, then git fetch
+# died rc=128 in ~2s with zero tests run. Fail before select-box.sh instead.
+Describe 'local-smoke.sh ref preflight (issue #2780)'
+  SCRIPT="${PFB_ROOT}/scripts/local-smoke.sh"
+
+  setup() {
+    scrub_git_env
+    unset PFB_REF
+    unset PFB_GIT_REMOTE
+    WORK="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/localsmokeref.XXXXXX")"
+    CALLS_DIR="${WORK}/calls"
+    mkdir -p "$CALLS_DIR"
+
+    FAKE_SELECT_BOX="${WORK}/fake-select-box.sh"
+    cat > "$FAKE_SELECT_BOX" <<'FAKEEOF'
+#!/bin/sh
+_call_file="$(mktemp "${CALLS_DIR}/call.XXXXXX")"
+printf '%s\n' "$*" > "$_call_file"
+exit 0
+FAKEEOF
+    chmod +x "$FAKE_SELECT_BOX"
+
+    # Stub git ls-remote: records argv, exits 0 iff WORK/ls-remote-ok exists.
+    # Default is miss (exit 2) so a forgotten marker cannot leak a lease.
+    FAKE_LS_REMOTE="${WORK}/fake-ls-remote.sh"
+    cat > "$FAKE_LS_REMOTE" <<'FAKEEOF'
+#!/bin/sh
+printf '%s\n' "$*" >> "${WORK}/ls-remote.args"
+if [ -f "${WORK}/ls-remote-ok" ]; then
+    exit 0
+fi
+exit 2
+FAKEEOF
+    chmod +x "$FAKE_LS_REMOTE"
+
+    TMPDIR="$WORK"
+    PFB_SELECT_BOX="$FAKE_SELECT_BOX"
+    PFB_BOXES="dummy@dummy"
+    PFB_LS_REMOTE="$FAKE_LS_REMOTE"
+    unset PFB_REF_PREFLIGHT
+    export PFB_SELECT_BOX PFB_BOXES WORK CALLS_DIR TMPDIR PFB_LS_REMOTE
+  }
+
+  teardown() {
+    rm -rf "$WORK"
+  }
+
+  BeforeEach 'setup'
+  AfterEach  'teardown'
+
+  call_count() { find "$CALLS_DIR" -type f 2>/dev/null | wc -l | tr -d ' '; }
+
+  run_and_diag() {
+    _out="$(sh "$SCRIPT" "$@" 2>&1)"
+    _rc=$?
+    printf 'exit=%s\n' "$_rc"
+    printf 'calls=%s\n' "$(call_count)"
+    if [ -f "${WORK}/ls-remote.args" ]; then
+      printf 'LS_REMOTE_CALLED=1\n'
+    else
+      printf 'LS_REMOTE_CALLED=0\n'
+    fi
+    printf '%s\n' "$_out"
+    cat "$CALLS_DIR"/* 2>/dev/null
+    cat "${WORK}/ls-remote.args" 2>/dev/null
+    return 0
+  }
+
+  Describe 'abbreviated SHA not in this clone'
+    It 'exits 2 and never leases a box'
+      When call run_and_diag --ref e1e1e1e1e1e1e1e1
+      The line 1 of output should equal 'exit=2'
+      The line 2 of output should equal 'calls=0'
+      The output should include 'abbreviated SHA'
+      The output should include '40-character'
+    End
+  End
+
+  Describe 'abbreviated SHA that resolves locally'
+    run_short_head() {
+      _full="$(git -C "${PFB_ROOT}" rev-parse HEAD)"
+      _short="$(printf '%.7s' "$_full")"
+      run_and_diag --ref "$_short"
+      _boot="$(cat "$CALLS_DIR"/* 2>/dev/null)"
+      case "$_boot" in
+        *"git fetch --quiet 'origin' '${_full}'"*) printf 'EXPANDED=1\n' ;;
+        *) printf 'EXPANDED=0\n' ;;
+      esac
+    }
+    It 'expands to the full 40-character SHA in the bootstrap fetch before leasing'
+      When call run_short_head
+      The line 1 of output should equal 'exit=0'
+      The line 2 of output should equal 'calls=1'
+      The output should include 'EXPANDED=1'
+    End
+  End
+
+  Describe 'branch missing from the box remote'
+    It 'exits 2, names the ref, and never leases a box'
+      When call run_and_diag --ref issue/not-on-remote
+      The line 1 of output should equal 'exit=2'
+      The line 2 of output should equal 'calls=0'
+      The output should include 'issue/not-on-remote'
+      The output should include 'not leasing'
+    End
+
+    It 'does not lease N boxes when --shards is set'
+      When call run_and_diag --ref issue/not-on-remote --shards 2
+      The line 1 of output should equal 'exit=2'
+      The line 2 of output should equal 'calls=0'
+    End
+  End
+
+  Describe 'branch present on the box remote'
+    present_branch() {
+      true > "${WORK}/ls-remote-ok"
+      run_and_diag --ref dummy
+    }
+    It 'leases once after a successful ls-remote'
+      When call present_branch
+      The line 1 of output should equal 'exit=0'
+      The line 2 of output should equal 'calls=1'
+      The output should include 'LS_REMOTE_CALLED=1'
+      The output should include "git fetch --quiet 'origin' 'dummy'"
+    End
+  End
 End

--- a/tests/shell/local_smoke_spec.sh
+++ b/tests/shell/local_smoke_spec.sh
@@ -370,8 +370,8 @@ FAKEEOF
     PFB_SELECT_BOX="$FAKE_SELECT_BOX"
     PFB_BOXES="dummy@dummy"
     PFB_LS_REMOTE="$FAKE_LS_REMOTE"
-    unset PFB_REF_PREFLIGHT
-    export PFB_SELECT_BOX PFB_BOXES WORK CALLS_DIR TMPDIR PFB_LS_REMOTE
+    PFB_REF_PREFLIGHT=1
+    export PFB_SELECT_BOX PFB_BOXES WORK CALLS_DIR TMPDIR PFB_LS_REMOTE PFB_REF_PREFLIGHT
   }
 
   teardown() {
@@ -411,7 +411,7 @@ FAKEEOF
 
   Describe 'abbreviated SHA that resolves locally'
     run_short_head() {
-      _full="$(git -C "${PFB_ROOT}" rev-parse HEAD)"
+      _full="$(git_fixture -C "${PFB_ROOT}" rev-parse HEAD)"
       _short="$(printf '%.7s' "$_full")"
       run_and_diag --ref "$_short"
       _boot="$(cat "$CALLS_DIR"/* 2>/dev/null)"


### PR DESCRIPTION
## Summary

`scripts/local-smoke.sh` leased a box, then `git fetch` of the requested ref ran **on the box**. A missing branch or an abbreviated SHA is not a valid fetch refspec, so the wrapper exited **128 in about two seconds** with zero tests run. `pfb-test` reported that as `FAIL smoke (rc=128, 2s)` — the same shape as a product failure.

Executed: `/srv/Smoke/results/20260827T220824Z-smoke`, `REF=issue/2635-download-a-non-gzip-blacklist` (checkout branch, not on the box remote), `fatal: couldn't find remote ref`, lease released, ~2s.

Before `select-box.sh`:

- Abbreviated hex (4–39 chars) is expanded with local `git rev-parse --verify`, or exit 2 naming the 40-character constraint.
- Branch/tag: `git ls-remote --exit-code` against the same remote the bootstrap will fetch. Miss → exit 2, no lease, message names the ref and the remote.
- Full 40-character SHA is passed through (loose objects are not advertised to `ls-remote`).
- Hermetic specs that inject `PFB_SELECT_BOX` and leave `PFB_REF_PREFLIGHT` unset skip ls-remote so `--ref dummy` rows keep working. Production sets neither, so the check stays on.

Closes #2780.

## Verification

| Frozen RED test | git hash-object | RED run tail |
| --- | --- | --- |
| `tests/shell/local_smoke_spec.sh` | `ff091145949c2b3c8459a27bdce29ca526bd9e42` | `5 failed / 21 passed; missing branch and unresolved short SHA leased a box` |

GREEN: `shellspec --shell dash tests/shell/local_smoke_spec.sh` 26 passed; sibling channel and pkgversion specs 4+4 passed; `git-env-scrub-guard.sh` clean.

Head `d5e0c8f4` (LAN mirror `issue/2780-local-smoke-missing-ref`). Follow-up on `cd907a6d` (Claude APPROVE of that SHA): dummy-ref skip for sibling specs, `git_fixture` for the HEAD rev-parse.

No live-VM run: the defect is the orchestrator preflight, hermetic against a fake `select-box.sh`.

🤖 Generated by Grok and posted on behalf of @BBcan177.