### PR TITLE
test: pin pkg diag redaction claim and pkg -vv capture

### DIFF
--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -5318,7 +5318,9 @@ def redact_pkg_urls(text: str) -> str:
     """Strip userinfo and token-shaped query values from pkg dump text.
 
     ``pkg -vv`` and ``/usr/local/etc/pkg/repos/*`` can embed credentials.
-    Capture-time redaction (issue #2754) so the diag tarball never holds them.
+    Capture-time redaction (issue #2754) is a partial mitigation: userinfo
+    and the named query keywords are stripped. Residual risk includes
+    path-segment tokens, compound names, headers, and ``;``-separated params.
     ABI / ALTABI / ``uname -mr`` have no URLs and are unchanged.
     """
     out = _PKG_USERINFO_RE.sub(r"\1REDACTED@", text)

--- a/tests/test_smoke_diag_pkg_abi.py
+++ b/tests/test_smoke_diag_pkg_abi.py
@@ -32,7 +32,7 @@ def test_collect_host_diagnostics_captures_pkg_vv_and_repo_confs() -> None:
     Then pkg -vv and /usr/local/etc/pkg/repos are in the bundle.
     """
     src = inspect.getsource(helpers.collect_host_diagnostics)
-    assert "pkg -vv" in src
+    assert 'pkg -vv > "$D/pkg/pkg_vv.txt"' in src
     assert "/usr/local/etc/pkg/repos" in src
 
 

--- a/tests/test_smoke_diag_pkg_abi.py
+++ b/tests/test_smoke_diag_pkg_abi.py
@@ -95,6 +95,18 @@ def test_redact_pkg_urls_leaves_clean_urls_intact() -> None:
     assert helpers.redact_pkg_urls(raw) == raw
 
 
+def test_redact_pkg_urls_docstring_names_partial_mitigation() -> None:
+    """Given redact_pkg_urls
+    When its docstring is read
+    Then it names a partial mitigation and residual path-segment risk,
+    not that the tarball never holds credentials.
+    """
+    src = inspect.getsource(helpers.redact_pkg_urls)
+    assert "never holds" not in src
+    assert "partial mitigation" in src
+    assert "path-segment" in src
+
+
 def test_collect_host_diagnostics_redacts_pkg_urls_at_capture() -> None:
     """Given the guest snapshot script
     When it captures pkg -vv and repo confs


### PR DESCRIPTION
## Summary

Follow-up on #2779 review findings F2 and F3. Off `origin/devel` after that PR merged (`cf9fca30`). Two commits; F2 is green alone.

- **F2** (`333b6909`): `redact_pkg_urls` docstring claimed the diag tarball never holds credentials. Soften to a **partial mitigation**. Residual risk (path-segment tokens, compound names, headers, `;`-separated params) is named. Pattern unchanged.
- **F3** (`4d89ad42`): `assert "pkg -vv" in src` stayed green when only the comment remained. Pin `'pkg -vv > "$D/pkg/pkg_vv.txt"'`.

Refs #2754. Does not close it (already closed).

## Verification

F2 frozen RED test file `tests/test_smoke_diag_pkg_abi.py` `git hash-object` `d478ff1de6a54b9e1e3cfc79d6422f7b69151912` — failed on `"never holds"` in the old docstring; same bytes GREEN after the docstring change. `uv run pytest tests/test_smoke_diag_pkg_abi.py` — 10 passed at `333b6909`.

F3: deleted `'pkg -vv > "$D/pkg/pkg_vv.txt" 2>&1; '` while keeping the `# ... pkg -vv ...` comment → RED on the new assert. Restored command, same test file `5a0e50740c67c7f0c71c69d6b52a67612d5e7cf7` → 10 passed.

`scripts/check_coverage_pairing.py` OK at both SHAs.

## Review

claude-dev: head `4d89ad42`. F2 intermediate `333b6909`. LAN push from pfb-dev to `git://10.20.41.1` may fail (prior timeout); GitHub has the branch.

🤖 Generated by Grok and posted on behalf of @BBcan177.