### PR TITLE
agent: install Graphify by floor, not exact pin

### DIFF
--- a/.agents/context/repository-intelligence.md
+++ b/.agents/context/repository-intelligence.md
@@ -19,7 +19,9 @@ Load when: every agent session, from `AGENTS.md`.
   then runs `graphify update <root>` when the root graph already exists. When the
   root graph is absent the initializer prints a notice and builds nothing: the
   first build's scope is a judgement call, so create it with a `/graphify` run in
-  an AI assistant. Install Graphify with `uv tool install graphifyy==0.9.50`.
+  an AI assistant. Install or refresh Graphify in one command with
+  `uv tool install --upgrade 'graphifyy>=0.9.51'` — a floor, never an exact pin, so a
+  fresh host and an outdated one both land on the current release.
 - Every worktree owns its ignored and untracked `graphify-out/` graph. Refresh it
   directly with `graphify update <root>`; there is no shared repository graph.
 - For indexed code discovery, understanding, cross-file architecture, call paths,

--- a/scripts/agent/ensure-graphify-merge-driver.sh
+++ b/scripts/agent/ensure-graphify-merge-driver.sh
@@ -24,7 +24,7 @@ main() {
 		exit 2
 	}
 
-	uv tool install graphifyy==0.9.50 || {
+	uv tool install --upgrade 'graphifyy>=0.9.51' || {
 		echo "ensure-graphify-merge-driver.sh: Graphify installation failed" >&2
 		exit 1
 	}

--- a/tests/shell/agent_graphify_merge_driver_spec.sh
+++ b/tests/shell/agent_graphify_merge_driver_spec.sh
@@ -40,10 +40,10 @@ GRAPHIFY
   BeforeEach 'setup'
   AfterEach 'cleanup'
 
-  It 'installs the exact Graphify pin and configures the requested Git root'
+  It 'installs at least the required Graphify, upgrading to the latest, and configures the requested Git root'
     When run sh "$script_abs" "$repo"
     The status should equal 0
-    The contents of file "$uv_log" should equal 'tool install graphifyy==0.9.50'
+    The contents of file "$uv_log" should equal 'tool install --upgrade graphifyy>=0.9.51'
     The contents of file "$graphify_log" should equal "$(printf '%s\thook install' "$repo")"
     The value "$(git_fixture -C "$repo" config --get merge.graphify.driver)" should include 'graphify merge-driver %O %A %B'
   End


### PR DESCRIPTION
Install Graphify by floor instead of exact pin (issue #2784).

**Problem.** `scripts/agent/ensure-graphify-merge-driver.sh` pinned `graphifyy==0.9.50` exactly. Every Graphify release therefore needed a repository commit before any host could take it, and a host already carrying a newer build was downgraded on every worktree initialization.

**Change.** One command that covers both cases:

```sh
uv tool install --upgrade 'graphifyy>=0.9.51'
```

It installs on a fresh host, moves an outdated host to the current release, and still refuses anything below the floor. The documented install command in `.agents/context/repository-intelligence.md` matches and says explicitly that this is a floor, never an exact pin.

**Why 0.9.51 is the floor.** It carries the graph-integrity fixes this repository depends on: the incomplete-build shrink guard stays armed when a chunk comes back hollow, unparseable, or omitting files (a lossy run can no longer overwrite a good graph with a smaller one); Leiden clustering canonicalizes undirected edge endpoints, so community assignments stop drifting between builds and machines; `graphify extract --force --code-only` fully rescans code instead of keeping stale import/alias resolution; and the cache's atexit stat-index flush no longer recreates a `graphify-out/` tree deleted during the run. Release notes: https://github.com/Graphify-Labs/graphify/releases/tag/v0.9.51

**Other agent tools.** Audited in the same pass — no pin remains anywhere in the agent bootstrap. `scripts/agent/setup-agent-tools.sh` already installs serena-agent, graphifyy, ast-grep-cli and semgrep with `uv tool install --upgrade`, and CodeGraph through `codegraph install -l global -y -t auto` / `codegraph upgrade`.

**RED/GREEN.** The spec pinning the exact install argv was retargeted first and run against the unchanged installer:

```
expected: "tool install --upgrade graphifyy>=0.9.51"
     got: "tool install graphifyy==0.9.51"
3 examples, 1 failure
```

After the installer moved, the same spec bytes pass (`3 examples, 0 failures`), and `scripts/agent/run-gates.sh --diff origin/devel` → `GATES: PASS` (coverage pairing, `sh -n`, shellcheck, full shellspec suite, markdownlint). The argv was also executed for real on this host: `uv tool install --upgrade 'graphifyy>=0.9.51'` installs, upgrades from 0.9.50, and is idempotent on re-run (`graphify 0.9.51`).

| Frozen RED test | git hash-object | RED run tail |
| --- | --- | --- |
| `tests/shell/agent_graphify_merge_driver_spec.sh` | `2cf658bd0a04dbfdcc035a64eb1291911db0ce64` | `shellspec tests/shell/agent_graphify_merge_driver_spec.sh against the unchanged installer: expected "tool install --upgrade graphifyy>=0.9.51", got "tool install graphifyy==0.9.51" (line 46); 3 examples, 1 failure. Same spec bytes after the installer moved: 3 examples, 0 failures.` |

Fixes #2784
