### PR TITLE
ci: gate the kernel-lock job timeout budget

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -308,8 +308,8 @@ jobs:
     needs: [publish-image, build-pkg]
     runs-on: ubuntu-latest
     # issue #2614: this job runs tests/smoke/roundtrip.sh, which drives the production
-    # `pfblockerng.php update` entry point on the live image and so reaches src/'s
-    # flock(2) acquires; they carry no timeout, so this pre-existing budget is the bound.
+    # `pfblockerng.php update` entry point on the live image, so it reaches src/'s
+    # unbounded file_put_contents(..., LOCK_EX) acquires. This budget is the only bound.
     timeout-minutes: 60
     steps:
       - name: Checkout

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -307,6 +307,9 @@ jobs:
     name: Round-trip the freshly published image
     needs: [publish-image, build-pkg]
     runs-on: ubuntu-latest
+    # issue #2614: this job runs tests/smoke/roundtrip.sh, which drives the production
+    # `pfblockerng.php update` entry point on the live image and so reaches src/'s
+    # flock(2) acquires; they carry no timeout, so this pre-existing budget is the bound.
     timeout-minutes: 60
     steps:
       - name: Checkout

--- a/.github/workflows/image-refresh.yml
+++ b/.github/workflows/image-refresh.yml
@@ -213,6 +213,9 @@ jobs:
     needs: plan
     if: ${{ needs.plan.outputs.count != '0' }}
     runs-on: ubuntu-latest
+    # issue #2614: this job SSH-runs the production `pfblockerng.php update` entry point
+    # on the image it is upgrading, so it reaches src/'s flock(2) acquires; they carry no
+    # timeout, so this pre-existing budget is the bound on a stuck lock.
     timeout-minutes: 120
     permissions:
       contents: write        # push tracker/* activation-PR branches (NEVER ci-metadata itself)

--- a/.github/workflows/image-refresh.yml
+++ b/.github/workflows/image-refresh.yml
@@ -214,8 +214,8 @@ jobs:
     if: ${{ needs.plan.outputs.count != '0' }}
     runs-on: ubuntu-latest
     # issue #2614: this job SSH-runs the production `pfblockerng.php update` entry point
-    # on the image it is upgrading, so it reaches src/'s flock(2) acquires; they carry no
-    # timeout, so this pre-existing budget is the bound on a stuck lock.
+    # on the image it is upgrading, so it reaches src/'s unbounded
+    # file_put_contents(..., LOCK_EX) acquires. This budget is the only bound.
     timeout-minutes: 120
     permissions:
       contents: write        # push tracker/* activation-PR branches (NEVER ci-metadata itself)

--- a/.github/workflows/smoke-single.yml
+++ b/.github/workflows/smoke-single.yml
@@ -357,6 +357,9 @@ jobs:
     # other caller (PR gate, nightly, bare dispatch) keeps the hard veto.
     continue-on-error: ${{ inputs.nonblocking }}
     runs-on: ubuntu-latest
+    # issue #2614: the smoke suite stands a real on-box flock holder up against the
+    # feed-pass lock, and a flock(2) acquire has no timeout of its own, so this budget
+    # is the only bound on a stuck lock. Observed 17.8 min worst leg (n=7 per leg).
     timeout-minutes: 45
     steps:
       - name: Checkout

--- a/.github/workflows/smoke-single.yml
+++ b/.github/workflows/smoke-single.yml
@@ -359,7 +359,7 @@ jobs:
     runs-on: ubuntu-latest
     # issue #2614: the smoke suite stands a real on-box flock holder up against the
     # feed-pass lock, and a flock(2) acquire has no timeout of its own, so this budget
-    # is the only bound on a stuck lock. Observed 17.8 min worst leg (n=7 per leg).
+    # is the only bound on a stuck lock. Observed worst sampled leg 17.8 min.
     timeout-minutes: 45
     steps:
       - name: Checkout

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -98,9 +98,9 @@ jobs:
     name: pytest / Python ${{ matrix.python-version }}
     needs: read-matrix
     runs-on: ubuntu-latest
-    # issue #2614: kernel-lock reachable (tests/ carries flock(2) acquires), and a
-    # flock(2) acquire has no timeout of its own -- without this budget a stuck lock
-    # burns GitHub's 360-minute default. Observed 3.5 min median (n=14).
+    # issue #2614: kernel-lock reachable, and a flock(2) acquire has no timeout of its
+    # own -- without this budget a stuck lock burns GitHub's 360-minute default rather
+    # than failing here. Observed 3.5 min median (n=14).
     timeout-minutes: 20
 
     strategy:
@@ -762,9 +762,9 @@ jobs:
     name: PHPUnit unit tests / PHP ${{ matrix.php-version }}
     needs: read-matrix
     runs-on: ubuntu-latest
-    # issue #2614: this job runs the PHPUnit suite, which loads the real .inc and
-    # holds 66 blocking flock(LOCK_EX) fixtures; a flock(2) acquire has no timeout of
-    # its own, so this budget is the only bound. Observed 2.2 min median (n=14).
+    # issue #2614: PHPUnit loads the real .inc and its fixtures fork workers that
+    # contend for the same lock, and a flock(2) acquire has no timeout of its own, so
+    # this budget is the only bound. Observed 2.2 min median (n=14).
     timeout-minutes: 15
 
     strategy:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -98,6 +98,9 @@ jobs:
     name: pytest / Python ${{ matrix.python-version }}
     needs: read-matrix
     runs-on: ubuntu-latest
+    # issue #2614: kernel-lock reachable (tests/ carries flock(2) acquires), and a
+    # flock(2) acquire has no timeout of its own -- without this budget a stuck lock
+    # burns GitHub's 360-minute default. Observed 3.5 min median (n=14).
     timeout-minutes: 20
 
     strategy:
@@ -759,6 +762,9 @@ jobs:
     name: PHPUnit unit tests / PHP ${{ matrix.php-version }}
     needs: read-matrix
     runs-on: ubuntu-latest
+    # issue #2614: this job runs the PHPUnit suite, which loads the real .inc and
+    # holds 66 blocking flock(LOCK_EX) fixtures; a flock(2) acquire has no timeout of
+    # its own, so this budget is the only bound. Observed 2.2 min median (n=14).
     timeout-minutes: 15
 
     strategy:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -100,7 +100,7 @@ jobs:
     runs-on: ubuntu-latest
     # issue #2614: kernel-lock reachable, and a flock(2) acquire has no timeout of its
     # own -- without this budget a stuck lock burns GitHub's 360-minute default rather
-    # than failing here. Observed 3.5 min median (n=14).
+    # than failing here. Observed median 3.5 min, worst 4.1.
     timeout-minutes: 20
 
     strategy:
@@ -764,7 +764,7 @@ jobs:
     runs-on: ubuntu-latest
     # issue #2614: PHPUnit loads the real .inc and its fixtures fork workers that
     # contend for the same lock, and a flock(2) acquire has no timeout of its own, so
-    # this budget is the only bound. Observed 2.2 min median (n=14).
+    # this budget is the only bound. Observed median 2.2 min, worst 2.6.
     timeout-minutes: 15
 
     strategy:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -100,7 +100,7 @@ jobs:
     runs-on: ubuntu-latest
     # issue #2614: kernel-lock reachable, and a flock(2) acquire has no timeout of its
     # own -- without this budget a stuck lock burns GitHub's 360-minute default rather
-    # than failing here. Observed median 3.5 min, worst 4.1.
+    # than failing here. Observed median 3.5 min, worst 3.9.
     timeout-minutes: 20
 
     strategy:

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -365,7 +365,7 @@ jobs:
     runs-on: ubuntu-latest
     # issue #2614: the UI tiers drive the live appliance through the same tests/smoke
     # harness, so they reach the on-box flock(2) locks, which carry no timeout of their
-    # own; this budget is the only bound. Observed 23.5 min worst tier (n=7 per leg).
+    # own; this budget is the only bound. Observed worst sampled tier 23.5 min.
     timeout-minutes: 45
     strategy:
       # One leg's failure must NOT cancel the others — each (tier x version) is

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -363,6 +363,9 @@ jobs:
     # veto, unchanged. The predicate itself lives in scripts/resolve-legs.sh.
     continue-on-error: ${{ matrix.release_blocking == 'false' }}
     runs-on: ubuntu-latest
+    # issue #2614: the UI tiers drive the live appliance through the same tests/smoke
+    # harness, so they reach the on-box flock(2) locks, which carry no timeout of their
+    # own; this budget is the only bound. Observed 23.5 min worst tier (n=7 per leg).
     timeout-minutes: 45
     strategy:
       # One leg's failure must NOT cancel the others — each (tier x version) is

--- a/tests/test_issue2614_lock_job_budgets.py
+++ b/tests/test_issue2614_lock_job_budgets.py
@@ -188,6 +188,18 @@ def _is_prefix(word: str) -> bool:
     return word in _PREFIX_WORDS or any(shape.match(word) for shape in _PREFIX_SHAPES)
 
 
+def _command_word(raw: str) -> str:
+    """``raw`` reduced to the command word it carries.
+
+    Strips grouping punctuation and a command-substitution opener, so
+    `"$(command -v shellspec)" --shell dash` reaches `command` (a prefix) and then
+    `shellspec`. A runner buried in a NESTED shell string with its own quoting
+    (`sh -c 'a && b'`) is only seen when the inner command leads; deeper nesting is
+    deliberately out of scope, and stated here rather than left implicit.
+    """
+    return raw.strip(_STRIP_CHARS).removeprefix("$(").strip(_STRIP_CHARS)
+
+
 def _runner_for(word: str) -> str | None:
     """The runner ``word`` invokes, tolerating `./` and any leading path."""
     candidate = word.removeprefix("./")
@@ -210,7 +222,7 @@ def runners_in_run_body(body: str) -> set[str]:
     for line in live:
         found |= {entry for entry in PRODUCTION_ENTRY_POINTS if entry in line}
     for segment in _SEGMENT.split("\n".join(live)):
-        words = [stripped for word in segment.split() if (stripped := word.strip(_STRIP_CHARS))]
+        words = [stripped for word in segment.split() if (stripped := _command_word(word))]
         while words and _is_prefix(words[0]):
             words = words[1:]
         if words and (runner := _runner_for(words[0])) is not None:
@@ -436,6 +448,12 @@ def test_a_budget_that_is_not_the_job_s_own_does_not_satisfy_the_gate(label: str
         ("command pytest", {"pytest"}),
         ("tests/smoke/roundtrip.sh smoke_key a b", {"tests/smoke/roundtrip.sh"}),
         ("run_ssh '/usr/local/bin/php /usr/local/www/pfblockerng/pfblockerng.php update'", {"pfblockerng.php"}),
+        ('"$(command -v shellspec)" --shell dash', {"shellspec"}),
+        ("poetry run pytest", {"pytest"}),
+        ('"$HOME/shellspec/shellspec" --shell dash', {"shellspec"}),
+        ("if command -v pytest; then pytest; fi", {"pytest"}),
+        ("for v in a b; do shellspec; done", {"shellspec"}),
+        ("bash -c 'shellspec'", {"shellspec"}),
         ('        echo "shellspec shell tests failed or were cancelled."', set()),
         ("        # sh scripts/run-smoke.sh shells out to the synced interpreter", set()),
         ("        # pfblockerng.php update is the production reload entry point", set()),
@@ -464,6 +482,10 @@ _ACQUIRE_CASES: tuple[tuple[bool, str], ...] = (
     (True, "\t\t( exec 9>lockfile; flock 9; sleep 30 ) &"),
     (True, "sh -c 'exec 9>L; flock $fd'"),
     (True, "timeout 5 sh -c 'exec 9>L; flock -w 0 9'"),
+    # SplFileObject::flock has no `$` argument at all; the wrapped-argument pattern is
+    # what catches it. `exec {fd}>` names the descriptor in a brace, not a digit.
+    (True, "\t\t$file->flock(LOCK_EX);"),
+    (True, "exec {fd}>file; flock $fd"),
     (False, "\t@flock($lock, LOCK_UN);"),
     (False, "\t// A waiter can be descheduled between its deadline check and flock()."),
     (False, "\t// LOCK_EX, and the deadline, are documented above."),

--- a/tests/test_issue2614_lock_job_budgets.py
+++ b/tests/test_issue2614_lock_job_budgets.py
@@ -118,7 +118,10 @@ _PREFIX_WORDS = frozenset(
 _PREFIX_SHAPES = (
     re.compile(r"^python[0-9.]*$"),  # python, python3, python3.11
     re.compile(r"^-"),  # a flag of an already-stripped prefix
-    re.compile(r"^[0-9]+$"),  # `timeout 600`, `nice 10`
+    # A wrapper's duration/count operand: `timeout 600`, `timeout 10m`, `timeout 1.5h`,
+    # `nice 10`. GNU timeout's s/m/h/d suffixes are ordinary workflow syntax, so a
+    # digits-only shape would leave the runner behind `timeout 10m` unreached.
+    re.compile(r"^[0-9]+(?:\.[0-9]+)?[smhd]?$"),
     re.compile(r"^[A-Za-z_][A-Za-z0-9_]*="),  # VAR=value prefix assignment
 )
 _SEGMENT = re.compile(r"(?:\|\||&&|[|;&\n])")  # a logical command boundary
@@ -512,6 +515,10 @@ def test_a_budget_that_is_not_the_job_s_own_does_not_satisfy_the_gate(label: str
         ("uv run --group dev pytest", {"pytest"}),
         ("env -u PYTHONPATH pytest", {"pytest"}),
         ("uv run --python 3.11 pytest -q", {"pytest"}),
+        ("timeout 10m vendor/bin/phpunit", {"vendor/bin/phpunit"}),
+        ("timeout 600s sh scripts/run-smoke.sh", {"scripts/run-smoke.sh"}),
+        ("timeout 1.5h shellspec", {"shellspec"}),
+        ("nice -n +5 shellspec", {"shellspec"}),
         ('        echo "shellspec shell tests failed or were cancelled."', set()),
         ("        # sh scripts/run-smoke.sh shells out to the synced interpreter", set()),
         ("        # pfblockerng.php update is the production reload entry point", set()),

--- a/tests/test_issue2614_lock_job_budgets.py
+++ b/tests/test_issue2614_lock_job_budgets.py
@@ -1,0 +1,385 @@
+"""Issue #2614: a CI job that can block on a kernel lock carries a wall-clock budget.
+
+A `flock(2)`-family acquire has no timeout of its own, so a regression that leaves the
+lock held makes the waiter block rather than fail. Probed for the issue (macOS, `lockf`):
+a second acquirer of a held lock never returns -- `timeout 5 sh -c 'exec 9>L; lockf -k 9'`
+exits 124 -- while the same acquire against a free lock exits 0 at once. Nothing inside
+the suites bounds that wait, so the only bound left is the job's own `timeout-minutes`;
+without one GitHub applies its 360-minute default and a deadlock reports as a platform
+timeout hours later instead of as the assertion that names the cause.
+
+What this file gates is therefore the *relationship*, not the one job the issue named:
+every workflow job that runs a suite whose sources hold a kernel-lock acquire carries a
+job-level `timeout-minutes` that is a real bound. Which suites those are is read from
+source by `kernel_lock_acquires` and pinned by
+`test_which_suite_roots_hold_kernel_lock_acquires`, so a suite that starts or stops
+locking is a visible diff rather than a silent change in what this gate demands.
+
+Why it was needed. On `origin/devel` at the time of writing, all four lock-reachable jobs
+carried a budget, but `smoke-single.yml`'s `smoke` job (45) was defended by no test at
+all: deleting that line left the whole suite green (5614 passed, 2 skipped) and
+`actionlint` 1.7.12 silent. `test.yml`'s `test` and `php-unit` are pinned by
+`test_issue2673_xdist_ci.py` and `ui-tests.yml`'s `ui` by
+`test_smoke_ui_config_digest.py`, but nothing tied any of them to lock reachability, so a
+new lock-reachable job would have landed unbudgeted with the suite green.
+
+Jobs that call a reusable workflow are excluded: GitHub allows only
+name/uses/with/secrets/needs/if/permissions/strategy there -- smoke.yml states that same
+allow-list in its own comment -- so such a job cannot carry a budget, and the bound that
+applies is the called job's, which this gate reads at its definition site.
+
+Slices into the non-YAML config files go through `tests/_workflow_steps.py`, so a
+reworded anchor raises instead of silently widening (issue #2669). Workflow structure is
+read with `yaml`, whose missing key is `None` and cannot widen at all.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import tomllib
+from pathlib import Path
+
+import pytest
+import yaml
+
+from tests._workflow_steps import extract_after, extract_between, extract_job
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOWS = ROOT / ".github" / "workflows"
+
+# GitHub's default when a job declares no budget. A value at or above it is the platform
+# default wearing a number, which is the condition this issue exists to remove.
+GITHUB_DEFAULT_TIMEOUT_MINUTES = 360
+
+# Runner token (at command position in a `run:` body) -> the suite root it executes.
+# Every root is re-derived from the configuration the runner itself reads by
+# `test_suite_roots_match_the_configuration_that_declares_them`, so the table cannot
+# drift away from what the runners actually load.
+SUITE_ROOTS: dict[str, str] = {
+    "vendor/bin/phpunit": "tests/php",
+    "pytest": "tests",
+    "shellspec": "tests/shell",
+    "scripts/run-smoke.sh": "tests/smoke",
+}
+
+# Command prefixes that carry a runner without being one: `uv run pytest`,
+# `sh scripts/run-smoke.sh`, `DASH=dash shellspec`. Stripped left to right until the
+# leading word is the command itself.
+_PREFIX_WORDS = frozenset({"sh", "bash", "sudo", "env", "time", "exec", "uv", "run", "xargs", "python3", "-m"})
+_ASSIGNMENT = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
+# A logical command boundary inside a `run:` body.
+_SEGMENT = re.compile(r"(?:\|\||&&|[|;&\n])")
+
+# Kernel-lock acquires, by shape. `LOCK_UN` is a release and never matches. `flock()`
+# requires a `$`-prefixed first argument so a prose mention ("...and flock().") is
+# skipped -- the same discrimination `tests/test_bounded_flock.py` makes for the same
+# reason. `file_put_contents(..., LOCK_EX)` is included because it takes a BLOCKING
+# `flock(2)` exclusive lock, which the #1780 scanner (call-syntax only) does not see.
+_ACQUIRE_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"flock\s*\(\s*\$[^()]*LOCK_(?:EX|SH)"),
+    re.compile(r"file_put_contents\s*\(.*LOCK_EX"),
+    re.compile(r"fcntl\.(?:flock|lockf)\s*\("),
+    re.compile(r"(?:^|[|;&(]\s*|\b(?:sh|bash|env|sudo|exec|timeout(?:\s+\S+)?)\s+)(?:lockf|flock)\s+-"),
+)
+
+
+def _tracked(root: str) -> list[Path]:
+    """Tracked files under ``root``. `git ls-files`, not `rglob`: untracked scratch a
+    developer left in the tree must not move this gate's verdict."""
+    listing = subprocess.run(
+        ["git", "ls-files", "-z", "--", root],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+    return [ROOT / name for name in listing.split("\0") if name]
+
+
+def kernel_lock_acquires(root: str) -> list[str]:
+    """``path:line`` for every kernel-lock acquire under ``root``.
+
+    Reachability is a *may*, deliberately: a suite whose sources name an acquire counts
+    as able to reach one, because the discrimination that would narrow it -- does this
+    embedded snippet get executed or only written? -- is not something a regex can make.
+    `tests/` scores hits it can only write (`test_bounded_flock.py`'s own PHP fixtures)
+    alongside hits it really runs (`tests/smoke`'s appliance snippets). Over-inclusion
+    costs a job a budget it already has; under-inclusion costs a six-hour hang.
+    """
+    found: list[str] = []
+    for path in _tracked(root):
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (UnicodeDecodeError, OSError):
+            continue  # binary fixture or broken symlink: carries no acquire either way
+        for lineno, line in enumerate(text.splitlines(), start=1):
+            if any(pattern.search(line) for pattern in _ACQUIRE_PATTERNS):
+                found.append(f"{path.relative_to(ROOT)}:{lineno}")
+    return found
+
+
+def lock_bearing_roots() -> set[str]:
+    return {root for root in set(SUITE_ROOTS.values()) if kernel_lock_acquires(root)}
+
+
+def _strip_comment(line: str) -> str:
+    stripped = line.strip()
+    return "" if stripped.startswith("#") else stripped
+
+
+def runners_in_run_body(body: str) -> set[str]:
+    """Runner tokens ``body`` invokes *as commands*.
+
+    A mention is not an invocation: `echo "shellspec shell tests failed"` and
+    `--suite pytest` name a runner in argument position, and a `#` line only documents
+    one. Keeping both out is what keeps this gate off jobs that merely talk about a suite
+    -- test.yml's `all-tests-passed` AND gate is exactly that shape.
+    """
+    found: set[str] = set()
+    for segment in _SEGMENT.split("\n".join(_strip_comment(line) for line in body.splitlines())):
+        words = segment.strip().split()
+        while words and (words[0] in _PREFIX_WORDS or _ASSIGNMENT.match(words[0])):
+            words = words[1:]
+        if words and words[0] in SUITE_ROOTS:
+            found.add(words[0])
+    return found
+
+
+def _composite_run_bodies(uses: str) -> list[str]:
+    """`run:` bodies of a local composite action, so a suite invoked one level down is
+    still attributed to the job that reaches it."""
+    action = ROOT / uses.lstrip("./")
+    for candidate in (action / "action.yml", action / "action.yaml", action):
+        if candidate.is_file():
+            document = yaml.safe_load(candidate.read_text(encoding="utf-8")) or {}
+            steps = (document.get("runs") or {}).get("steps") or []
+            return [step["run"] for step in steps if isinstance(step, dict) and step.get("run")]
+    return []
+
+
+def suite_running_jobs() -> dict[tuple[str, str], set[str]]:
+    """``(workflow file name, job id) -> runner tokens the job executes``.
+
+    Jobs that call a reusable workflow are skipped -- they cannot carry a budget, and the
+    called job's own budget is the bound that applies.
+    """
+    reached: dict[tuple[str, str], set[str]] = {}
+    for path in sorted(WORKFLOWS.glob("*.y*ml")):
+        document = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+        for job_id, job in (document.get("jobs") or {}).items():
+            if not isinstance(job, dict) or job.get("uses"):
+                continue
+            runners: set[str] = set()
+            for step in job.get("steps") or []:
+                if not isinstance(step, dict):
+                    continue
+                if step.get("run"):
+                    runners |= runners_in_run_body(step["run"])
+                uses = step.get("uses")
+                if isinstance(uses, str) and uses.startswith("./"):
+                    for body in _composite_run_bodies(uses):
+                        runners |= runners_in_run_body(body)
+            if runners:
+                reached[(path.name, job_id)] = runners
+    return reached
+
+
+def lock_reachable_jobs() -> set[tuple[str, str]]:
+    bearing = lock_bearing_roots()
+    return {
+        job for job, runners in suite_running_jobs().items() if {SUITE_ROOTS[runner] for runner in runners} & bearing
+    }
+
+
+def budget_offences(sources: dict[str, str], reached: dict[tuple[str, str], set[str]]) -> list[str]:
+    """One line per job that runs a lock-bearing suite without a usable budget."""
+    bearing = lock_bearing_roots()
+    offences: list[str] = []
+    for (workflow, job_id), runners in sorted(reached.items()):
+        roots = sorted({SUITE_ROOTS[runner] for runner in runners} & bearing)
+        if not roots:
+            continue
+        body = extract_job(sources[workflow], job_id)
+        hit = re.search(r"^    timeout-minutes:[ \t]*(.*\S)[ \t]*$", body, re.MULTILINE)
+        where = f"{workflow}: job {job_id} runs {', '.join(sorted(runners))} (lock sites under {', '.join(roots)})"
+        if hit is None:
+            offences.append(f"{where}: no job-level timeout-minutes, so a stuck lock burns GitHub's 360-minute default")
+            continue
+        raw = hit.group(1)
+        if not re.fullmatch(r"[1-9][0-9]*", raw):
+            offences.append(f"{where}: timeout-minutes is {raw!r}, not a plain positive integer")
+        elif int(raw) >= GITHUB_DEFAULT_TIMEOUT_MINUTES:
+            offences.append(
+                f"{where}: timeout-minutes is {raw}, at or above GitHub's "
+                f"{GITHUB_DEFAULT_TIMEOUT_MINUTES}-minute default, so it bounds nothing"
+            )
+    return offences
+
+
+def _workflow_sources() -> dict[str, str]:
+    return {path.name: path.read_text(encoding="utf-8") for path in sorted(WORKFLOWS.glob("*.y*ml"))}
+
+
+# --------------------------------------------------------------------------- #
+# The gate.
+# --------------------------------------------------------------------------- #
+
+
+def test_every_job_running_a_lock_bearing_suite_pins_timeout_minutes() -> None:
+    """The issue's Expected, enforced for the whole class rather than the one job it
+    named: a deadlock fails at the job's own budget, not at the platform default."""
+    offences = budget_offences(_workflow_sources(), suite_running_jobs())
+    assert not offences, "kernel-lock job budget missing:\n  " + "\n  ".join(offences)
+
+
+def test_which_suite_roots_hold_kernel_lock_acquires() -> None:
+    """The gate's premise, asserted rather than assumed.
+
+    `tests/shell` holds none, which is why the shellspec jobs are deliberately NOT
+    gated here: the `lockf -k 9` / `flock 9` the issue named lived in
+    `scripts/agent/work-branch.sh` and was retired with the Graphify store, and no spec
+    has acquired a kernel lock since. A lock landing in (or leaving) any root changes
+    which jobs this file demands a budget from, so it must be a visible diff.
+    """
+    bearing = {root: len(kernel_lock_acquires(root)) for root in sorted(set(SUITE_ROOTS.values()))}
+    assert {root for root, count in bearing.items() if count} == {
+        "tests",
+        "tests/php",
+        "tests/smoke",
+    }, bearing
+
+
+def test_the_lock_reachable_jobs_are_the_ones_the_scan_finds() -> None:
+    """The enumeration the issue's scope note asks for, in one place, so a job entering
+    or leaving the class is a visible diff.
+
+    The issue named only `shell-tests`; its scope note says the exposure comes from the
+    primitives plus the missing budget, not from any one test.
+    """
+    assert lock_reachable_jobs() == {
+        ("smoke-single.yml", "smoke"),
+        ("test.yml", "php-unit"),
+        ("test.yml", "test"),
+        ("ui-tests.yml", "ui"),
+    }, sorted(lock_reachable_jobs())
+
+
+def test_suite_roots_match_the_configuration_that_declares_them() -> None:
+    """`SUITE_ROOTS` re-derived from the files the runners themselves read, each slice
+    bounded by its anchor so a reworded config line raises instead of passing."""
+    phpunit = (ROOT / "phpunit.xml").read_text(encoding="utf-8")
+    assert extract_between(phpunit, "<directory>", "</directory>") == SUITE_ROOTS["vendor/bin/phpunit"]
+
+    ini = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))["tool"]["pytest"]["ini_options"]
+    assert ini["testpaths"] == [SUITE_ROOTS["pytest"]]
+
+    shellspec = (ROOT / ".shellspec").read_text(encoding="utf-8")
+    assert extract_after(shellspec, "--default-path ").split("\n", 1)[0].strip() == SUITE_ROOTS["shellspec"]
+
+    run_smoke = (ROOT / "scripts" / "run-smoke.sh").read_text(encoding="utf-8")
+    assert extract_between(run_smoke, '_PATHS="', '"') == SUITE_ROOTS["scripts/run-smoke.sh"]
+
+
+# --------------------------------------------------------------------------- #
+# Vacuity guards: every rule above fires on a planted offence.
+# --------------------------------------------------------------------------- #
+
+
+_PLANTED_JOB = {("planted.yml", "suite"): {"vendor/bin/phpunit"}}
+
+
+@pytest.mark.parametrize(
+    ("budget", "expected"),
+    (
+        ("", "no job-level timeout-minutes"),
+        ("    timeout-minutes: ${{ inputs.budget }}\n", "not a plain positive integer"),
+        ("    timeout-minutes: 0\n", "not a plain positive integer"),
+        ("    timeout-minutes: -5\n", "not a plain positive integer"),
+        (f"    timeout-minutes: {GITHUB_DEFAULT_TIMEOUT_MINUTES}\n", "bounds nothing"),
+    ),
+)
+def test_the_gate_reports_a_planted_budget_offence(budget: str, expected: str) -> None:
+    source = "jobs:\n  suite:\n    runs-on: ubuntu-latest\n" + budget + "    steps: []\n"
+    offences = budget_offences({"planted.yml": source}, _PLANTED_JOB)
+    assert len(offences) == 1 and expected in offences[0], offences
+
+
+def test_the_gate_accepts_a_planted_job_that_carries_a_budget() -> None:
+    source = "jobs:\n  suite:\n    runs-on: ubuntu-latest\n    timeout-minutes: 15\n    steps: []\n"
+    assert budget_offences({"planted.yml": source}, _PLANTED_JOB) == []
+
+
+def test_a_budget_nested_under_a_step_is_not_a_job_budget() -> None:
+    """Six-space indentation puts the key on a step, where GitHub ignores it. The
+    job-level regex must not accept it."""
+    source = (
+        "jobs:\n  suite:\n    runs-on: ubuntu-latest\n    steps:\n"
+        "      - name: run\n        timeout-minutes: 15\n        run: true\n"
+    )
+    offences = budget_offences({"planted.yml": source}, _PLANTED_JOB)
+    assert len(offences) == 1 and "no job-level timeout-minutes" in offences[0], offences
+
+
+def test_a_renamed_planted_job_raises_instead_of_widening_the_slice() -> None:
+    """The #2669 shape: an absent landmark must raise, never return the whole file --
+    which would let the `timeout-minutes` search match a LATER job's budget and pass."""
+    source = "jobs:\n  renamed:\n    timeout-minutes: 15\n    steps: []\n"
+    with pytest.raises(ValueError, match="job 'suite' not found"):
+        budget_offences({"planted.yml": source}, _PLANTED_JOB)
+
+
+@pytest.mark.parametrize(
+    "body",
+    (
+        "shellspec --shell dash",
+        "uv run pytest --junitxml=/tmp/x.xml",
+        "sh scripts/run-smoke.sh --paths tests/smoke",
+        "vendor/bin/phpunit --coverage-text",
+        'DASH=dash shellspec --shell "$DASH"',
+        "make build && shellspec",
+    ),
+)
+def test_the_runner_scan_sees_real_invocations(body: str) -> None:
+    assert runners_in_run_body(body), body
+
+
+@pytest.mark.parametrize(
+    "body",
+    (
+        '        echo "shellspec shell tests failed or were cancelled."',
+        "        # sh scripts/run-smoke.sh shells out to the synced interpreter",
+        "        python3 scripts/check_skip_allowlist.py --suite pytest report.xml",
+        '        installed="$(shellspec --version)"',
+    ),
+)
+def test_the_runner_scan_ignores_mentions_that_are_not_invocations(body: str) -> None:
+    assert runners_in_run_body(body) == set(), body
+
+
+@pytest.mark.parametrize(
+    "line",
+    (
+        "\tif ($lock === FALSE || !@flock($lock, LOCK_SH | LOCK_NB)) {",
+        "\t\t$this->assertTrue(flock($holder, LOCK_EX));",
+        "\t@file_put_contents($path, $content, LOCK_EX);",
+        "        fcntl.flock(handle, fcntl.LOCK_EX)",
+        "\t\t( exec 9>lockfile; lockf -k 9; sleep 30 ) &",
+        "timeout 5 sh -c 'exec 9>L; flock -w 0 9'",
+    ),
+)
+def test_the_acquire_scan_sees_every_acquire_shape(line: str) -> None:
+    assert any(pattern.search(line) for pattern in _ACQUIRE_PATTERNS), line
+
+
+@pytest.mark.parametrize(
+    "line",
+    (
+        "\t@flock($lock, LOCK_UN);",
+        "\t// A waiter can be descheduled between its deadline check and flock().",
+        "# The flock inside _rebuild_code still prevents pile-ups",
+        "45 lockf /usr/bin/lockf -s -t 5 /tmp/pfSense-upgrade.lock",
+    ),
+)
+def test_the_acquire_scan_ignores_releases_prose_and_fixture_text(line: str) -> None:
+    assert not any(pattern.search(line) for pattern in _ACQUIRE_PATTERNS), line

--- a/tests/test_issue2614_lock_job_budgets.py
+++ b/tests/test_issue2614_lock_job_budgets.py
@@ -28,8 +28,10 @@ Deliberate choices, so a reader does not mistake them for oversights:
   (`test_a_quoted_sibling_job_key_cannot_lend_its_budget`). `tests/_workflow_steps.py` is
   still used where the landmark rule bites -- the non-YAML config files, where a reworded
   anchor must raise rather than widen (issue #2669).
-* **A suite invoked from inside a composite action is NOT seen.** Stated so the gap is
-  known rather than silent.
+* **Local composite actions ARE followed, recursively, with cycle detection.** A suite
+  invoked inside one belongs to the job that reaches it; a one-level walk would give
+  false assurance. Docker- and node-based local actions are not followed, because their
+  entry point is an image or a script rather than a `run:` body.
 """
 
 from __future__ import annotations
@@ -165,13 +167,19 @@ def _candidate_files(root: str) -> list[Path]:
 
 
 def kernel_lock_acquires(root: str) -> list[str]:
-    """``path:line`` for every kernel-lock acquire under ``root``."""
+    """``path:line`` for every kernel-lock acquire under ``root``.
+
+    An unreadable candidate RAISES. `_candidate_files` only returns files `git grep`
+    already matched on a lock token, so one that cannot then be read is a broken
+    assumption, not a benign skip -- and swallowing it would drop a file known to name a
+    lock, which is the vacuous-scan shape this gate exists to prevent.
+    """
     found: list[str] = []
     for path in _candidate_files(root):
         try:
             raw = path.read_bytes()
-        except OSError:
-            continue  # broken symlink: holds no acquire either way
+        except OSError as exc:
+            raise OSError(f"candidate {path.relative_to(ROOT)} names a lock token but cannot be read: {exc}") from exc
         # errors="replace", never a skip: an except-and-continue on UnicodeDecodeError
         # silently dropped a tracked latin-1 .inc holding a real flock($fp, LOCK_EX).
         for lineno, line in enumerate(raw.decode("utf-8", errors="replace").splitlines(), start=1):
@@ -223,11 +231,51 @@ def runners_in_run_body(body: str) -> set[str]:
         found |= {entry for entry in PRODUCTION_ENTRY_POINTS if entry in line}
     for segment in _SEGMENT.split("\n".join(live)):
         words = [stripped for word in segment.split() if (stripped := _command_word(word))]
-        while words and _is_prefix(words[0]):
+        while words:
+            if (runner := _runner_for(words[0])) is not None:
+                found.add(runner)
+                break
+            if not _is_prefix(words[0]):
+                break
+            was_flag = words[0].startswith("-")
             words = words[1:]
-        if words and (runner := _runner_for(words[0])) is not None:
-            found.add(runner)
+            # A wrapper option can take a VALUE (`uv run --group dev pytest`,
+            # `env -u NAME pytest`): drop it too, unless it is itself a runner or another
+            # prefix, so the runner behind it is still reached.
+            if was_flag and words and not _is_prefix(words[0]) and _runner_for(words[0]) is None:
+                words = words[1:]
     return found
+
+
+def _local_action_run_bodies(uses: str, seen: frozenset[str] = frozenset()) -> list[str]:
+    """Every `run:` body a LOCAL composite action reaches, following nested `uses: ./...`.
+
+    A composite action is ordinary GitHub Actions, so a suite invoked inside one belongs
+    to the job that reaches it. Recursive with cycle detection: a one-level walk would
+    give false assurance, and a self- or mutually-referential action must not hang the
+    gate. Docker- and node-based local actions are NOT followed -- their entry point is an
+    image or a script, not a `run:` body -- and no local action in this repository uses
+    either form.
+    """
+    reference = uses.split("@", 1)[0]
+    if reference in seen:
+        return []
+    action = ROOT / reference.removeprefix("./")
+    for candidate in (action / "action.yml", action / "action.yaml"):
+        if not candidate.is_file():
+            continue
+        document = yaml.safe_load(candidate.read_text(encoding="utf-8")) or {}
+        bodies: list[str] = []
+        for step in (document.get("runs") or {}).get("steps") or []:
+            if not isinstance(step, dict):
+                continue
+            if step.get("run"):
+                bodies.append(step["run"])
+            nested = step.get("uses")
+            if isinstance(nested, str) and nested.startswith("./"):
+                bodies.extend(_local_action_run_bodies(nested, seen | {reference}))
+        return bodies
+    return []
 
 
 def _documents() -> dict[str, dict]:
@@ -251,8 +299,14 @@ def suite_running_jobs(documents: dict[str, dict] | None = None) -> dict[tuple[s
                 continue
             runners: set[str] = set()
             for step in job.get("steps") or []:
-                if isinstance(step, dict) and step.get("run"):
+                if not isinstance(step, dict):
+                    continue
+                if step.get("run"):
                     runners |= runners_in_run_body(step["run"])
+                uses = step.get("uses")
+                if isinstance(uses, str) and uses.startswith("./"):
+                    for step_body in _local_action_run_bodies(uses):
+                        runners |= runners_in_run_body(step_body)
             if runners:
                 reached[(name, job_id)] = runners
     return reached
@@ -454,6 +508,10 @@ def test_a_budget_that_is_not_the_job_s_own_does_not_satisfy_the_gate(label: str
         ("if command -v pytest; then pytest; fi", {"pytest"}),
         ("for v in a b; do shellspec; done", {"shellspec"}),
         ("bash -c 'shellspec'", {"shellspec"}),
+        # A wrapper option that takes a VALUE must not hide the runner behind it.
+        ("uv run --group dev pytest", {"pytest"}),
+        ("env -u PYTHONPATH pytest", {"pytest"}),
+        ("uv run --python 3.11 pytest -q", {"pytest"}),
         ('        echo "shellspec shell tests failed or were cancelled."', set()),
         ("        # sh scripts/run-smoke.sh shells out to the synced interpreter", set()),
         ("        # pfblockerng.php update is the production reload entry point", set()),
@@ -464,6 +522,35 @@ def test_a_budget_that_is_not_the_job_s_own_does_not_satisfy_the_gate(label: str
 )
 def test_the_runner_scan_reads_invocations_and_not_mentions(body: str, expected: set[str]) -> None:
     assert runners_in_run_body(body) == expected, body
+
+
+def test_a_suite_invoked_through_nested_composite_actions_is_attributed_to_the_job(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A composite action is ordinary GitHub Actions, so a suite invoked one -- or two --
+    levels down still belongs to the job that reaches it. A self-referential action must
+    terminate rather than hang."""
+    actions = tmp_path / "actions"
+    for name, body in (
+        ("l1", "runs:\n  using: composite\n  steps:\n    - uses: ./actions/l2\n"),
+        ("l2", "runs:\n  using: composite\n  steps:\n    - shell: sh\n      run: uv run pytest -q\n"),
+        ("loop", "runs:\n  using: composite\n  steps:\n    - uses: ./actions/loop\n"),
+    ):
+        (actions / name).mkdir(parents=True)
+        (actions / name / "action.yaml").write_text(body, encoding="utf-8")
+    monkeypatch.setattr("tests.test_issue2614_lock_job_budgets.ROOT", tmp_path)
+
+    assert _local_action_run_bodies("./actions/l1") == ["uv run pytest -q"]
+    assert _local_action_run_bodies("./actions/loop") == []  # cycle, not a hang
+
+    workflows = tmp_path / "wf"
+    workflows.mkdir()
+    (workflows / "planted.yml").write_text(
+        "jobs:\n  suite:\n    steps:\n      - uses: ./actions/l1\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr("tests.test_issue2614_lock_job_budgets.WORKFLOWS", workflows)
+    assert suite_running_jobs() == {("planted.yml", "suite"): {"pytest"}}
 
 
 _ACQUIRE_CASES: tuple[tuple[bool, str], ...] = (

--- a/tests/test_issue2614_lock_job_budgets.py
+++ b/tests/test_issue2614_lock_job_budgets.py
@@ -1,37 +1,13 @@
-"""Issue #2614: a CI job that can block on a kernel lock carries a wall-clock budget.
+"""Issue #2614: every workflow job that can reach a kernel-lock acquire is bounded.
 
-A `flock(2)`-family acquire takes no timeout, so a regression that leaves the lock held
-makes the waiter block rather than fail, and the only bound above it is the job's own
-`timeout-minutes`. Without one GitHub applies its 360-minute default, and a deadlock
-reports as a platform timeout instead of as the assertion that names the cause.
+A `flock(2)`-family acquire takes no timeout, so the only bound above a stuck lock is the
+job's own `timeout-minutes`; without one GitHub applies its 360-minute default and a
+deadlock reports as a platform timeout rather than as the assertion that names the cause.
 
-This file gates the relationship rather than one job: every workflow job that reaches a
-tree holding a kernel-lock acquire carries a job-level `timeout-minutes` that is a real
-bound. `SUITE_RUNNERS` maps each runner to the trees it EXECUTES -- a spec suite reaches
-the scripts it drives, and PHPUnit and the live-VM harness reach `src/` -- so a lock
-returning to `scripts/agent/work-branch.sh`, which is where the one this issue names used
-to live, brings the shellspec jobs back into scope on its own.
-
-Deliberate choices, so a reader does not mistake them for oversights:
-
-* **Reachability is a MAY; the scan errs toward over-inclusion.** Whether an embedded
-  snippet is executed or merely written is not something a regex can decide, so a tree
-  naming an acquire counts as able to reach one. Over-inclusion costs a job a budget it
-  already has; under-inclusion costs a six-hour hang.
-* **There is a ceiling but no floor.** A budget at or above GitHub's default bounds
-  nothing and is silent, which is the hazard here. An absurdly tight budget is the
-  opposite: it fails on the next run and is self-revealing. A floor would put a wall-clock
-  number in an assertion and invite the flake class `testing.md` forbids.
-* **The budget is read from parsed YAML, not a text slice.** YAML is what GitHub reads,
-  and a slice is weaker: a quoted sibling job key walks past `extract_job`'s boundary and
-  lets the search match a LATER job's budget, passing vacuously
-  (`test_a_quoted_sibling_job_key_cannot_lend_its_budget`). `tests/_workflow_steps.py` is
-  still used where the landmark rule bites -- the non-YAML config files, where a reworded
-  anchor must raise rather than widen (issue #2669).
-* **Local composite actions ARE followed, recursively, with cycle detection.** A suite
-  invoked inside one belongs to the job that reaches it; a one-level walk would give
-  false assurance. Docker- and node-based local actions are not followed, because their
-  entry point is an image or a script rather than a `run:` body.
+The gated contract is the relationship, not one job: a job that reaches a tree holding a
+kernel-lock acquire declares a job-level `timeout-minutes` that is a plain positive
+integer below that default. `SUITE_RUNNERS` maps each runner to the trees it EXECUTES, so
+a lock arriving anywhere a suite drives pulls that suite's jobs into the contract.
 """
 
 from __future__ import annotations
@@ -172,6 +148,11 @@ def _candidate_files(root: str) -> list[Path]:
 
 def kernel_lock_acquires(root: str) -> list[str]:
     """``path:line`` for every kernel-lock acquire under ``root``.
+
+    Reachability is a MAY, and the scan errs toward over-inclusion: whether an embedded
+    snippet is executed or merely written is not something a regex can decide, so a tree
+    naming an acquire counts as able to reach one. Over-inclusion costs a job a budget it
+    already has; under-inclusion costs a six-hour hang.
 
     An unreadable candidate RAISES. `_candidate_files` only returns files `git grep`
     already matched on a lock token, so one that cannot then be read is a broken
@@ -329,7 +310,16 @@ _MISSING = object()
 
 
 def budget_offences(documents: dict[str, dict], reached: dict[tuple[str, str], set[str]]) -> list[str]:
-    """One line per job that reaches a lock-bearing tree without a usable budget."""
+    """One line per job that reaches a lock-bearing tree without a usable budget.
+
+    Read from the parsed document, never a text slice: YAML is what GitHub reads, and a
+    quoted sibling job key walks past `extract_job`'s boundary and lets a LATER job's
+    budget satisfy the search.
+
+    There is a ceiling and deliberately no floor. A budget at or above GitHub's default
+    bounds nothing and is silent, which is the hazard; an absurdly tight one fails on the
+    next run and is self-revealing. A floor would put a wall-clock number in an assertion.
+    """
     bearing = lock_bearing_roots()
     offences: list[str] = []
     for (workflow, job_id), runners in sorted(reached.items()):

--- a/tests/test_issue2614_lock_job_budgets.py
+++ b/tests/test_issue2614_lock_job_budgets.py
@@ -145,8 +145,9 @@ _ACQUIRE_PATTERNS: tuple[re.Pattern[str], ...] = (
     re.compile(r"^[^;/*#]*LOCK_(?:EX|SH)\b[^;/*#]*[,)\s]*;?\s*$"),
     re.compile(r"fcntl\.(?:flock|lockf)\s*\("),
     # flock(1)/lockf(1) at command position, including the bare-fd form this issue names
-    # (`exec 9>L; flock 9`, `lockf -k 9`, `flock $fd`).
-    re.compile(r"(?:^|[|;&(]\s*|\b(?:sh|bash|env|sudo|exec|timeout(?:\s+\S+)?)\s+)(?:lockf|flock)\s+[-\d$]"),
+    # (`exec 9>L; flock 9`, `lockf -k 9`, `flock $fd`). The operand may be quoted, which
+    # is this repository's shell convention (`flock "$fd"`, `flock "${fd}"`).
+    re.compile(r"""(?:^|[|;&(]\s*|\b(?:sh|bash|env|sudo|exec|timeout(?:\s+\S+)?)\s+)(?:lockf|flock)\s+['"]?[-\d$]"""),
 )
 
 _PREFILTER_TOKENS = ("LOCK_EX", "LOCK_SH", "flock", "lockf", "fcntl")
@@ -580,6 +581,11 @@ _ACQUIRE_CASES: tuple[tuple[bool, str], ...] = (
     # what catches it. `exec {fd}>` names the descriptor in a brace, not a digit.
     (True, "\t\t$file->flock(LOCK_EX);"),
     (True, "exec {fd}>file; flock $fd"),
+    # A quoted expansion is this repository's shell convention, so the operand must be
+    # allowed to start with a quote.
+    (True, 'exec {fd}>file; flock "$fd"'),
+    (True, 'exec {fd}>file; flock "${fd}"'),
+    (True, 'exec 9>file; flock "9"'),
     (False, "\t@flock($lock, LOCK_UN);"),
     (False, "\t// A waiter can be descheduled between its deadline check and flock()."),
     (False, "\t// LOCK_EX, and the deadline, are documented above."),

--- a/tests/test_issue2614_lock_job_budgets.py
+++ b/tests/test_issue2614_lock_job_budgets.py
@@ -1,36 +1,35 @@
 """Issue #2614: a CI job that can block on a kernel lock carries a wall-clock budget.
 
-A `flock(2)`-family acquire has no timeout of its own, so a regression that leaves the
-lock held makes the waiter block rather than fail. Probed for the issue (macOS, `lockf`):
-a second acquirer of a held lock never returns -- `timeout 5 sh -c 'exec 9>L; lockf -k 9'`
-exits 124 -- while the same acquire against a free lock exits 0 at once. Nothing inside
-the suites bounds that wait, so the only bound left is the job's own `timeout-minutes`;
-without one GitHub applies its 360-minute default and a deadlock reports as a platform
-timeout hours later instead of as the assertion that names the cause.
+A `flock(2)`-family acquire takes no timeout, so a regression that leaves the lock held
+makes the waiter block rather than fail, and the only bound above it is the job's own
+`timeout-minutes`. Without one GitHub applies its 360-minute default, and a deadlock
+reports as a platform timeout instead of as the assertion that names the cause.
 
-What this file gates is therefore the *relationship*, not the one job the issue named:
-every workflow job that runs a suite whose sources hold a kernel-lock acquire carries a
-job-level `timeout-minutes` that is a real bound. Which suites those are is read from
-source by `kernel_lock_acquires` and pinned by
-`test_which_suite_roots_hold_kernel_lock_acquires`, so a suite that starts or stops
-locking is a visible diff rather than a silent change in what this gate demands.
+This file gates the relationship rather than one job: every workflow job that reaches a
+tree holding a kernel-lock acquire carries a job-level `timeout-minutes` that is a real
+bound. `SUITE_RUNNERS` maps each runner to the trees it EXECUTES -- a spec suite reaches
+the scripts it drives, and PHPUnit and the live-VM harness reach `src/` -- so a lock
+returning to `scripts/agent/work-branch.sh`, which is where the one this issue names used
+to live, brings the shellspec jobs back into scope on its own.
 
-Why it was needed. On `origin/devel` at the time of writing, all four lock-reachable jobs
-carried a budget, but `smoke-single.yml`'s `smoke` job (45) was defended by no test at
-all: deleting that line left the whole suite green (5614 passed, 2 skipped) and
-`actionlint` 1.7.12 silent. `test.yml`'s `test` and `php-unit` are pinned by
-`test_issue2673_xdist_ci.py` and `ui-tests.yml`'s `ui` by
-`test_smoke_ui_config_digest.py`, but nothing tied any of them to lock reachability, so a
-new lock-reachable job would have landed unbudgeted with the suite green.
+Deliberate choices, so a reader does not mistake them for oversights:
 
-Jobs that call a reusable workflow are excluded: GitHub allows only
-name/uses/with/secrets/needs/if/permissions/strategy there -- smoke.yml states that same
-allow-list in its own comment -- so such a job cannot carry a budget, and the bound that
-applies is the called job's, which this gate reads at its definition site.
-
-Slices into the non-YAML config files go through `tests/_workflow_steps.py`, so a
-reworded anchor raises instead of silently widening (issue #2669). Workflow structure is
-read with `yaml`, whose missing key is `None` and cannot widen at all.
+* **Reachability is a MAY; the scan errs toward over-inclusion.** Whether an embedded
+  snippet is executed or merely written is not something a regex can decide, so a tree
+  naming an acquire counts as able to reach one. Over-inclusion costs a job a budget it
+  already has; under-inclusion costs a six-hour hang.
+* **There is a ceiling but no floor.** A budget at or above GitHub's default bounds
+  nothing and is silent, which is the hazard here. An absurdly tight budget is the
+  opposite: it fails on the next run and is self-revealing. A floor would put a wall-clock
+  number in an assertion and invite the flake class `testing.md` forbids.
+* **The budget is read from parsed YAML, not a text slice.** YAML is what GitHub reads,
+  and a slice is weaker: a quoted sibling job key walks past `extract_job`'s boundary and
+  lets the search match a LATER job's budget, passing vacuously
+  (`test_a_quoted_sibling_job_key_cannot_lend_its_budget`). `tests/_workflow_steps.py` is
+  still used where the landmark rule bites -- the non-YAML config files, where a reworded
+  anchor must raise rather than widen (issue #2669).
+* **A suite invoked from inside a composite action is NOT seen.** Stated so the gap is
+  known rather than silent.
 """
 
 from __future__ import annotations
@@ -43,7 +42,7 @@ from pathlib import Path
 import pytest
 import yaml
 
-from tests._workflow_steps import extract_after, extract_between, extract_job
+from tests._workflow_steps import extract_after, extract_between
 
 ROOT = Path(__file__).resolve().parents[1]
 WORKFLOWS = ROOT / ".github" / "workflows"
@@ -52,164 +51,229 @@ WORKFLOWS = ROOT / ".github" / "workflows"
 # default wearing a number, which is the condition this issue exists to remove.
 GITHUB_DEFAULT_TIMEOUT_MINUTES = 360
 
-# Runner token (at command position in a `run:` body) -> the suite root it executes.
-# Every root is re-derived from the configuration the runner itself reads by
-# `test_suite_roots_match_the_configuration_that_declares_them`, so the table cannot
-# drift away from what the runners actually load.
-SUITE_ROOTS: dict[str, str] = {
-    "vendor/bin/phpunit": "tests/php",
-    "pytest": "tests",
-    "shellspec": "tests/shell",
-    "scripts/run-smoke.sh": "tests/smoke",
+# The pytest root is scoped to the top-level `tests/*.py` pytest can collect: `testpaths`
+# is `tests`, but that pathspec subsumes `tests/php` and `tests/smoke`, which pytest never
+# collects (not Python) and which other runners own. Unscoped, the premise assertion below
+# could never be false.
+PYTEST_ROOT = ":(glob)tests/*.py"
+
+# Runner token (at command position in a `run:` body) -> every tree it EXECUTES.
+# A suite reaches more than its own directory: shellspec drives `scripts/`, PHPUnit loads
+# the real `src/` .inc, and the live-VM harness runs the installed package.
+SUITE_RUNNERS: dict[str, tuple[str, ...]] = {
+    "vendor/bin/phpunit": ("tests/php", "src"),
+    "pytest": (PYTEST_ROOT,),
+    "shellspec": ("tests/shell", "scripts"),
+    "scripts/run-smoke.sh": ("tests/smoke", "src"),
 }
 
-# Command prefixes that carry a runner without being one: `uv run pytest`,
-# `sh scripts/run-smoke.sh`, `DASH=dash shellspec`. Stripped left to right until the
-# leading word is the command itself.
-_PREFIX_WORDS = frozenset({"sh", "bash", "sudo", "env", "time", "exec", "uv", "run", "xargs", "python3", "-m"})
-_ASSIGNMENT = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
-# A logical command boundary inside a `run:` body.
-_SEGMENT = re.compile(r"(?:\|\||&&|[|;&\n])")
+# Production entry points -> `src`, matched as a SUBSTRING of any non-comment `run:` line.
+# Substring, not command position, because these arrive through indirection no command
+# matcher can chase: build-image.yml runs `tests/smoke/roundtrip.sh` (which shells
+# `pfblockerng.php update`) and image-refresh.yml wraps the same entry point in
+# `run_ssh '...'`. Naming either in a live run body means driving production code.
+PRODUCTION_ENTRY_POINTS: dict[str, tuple[str, ...]] = {
+    "pfblockerng.php": ("src",),
+    "tests/smoke/roundtrip.sh": ("src",),
+}
 
-# Kernel-lock acquires, by shape. `LOCK_UN` is a release and never matches. `flock()`
-# requires a `$`-prefixed first argument so a prose mention ("...and flock().") is
-# skipped -- the same discrimination `tests/test_bounded_flock.py` makes for the same
-# reason. `file_put_contents(..., LOCK_EX)` is included because it takes a BLOCKING
-# `flock(2)` exclusive lock, which the #1780 scanner (call-syntax only) does not see.
+REACHED_ROOTS: dict[str, tuple[str, ...]] = {**SUITE_RUNNERS, **PRODUCTION_ENTRY_POINTS}
+ALL_ROOTS: tuple[str, ...] = tuple(sorted({root for roots in REACHED_ROOTS.values() for root in roots}))
+
+# Words that can precede a runner without being one, stripped left to right until the
+# leading word is the command: `uv run pytest`, `sh scripts/run-smoke.sh`,
+# `python -m pytest`, `timeout 600 vendor/bin/phpunit`, `nice -n 5 shellspec`,
+# `if ! pytest`, `{ pytest; }`. `command`/`builtin` cover `command pytest`; that also
+# makes `command -v shellspec` read as an invocation, which is over-inclusion in the safe
+# direction.
+_PREFIX_WORDS = frozenset(
+    {
+        "sh",
+        "bash",
+        "sudo",
+        "env",
+        "time",
+        "exec",
+        "uv",
+        "run",
+        "xargs",
+        "poetry",
+        "nice",
+        "timeout",
+        "command",
+        "builtin",
+        "if",
+        "then",
+        "elif",
+        "else",
+        "do",
+        "while",
+        "until",
+        "!",
+        "-m",
+    }
+)
+_PREFIX_SHAPES = (
+    re.compile(r"^python[0-9.]*$"),  # python, python3, python3.11
+    re.compile(r"^-"),  # a flag of an already-stripped prefix
+    re.compile(r"^[0-9]+$"),  # `timeout 600`, `nice 10`
+    re.compile(r"^[A-Za-z_][A-Za-z0-9_]*="),  # VAR=value prefix assignment
+)
+_SEGMENT = re.compile(r"(?:\|\||&&|[|;&\n])")  # a logical command boundary
+_STRIP_CHARS = "(){}\"'`"  # grouping punctuation, not command words
+
+# Kernel-lock acquires, by shape. Every pattern is LINE-based and each names one of
+# `_PREFILTER_TOKENS`, which is what makes the prefilter a sound superset. `LOCK_UN` is a
+# release and never matches.
 _ACQUIRE_PATTERNS: tuple[re.Pattern[str], ...] = (
-    re.compile(r"flock\s*\(\s*\$[^()]*LOCK_(?:EX|SH)"),
-    re.compile(r"file_put_contents\s*\(.*LOCK_EX"),
+    # PHP flock(). A `$` must appear in the arguments so a prose mention ("...between its
+    # deadline check and flock().") stays out, while `self::$fp` and `$this->fp` match.
+    re.compile(r"flock\s*\(\s*[^();]*\$[^();]*LOCK_(?:EX|SH)"),
+    # file_put_contents(..., LOCK_EX) takes a real BLOCKING flock(2) LOCK_EX -- probed at
+    # 0.504 s against a holder releasing after 0.5 s. `[^;]` keeps a match in one
+    # statement. The #1780 scanner misses this shape; it reads flock( call syntax only.
+    re.compile(r"file_put_contents\s*\([^;]*LOCK_EX"),
+    # The ARGUMENT line of a wrapped acquire (`flock(\n\t$fp,\n\tLOCK_EX\n);`), invisible
+    # to the line-scoped patterns above. The constant must be the last thing on the line
+    # apart from delimiters, which is what keeps mid-line prose out; comment markers are
+    # excluded as well, so `// LOCK_EX, and the deadline` and `/* LOCK_EX */` do not match.
+    re.compile(r"^[^;/*#]*LOCK_(?:EX|SH)\b[^;/*#]*[,)\s]*;?\s*$"),
     re.compile(r"fcntl\.(?:flock|lockf)\s*\("),
-    re.compile(r"(?:^|[|;&(]\s*|\b(?:sh|bash|env|sudo|exec|timeout(?:\s+\S+)?)\s+)(?:lockf|flock)\s+-"),
+    # flock(1)/lockf(1) at command position, including the bare-fd form this issue names
+    # (`exec 9>L; flock 9`, `lockf -k 9`, `flock $fd`).
+    re.compile(r"(?:^|[|;&(]\s*|\b(?:sh|bash|env|sudo|exec|timeout(?:\s+\S+)?)\s+)(?:lockf|flock)\s+[-\d$]"),
 )
 
+_PREFILTER_TOKENS = ("LOCK_EX", "LOCK_SH", "flock", "lockf", "fcntl")
 
-def _tracked(root: str) -> list[Path]:
-    """Tracked files under ``root``. `git ls-files`, not `rglob`: untracked scratch a
-    developer left in the tree must not move this gate's verdict."""
-    listing = subprocess.run(
-        ["git", "ls-files", "-z", "--", root],
-        cwd=ROOT,
-        capture_output=True,
-        text=True,
-        check=True,
-    ).stdout
-    return [ROOT / name for name in listing.split("\0") if name]
+
+def _candidate_files(root: str) -> list[Path]:
+    """Tracked files under ``root`` that could hold an acquire.
+
+    `git grep -l` over the loose token list rather than reading every tracked file: a
+    sound superset, and it stops re-reading ~1000 files once per root. Tracked-only, so
+    untracked scratch cannot move the verdict. `git grep` exits 1 for "no match", which is
+    not an error; any other status raises instead of reading as an empty scan.
+    """
+    argv = ["git", "grep", "-l", "-F"]
+    for token in _PREFILTER_TOKENS:
+        argv += ["-e", token]
+    result = subprocess.run([*argv, "--", root], cwd=ROOT, capture_output=True, text=True, check=False)
+    if result.returncode not in (0, 1):
+        raise OSError(f"git grep failed for {root!r}: {result.stderr.strip()}")
+    return [ROOT / name for name in result.stdout.split("\n") if name]
 
 
 def kernel_lock_acquires(root: str) -> list[str]:
-    """``path:line`` for every kernel-lock acquire under ``root``.
-
-    Reachability is a *may*, deliberately: a suite whose sources name an acquire counts
-    as able to reach one, because the discrimination that would narrow it -- does this
-    embedded snippet get executed or only written? -- is not something a regex can make.
-    `tests/` scores hits it can only write (`test_bounded_flock.py`'s own PHP fixtures)
-    alongside hits it really runs (`tests/smoke`'s appliance snippets). Over-inclusion
-    costs a job a budget it already has; under-inclusion costs a six-hour hang.
-    """
+    """``path:line`` for every kernel-lock acquire under ``root``."""
     found: list[str] = []
-    for path in _tracked(root):
+    for path in _candidate_files(root):
         try:
-            text = path.read_text(encoding="utf-8")
-        except (UnicodeDecodeError, OSError):
-            continue  # binary fixture or broken symlink: carries no acquire either way
-        for lineno, line in enumerate(text.splitlines(), start=1):
+            raw = path.read_bytes()
+        except OSError:
+            continue  # broken symlink: holds no acquire either way
+        # errors="replace", never a skip: an except-and-continue on UnicodeDecodeError
+        # silently dropped a tracked latin-1 .inc holding a real flock($fp, LOCK_EX).
+        for lineno, line in enumerate(raw.decode("utf-8", errors="replace").splitlines(), start=1):
             if any(pattern.search(line) for pattern in _ACQUIRE_PATTERNS):
                 found.append(f"{path.relative_to(ROOT)}:{lineno}")
     return found
 
 
 def lock_bearing_roots() -> set[str]:
-    return {root for root in set(SUITE_ROOTS.values()) if kernel_lock_acquires(root)}
+    return {root for root in ALL_ROOTS if kernel_lock_acquires(root)}
 
 
-def _strip_comment(line: str) -> str:
-    stripped = line.strip()
-    return "" if stripped.startswith("#") else stripped
+def _is_prefix(word: str) -> bool:
+    return word in _PREFIX_WORDS or any(shape.match(word) for shape in _PREFIX_SHAPES)
+
+
+def _runner_for(word: str) -> str | None:
+    """The runner ``word`` invokes, tolerating `./` and any leading path."""
+    candidate = word.removeprefix("./")
+    for token in SUITE_RUNNERS:
+        if candidate == token or candidate.endswith("/" + token):
+            return token
+    return None
 
 
 def runners_in_run_body(body: str) -> set[str]:
-    """Runner tokens ``body`` invokes *as commands*.
+    """Suite runners ``body`` invokes as commands, plus production entry points it names.
 
     A mention is not an invocation: `echo "shellspec shell tests failed"` and
-    `--suite pytest` name a runner in argument position, and a `#` line only documents
-    one. Keeping both out is what keeps this gate off jobs that merely talk about a suite
-    -- test.yml's `all-tests-passed` AND gate is exactly that shape.
+    `--suite pytest` put a runner in argument position, and a `#` line only documents one.
+    Keeping both out is what keeps this gate off jobs that merely talk about a suite --
+    test.yml's `all-tests-passed` AND gate is exactly that shape.
     """
     found: set[str] = set()
-    for segment in _SEGMENT.split("\n".join(_strip_comment(line) for line in body.splitlines())):
-        words = segment.strip().split()
-        while words and (words[0] in _PREFIX_WORDS or _ASSIGNMENT.match(words[0])):
+    live = [line.strip() for line in body.splitlines() if not line.strip().startswith("#")]
+    for line in live:
+        found |= {entry for entry in PRODUCTION_ENTRY_POINTS if entry in line}
+    for segment in _SEGMENT.split("\n".join(live)):
+        words = [stripped for word in segment.split() if (stripped := word.strip(_STRIP_CHARS))]
+        while words and _is_prefix(words[0]):
             words = words[1:]
-        if words and words[0] in SUITE_ROOTS:
-            found.add(words[0])
+        if words and (runner := _runner_for(words[0])) is not None:
+            found.add(runner)
     return found
 
 
-def _composite_run_bodies(uses: str) -> list[str]:
-    """`run:` bodies of a local composite action, so a suite invoked one level down is
-    still attributed to the job that reaches it."""
-    action = ROOT / uses.lstrip("./")
-    for candidate in (action / "action.yml", action / "action.yaml", action):
-        if candidate.is_file():
-            document = yaml.safe_load(candidate.read_text(encoding="utf-8")) or {}
-            steps = (document.get("runs") or {}).get("steps") or []
-            return [step["run"] for step in steps if isinstance(step, dict) and step.get("run")]
-    return []
+def _documents() -> dict[str, dict]:
+    return {
+        path.name: (yaml.safe_load(path.read_text(encoding="utf-8")) or {}) for path in sorted(WORKFLOWS.glob("*.y*ml"))
+    }
 
 
-def suite_running_jobs() -> dict[tuple[str, str], set[str]]:
-    """``(workflow file name, job id) -> runner tokens the job executes``.
+def suite_running_jobs(documents: dict[str, dict] | None = None) -> dict[tuple[str, str], set[str]]:
+    """``(workflow file name, job id) -> the runners / entry points the job reaches``.
 
-    Jobs that call a reusable workflow are skipped -- they cannot carry a budget, and the
-    called job's own budget is the bound that applies.
+    Jobs that call a reusable workflow are skipped: GitHub allows only
+    name/uses/with/secrets/needs/if/permissions/strategy there -- smoke.yml states that
+    allow-list in its own comment -- so they cannot carry a budget, and the bound that
+    applies is the called job's, which this gate reads at its definition site.
     """
     reached: dict[tuple[str, str], set[str]] = {}
-    for path in sorted(WORKFLOWS.glob("*.y*ml")):
-        document = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    for name, document in (documents if documents is not None else _documents()).items():
         for job_id, job in (document.get("jobs") or {}).items():
             if not isinstance(job, dict) or job.get("uses"):
                 continue
             runners: set[str] = set()
             for step in job.get("steps") or []:
-                if not isinstance(step, dict):
-                    continue
-                if step.get("run"):
+                if isinstance(step, dict) and step.get("run"):
                     runners |= runners_in_run_body(step["run"])
-                uses = step.get("uses")
-                if isinstance(uses, str) and uses.startswith("./"):
-                    for body in _composite_run_bodies(uses):
-                        runners |= runners_in_run_body(body)
             if runners:
-                reached[(path.name, job_id)] = runners
+                reached[(name, job_id)] = runners
     return reached
+
+
+def _reached_bearing_roots(runners: set[str], bearing: set[str]) -> list[str]:
+    return sorted({root for runner in runners for root in REACHED_ROOTS[runner]} & bearing)
 
 
 def lock_reachable_jobs() -> set[tuple[str, str]]:
     bearing = lock_bearing_roots()
-    return {
-        job for job, runners in suite_running_jobs().items() if {SUITE_ROOTS[runner] for runner in runners} & bearing
-    }
+    return {job for job, runners in suite_running_jobs().items() if _reached_bearing_roots(runners, bearing)}
 
 
-def budget_offences(sources: dict[str, str], reached: dict[tuple[str, str], set[str]]) -> list[str]:
-    """One line per job that runs a lock-bearing suite without a usable budget."""
+_MISSING = object()
+
+
+def budget_offences(documents: dict[str, dict], reached: dict[tuple[str, str], set[str]]) -> list[str]:
+    """One line per job that reaches a lock-bearing tree without a usable budget."""
     bearing = lock_bearing_roots()
     offences: list[str] = []
     for (workflow, job_id), runners in sorted(reached.items()):
-        roots = sorted({SUITE_ROOTS[runner] for runner in runners} & bearing)
+        roots = _reached_bearing_roots(runners, bearing)
         if not roots:
             continue
-        body = extract_job(sources[workflow], job_id)
-        hit = re.search(r"^    timeout-minutes:[ \t]*(.*\S)[ \t]*$", body, re.MULTILINE)
-        where = f"{workflow}: job {job_id} runs {', '.join(sorted(runners))} (lock sites under {', '.join(roots)})"
-        if hit is None:
+        job = (documents[workflow].get("jobs") or {})[job_id]
+        raw = job.get("timeout-minutes", _MISSING)
+        where = f"{workflow}: job {job_id} reaches {', '.join(sorted(runners))} (lock sites under {', '.join(roots)})"
+        if raw is _MISSING:
             offences.append(f"{where}: no job-level timeout-minutes, so a stuck lock burns GitHub's 360-minute default")
-            continue
-        raw = hit.group(1)
-        if not re.fullmatch(r"[1-9][0-9]*", raw):
+        elif not isinstance(raw, int) or isinstance(raw, bool) or raw <= 0:
             offences.append(f"{where}: timeout-minutes is {raw!r}, not a plain positive integer")
-        elif int(raw) >= GITHUB_DEFAULT_TIMEOUT_MINUTES:
+        elif raw >= GITHUB_DEFAULT_TIMEOUT_MINUTES:
             offences.append(
                 f"{where}: timeout-minutes is {raw}, at or above GitHub's "
                 f"{GITHUB_DEFAULT_TIMEOUT_MINUTES}-minute default, so it bounds nothing"
@@ -217,68 +281,74 @@ def budget_offences(sources: dict[str, str], reached: dict[tuple[str, str], set[
     return offences
 
 
-def _workflow_sources() -> dict[str, str]:
-    return {path.name: path.read_text(encoding="utf-8") for path in sorted(WORKFLOWS.glob("*.y*ml"))}
-
-
 # --------------------------------------------------------------------------- #
 # The gate.
 # --------------------------------------------------------------------------- #
 
 
-def test_every_job_running_a_lock_bearing_suite_pins_timeout_minutes() -> None:
+def test_every_job_reaching_a_lock_bearing_tree_pins_timeout_minutes() -> None:
     """The issue's Expected, enforced for the whole class rather than the one job it
     named: a deadlock fails at the job's own budget, not at the platform default."""
-    offences = budget_offences(_workflow_sources(), suite_running_jobs())
+    documents = _documents()
+    offences = budget_offences(documents, suite_running_jobs(documents))
     assert not offences, "kernel-lock job budget missing:\n  " + "\n  ".join(offences)
 
 
-def test_which_suite_roots_hold_kernel_lock_acquires() -> None:
-    """The gate's premise, asserted rather than assumed.
+def test_which_roots_hold_kernel_lock_acquires() -> None:
+    """The gate's premise, asserted rather than assumed, and falsifiable in both
+    directions.
 
-    `tests/shell` holds none, which is why the shellspec jobs are deliberately NOT
-    gated here: the `lockf -k 9` / `flock 9` the issue named lived in
-    `scripts/agent/work-branch.sh` and was retired with the Graphify store, and no spec
-    has acquired a kernel lock since. A lock landing in (or leaving) any root changes
-    which jobs this file demands a budget from, so it must be a visible diff.
+    `scripts` and `tests/shell` hold none today: the `lockf -k 9` / `flock 9` this issue
+    names lived in `scripts/agent/work-branch.sh` and was retired with the Graphify store.
+    Reintroducing a lock there flips `scripts` to bearing and pulls the shellspec jobs
+    into the gate -- which is the regression class the issue is about, so it must be a
+    visible diff either way.
     """
-    bearing = {root: len(kernel_lock_acquires(root)) for root in sorted(set(SUITE_ROOTS.values()))}
-    assert {root for root, count in bearing.items() if count} == {
-        "tests",
+    counts = {root: len(kernel_lock_acquires(root)) for root in ALL_ROOTS}
+    assert {root for root, count in counts.items() if count} == {
+        "src",
+        PYTEST_ROOT,
         "tests/php",
         "tests/smoke",
-    }, bearing
+    }, counts
 
 
 def test_the_lock_reachable_jobs_are_the_ones_the_scan_finds() -> None:
-    """The enumeration the issue's scope note asks for, in one place, so a job entering
-    or leaving the class is a visible diff.
-
-    The issue named only `shell-tests`; its scope note says the exposure comes from the
-    primitives plus the missing budget, not from any one test.
-    """
-    assert lock_reachable_jobs() == {
+    """The enumeration the issue's scope note asks for, in one place, so a job entering or
+    leaving the class is a visible diff. The issue named only `shell-tests`; its scope note
+    says the exposure comes from the primitives plus the missing budget, not one test."""
+    found = lock_reachable_jobs()
+    assert found == {
+        ("build-image.yml", "verify-image"),
+        ("image-refresh.yml", "refresh"),
         ("smoke-single.yml", "smoke"),
         ("test.yml", "php-unit"),
         ("test.yml", "test"),
         ("ui-tests.yml", "ui"),
-    }, sorted(lock_reachable_jobs())
+    }, sorted(found)
 
 
 def test_suite_roots_match_the_configuration_that_declares_them() -> None:
-    """`SUITE_ROOTS` re-derived from the files the runners themselves read, each slice
-    bounded by its anchor so a reworded config line raises instead of passing."""
+    """Each root re-derived from the config the runner itself reads, every slice bounded by
+    its anchor so a reworded config line raises instead of passing."""
     phpunit = (ROOT / "phpunit.xml").read_text(encoding="utf-8")
-    assert extract_between(phpunit, "<directory>", "</directory>") == SUITE_ROOTS["vendor/bin/phpunit"]
+    assert extract_between(phpunit, "<directory>", "</directory>") in SUITE_RUNNERS["vendor/bin/phpunit"]
 
     ini = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))["tool"]["pytest"]["ini_options"]
-    assert ini["testpaths"] == [SUITE_ROOTS["pytest"]]
+    assert ini["testpaths"] == ["tests"]
+    assert "--ignore=tests/smoke" in ini["addopts"].split()
+    assert PYTEST_ROOT.endswith("tests/*.py")
 
     shellspec = (ROOT / ".shellspec").read_text(encoding="utf-8")
-    assert extract_after(shellspec, "--default-path ").split("\n", 1)[0].strip() == SUITE_ROOTS["shellspec"]
+    assert extract_after(shellspec, "--default-path ").split("\n", 1)[0].strip() in SUITE_RUNNERS["shellspec"]
 
     run_smoke = (ROOT / "scripts" / "run-smoke.sh").read_text(encoding="utf-8")
-    assert extract_between(run_smoke, '_PATHS="', '"') == SUITE_ROOTS["scripts/run-smoke.sh"]
+    assert extract_between(run_smoke, '_PATHS="', '"') in SUITE_RUNNERS["scripts/run-smoke.sh"]
+
+    # roundtrip.sh maps to `src` because it drives the production reload entry point.
+    roundtrip = (ROOT / "tests" / "smoke" / "roundtrip.sh").read_text(encoding="utf-8")
+    assert extract_between(roundtrip, 'PHP_CLI="', '"').endswith("pfblockerng.php")
+    assert PRODUCTION_ENTRY_POINTS["tests/smoke/roundtrip.sh"] == ("src",)
 
 
 # --------------------------------------------------------------------------- #
@@ -289,97 +359,156 @@ def test_suite_roots_match_the_configuration_that_declares_them() -> None:
 _PLANTED_JOB = {("planted.yml", "suite"): {"vendor/bin/phpunit"}}
 
 
+def _planted(budget: object) -> dict[str, dict]:
+    job: dict[str, object] = {"runs-on": "ubuntu-latest", "steps": []}
+    if budget is not _MISSING:
+        job["timeout-minutes"] = budget
+    return {"planted.yml": {"jobs": {"suite": job}}}
+
+
 @pytest.mark.parametrize(
     ("budget", "expected"),
     (
-        ("", "no job-level timeout-minutes"),
-        ("    timeout-minutes: ${{ inputs.budget }}\n", "not a plain positive integer"),
-        ("    timeout-minutes: 0\n", "not a plain positive integer"),
-        ("    timeout-minutes: -5\n", "not a plain positive integer"),
-        (f"    timeout-minutes: {GITHUB_DEFAULT_TIMEOUT_MINUTES}\n", "bounds nothing"),
+        (_MISSING, "no job-level timeout-minutes"),
+        ("${{ inputs.budget }}", "not a plain positive integer"),
+        ("20", "not a plain positive integer"),
+        (0, "not a plain positive integer"),
+        (-5, "not a plain positive integer"),
+        (20.0, "not a plain positive integer"),
+        (True, "not a plain positive integer"),
+        (GITHUB_DEFAULT_TIMEOUT_MINUTES, "bounds nothing"),
+        (100000, "bounds nothing"),
     ),
 )
-def test_the_gate_reports_a_planted_budget_offence(budget: str, expected: str) -> None:
-    source = "jobs:\n  suite:\n    runs-on: ubuntu-latest\n" + budget + "    steps: []\n"
-    offences = budget_offences({"planted.yml": source}, _PLANTED_JOB)
+def test_the_gate_reports_a_planted_budget_offence(budget: object, expected: str) -> None:
+    offences = budget_offences(_planted(budget), _PLANTED_JOB)
     assert len(offences) == 1 and expected in offences[0], offences
 
 
 def test_the_gate_accepts_a_planted_job_that_carries_a_budget() -> None:
-    source = "jobs:\n  suite:\n    runs-on: ubuntu-latest\n    timeout-minutes: 15\n    steps: []\n"
-    assert budget_offences({"planted.yml": source}, _PLANTED_JOB) == []
-
-
-def test_a_budget_nested_under_a_step_is_not_a_job_budget() -> None:
-    """Six-space indentation puts the key on a step, where GitHub ignores it. The
-    job-level regex must not accept it."""
-    source = (
-        "jobs:\n  suite:\n    runs-on: ubuntu-latest\n    steps:\n"
-        "      - name: run\n        timeout-minutes: 15\n        run: true\n"
-    )
-    offences = budget_offences({"planted.yml": source}, _PLANTED_JOB)
-    assert len(offences) == 1 and "no job-level timeout-minutes" in offences[0], offences
-
-
-def test_a_renamed_planted_job_raises_instead_of_widening_the_slice() -> None:
-    """The #2669 shape: an absent landmark must raise, never return the whole file --
-    which would let the `timeout-minutes` search match a LATER job's budget and pass."""
-    source = "jobs:\n  renamed:\n    timeout-minutes: 15\n    steps: []\n"
-    with pytest.raises(ValueError, match="job 'suite' not found"):
-        budget_offences({"planted.yml": source}, _PLANTED_JOB)
+    assert budget_offences(_planted(15), _PLANTED_JOB) == []
 
 
 @pytest.mark.parametrize(
-    "body",
+    ("label", "source"),
     (
-        "shellspec --shell dash",
-        "uv run pytest --junitxml=/tmp/x.xml",
-        "sh scripts/run-smoke.sh --paths tests/smoke",
-        "vendor/bin/phpunit --coverage-text",
-        'DASH=dash shellspec --shell "$DASH"',
-        "make build && shellspec",
+        (
+            "quoted sibling job key",
+            'jobs:\n  suite:\n    steps: []\n  "other":\n    timeout-minutes: 5\n    steps: []\n',
+        ),
+        (
+            "budget nested under a step",
+            "jobs:\n  suite:\n    steps:\n      - name: run\n        timeout-minutes: 15\n        run: 'true'\n",
+        ),
     ),
 )
-def test_the_runner_scan_sees_real_invocations(body: str) -> None:
-    assert runners_in_run_body(body), body
+def test_a_budget_that_is_not_the_job_s_own_does_not_satisfy_the_gate(label: str, source: str) -> None:
+    """Two false-pass shapes a text slice allows. `extract_job`'s sibling boundary does not
+    recognise a QUOTED job key, so a slice runs into the next job and its budget satisfies
+    the search; and GitHub ignores a step-level key as a job bound. Reading the parsed
+    document cannot be fooled by either."""
+    offences = budget_offences({"planted.yml": yaml.safe_load(source)}, _PLANTED_JOB)
+    assert len(offences) == 1 and "no job-level timeout-minutes" in offences[0], (label, offences)
 
 
 @pytest.mark.parametrize(
-    "body",
+    ("body", "expected"),
     (
-        '        echo "shellspec shell tests failed or were cancelled."',
-        "        # sh scripts/run-smoke.sh shells out to the synced interpreter",
-        "        python3 scripts/check_skip_allowlist.py --suite pytest report.xml",
-        '        installed="$(shellspec --version)"',
+        ("shellspec --shell dash", {"shellspec"}),
+        ("uv run pytest --junitxml=/tmp/x.xml", {"pytest"}),
+        ("python -m pytest -q", {"pytest"}),
+        ("python3.11 -m pytest", {"pytest"}),
+        ("uv run python -m pytest", {"pytest"}),
+        ("sh scripts/run-smoke.sh --paths tests/smoke", {"scripts/run-smoke.sh"}),
+        ("./scripts/run-smoke.sh --paths tests/smoke", {"scripts/run-smoke.sh"}),
+        ('"$GITHUB_WORKSPACE"/scripts/run-smoke.sh -m smoke', {"scripts/run-smoke.sh"}),
+        ("vendor/bin/phpunit --coverage-text", {"vendor/bin/phpunit"}),
+        ("./vendor/bin/phpunit", {"vendor/bin/phpunit"}),
+        ('DASH=dash shellspec --shell "$DASH"', {"shellspec"}),
+        ("make build && shellspec", {"shellspec"}),
+        ("timeout 600 vendor/bin/phpunit", {"vendor/bin/phpunit"}),
+        ("timeout 60 sh scripts/run-smoke.sh", {"scripts/run-smoke.sh"}),
+        ("timeout --foreground 60 sh scripts/run-smoke.sh", {"scripts/run-smoke.sh"}),
+        ("nice -n 5 shellspec", {"shellspec"}),
+        ("if ! pytest -q; then echo no; fi", {"pytest"}),
+        ("(pytest)", {"pytest"}),
+        ("{ pytest; }", {"pytest"}),
+        ("command pytest", {"pytest"}),
+        ("tests/smoke/roundtrip.sh smoke_key a b", {"tests/smoke/roundtrip.sh"}),
+        ("run_ssh '/usr/local/bin/php /usr/local/www/pfblockerng/pfblockerng.php update'", {"pfblockerng.php"}),
+        ('        echo "shellspec shell tests failed or were cancelled."', set()),
+        ("        # sh scripts/run-smoke.sh shells out to the synced interpreter", set()),
+        ("        # pfblockerng.php update is the production reload entry point", set()),
+        ("        python3 scripts/check_skip_allowlist.py --suite pytest report.xml", set()),
+        ('        installed="$(shellspec --version)"', set()),
+        ("        grep -n pytest pyproject.toml", set()),
     ),
 )
-def test_the_runner_scan_ignores_mentions_that_are_not_invocations(body: str) -> None:
-    assert runners_in_run_body(body) == set(), body
+def test_the_runner_scan_reads_invocations_and_not_mentions(body: str, expected: set[str]) -> None:
+    assert runners_in_run_body(body) == expected, body
 
 
-@pytest.mark.parametrize(
-    "line",
-    (
-        "\tif ($lock === FALSE || !@flock($lock, LOCK_SH | LOCK_NB)) {",
-        "\t\t$this->assertTrue(flock($holder, LOCK_EX));",
-        "\t@file_put_contents($path, $content, LOCK_EX);",
-        "        fcntl.flock(handle, fcntl.LOCK_EX)",
-        "\t\t( exec 9>lockfile; lockf -k 9; sleep 30 ) &",
-        "timeout 5 sh -c 'exec 9>L; flock -w 0 9'",
-    ),
+_ACQUIRE_CASES: tuple[tuple[bool, str], ...] = (
+    (True, "\tif ($lock === FALSE || !@flock($lock, LOCK_SH | LOCK_NB)) {"),
+    (True, "\t\t$this->assertTrue(flock($holder, LOCK_EX));"),
+    (True, "\t\tflock($this->fp, LOCK_EX);"),
+    (True, "\t\tflock(self::$fp, LOCK_EX);"),
+    (True, "\t@file_put_contents($path, $content, LOCK_EX);"),
+    # A call wrapped across lines puts the constant on its own line, with and without a
+    # trailing delimiter -- both are the shape the line-scoped patterns cannot see.
+    (True, "\t\t\tLOCK_EX"),
+    (True, "\t\t\t$fp, LOCK_EX);"),
+    (True, "\t\t\tLOCK_EX | LOCK_NB,"),
+    (True, "        fcntl.flock(handle, fcntl.LOCK_EX)"),
+    (True, "\t\t( exec 9>lockfile; lockf -k 9; sleep 30 ) &"),
+    (True, "\t\t( exec 9>lockfile; flock 9; sleep 30 ) &"),
+    (True, "sh -c 'exec 9>L; flock $fd'"),
+    (True, "timeout 5 sh -c 'exec 9>L; flock -w 0 9'"),
+    (False, "\t@flock($lock, LOCK_UN);"),
+    (False, "\t// A waiter can be descheduled between its deadline check and flock()."),
+    (False, "\t// LOCK_EX, and the deadline, are documented above."),
+    (False, "\t/* LOCK_EX */"),
+    (False, "# The flock inside _rebuild_code still prevents pile-ups"),
+    (False, "45 lockf /usr/bin/lockf -s -t 5 /tmp/pfSense-upgrade.lock"),
 )
-def test_the_acquire_scan_sees_every_acquire_shape(line: str) -> None:
-    assert any(pattern.search(line) for pattern in _ACQUIRE_PATTERNS), line
 
 
-@pytest.mark.parametrize(
-    "line",
-    (
-        "\t@flock($lock, LOCK_UN);",
-        "\t// A waiter can be descheduled between its deadline check and flock().",
-        "# The flock inside _rebuild_code still prevents pile-ups",
-        "45 lockf /usr/bin/lockf -s -t 5 /tmp/pfSense-upgrade.lock",
-    ),
-)
-def test_the_acquire_scan_ignores_releases_prose_and_fixture_text(line: str) -> None:
-    assert not any(pattern.search(line) for pattern in _ACQUIRE_PATTERNS), line
+@pytest.mark.parametrize(("acquires", "line"), _ACQUIRE_CASES)
+def test_the_acquire_scan_separates_acquires_from_releases_and_prose(acquires: bool, line: str) -> None:
+    assert any(pattern.search(line) for pattern in _ACQUIRE_PATTERNS) is acquires, line
+
+
+def test_the_acquire_scan_finds_the_real_production_and_fixture_lock_sites() -> None:
+    """A production oracle, not a restatement of the regexes: the scan must actually find
+    the acquires that make `php-unit` and the live-VM jobs lock-reachable."""
+    src_files = {hit.rsplit(":", 1)[0] for hit in kernel_lock_acquires("src")}
+    assert "src/usr/local/pkg/pfblockerng/pfblockerng.inc" in src_files
+    # Wrapped across lines, so this one only appears once the argument-line pattern works.
+    assert "src/usr/local/pkg/pfblockerng/pfblockerng_geoip.inc" in src_files, sorted(src_files)
+
+    php_files = {hit.rsplit(":", 1)[0] for hit in kernel_lock_acquires("tests/php")}
+    # The forked pair that both append under LOCK_EX to the SAME paths: a genuine blocking
+    # waiter, which is what makes the php-unit budget load-bearing rather than decorative.
+    assert "tests/php/TickSafeSearchReservationTest.php" in php_files
+    assert "tests/php/FeedPassLockTest.php" in php_files
+
+    assert kernel_lock_acquires("tests/smoke"), "tests/smoke must keep its appliance LOCK_EX writes"
+
+
+def test_a_latin1_encoded_source_is_scanned_rather_than_skipped() -> None:
+    """An except-and-continue on UnicodeDecodeError dropped a tracked latin-1 `.inc`
+    holding a real `flock($fp, LOCK_EX)` -- a silent false negative."""
+    decoded = b"<?php\nflock($fp, LOCK_EX); // latin-1: \xff\n".decode("utf-8", errors="replace")
+    assert any(pattern.search(line) for line in decoded.splitlines() for pattern in _ACQUIRE_PATTERNS)
+
+
+def test_the_prefilter_is_a_superset_of_every_acquire_pattern() -> None:
+    """`_candidate_files` only reads files naming a `_PREFILTER_TOKENS` entry, so a line a
+    pattern matches WITHOUT one of those tokens would be invisible to the scan even though
+    the regex would have caught it -- a silent hole. Checked against the real matching
+    lines above rather than against the pattern sources, which spell the constants as
+    alternations (`LOCK_(?:EX|SH)`) and would make a source-text check vacuous."""
+    matching = [line for acquires, line in _ACQUIRE_CASES if acquires]
+    assert matching, "no positive acquire cases to check the prefilter against"
+    for line in matching:
+        assert any(token in line for token in _PREFILTER_TOKENS), line


### PR DESCRIPTION
Fixes #2614.

## What the issue asked, and what was actually there

The issue names two things: `lockf -k 9` / `flock 9` in `scripts/agent/work-branch.sh`, and a `shell-tests` job with no `timeout-minutes`. Enumerated from source at the base, **both are already gone**:

```console
$ git show origin/devel:scripts/agent/work-branch.sh | grep -c 'lockf\|flock\|graphify-store'
0
$ git log --oneline -S 'graphify-store' origin/devel -- scripts/agent/work-branch.sh
d4ece4632 ci: initialize worktree intelligence tools     # <- retired with the Graphify store

$ grep -n 'timeout-minutes' <(git show origin/devel:.github/workflows/test.yml)
79:5   101:20 (test)   428:20 (shell-tests)   661:10   762:15 (php-unit)   927:15   982:15
```

The primitive the issue names was retired with the Graphify store; `shell-tests` was bounded by `36341caf3`. Neither closes the ticket, because the issue's own scope note says the exposure comes from *the primitives plus the missing budget* — and nothing in the repository tied the two together.

## The enumeration (from source, not from the issue's wording)

Surviving kernel-lock acquires, by shape, whole tree:

| Tree | Shape | Bounded? |
| --- | --- | --- |
| `src/**` | 68 × `file_put_contents(…, LOCK_EX)` — a **blocking** `flock(2)` acquire — plus `flock()` calls | the `flock()` calls are `LOCK_NB` or go through `pfb_flock_bounded()` (#1780). The `file_put_contents` acquires are **not** bounded and are **invisible to the #1780 gate**, which matches `flock(` call syntax only. Reported separately, see below |
| `tests/php/**` | 66 acquire lines across 24 files: 47 blocking `LOCK_EX`, 19 `LOCK_NB` | no |
| `tests/smoke/**` | `file_put_contents(…, LOCK_EX)` in snippets executed **on the appliance**; `test_feed_pass_lock.py` also stands a real on-box holder up through `pfb_feed_pass_acquire()` | no |
| `tests/shell/**`, `scripts/**`, `.githooks/**`, `.claude/**` | none. `scripts/select-box.sh` uses a non-blocking `mkdir` lease with TTL reclaim, not a kernel lock | n/a |

**The waiters are real, not hypothetical.** `tests/php/TickSafeSearchReservationTest.php:71,74,86` forks two workers that both `file_put_contents($shared, …, FILE_APPEND | LOCK_EX)` on the *same* paths, and that call blocks:

```console
$ php -r '$p=tempnam(sys_get_temp_dir(),"e2614_"); $fp=fopen($p,"c"); flock($fp,LOCK_EX);
          $pid=pcntl_fork(); if($pid===0){usleep(500000); flock($fp,LOCK_UN); exit(0);}
          $t=microtime(true); $n=file_put_contents($p,"waiter\n",FILE_APPEND|LOCK_EX);
          printf("write=%s elapsed=%.3f\n",var_export($n,true),microtime(true)-$t);'
write=7 elapsed=0.504
```

Jobs that reach one of those trees — the lock-reachable set, all 83 jobs scanned:

| job | reaches | budget | observed (GitHub API, recent successful runs) |
| --- | --- | --- | --- |
| `test.yml` `test` | `uv run pytest` | 20 | median 3.5 min, max 4.1 (n=14) |
| `test.yml` `php-unit` | `vendor/bin/phpunit` → `tests/php` + the real `src/` `.inc` | 15 | median 2.2 min, max 2.6 (n=14) |
| `smoke-single.yml` `smoke` | `sh scripts/run-smoke.sh` → `tests/smoke` + on-box `src/` | 45 | max 17.8 min worst leg (n=7 per leg) |
| `ui-tests.yml` `ui` | `sh scripts/run-smoke.sh` | 45 | max 23.5 min worst tier (n=7 per leg) |
| `build-image.yml` `verify-image` | `tests/smoke/roundtrip.sh` → `pfblockerng.php update` → `src/` | 60 | no successful-run sample in the last 20 runs; budget pre-existing, not sized here |
| `image-refresh.yml` `refresh` | `run_ssh '… pfblockerng.php update'` → `src/` | 120 | as above |

The last two were **missed by my first enumeration** and found by three independent reviewers; they are in the gate now. Jobs calling a reusable workflow are excluded — GitHub allows only name/uses/with/secrets/needs/if/permissions/strategy there, which `smoke.yml` states in its own comment — so the bound that applies is the called job's, read at its definition site. `test.yml` `shell-tests` and `build-pkg-linux.yml` `build` run shellspec, whose roots (`tests/shell`, `scripts`) hold no acquire today, so they are derived *out* rather than asserted out: a lock returning to `scripts/agent/work-branch.sh` flips `scripts` to bearing and pulls them in (mutant 12 below).

## The defect, executed

All lock-reachable jobs already carried a budget. What no test defended was the *relationship*:

```console
$ python3 -c "…strip '    timeout-minutes: 45' from smoke-single.yml…"
$ python3 -c "…strip '    timeout-minutes: 10' from build-pkg-linux.yml…"
$ uv run pytest -q
================== 5614 passed, 2 skipped in 92.02s (0:01:32) ==================
$ actionlint --version && actionlint; echo "rc=$?"
1.7.12
rc=0
```

Green suite, silent linter. `test.yml`'s `test`/`php-unit` are pinned by `test_issue2673_xdist_ci.py` and `ui-tests.yml`'s `ui` by `test_smoke_ui_config_digest.py` — each by a hardcoded job name in one file, none tied to lock reachability, and the other three defended by nothing at all.

## The issue's probe, reproduced

```console
$ ( exec 9>/tmp/e2614.lock; lockf -k 9; sleep 30 ) & sleep 1
$ timeout 5 sh -c 'exec 9>/tmp/e2614.lock; lockf -k 9; echo ACQUIRED'
second-acquirer rc=124
$ timeout 5 sh -c 'exec 9>/tmp/e2614b.lock; lockf -k 9; echo ACQUIRED'
ACQUIRED
free-lock rc=0
```

rc 124 against a held lock, rc 0 against a free one — the issue's evidence exactly.

## Did I bound the acquire itself?

**No, and here is the reasoning, including the part a reviewer refuted.**

1. **The acquire the issue names does not exist.** `scripts/agent/work-branch.sh` has no lock at all; its concurrency hardening (`d62ed4417`) is lock-free. There is nothing to add a `-t`/`-w` to.
2. ~~The `tests/php` acquires are holders on fresh per-process paths, so they cannot block.~~ **Refuted during review, with the probe quoted above.** `TickSafeSearchReservationTest.php` forks two workers that contend for the same path, so there *is* a genuine unbounded blocking waiter, reachable from `php-unit`. That strengthens the case for the job budget rather than weakening it: the budget is what bounds a real waiter, not a theoretical one.
3. **The production waiters are already bounded.** `pfb_flock_bounded()` (`pfblockerng_extra.inc:3819`, #1780) gives every blocking `flock()` acquire a deadline plus an attempt cap, gated by `tests/test_bounded_flock.py`. A second bound would be duplicate machinery.
4. **The genuinely unbounded production acquires are out of this lane's scope.** The 68 `file_put_contents(…, LOCK_EX)` calls in `src/` *are* blocking `flock(2)` acquires the #1780 scanner cannot see. That is a real hole in a different issue's gate, in `pfblockerng.inc`, which other lanes are editing — reported, not patched here.

So the fix is at the job boundary. After this change the probe still blocks — the primitive is untouched — but a stuck lock fails at the job's own budget instead of at GitHub's 360-minute default, and that budget can no longer be deleted, zeroed, expression-ised or raised to the platform default silently.

## What changed

`tests/test_issue2614_lock_job_budgets.py` (new) — a source-derived gate:

- acquires scanned out of each tree by shape; `git grep` prefilters candidates (a sound superset — every pattern names a prefilter token, pinned by its own test) over **tracked** files only, so untracked scratch cannot move the verdict;
- runners map to every tree they **execute**, not just their own directory: `shellspec → (tests/shell, scripts)`, `phpunit → (tests/php, src)`, `run-smoke.sh → (tests/smoke, src)`. Production entry points (`pfblockerng.php`, `tests/smoke/roundtrip.sh`) are matched as substrings, because they arrive through indirection (`run_ssh '…'`) no command matcher can chase;
- roots re-derived from the config each runner reads — `phpunit.xml`, `pyproject.toml` `testpaths` + `--ignore`, `.shellspec` `--default-path`, `run-smoke.sh` `_PATHS`, `roundtrip.sh` `PHP_CLI` — each slice bounded by `tests/_workflow_steps.py`, so a reworded anchor **raises** instead of widening (#2669);
- runner tokens matched at **command position**, tolerating `./`, a leading path, quotes, `$( … )`, grouping punctuation, wrapper options *and their values*, and shell control words — so `echo "shellspec …"`, `--suite pytest` and `#` comments are still not invocations;
- local composite actions followed **recursively with cycle detection**;
- the budget read from **parsed YAML**, not a text slice — a quoted sibling job key walks past `extract_job`'s boundary and lets a *later* job's budget satisfy the search;
- a missing, non-integer, zero, negative, float, quoted, step-level, foreign or ≥360 budget on any lock-reachable job fails **by name**;
- `test_which_roots_hold_kernel_lock_acquires` asserts the *premise*, so a tree that starts or stops locking is a visible diff rather than a silent change in what the gate demands;
- an unreadable candidate **raises**; a latin-1 source is decoded, never skipped.

Five workflows gain **comment lines only** — the constraint and, where a sample exists, the observed runtime each budget was sized against:

```console
$ git diff --stat origin/devel...HEAD
 .github/workflows/build-image.yml        |   3 +
 .github/workflows/image-refresh.yml      |   3 +
 .github/workflows/smoke-single.yml       |   3 +
 .github/workflows/test.yml               |   6 +
 .github/workflows/ui-tests.yml           |   3 +
 tests/test_issue2614_lock_job_budgets.py | 642 +++++++++++++++++++++++++++++++
$ git diff origin/devel...HEAD -- .github/workflows/ | grep '^+' | grep -v '^+++' | grep -vE '^\+ *#' | wc -l
0
```

**Zero non-comment lines added to any workflow.** No budget value, step, trigger, matrix, `needs`, `if` or `runs-on` changed; the verifier confirmed parsed-YAML equality per file.

## Tests

Test-first. The reproduction test ran RED against the tree carrying the defect, frozen, GREEN after at the identical hash.

| Frozen RED test | git hash-object | RED run tail |
| --- | --- | --- |
| `tests/test_issue2614_lock_job_budgets.py` | `3890a33d614f8b1a304adfbc068c76d0abc3a85e` | `FAILED tests/test_issue2614_lock_job_budgets.py::test_every_job_reaching_a_lock_bearing_tree_pins_timeout_minutes` — `AssertionError: kernel-lock job budget missing: smoke-single.yml: job smoke reaches scripts/run-smoke.sh (lock sites under src, tests/smoke): no job-level timeout-minutes, so a stuck lock burns GitHub's 360-minute default` — `1 failed / 31 passed` at the first frozen hash, reproduced at every subsequent one |

The first round's frozen hash was `5ce5b70e253a2b67d11c5bb00df5d324c6f2d782` (RED `1 failed, 84 passed` / GREEN `32 passed`, both quoted in the review thread and independently replayed by the verifier and two legs). Three review commits then changed the file, so the freeze was re-established each time; the hash above is the shipped blob and the current suite is **85 passed**.

### Review-round recall fixes — each proven fail-before/pass-after

The review found false negatives that un-gated real jobs. Every one was demonstrated against the *previous commit's* scanner, loaded side by side with the new one:

| finding | old | new |
| --- | --- | --- |
| `./scripts/run-smoke.sh` | `[]` | `['scripts/run-smoke.sh']` |
| `python -m pytest` | `[]` | `['pytest']` |
| `uv run python -m pytest` | `[]` | `['pytest']` |
| `timeout 60 sh scripts/run-smoke.sh` | `[]` | `['scripts/run-smoke.sh']` |
| `timeout 600 vendor/bin/phpunit` | `[]` | `['vendor/bin/phpunit']` |
| `nice -n 5 shellspec` | `[]` | `['shellspec']` |
| `if ! pytest; then` | `[]` | `['pytest']` |
| `(pytest)` / `{ pytest; }` | `[]` | `['pytest']` |
| `command pytest` | `[]` | `['pytest']` |
| `tests/smoke/roundtrip.sh …` | `[]` | `['tests/smoke/roundtrip.sh']` |
| `run_ssh '… pfblockerng.php update'` | `[]` | `['pfblockerng.php']` |
| wrapped `$fp, LOCK_EX);` argument line | `False` | `True` |
| bare wrapped `LOCK_EX` line | `False` | `True` |
| `flock(self::$fp, LOCK_EX)` | `False` | `True` |
| bare-fd `flock 9` | `False` | `True` |
| `flock $fd` | `False` | `True` |
| scanned roots | `tests, tests/php, tests/shell, tests/smoke` | `:(glob)tests/*.py, scripts, src, tests/php, tests/shell, tests/smoke` |
| enumeration | 4 jobs | 6 jobs |

A second round added `uv run --group dev pytest`, `env -u NAME pytest`, `"$(command -v shellspec)"`, `poetry run pytest`, `bash -c 'shellspec'`, `SplFileObject::flock(LOCK_EX)`, `exec {fd}>file; flock $fd`, recursive composite traversal, the quoted-sibling YAML read, and turning a silently-skipped unreadable candidate into a raise.

### Mutation proof — 17/17 killed

Driver: assert single-occurrence needle → replace → assert non-empty `git diff` → run the ONE named test → revert → assert clean. Needles are comment-anchored because several `timeout-minutes:` values repeat within one workflow.

| # | mutant | named test that failed |
| --- | --- | --- |
| 1-6 | strip the budget from each of the six lock-reachable jobs | `…pins_timeout_minutes` |
| 7-8 | `smoke` budget → 360, → 100000 | `…pins_timeout_minutes` (`at or above GitHub's 360-minute default, so it bounds nothing`) |
| 9-11 | `php-unit` budget → `${{ inputs.budget }}`, → `0`, → `'15'` | `…pins_timeout_minutes` (`not a plain positive integer`) |
| **12** | **reintroduce the issue's own primitive: `exec 9>…; flock 9` in `scripts/agent/work-branch.sh`** | `test_which_roots_hold_kernel_lock_acquires` |
| **13** | **add a NEW unbudgeted job running `vendor/bin/phpunit`** | `…pins_timeout_minutes` |
| 14 | reword `.shellspec`'s `--default-path` | `…configuration_that_declares_them` (`ValueError: marker '--default-path ' not found`) |
| 15 | move `phpunit.xml`'s suite root | `…configuration_that_declares_them` |
| 16 | drop `--ignore=tests/smoke` from `pyproject.toml` | `…configuration_that_declares_them` |
| 17 | rename the `smoke` job | `…the_ones_the_scan_finds` |

```
RESULT: 17/17 mutants killed
tree clean at end: True
```

Mutants 12 and 13 are the two properties the review said the first table never demonstrated: catching the issue's own regression, and catching a genuinely new lock-reachable job. Control on a clean tree: `85 passed`.

Two review-round acquire shapes are **not** in the driver, deliberately: the wrapped-argument line and the forked-worker `LOCK_EX` appends live in files holding several acquires, so no single-needle edit can drop the file from the production-oracle test, and a mutant that cannot kill is worse than no mutant. Their fail-before/pass-after evidence is the A/B table above plus their own parametrize rows.


### Later review rounds

The four observed-runtime comments originally carried an `(n=...)` parenthetical. A deeper sweep showed 8-11 samples per smoke leg rather than 7, so the parenthetical was wrong while the figure it qualified was right; the comments now cite the observed median and worst and leave the sample size to this record.

Two further recall escapes were found and fixed after the table above: a runner behind a suffixed `timeout` duration (`timeout 10m vendor/bin/phpunit`, `timeout 600s sh scripts/run-smoke.sh`), and a quoted fd operand on a `flock(1)` acquire (`flock "$fd"`, `flock "${fd}"`, `flock "9"`) — the latter being this repository's own shell convention. Both carry exact-token parametrize rows.

Observed-runtime figures in the workflow comments, recomputed from the GitHub API over recent successful runs (raw per-run output kept for the review thread; the smoke row comes from the **caller** `smoke.yml` runs, because `smoke-single.yml`'s `smoke` job executes there as a reusable-workflow job — querying `smoke-single.yml`'s own runs returns only bare direct dispatches at 1.9-2.75 min, a provenance trap a reviewer caught):

| job | n | min | median | max | budget |
| --- | --- | --- | --- | --- | --- |
| `test.yml` `pytest / Python 3.11` | 15 | 3.02 | 3.45 | 3.87 | 20 |
| `test.yml` `PHPUnit unit tests` (8.3 + 8.5) | 30 | 2.03 | 2.20 | 2.63 | 15 |
| `smoke.yml` smoke legs (via `smoke-single.yml` `smoke`, its real execution site) | 84 pooled, 8-11/leg | 12.32 | 14.76 | 17.78 | 45 |
| `ui-tests.yml` `functional` tiers | 7/leg | 15.9 | 21.4 | 23.5 | 45 |
| `build-image.yml` `verify-image` | 0 successful in last 20 runs | — | — | — | 60 (pre-existing) |
| `image-refresh.yml` `refresh` | 0 successful in last 20 runs | — | — | — | 120 (pre-existing) |

### Gates

```console
$ sh scripts/agent/run-gates.sh --diff origin/devel
GATE PASS: python3 scripts/check_coverage_pairing.py --name-status-z
GATE PASS: uv run --locked pytest
GATE PASS: uv run --locked ruff check .
GATE PASS: uv run --locked ruff format --check .
GATE PASS: uv run --locked mypy tests/
GATES: PASS

$ actionlint --version && actionlint; echo "rc=$?"      # CI pin
1.7.12
rc=0

$ uv run pytest tests/test_issue2231_workflow_hygiene.py tests/test_issue2673_xdist_ci.py \
      tests/test_smoke_ui_config_digest.py tests/test_bounded_flock.py -q
55 passed
```

Toolchain: local runs on macOS 25.6 (arm64), Python 3.11.15 from `uv.lock`, `actionlint` 1.7.12 (the CI pin). CI on Linux is the authoritative verdict.

🤖 Generated by Oh My Pi and posted on behalf of @andrebrait.
