### PR TITLE
tests: align the worktree-intelligence pin with the tracked root graph (#2788)

### DIFF
--- a/tests/test_cross_agent_tooling.py
+++ b/tests/test_cross_agent_tooling.py
@@ -203,12 +203,14 @@ def test_repository_intelligence_initializes_each_worktree_directly() -> None:
         "tests/` is",
         "harness/test",
         "stubs/` is shim/support",
-        "ignored and untracked",
+        "graph.json` is tracked",
+        "everything else under `graphify-out/` is ignored",
     ):
         assert contract in routing, f"direct worktree initialization routing lost {contract}"
 
     folded_routing = routing.casefold()
     for obsolete in (
+        "ignored and untracked",
         "graphify-refresh-required",
         "graphify-store.py",
         ".git/graphify-store.lock",
@@ -225,12 +227,20 @@ def test_repository_intelligence_initializes_each_worktree_directly() -> None:
     attrs = attrs_text.splitlines()
     graphify_attribute = "graphify-out/graph.json merge=graphify"
     assert attrs.count(graphify_attribute) == 1, f"expected exact .gitattributes row: {graphify_attribute}"
-    assert (
-        subprocess.run(["git", "ls-files", "graphify-out"], cwd=ROOT, check=True, text=True, capture_output=True).stdout
-        == ""
-    )
+    # The root graph is tracked so a fresh checkout starts with the map; everything
+    # else under graphify-out/ is regenerated from it and stays ignored. Asserting the
+    # exact set fails both ways: a dropped graph and a tracked generated artifact.
+    assert subprocess.run(
+        ["git", "ls-files", "graphify-out"], cwd=ROOT, check=True, text=True, capture_output=True
+    ).stdout.split() == ["graphify-out/graph.json"]
     root_ignore = (ROOT / ".gitignore").read_text(encoding="utf-8").splitlines()
-    assert "graphify-out/" in root_ignore, "generated Graphify output must remain ignored"
+    # The pair, in order: ignore the directory's contents, then re-include only the
+    # tracked graph. Either line alone gets the tracking wrong.
+    assert "graphify-out/*" in root_ignore, "generated Graphify output must remain ignored"
+    assert "!graphify-out/graph.json" in root_ignore, "the tracked root graph must be re-included"
+    assert root_ignore.index("graphify-out/*") < root_ignore.index("!graphify-out/graph.json"), (
+        "the re-include must follow the ignore, or the graph is not tracked"
+    )
     for obsolete_path in ("scripts/agent/graphify-store.py", "tests/test_graphify_store.py"):
         assert not (ROOT / obsolete_path).exists(), f"obsolete Graphify store path returned: {obsolete_path}"
 

--- a/tests/test_cross_agent_tooling.py
+++ b/tests/test_cross_agent_tooling.py
@@ -235,9 +235,11 @@ def test_repository_intelligence_initializes_each_worktree_directly() -> None:
     ).stdout.split() == ["graphify-out/graph.json"]
     root_ignore = (ROOT / ".gitignore").read_text(encoding="utf-8").splitlines()
     # The pair, in order: ignore the directory's contents, then re-include only the
-    # tracked graph. Either line alone gets the tracking wrong.
-    assert "graphify-out/*" in root_ignore, "generated Graphify output must remain ignored"
-    assert "!graphify-out/graph.json" in root_ignore, "the tracked root graph must be re-included"
+    # tracked graph. Either line alone gets the tracking wrong, and so does a later
+    # duplicate of the ignore -- git takes the LAST matching rule, while index()
+    # reports the first, so the count is asserted before the order.
+    assert root_ignore.count("graphify-out/*") == 1, "generated Graphify output must remain ignored, once"
+    assert root_ignore.count("!graphify-out/graph.json") == 1, "the tracked root graph must be re-included, once"
     assert root_ignore.index("graphify-out/*") < root_ignore.index("!graphify-out/graph.json"), (
         "the re-include must follow the ignore, or the graph is not tracked"
     )


### PR DESCRIPTION
Fixes #2788.

`234d06d9` made `graphify-out/graph.json` tracked and kept everything else under `graphify-out/` ignored. `tests/test_cross_agent_tooling.py::test_repository_intelligence_initializes_each_worktree_directly` was not brought along, so it failed on every `devel` run afterwards — and, because the PR Python job runs against the merge ref, on every open PR regardless of its contents.

The test also contradicted itself: it already required the `graphify-out/graph.json merge=graphify` attribute, which only a *tracked* file needs, while asserting three lines later that `git ls-files graphify-out` is empty.

## What changed

The pins now record the committed design rather than the wording it replaced:

- the routing document must state both halves of the split — `` graph.json` is tracked `` and ``everything else under `graphify-out/` is ignored``;
- the retired `ignored and untracked` phrasing joins the obsolete list, so it cannot come back unnoticed;
- `git ls-files graphify-out` must be exactly `["graphify-out/graph.json"]`, which fails both ways — a dropped graph and a tracked generated artifact;
- `.gitignore` must carry `graphify-out/*` and `!graphify-out/graph.json`, in that order, since either line alone gets the tracking wrong.

## Evidence

Before, at the `devel` tip in a clean clone:

```console
$ uv run --locked pytest tests/test_cross_agent_tooling.py::test_repository_intelligence_initializes_each_worktree_directly -q
tests/test_cross_agent_tooling.py:208: AssertionError
  - AssertionError: direct worktree initialization routing lost ignored and untracked
1 failed in 0.73s
```

After: `12 passed`.

Every new assertion was proved failable rather than assumed — four mutations, four distinct named kills:

| Mutation | Assertion that fired |
| --- | --- |
| document line reverted to the retired wording | ``direct worktree initialization routing lost graph.json` is tracked`` |
| `!graphify-out/graph.json` dropped | `the tracked root graph must be re-included` |
| the two `.gitignore` lines swapped | `the re-include must follow the ignore, or the graph is not tracked` |
| `graphify-out/graph.json` untracked | `assert [] == ['graphify-out/graph.json']` |

Canonical gates PASS (`pytest`, `ruff check`, `ruff format --check`, `mypy`, coverage pairing).

Found while landing #2668 (PR #2782), which cannot present a green CI run until this is fixed.

🤖 Generated by Oh My Pi and posted on behalf of @andrebrait.
