### PR TITLE
tests: repin the graphify contract on the tracked root graph

### DIFF
--- a/tests/test_cross_agent_tooling.py
+++ b/tests/test_cross_agent_tooling.py
@@ -203,7 +203,8 @@ def test_repository_intelligence_initializes_each_worktree_directly() -> None:
         "tests/` is",
         "harness/test",
         "stubs/` is shim/support",
-        "ignored and untracked",
+        "`graphify-out/graph.json` is tracked",
+        "ensure-graphify-merge-driver.sh",
     ):
         assert contract in routing, f"direct worktree initialization routing lost {contract}"
 
@@ -225,12 +226,15 @@ def test_repository_intelligence_initializes_each_worktree_directly() -> None:
     attrs = attrs_text.splitlines()
     graphify_attribute = "graphify-out/graph.json merge=graphify"
     assert attrs.count(graphify_attribute) == 1, f"expected exact .gitattributes row: {graphify_attribute}"
-    assert (
-        subprocess.run(["git", "ls-files", "graphify-out"], cwd=ROOT, check=True, text=True, capture_output=True).stdout
-        == ""
+    tracked = subprocess.run(
+        ["git", "ls-files", "graphify-out"], cwd=ROOT, check=True, text=True, capture_output=True
+    ).stdout.split()
+    assert tracked == ["graphify-out/graph.json"], (
+        f"the root graph is the only tracked Graphify artifact; found {tracked}"
     )
     root_ignore = (ROOT / ".gitignore").read_text(encoding="utf-8").splitlines()
-    assert "graphify-out/" in root_ignore, "generated Graphify output must remain ignored"
+    assert "graphify-out/*" in root_ignore, "every generated Graphify output must stay ignored"
+    assert "!graphify-out/graph.json" in root_ignore, "the tracked root graph must be negated back in"
     for obsolete_path in ("scripts/agent/graphify-store.py", "tests/test_graphify_store.py"):
         assert not (ROOT / obsolete_path).exists(), f"obsolete Graphify store path returned: {obsolete_path}"
 


### PR DESCRIPTION
Closes #2791.

`devel` is red. `234d06d9` began tracking `graphify-out/graph.json` and rewrote the routing bullet in `.agents/context/repository-intelligence.md`, but the contract pin in `tests/test_cross_agent_tooling.py` still described the previous model.

```
FAILED tests/test_cross_agent_tooling.py::test_repository_intelligence_initializes_each_worktree_directly
AssertionError: direct worktree initialization routing lost ignored and untracked
1 failed, 5619 passed, 2 skipped
```

Three assertions encoded the old contract and are re-pinned on the current one:

| was | is |
| --- | --- |
| routing contains `ignored and untracked` | routing contains ``` `graphify-out/graph.json` is tracked ``` and names `ensure-graphify-merge-driver.sh` |
| `git ls-files graphify-out` returns nothing | it returns exactly `graphify-out/graph.json` |
| root ignore contains bare `graphify-out/` | it contains `graphify-out/*` and `!graphify-out/graph.json` |

The `.gitattributes` merge-driver row assertion is unchanged. The assertions still fail on a regression in either direction: dropping the negation, tracking a second artifact under `graphify-out/`, or reverting the routing wording each break a named assertion.

## Verification

Red before, at `devel` tip:

```
FAILED tests/test_cross_agent_tooling.py::test_repository_intelligence_initializes_each_worktree_directly
1 failed in 0.62s
```

Green after, plus full gates for the diff:

```
12 passed in 0.54s

GATE PASS: python3 scripts/check_coverage_pairing.py --name-status-z
GATE PASS: uv run --locked pytest
GATE PASS: uv run --locked ruff check .
GATE PASS: uv run --locked ruff format --check .
GATE PASS: uv run --locked mypy tests/
GATES: PASS
```

Authored by an OMP agent session; no `coauthor.omp.*` identity is configured in this checkout, so the commit carries no co-author trailer.