### PR TITLE
agent: refresh the Claude Code and Codex Graphify skills

### DIFF
--- a/scripts/agent/setup-agent-tools.sh
+++ b/scripts/agent/setup-agent-tools.sh
@@ -173,13 +173,18 @@ setup_serena_client() {
 }
 
 configure_agents() {
+	# `graphify <client> install` wires the client's always-on hooks for the scope
+	# it runs in; `graphify install --platform <client>` copies the skill itself.
+	# The two are disjoint for Claude Code and Codex, so an upgrade needs both or
+	# the client keeps running the previous release's skill. Copilot and Pi have
+	# no hook wiring: their client subcommand IS the skill copy.
 	if command -v claude >/dev/null 2>&1; then
 		setup_serena_client claude claude-code
-		(cd "$HOME" && graphify claude install)
+		(cd "$HOME" && graphify claude install && graphify install --platform claude)
 	fi
 	if command -v codex >/dev/null 2>&1; then
 		setup_serena_client codex codex
-		(cd "$HOME" && graphify codex install)
+		(cd "$HOME" && graphify codex install && graphify install --platform codex)
 	fi
 	if command -v grok >/dev/null 2>&1; then
 		setup_serena_client grok grok

--- a/tests/shell/agent_tools_setup_spec.sh
+++ b/tests/shell/agent_tools_setup_spec.sh
@@ -249,9 +249,22 @@ if [ "$*" = 'install --platform agents' ] && [ "$(pwd -P)" = "$DEBIAN_REPOSITORY
   printf '%s\n' '# graphify rewrote repository agents' > "$DEBIAN_REPOSITORY/AGENTS.md"
   printf '%s\n' '# graphify rewrote repository policy' > "$DEBIAN_REPOSITORY/.agents/policy/invariants.txt"
 fi
-if [ "$*" = 'copilot install' ]; then
-  mkdir -p "$HOME/.copilot/skills/graphify"
-  printf '%s\n' '0.9.50' > "$HOME/.copilot/skills/graphify/.graphify_version"
+# Only the skill copy refreshes a client's installed skill; the per-client hook
+# wiring (`graphify claude install`) leaves it untouched, exactly as the real
+# Graphify does.
+case "$*" in
+  'copilot install'|'pi install') stub_client=${1} ;;
+  'install --platform claude') stub_client=claude ;;
+  'install --platform codex') stub_client=codex ;;
+  *) stub_client='' ;;
+esac
+if [ -n "$stub_client" ]; then
+  case "$stub_client" in
+    pi) stub_skill_dir="$HOME/.pi/agent/skills/graphify" ;;
+    *) stub_skill_dir="$HOME/.$stub_client/skills/graphify" ;;
+  esac
+  mkdir -p "$stub_skill_dir"
+  printf '%s\n' '0.9.51' > "$stub_skill_dir/.graphify_version"
 fi
 GRAPHIFY
     for tool in ast-grep semgrep; do
@@ -725,9 +738,31 @@ UNMANAGED_UV
     printf '%s\n' '0.9.48' > "$home/.copilot/skills/graphify/.graphify_version"
     When run sh "$script_abs" "$repository"
     The status should equal 0
-    The contents of file "$home/.copilot/skills/graphify/.graphify_version" should equal '0.9.50'
+    The contents of file "$home/.copilot/skills/graphify/.graphify_version" should equal '0.9.51'
     Assert [ "$(grep -Fxc "graphify:$home:copilot install" "$tool_log")" -eq 1 ]
     The contents of file "$tool_log" should not include 'serena:setup'
+  End
+
+  It 'refreshes the detected Claude Code Graphify skill as well as its hook wiring'
+    enable_client claude
+    mkdir -p "$home/.claude/skills/graphify"
+    printf '%s\n' '0.9.48' > "$home/.claude/skills/graphify/.graphify_version"
+    When run sh "$script_abs" "$repository"
+    The status should equal 0
+    The contents of file "$home/.claude/skills/graphify/.graphify_version" should equal '0.9.51'
+    Assert [ "$(grep -Fxc "graphify:$home:claude install" "$tool_log")" -eq 1 ]
+    Assert [ "$(grep -Fxc "graphify:$home:install --platform claude" "$tool_log")" -eq 1 ]
+  End
+
+  It 'refreshes the detected Codex Graphify skill as well as its hook wiring'
+    enable_client codex
+    mkdir -p "$home/.codex/skills/graphify"
+    printf '%s\n' '0.9.48' > "$home/.codex/skills/graphify/.graphify_version"
+    When run sh "$script_abs" "$repository"
+    The status should equal 0
+    The contents of file "$home/.codex/skills/graphify/.graphify_version" should equal '0.9.51'
+    Assert [ "$(grep -Fxc "graphify:$home:codex install" "$tool_log")" -eq 1 ]
+    Assert [ "$(grep -Fxc "graphify:$home:install --platform codex" "$tool_log")" -eq 1 ]
   End
 
   It 'uses one Pi-compatible home-scoped Graphify install for detected OMP'


### PR DESCRIPTION
Refresh the Claude Code and Codex Graphify skills, not just their hook wiring (issue #2785).

**Problem.** `scripts/agent/setup-agent-tools.sh` refreshed each detected client's Graphify with the client subcommand alone. For Claude Code and Codex that command only writes the client's always-on hook wiring; copying the skill is a different command. After a Graphify upgrade both clients therefore kept the previous release's skill while the script reported success — observed live: `uv tool install --upgrade 'graphifyy>=0.9.51'` succeeded, then every invocation printed `warning: skill is from graphify 0.9.50, package is 0.9.51` while `~/.claude/skills/graphify/.graphify_version` and `~/.codex/skills/graphify/.graphify_version` still read `0.9.50`.

**Probe.** Each form run into a scratch `HOME` with an empty working directory, recording every file written:

| platform | `graphify <client> install` | `graphify install --platform <client>` |
| --- | --- | --- |
| claude | `./.claude/settings.json`, `./CLAUDE.md` — hooks only | `~/.claude/skills/graphify/**` — skill only |
| codex | `./.codex/hooks.json`, `./AGENTS.md` — hooks only | `~/.codex/skills/graphify/**` — skill only |
| copilot | `~/.copilot/skills/graphify/**` | identical |
| pi | `~/.pi/agent/skills/graphify/**` | identical |

So the two forms are disjoint for Claude Code and Codex and interchangeable for Copilot and Pi. Graphify's own reference documents them as separate jobs (`graphify claude install` = per-project always-on wiring; `install [--platform P]` = "copy skill to platform config dir"), so this is our incomplete usage, not an upstream defect.

**Change.** Claude Code and Codex run both commands; Copilot and Pi keep their single subcommand, which already is the skill copy; Grok keeps `install --platform agents`.

**Coverage.** The fake Graphify in the spec now stamps a client's skill version only for a skill copy and never for hook wiring, mirroring the real tool. The two new cases seed a stale stamp and require both the hook line and the skill-copy line in the tool log, so dropping either command fails a named assertion.

**RED/GREEN.** RED before the fix — only the two new cases failed:

```
1) refreshes the detected Claude Code Graphify skill as well as its hook wiring FAILED
   got: "0.9.48"            # skill stamp never refreshed
   Assert [ 0 -eq 1 ]       # no `install --platform claude` line
2) refreshes the detected Codex Graphify skill as well as its hook wiring FAILED
42 examples, 2 failures
```

GREEN after the fix with the same spec bytes: `42 examples, 0 failures`. `scripts/agent/run-gates.sh --diff origin/devel` → `GATES: PASS` (coverage pairing, `sh -n`, shellcheck, full shellspec suite).

| Frozen RED test | git hash-object | RED run tail |
| --- | --- | --- |
| `tests/shell/agent_tools_setup_spec.sh` | `5e94e7d993a775f9b5d4779597956d66428f17e7` | `shellspec tests/shell/agent_tools_setup_spec.sh against the unchanged script: 1) refreshes the detected Claude Code Graphify skill as well as its hook wiring — got: "0.9.48" (line 763) and Assert [ 0 -eq 1 ] (line 765); 2) refreshes the detected Codex Graphify skill as well as its hook wiring — same two assertions; 42 examples, 2 failures. Same spec bytes after the fix: 42 examples, 0 failures.` |

Fixes #2785
