### PR TITLE
install.sh: name the repository repair sequence when a pkg step fails

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -92,6 +92,25 @@ die() {
     exit "${_die_code}"
 }
 
+# pfb_pkg_repair_hint — print the pfSense repository-repair sequence to stderr, for the
+# failures a broken pkg(8) setup on the box itself can cause: the catalogue refresh, and
+# the delete/install (issue #2789). Stale or half-written Netgate repo files, or an
+# interrupted upgrade, leave pkg unable to refresh ANY catalogue, and no conf this script
+# writes can repair that. Guidance only, never run for the user: pfSense-upgrade can move
+# the box to a different pfSense version, which is not a package installer's call.
+#
+# Deliberately NOT printed for the conf-resolution failures that also exit 4, nor for a
+# package-script failure, where pkg fetched and extracted fine and the box's repository
+# setup is not implicated — a hint pointing at the wrong cause costs more than none.
+pfb_pkg_repair_hint() {
+    cat >&2 <<'HINT'
+install.sh: if this box's own pkg setup is at fault, rebuild it, then re-run this script:
+install.sh:   pfSense-repoc
+install.sh:   pfSense-repo-setup
+install.sh:   pfSense-upgrade
+HINT
+}
+
 # _pkg ARGS... — every pkg(8) invocation: /dev/null stdin (piped-script safety, see
 # header) + ASSUME_ALWAYS_YES so a stray prompt cannot wedge a non-interactive run.
 # Callers add -y themselves on verbs that take it (delete/install); read-only verbs
@@ -286,6 +305,7 @@ _pkg_mutate() {
     printf 'done\n' >"${_mut_done}"
     wait "${_mut_reader}" 2>/dev/null || true
     if [ "${_mut_rc}" -ne 0 ]; then
+        pfb_pkg_repair_hint
         die "${_mut_code}" "${_mut_msg}"
     fi
     while IFS= read -r _mut_line || [ -n "${_mut_line}" ]; do
@@ -331,6 +351,13 @@ Exit codes:
      catalogue offers nothing, or pkg version -t gave no usable answer
   5  a pkg operation (delete/install) failed, including a package-script failure while pkg exited 0
   6  post-install verification failed
+
+A failed pkg step is often this box's own repository setup rather than the pfBlockerNG
+conf: rebuild it, then re-run this script.
+
+  pfSense-repoc
+  pfSense-repo-setup
+  pfSense-upgrade
 USAGE_TAIL
 }
 
@@ -479,6 +506,7 @@ pfb_channel_install() {
     printf '==> pkg update -f -r %s (refreshing the pfBlockerNG catalog)\n' "${REPO_NAME}"
     _pkg update -f -r "${REPO_NAME}" || {
         [ "${CONF_CREATED}" -eq 1 ] && rm -f "${CONF_PATH}"
+        pfb_pkg_repair_hint
         die 4 "$(printf '%s update -f -r %s failed — the catalog was not refreshed. Repo '\''%s'\'' is unreachable or serving an unreadable catalog. Inspect with: %s -d update -r %s' \
             "${PKG_BIN}" "${REPO_NAME}" "${REPO_NAME}" "${PKG_BIN}" "${REPO_NAME}")"
     }
@@ -503,6 +531,7 @@ pfb_channel_install() {
     done
     [ -n "${OFFERED}" ] || {
         [ "${CONF_CREATED}" -eq 1 ] && rm -f "${CONF_PATH}"
+        pfb_pkg_repair_hint
         die 4 "repo '${REPO_NAME}' does not offer ${CANONICAL_PKG} — run \`pkg update -f\`, and check the ${PFB_CHANNEL} catalogue has a build for this pfSense edition/version"
     }
     printf '==> Target: %s-%s (repo %s)\n' "${CANONICAL_PKG}" "${OFFERED}" "${REPO_NAME}"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -92,23 +92,31 @@ die() {
     exit "${_die_code}"
 }
 
-# pfb_pkg_repair_hint — print the pfSense repository-repair sequence to stderr, for the
+# pfb_pkg_die CODE MSG... — die(), then the pfSense repository-repair sequence, for the
 # failures a broken pkg(8) setup on the box itself can cause: the catalogue refresh, and
 # the delete/install (issue #2789). Stale or half-written Netgate repo files, or an
 # interrupted upgrade, leave pkg unable to refresh ANY catalogue, and no conf this script
 # writes can repair that. Guidance only, never run for the user: pfSense-upgrade can move
 # the box to a different pfSense version, which is not a package installer's call.
 #
-# Deliberately NOT printed for the conf-resolution failures that also exit 4, nor for a
+# The diagnosis prints FIRST: the remedy is conditional on it, and a reader who has not
+# yet been told what failed cannot judge whether these three commands are their answer.
+# die() exits, hence a wrapper rather than a call beside it.
+#
+# Deliberately NOT used for the conf-resolution failures that also exit 4, nor for a
 # package-script failure, where pkg fetched and extracted fine and the box's repository
 # setup is not implicated — a hint pointing at the wrong cause costs more than none.
-pfb_pkg_repair_hint() {
+pfb_pkg_die() {
+    _pkg_die_code="$1"
+    shift
+    printf 'install.sh: %s\n' "$*" >&2
     cat >&2 <<'HINT'
 install.sh: if this box's own pkg setup is at fault, rebuild it, then re-run this script:
 install.sh:   pfSense-repoc
 install.sh:   pfSense-repo-setup
 install.sh:   pfSense-upgrade
 HINT
+    exit "${_pkg_die_code}"
 }
 
 # _pkg ARGS... — every pkg(8) invocation: /dev/null stdin (piped-script safety, see
@@ -305,8 +313,7 @@ _pkg_mutate() {
     printf 'done\n' >"${_mut_done}"
     wait "${_mut_reader}" 2>/dev/null || true
     if [ "${_mut_rc}" -ne 0 ]; then
-        pfb_pkg_repair_hint
-        die "${_mut_code}" "${_mut_msg}"
+        pfb_pkg_die "${_mut_code}" "${_mut_msg}"
     fi
     while IFS= read -r _mut_line || [ -n "${_mut_line}" ]; do
         # Hook stdout often ends without a newline, so pkg's message is glued
@@ -506,8 +513,7 @@ pfb_channel_install() {
     printf '==> pkg update -f -r %s (refreshing the pfBlockerNG catalog)\n' "${REPO_NAME}"
     _pkg update -f -r "${REPO_NAME}" || {
         [ "${CONF_CREATED}" -eq 1 ] && rm -f "${CONF_PATH}"
-        pfb_pkg_repair_hint
-        die 4 "$(printf '%s update -f -r %s failed — the catalog was not refreshed. Repo '\''%s'\'' is unreachable or serving an unreadable catalog. Inspect with: %s -d update -r %s' \
+        pfb_pkg_die 4 "$(printf '%s update -f -r %s failed — the catalog was not refreshed. Repo '\''%s'\'' is unreachable or serving an unreadable catalog. Inspect with: %s -d update -r %s' \
             "${PKG_BIN}" "${REPO_NAME}" "${REPO_NAME}" "${PKG_BIN}" "${REPO_NAME}")"
     }
 
@@ -531,8 +537,7 @@ pfb_channel_install() {
     done
     [ -n "${OFFERED}" ] || {
         [ "${CONF_CREATED}" -eq 1 ] && rm -f "${CONF_PATH}"
-        pfb_pkg_repair_hint
-        die 4 "repo '${REPO_NAME}' does not offer ${CANONICAL_PKG} — run \`pkg update -f\`, and check the ${PFB_CHANNEL} catalogue has a build for this pfSense edition/version"
+        pfb_pkg_die 4 "repo '${REPO_NAME}' does not offer ${CANONICAL_PKG} — run \`pkg update -f\`, and check the ${PFB_CHANNEL} catalogue has a build for this pfSense edition/version"
     }
     printf '==> Target: %s-%s (repo %s)\n' "${CANONICAL_PKG}" "${OFFERED}" "${REPO_NAME}"
 

--- a/tests/test_channel_install.py
+++ b/tests/test_channel_install.py
@@ -1758,3 +1758,96 @@ def test_output_reader_does_not_outlive_the_run() -> None:
             with contextlib.suppress(ProcessLookupError):
                 os.kill(proc.pid, signal.SIGKILL)
             proc.wait(timeout=30)
+
+
+# --------------------------------------------------------------------------- #
+# 22. pkg-setup repair hint (issue #2789): a failed pkg step is frequently the
+#     box's own repository setup, not our conf. The three recovery commands ride
+#     the failure output, but only where that setup can be the cause.
+# --------------------------------------------------------------------------- #
+
+_REPAIR_COMMANDS = ("pfSense-repoc", "pfSense-repo-setup", "pfSense-upgrade")
+
+
+def _repair_hint_shown(proc: subprocess.CompletedProcess[str]) -> bool:
+    combined = proc.stdout + proc.stderr
+    return all(command in combined for command in _REPAIR_COMMANDS)
+
+
+def test_pkg_update_failure_prints_the_repository_repair_sequence() -> None:
+    with tempfile.TemporaryDirectory() as root:
+        proc = _run_install(root, "testing", update_fails=True)
+
+        assert proc.returncode == 4, proc.stdout + proc.stderr
+        assert _repair_hint_shown(proc), proc.stdout + proc.stderr
+
+
+def test_empty_catalogue_failure_prints_the_repository_repair_sequence() -> None:
+    with tempfile.TemporaryDirectory() as root:
+        proc = _run_install(root, "edge", catalog=())
+
+        assert proc.returncode == 4, proc.stdout + proc.stderr
+        assert _repair_hint_shown(proc), proc.stdout + proc.stderr
+
+
+def test_pkg_install_failure_prints_the_repository_repair_sequence() -> None:
+    with tempfile.TemporaryDirectory() as root:
+        proc = _run_install(root, "stable", extra_env={"PFB_STUB_MUTATE_RC": "7"})
+
+        assert proc.returncode == 5, proc.stdout + proc.stderr
+        assert _repair_hint_shown(proc), proc.stdout + proc.stderr
+
+
+def test_conf_resolution_failure_does_not_print_the_repository_repair_sequence() -> None:
+    """A conf the generator hook could not resolve is our own bootstrap failing, with
+    pkg never reached. Printing pkg-repository repair steps there would send the user
+    after the wrong cause."""
+    with tempfile.TemporaryDirectory() as root:
+        channel = "stable"
+        pkg_bin = _write_pkg_stub(root)
+        _seed_box(root)
+        _seed_catalog(root, _repo_name(channel), ("4.0.0",))
+        manifest = _seed_info_manifest(root, (_DEFAULT_PAYLOAD_PATH,))
+        _seed_payload(root, _DEFAULT_PAYLOAD_PATH)
+        # Detection failure: blank /etc/version, so the hook leaves the seeded conf alone.
+        with open(os.path.join(root, "etc", "version"), "w") as fh:
+            fh.write("")
+        _seed_conf_file(
+            root,
+            _conf_name(channel),
+            "# Generated at boot by pfblockerng_repo_generate (ADR-39)\n"
+            'pfblockerng-stable: {\n  url: "https://other.example/pkg/stable/ce-2.8",\n'
+            "  mirror_type: none,\n  signature_type: none,\n  priority: 100,\n  enabled: yes\n}\n",
+        )
+        env = {
+            **os.environ,
+            "PFBLOCKERNG_ROOT": root,
+            "PKG_BIN": pkg_bin,
+            "PFB_BASE_URL": _BASE_URL,
+            "PFB_TEST_ROOT": root,
+            "PFB_STUB_INFO_MANIFEST": manifest,
+        }
+        proc = subprocess.run(
+            ["sh", str(_SCRIPT), "--channel", channel], env=env, capture_output=True, text=True, check=False
+        )
+
+        assert proc.returncode == 4, proc.stdout + proc.stderr
+        assert not _repair_hint_shown(proc), proc.stdout + proc.stderr
+
+
+def test_postinstall_script_failure_does_not_print_the_repository_repair_sequence() -> None:
+    """Our POST-INSTALL failing is our package's own script, not the box's repository
+    setup — pkg fetched and extracted the package just fine."""
+    with tempfile.TemporaryDirectory() as root:
+        proc = _run_install(root, "stable", extra_env={"PFB_STUB_POSTINSTALL_FAIL": "1"})
+
+        assert proc.returncode == 5, proc.stdout + proc.stderr
+        assert not _repair_hint_shown(proc), proc.stdout + proc.stderr
+
+
+def test_usage_documents_the_repository_repair_sequence() -> None:
+    proc = _run_argv("--help")
+
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    for command in _REPAIR_COMMANDS:
+        assert command in proc.stdout, proc.stdout

--- a/tests/test_channel_install.py
+++ b/tests/test_channel_install.py
@@ -1769,9 +1769,17 @@ def test_output_reader_does_not_outlive_the_run() -> None:
 _REPAIR_COMMANDS = ("pfSense-repoc", "pfSense-repo-setup", "pfSense-upgrade")
 
 
+def _repair_hint_on_stderr(proc: subprocess.CompletedProcess[str]) -> bool:
+    """The hint rides stderr beside die()'s diagnosis: a user who captures only stderr
+    for a bug report still gets the remedy."""
+    return all(command in proc.stderr for command in _REPAIR_COMMANDS)
+
+
 def _repair_hint_shown(proc: subprocess.CompletedProcess[str]) -> bool:
+    """Either stream — strictly stronger than the stderr check, so the negative cases
+    cannot pass merely because the hint went to stdout."""
     combined = proc.stdout + proc.stderr
-    return all(command in combined for command in _REPAIR_COMMANDS)
+    return any(command in combined for command in _REPAIR_COMMANDS)
 
 
 def test_pkg_update_failure_prints_the_repository_repair_sequence() -> None:
@@ -1779,7 +1787,10 @@ def test_pkg_update_failure_prints_the_repository_repair_sequence() -> None:
         proc = _run_install(root, "testing", update_fails=True)
 
         assert proc.returncode == 4, proc.stdout + proc.stderr
-        assert _repair_hint_shown(proc), proc.stdout + proc.stderr
+        assert _repair_hint_on_stderr(proc), proc.stdout + proc.stderr
+        assert proc.stderr.index("failed") < proc.stderr.index("pfSense-repoc"), (
+            f"the diagnosis must precede the remedy:\n{proc.stderr}"
+        )
 
 
 def test_empty_catalogue_failure_prints_the_repository_repair_sequence() -> None:
@@ -1787,7 +1798,7 @@ def test_empty_catalogue_failure_prints_the_repository_repair_sequence() -> None
         proc = _run_install(root, "edge", catalog=())
 
         assert proc.returncode == 4, proc.stdout + proc.stderr
-        assert _repair_hint_shown(proc), proc.stdout + proc.stderr
+        assert _repair_hint_on_stderr(proc), proc.stdout + proc.stderr
 
 
 def test_pkg_install_failure_prints_the_repository_repair_sequence() -> None:
@@ -1795,20 +1806,16 @@ def test_pkg_install_failure_prints_the_repository_repair_sequence() -> None:
         proc = _run_install(root, "stable", extra_env={"PFB_STUB_MUTATE_RC": "7"})
 
         assert proc.returncode == 5, proc.stdout + proc.stderr
-        assert _repair_hint_shown(proc), proc.stdout + proc.stderr
+        assert _repair_hint_on_stderr(proc), proc.stdout + proc.stderr
 
 
-def test_conf_resolution_failure_does_not_print_the_repository_repair_sequence() -> None:
-    """A conf the generator hook could not resolve is our own bootstrap failing, with
-    pkg never reached. Printing pkg-repository repair steps there would send the user
-    after the wrong cause."""
+def test_stale_conf_rejection_does_not_print_the_repository_repair_sequence() -> None:
+    """A conf carrying the boot marker but resolving to another base is rejected before
+    pkg is reached — our own bootstrap failing. Pointing the user at pkg-repository
+    repair there would send them after the wrong cause."""
     with tempfile.TemporaryDirectory() as root:
         channel = "stable"
-        pkg_bin = _write_pkg_stub(root)
-        _seed_box(root)
-        _seed_catalog(root, _repo_name(channel), ("4.0.0",))
-        manifest = _seed_info_manifest(root, (_DEFAULT_PAYLOAD_PATH,))
-        _seed_payload(root, _DEFAULT_PAYLOAD_PATH)
+        argv, env = _prepare_install(root, channel)
         # Detection failure: blank /etc/version, so the hook leaves the seeded conf alone.
         with open(os.path.join(root, "etc", "version"), "w") as fh:
             fh.write("")
@@ -1819,19 +1826,28 @@ def test_conf_resolution_failure_does_not_print_the_repository_repair_sequence()
             'pfblockerng-stable: {\n  url: "https://other.example/pkg/stable/ce-2.8",\n'
             "  mirror_type: none,\n  signature_type: none,\n  priority: 100,\n  enabled: yes\n}\n",
         )
-        env = {
-            **os.environ,
-            "PFBLOCKERNG_ROOT": root,
-            "PKG_BIN": pkg_bin,
-            "PFB_BASE_URL": _BASE_URL,
-            "PFB_TEST_ROOT": root,
-            "PFB_STUB_INFO_MANIFEST": manifest,
-        }
-        proc = subprocess.run(
-            ["sh", str(_SCRIPT), "--channel", channel], env=env, capture_output=True, text=True, check=False
-        )
+
+        proc = subprocess.run(argv, env=env, capture_output=True, text=True, check=False)
 
         assert proc.returncode == 4, proc.stdout + proc.stderr
+        assert "a stale or foreign conf" in proc.stderr, proc.stderr
+        assert not _repair_hint_shown(proc), proc.stdout + proc.stderr
+
+
+def test_unresolved_conf_does_not_print_the_repository_repair_sequence() -> None:
+    """The sibling exit-4 site: a conf with no boot marker at all means the generator
+    hook never resolved it, which is again our bootstrap and not the box's pkg setup."""
+    with tempfile.TemporaryDirectory() as root:
+        channel = "stable"
+        argv, env = _prepare_install(root, channel)
+        with open(os.path.join(root, "etc", "version"), "w") as fh:
+            fh.write("")
+        _seed_conf_file(root, _conf_name(channel), "# hand-written, no generator marker\n")
+
+        proc = subprocess.run(argv, env=env, capture_output=True, text=True, check=False)
+
+        assert proc.returncode == 4, proc.stdout + proc.stderr
+        assert "no marker line" in proc.stderr, proc.stderr
         assert not _repair_hint_shown(proc), proc.stdout + proc.stderr
 
 


### PR DESCRIPTION
## Verification

Seven tests in `tests/test_channel_install.py` — three positive paths, three negative paths, one usage assertion. The shipped test bytes were executed RED against `devel`'s `install.sh`, then GREEN against this branch's, with the file byte-identical across both runs:

| Frozen RED test | git hash-object | RED run tail |
| --- | --- | --- |
| `tests/test_channel_install.py` | `5209a4301957e7202009b94abddda6c8ab454a61` | `4 failed, 3 passed in 5.41s` |

Green after, same bytes (`git hash-object` unchanged):

```
7 passed in 2.00s
```

Both directions were proven to bite by mutating the production code and re-running the unchanged tests:

| mutation | result |
| --- | --- |
| `cat >&2 <<'HINT'` → `cat <<'HINT'` (hint to stdout) | 3 failed, 4 passed |
| ordinary `die()` also emits `pfSense-repoc` | 3 failed, 4 passed |

Full gates on the rebased branch:

```
GATE PASS: python3 scripts/check_coverage_pairing.py --name-status-z
GATE PASS: uv run --locked pytest
GATE PASS: uv run --locked ruff check .
GATE PASS: uv run --locked ruff format --check .
GATE PASS: uv run --locked mypy tests/
GATE PASS: sh -n scripts/install.sh
GATE PASS: shellcheck scripts/install.sh
GATE PASS: shellspec --shell $(command -v dash || command -v sh)
GATES: PASS
```

## Review

Reviewed independently per `.agents/policy/landing.md`; verdict was correct-with-findings, no blockers or majors. All four findings are addressed in the second commit: the hint now follows the diagnosis instead of preceding it, the positive tests assert stderr rather than the merged streams, the negative fixtures go through `_prepare_install` (restoring the `_CA_ENV_VARS` scrub the hand-rolled environment skipped), and the previously uncovered marker-absent exit-4 site gained its own negative test.

Authored by an OMP agent session; no `coauthor.omp.*` identity is configured in this checkout, so the commits carry no co-author trailer.
