### PR TITLE
agent: record the no-pin install rule for agent tools

### DIFF
--- a/.agents/context/repository-intelligence.md
+++ b/.agents/context/repository-intelligence.md
@@ -8,6 +8,13 @@ Load when: every agent session, from `AGENTS.md`.
   Serena, CodeGraph, Graphify, and Worktrunk; configures only detected clients;
   disables Serena's web dashboard; and keeps Worktrunk worktrees outside the
   repository root.
+- Every agent tool installs through one command that both installs on a fresh host
+  and upgrades an outdated one — `uv tool install --upgrade <tool>`, `codegraph upgrade`,
+  or the tool's own installer. A `>=` floor rides along only when a minimum release is
+  required; an exact `==` pin is never the answer, because it makes every upstream
+  release wait on a repository commit and downgrades a host that is already ahead.
+  When a setup script fails because a dependency is absent, that missing dependency is
+  installed the same way, never pinned to whatever version the failure happened to name.
 - Initialize a checkout with `sh scripts/agent/init-worktree-tools.sh .`.
   `work-branch.sh --worktree` runs the same initializer after creating a worktree and
   removes the new worktree and branch if initialization fails; it uses Git directly

--- a/tests/test_cross_agent_tooling.py
+++ b/tests/test_cross_agent_tooling.py
@@ -205,6 +205,11 @@ def test_repository_intelligence_initializes_each_worktree_directly() -> None:
         "stubs/` is shim/support",
         "graph.json` is tracked",
         "everything else under `graphify-out/` is ignored",
+        # Every agent tool installs the same way: one command that installs on a
+        # fresh host and upgrades an outdated one, a floor at most, never a pin --
+        # including the install added when a setup script hits a missing dependency.
+        "an exact `==` pin is never the answer",
+        "installed the same way, never pinned",
     ):
         assert contract in routing, f"direct worktree initialization routing lost {contract}"
 


### PR DESCRIPTION
Record the no-pin install rule for agent tools (issue #2798).

**Why.** #2784 removed the last exact version pin from the agent bootstrap (`graphifyy==0.9.50` → `uv tool install --upgrade 'graphifyy>=0.9.51'`), and an audit confirmed nothing else pins: `serena-agent`, `ast-grep-cli` and `semgrep` already install with `uv tool install --upgrade`, CodeGraph through `codegraph upgrade` or its own installer. But the rule behind that change was written nowhere, so the next missing-dependency failure could reintroduce a pin without contradicting any documented contract.

**Rule.** `.agents/context/repository-intelligence.md` now states it: every agent tool installs through one command that both installs on a fresh host and upgrades an outdated one; a `>=` floor rides along only when a minimum release is required; an exact `==` pin is never the answer, because it makes every upstream release wait on a repository commit and downgrades a host that is already ahead; and a dependency a setup script finds missing is installed the same way rather than pinned to whatever version the failure happened to name.

**Coverage.** The routing gate pins both halves of the rule, the way it pins every other contract in that document.

**RED/GREEN.** The two rows were added first and run against the unchanged document:

```
AssertionError: direct worktree initialization routing lost an exact `==` pin is never the answer
1 failed
```

GREEN after the document gained the rule (`1 passed`), and each row was mutation checked on its own — rewording either clause fails the gate by name:

```
-- mutated away: installed the same way, never pinned
AssertionError: direct worktree initialization routing lost installed the same way, never pinned
-- mutated away: an exact `==` pin is never the answer
AssertionError: direct worktree initialization routing lost an exact `==` pin is never the answer
```

An earlier attempt pinned `never an exact pin` and `uv tool install --upgrade`; both already appeared in the Graphify-specific sentence, so those rows passed without the rule existing. They were replaced with phrases unique to the general rule before the RED run above.

`scripts/agent/run-gates.sh --diff origin/devel` → `GATES: PASS` (coverage pairing, full pytest, ruff check, ruff format, mypy, markdownlint).

**Not included:** `graphify update .` in this worktree rewrites `graphify-out/graph.json` whole (~28k insertions / ~27k deletions of renumbered communities) with nothing that reflects these twelve lines, so the tracked graph is left as `devel` has it rather than buried under a regeneration from a different machine.

| Frozen RED test | git hash-object | RED run tail |
| --- | --- | --- |
| `tests/test_cross_agent_tooling.py` | `9289e36a867716ef7a50d1af6e4dae01edfcd3fd` | `uv run --locked pytest tests/test_cross_agent_tooling.py::test_repository_intelligence_initializes_each_worktree_directly with the document reverted: AssertionError: direct worktree initialization routing lost an exact == pin is never the answer (line 214); 1 failed. Same test bytes after the document gained the rule: 1 passed, and 12 passed for the whole file.` |

Fixes #2798
