### PR TITLE
graphify: mark the tracked root graph as generated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,4 +5,8 @@
 # scripts/git-no-docs.sh — it derives its excludes from these entries.
 legacy/** linguist-documentation
 docs/** linguist-documentation
-graphify-out/graph.json merge=graphify
+# The tracked root graph is generated output: `graphify update` rewrites it whole, so
+# suppressing its diff is the point — linguist-generated collapses it in pull-request
+# diffs and drops it from the language stats, while merge=graphify keeps resolving
+# parallel updates through the union driver.
+graphify-out/graph.json merge=graphify linguist-generated=true

--- a/tests/test_cross_agent_tooling.py
+++ b/tests/test_cross_agent_tooling.py
@@ -230,7 +230,10 @@ def test_repository_intelligence_initializes_each_worktree_directly() -> None:
     attrs_text = (ROOT / ".gitattributes").read_text(encoding="utf-8")
     assert attrs_text.strip(), ".gitattributes must not be empty"
     attrs = attrs_text.splitlines()
-    graphify_attribute = "graphify-out/graph.json merge=graphify"
+    # linguist-generated collapses the whole-file rewrites in pull-request diffs and
+    # keeps them out of the language stats; merge=graphify still resolves parallel
+    # updates, so both attributes must ride on the row.
+    graphify_attribute = "graphify-out/graph.json merge=graphify linguist-generated=true"
     assert attrs.count(graphify_attribute) == 1, f"expected exact .gitattributes row: {graphify_attribute}"
     # The root graph is tracked so a fresh checkout starts with the map; everything
     # else under graphify-out/ is regenerated from it and stays ignored. Asserting the


### PR DESCRIPTION
Mark the tracked root graph as generated for GitHub (issue #2800).

**Problem.** `graphify update` rewrites `graphify-out/graph.json` whole — a refresh riding along with a twelve-line change produced roughly 28k insertions and 27k deletions of renumbered communities. GitHub rendered that as a normal diff, counted it in the pull request's changed-line totals and fed it to the language statistics.

**Change.** One row in `.gitattributes`:

```
graphify-out/graph.json merge=graphify linguist-generated=true
```

GitHub now collapses the file in pull-request diffs and leaves it out of the language stats; the union merge driver keeps resolving parallel updates. The file's header comment cited diff suppression as the reason `legacy/` and `docs/` stay on `linguist-documentation` — suppression is precisely what a generated artifact wants, so the new comment states that on the row itself instead of leaving the file reading self-contradictory.

**Evidence.** The gate pinning the exact attributes row was updated first and run against the unchanged file:

```
AssertionError: expected exact .gitattributes row: graphify-out/graph.json merge=graphify linguist-generated=true
1 failed
```

GREEN after the row moved (`12 passed`), and the attributes resolve live on the path:

```
$ git check-attr merge linguist-generated -- graphify-out/graph.json
graphify-out/graph.json: merge: graphify
graphify-out/graph.json: linguist-generated: true
```

Both attributes are load-bearing in the gate — dropping either one from the row fails it by name (mutation-checked in both directions). `scripts/agent/run-gates.sh --diff origin/devel` → `GATES: PASS` (coverage pairing, full pytest, ruff check, ruff format, mypy).

The tracked graph itself is left as `devel` has it: this change does not move the code graph, so a regeneration from another machine would add churn with no information in it.

| Frozen RED test | git hash-object | RED run tail |
| --- | --- | --- |
| `tests/test_cross_agent_tooling.py` | `56223c44bbc0c3e7524051f08e9d8dd0b76ff603` | `uv run --locked pytest tests/test_cross_agent_tooling.py against the unchanged .gitattributes: AssertionError: expected exact .gitattributes row: graphify-out/graph.json merge=graphify linguist-generated=true (line 237); 1 failed, 11 passed. Same test bytes after the row moved: 12 passed.` |

Fixes #2800
