### PR TITLE
agent: route PHP .inc files to intelephense under OMP

### DIFF
--- a/.omp/lsp.json
+++ b/.omp/lsp.json
@@ -1,11 +1,8 @@
 {
   "servers": {
     "intelephense": {
-      "command": "intelephense",
-      "args": ["--stdio"],
       "fileTypes": [".php", ".phtml", ".inc"],
       "languageId": "php",
-      "rootMarkers": ["composer.json", "composer.lock", ".git"],
       "settings": {
         "intelephense": {
           "environment": { "phpVersion": "8.3" },

--- a/.omp/lsp.json
+++ b/.omp/lsp.json
@@ -1,0 +1,17 @@
+{
+  "servers": {
+    "intelephense": {
+      "command": "intelephense",
+      "args": ["--stdio"],
+      "fileTypes": [".php", ".phtml", ".inc"],
+      "languageId": "php",
+      "rootMarkers": ["composer.json", "composer.lock", ".git"],
+      "settings": {
+        "intelephense": {
+          "environment": { "phpVersion": "8.3" },
+          "files": { "associations": ["*.php", "*.phtml", "*.inc"] }
+        }
+      }
+    }
+  }
+}

--- a/tests/test_cross_agent_tooling.py
+++ b/tests/test_cross_agent_tooling.py
@@ -281,9 +281,11 @@ def test_omp_language_servers_route_php_include_files() -> None:
     assert server["languageId"] == "php", "an inferred language id follows the extension, not PHP"
 
     # Routing didOpen is not enough: intelephense's own workspace scan is driven by
-    # files.associations, and cross-file references come from that index.
+    # files.associations, and cross-file references come from that index. The array
+    # replaces intelephense's own default, so dropping *.php or *.phtml here would
+    # unindex ordinary PHP files.
     settings = server["settings"]["intelephense"]
-    assert "*.inc" in settings["files"]["associations"]
+    assert {"*.php", "*.phtml", "*.inc"} <= set(settings["files"]["associations"])
 
     # The editor already carries the same association and PHP version; the two agent
     # surfaces must not drift apart.

--- a/tests/test_cross_agent_tooling.py
+++ b/tests/test_cross_agent_tooling.py
@@ -272,15 +272,13 @@ def test_omp_language_servers_route_php_include_files() -> None:
     # pfSense ships PHP include files as .inc, and OMP's built-in intelephense entry
     # claims only .php/.phtml -- so without this override every .inc file, including
     # the largest production file in the package, is invisible to lsp
-    # definition/references/rename/diagnostics (issue #2802). OMP merges server
-    # overrides shallowly, so an entry that omits command/args/rootMarkers drops the
-    # defaults it does not restate.
+    # definition/references/rename/diagnostics (issue #2802). Only the fields that
+    # differ from the built-in entry are overridden: OMP merges the built-in config
+    # under the override, so omitted top-level fields are inherited, while a field
+    # the override does supply replaces the built-in value whole.
     server = json.loads((ROOT / ".omp/lsp.json").read_text(encoding="utf-8"))["servers"]["intelephense"]
-    assert server["command"] == "intelephense"
-    assert server["args"] == ["--stdio"]
     assert set(server["fileTypes"]) == {".php", ".phtml", ".inc"}
     assert server["languageId"] == "php", "an inferred language id follows the extension, not PHP"
-    assert set(server["rootMarkers"]) == {"composer.json", "composer.lock", ".git"}
 
     # Routing didOpen is not enough: intelephense's own workspace scan is driven by
     # files.associations, and cross-file references come from that index.

--- a/tests/test_cross_agent_tooling.py
+++ b/tests/test_cross_agent_tooling.py
@@ -268,6 +268,33 @@ def test_codegraph_generated_state_is_ignored_by_its_own_tracked_contract() -> N
     assert ".codegraph/" not in root_ignore, "root ignore would hide CodeGraph's own tracked contract"
 
 
+def test_omp_language_servers_route_php_include_files() -> None:
+    # pfSense ships PHP include files as .inc, and OMP's built-in intelephense entry
+    # claims only .php/.phtml -- so without this override every .inc file, including
+    # the largest production file in the package, is invisible to lsp
+    # definition/references/rename/diagnostics (issue #2802). OMP merges server
+    # overrides shallowly, so an entry that omits command/args/rootMarkers drops the
+    # defaults it does not restate.
+    server = json.loads((ROOT / ".omp/lsp.json").read_text(encoding="utf-8"))["servers"]["intelephense"]
+    assert server["command"] == "intelephense"
+    assert server["args"] == ["--stdio"]
+    assert set(server["fileTypes"]) == {".php", ".phtml", ".inc"}
+    assert server["languageId"] == "php", "an inferred language id follows the extension, not PHP"
+    assert set(server["rootMarkers"]) == {"composer.json", "composer.lock", ".git"}
+
+    # Routing didOpen is not enough: intelephense's own workspace scan is driven by
+    # files.associations, and cross-file references come from that index.
+    settings = server["settings"]["intelephense"]
+    assert "*.inc" in settings["files"]["associations"]
+
+    # The editor already carries the same association and PHP version; the two agent
+    # surfaces must not drift apart.
+    vscode = (ROOT / ".vscode/settings.json").read_text(encoding="utf-8")
+    assert '"*.inc": "php"' in vscode
+    php_version = settings["environment"]["phpVersion"]
+    assert f'"intelephense.environment.phpVersion": "{php_version}"' in vscode
+
+
 def test_copilot_roles_are_pinned_and_defined() -> None:
     tiers = dict(
         line.split("=", 1)


### PR DESCRIPTION
## Problem

OMP's language-server layer never saw this repository's PHP include files. Intelephense came
from OMP's built-in defaults, which declare `fileTypes: [".php", ".phtml"]`, and no `lsp.json`
existed in any location OMP merges (`~/.omp/agent/`, `<cwd>/.omp/`, repository root). Every
`.inc` file was therefore invisible to `lsp` definition, references, hover, rename, and
diagnostics — including `src/usr/local/pkg/pfblockerng/pfblockerng.inc`, the largest production
file in the package.

The editor has associated `*.inc` with PHP since `.vscode/settings.json` landed, and CodeGraph
classifies every `.inc` as `php`, so OMP was the odd surface out.

## Change

`.omp/lsp.json` overrides only the intelephense fields that differ from OMP's built-in entry:

- `.inc` added to `fileTypes`; a supplied top-level field replaces the built-in value whole, so
  the list restates `.php` and `.phtml`.
- `languageId` pinned to `php`, because an omitted id is inferred from the extension and `.inc`
  would otherwise open as plaintext.
- `settings.intelephense.files.associations` includes `*.inc` so the server's own workspace scan
  indexes those files for cross-file references, not just accepts them on open; `phpVersion`
  matches the editor pin.

`command`, `args`, and `rootMarkers` are deliberately absent: OMP builds each override as
`{ ...builtin, ...override }` before validating it, so an override of a built-in server inherits
every top-level field it omits. The first revision of this PR restated them and asserted them in
the test; review showed that claim was wrong, and both were cut.

## Verification

- `tests/test_cross_agent_tooling.py::test_omp_language_servers_route_php_include_files` was run
  RED before the config existed (`FileNotFoundError: … /.omp/lsp.json`), frozen, and re-run GREEN
  unchanged afterwards; the whole file passes (13 tests). Mutation gate re-run after the trim:
  removing `.inc` from `fileTypes`, dropping `languageId`, removing `*.inc` from the associations,
  and diverging `phpVersion` from `.vscode/settings.json` each fail the test.
- Baseline evidence: `lsp symbols` on `pfblockerng.inc` returned `No language server found for
  this action`, while the same action on `src/usr/local/www/pfblockerng/pfblockerng.php` returned
  a full symbol tree, and `lsp status` listed `intelephense (configured, not started)` — the gap
  was routing, not availability.
- Loader probe against the installed `pi-coding-agent` (`loadConfig` + `getServerForFile`): the
  trimmed override resolves `command: intelephense`, `args: ["--stdio"]`, and the built-in root
  markers; routes `.inc` and `.php` to intelephense with language id `php`; and leaves `pyright`,
  `ruff`, `yamlls` and the `vscode-*` servers active and routing (`.py` still resolves to
  pyright).
- Live server probe from the correctness review leg: a real intelephense client opened
  `pfblockerng.inc` with language id `php` and returned 530 document symbols, and a
  `workspace/symbol` query found a symbol inside a `.inc` file without opening it — with a
  negative control (associations without `*.inc`) returning zero matches.
- The tracked root graph is refreshed alongside the change and contains the new test node.

## Out of scope

Graphify has the same blind spot from a different cause: `.inc` is hard-mapped to the Pascal
extractor, so the PHP include corpus yields 20 nodes instead of 755. That is tracked upstream in
Graphify-Labs/graphify#2961. `ast_grep`/`ast_edit` share an internal language map with no
configuration surface and remain unaffected.

Fixes #2802


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added PHP language-server support for `.php`, `.phtml`, and `.inc` files.
  * Configured PHP 8.3 support and workspace scanning for PHP include files.

* **Tests**
  * Added coverage to verify PHP file associations and consistency with the existing editor configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->