### PR TITLE
install.sh: gate pfSense-upgrade behind a retry, not a flat list

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -106,7 +106,7 @@ die() {
 # named where it is proposed (issue #2803).
 #
 # The diagnosis prints FIRST: the remedy is conditional on it, and a reader who has not
-# yet been told what failed cannot judge whether these three commands are their answer.
+# yet been told what failed cannot judge whether this sequence is their answer.
 # die() exits, hence a wrapper rather than a call beside it.
 #
 # Deliberately NOT used for the conf-resolution failures that also exit 4, nor for a
@@ -372,9 +372,9 @@ conf: rebuild it, then re-run this script.
   pfSense-repoc
   pfSense-repo-setup
 
-Only if the re-run still fails, escalate to pfSense-upgrade. Run bare it applies any
-pfSense release upgrade the box's branch offers, and reboots when it does, so it is a
-deliberate last step rather than part of the sequence above.
+Only if the re-run still fails, escalate to pfSense-upgrade. With no arguments it applies
+any pfSense release upgrade the box's branch offers, and reboots when it does, so it is
+a deliberate last step rather than part of the sequence above.
 USAGE_TAIL
 }
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -96,8 +96,14 @@ die() {
 # failures a broken pkg(8) setup on the box itself can cause: the catalogue refresh, and
 # the delete/install (issue #2789). Stale or half-written Netgate repo files, or an
 # interrupted upgrade, leave pkg unable to refresh ANY catalogue, and no conf this script
-# writes can repair that. Guidance only, never run for the user: pfSense-upgrade can move
-# the box to a different pfSense version, which is not a package installer's call.
+# writes can repair that. Guidance only, never run for the user.
+#
+# The two repository-rebuild commands come first and are cheap and local. A bare
+# `pfSense-upgrade` is NOT a third item beside them: upstream sets
+# `: ${action:="upgrade"}` when no action flag is given, so it applies whatever release
+# the box's branch offers and reboots afterwards. It is the escalation for a mismatch
+# rebuilding the repository files did not fix, and it is stated as such, with the reboot
+# named where it is proposed (issue #2803).
 #
 # The diagnosis prints FIRST: the remedy is conditional on it, and a reader who has not
 # yet been told what failed cannot judge whether these three commands are their answer.
@@ -111,10 +117,11 @@ pfb_pkg_die() {
     shift
     printf 'install.sh: %s\n' "$*" >&2
     cat >&2 <<'HINT'
-install.sh: if this box's own pkg setup is at fault, rebuild it, then re-run this script:
+install.sh: if this box's own pkg setup is at fault, rebuild it and re-run this script:
 install.sh:   pfSense-repoc
 install.sh:   pfSense-repo-setup
-install.sh:   pfSense-upgrade
+install.sh: only if the re-run still fails, escalate to pfSense-upgrade — it applies any
+install.sh: pfSense release upgrade the box's branch offers, and reboots when it does.
 HINT
     exit "${_pkg_die_code}"
 }
@@ -364,7 +371,10 @@ conf: rebuild it, then re-run this script.
 
   pfSense-repoc
   pfSense-repo-setup
-  pfSense-upgrade
+
+Only if the re-run still fails, escalate to pfSense-upgrade. Run bare it applies any
+pfSense release upgrade the box's branch offers, and reboots when it does, so it is a
+deliberate last step rather than part of the sequence above.
 USAGE_TAIL
 }
 

--- a/tests/test_channel_install.py
+++ b/tests/test_channel_install.py
@@ -1803,13 +1803,16 @@ def test_repair_hint_gates_pfsense_upgrade_behind_a_retry() -> None:
 
         assert proc.returncode == 4, proc.stdout + proc.stderr
         hint = proc.stderr
-        assert hint.index("pfSense-repo-setup") < hint.index("pfSense-upgrade"), hint
-        # The retry sits BETWEEN the cheap repair and the escalation.
-        assert "re-run" in hint.split("pfSense-repo-setup", 1)[1].split("pfSense-upgrade", 1)[0], (
-            f"the hint must tell the user to retry before escalating:\n{hint}"
+        before, _, escalation = hint.partition("pfSense-upgrade")
+        assert escalation, f"the escalation command is missing entirely:\n{hint}"
+        between = before.split("pfSense-repo-setup", 1)[1]
+        # Shape, not just vocabulary: an indented bare command is a third list item, which
+        # is the regression this gate exists to catch — the words alone all survive it.
+        assert "install.sh:   pfSense-upgrade" not in hint, (
+            f"pfSense-upgrade must not be a list item beside the two repair commands:\n{hint}"
         )
-        escalation = hint.split("pfSense-repo-setup", 1)[1]
-        assert "only if" in escalation, f"pfSense-upgrade must be conditional:\n{hint}"
+        assert "re-run" in between, f"the retry must sit before the escalation:\n{hint}"
+        assert "only if" in between, f"pfSense-upgrade must be conditional:\n{hint}"
         assert "reboot" in escalation, f"the reboot must be stated where it is proposed:\n{hint}"
 
 
@@ -1818,11 +1821,14 @@ def test_usage_gates_pfsense_upgrade_behind_a_retry() -> None:
 
     assert proc.returncode == 0, proc.stdout + proc.stderr
     text = proc.stdout
-    assert text.index("pfSense-repo-setup") < text.index("pfSense-upgrade"), text
-    # Help text is prose, so the gate word may open a sentence.
-    escalation = text.split("pfSense-repo-setup", 1)[1].casefold()
-    assert "only if" in escalation, text
-    assert "reboot" in escalation, text
+    before, _, escalation = text.partition("pfSense-upgrade")
+    assert escalation, text
+    # Help text is prose, so the gate words may open a sentence.
+    between = before.split("pfSense-repo-setup", 1)[1].casefold()
+    assert "\n  pfSense-upgrade" not in text, f"pfSense-upgrade must not be a list item:\n{text}"
+    assert "re-run" in between, text
+    assert "only if" in between, text
+    assert "reboot" in escalation.casefold(), text
 
 
 def test_empty_catalogue_failure_prints_the_repository_repair_sequence() -> None:

--- a/tests/test_channel_install.py
+++ b/tests/test_channel_install.py
@@ -1793,6 +1793,38 @@ def test_pkg_update_failure_prints_the_repository_repair_sequence() -> None:
         )
 
 
+def test_repair_hint_gates_pfsense_upgrade_behind_a_retry() -> None:
+    """issue #2803: a bare `pfSense-upgrade` applies the box's pending release upgrade
+    and reboots (upstream sets `: ${action:="upgrade"}` when no action flag is given),
+    so it is the escalation after rebuilding the repository files and retrying — never
+    the third item of a flat list the user works through in order."""
+    with tempfile.TemporaryDirectory() as root:
+        proc = _run_install(root, "testing", update_fails=True)
+
+        assert proc.returncode == 4, proc.stdout + proc.stderr
+        hint = proc.stderr
+        assert hint.index("pfSense-repo-setup") < hint.index("pfSense-upgrade"), hint
+        # The retry sits BETWEEN the cheap repair and the escalation.
+        assert "re-run" in hint.split("pfSense-repo-setup", 1)[1].split("pfSense-upgrade", 1)[0], (
+            f"the hint must tell the user to retry before escalating:\n{hint}"
+        )
+        escalation = hint.split("pfSense-repo-setup", 1)[1]
+        assert "only if" in escalation, f"pfSense-upgrade must be conditional:\n{hint}"
+        assert "reboot" in escalation, f"the reboot must be stated where it is proposed:\n{hint}"
+
+
+def test_usage_gates_pfsense_upgrade_behind_a_retry() -> None:
+    proc = _run_argv("--help")
+
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    text = proc.stdout
+    assert text.index("pfSense-repo-setup") < text.index("pfSense-upgrade"), text
+    # Help text is prose, so the gate word may open a sentence.
+    escalation = text.split("pfSense-repo-setup", 1)[1].casefold()
+    assert "only if" in escalation, text
+    assert "reboot" in escalation, text
+
+
 def test_empty_catalogue_failure_prints_the_repository_repair_sequence() -> None:
     with tempfile.TemporaryDirectory() as root:
         proc = _run_install(root, "edge", catalog=())


### PR DESCRIPTION
Closes #2803.

#2789 printed the recovery commands as one flat sequence, which reads as "run all three". That is wrong for the third one. From upstream's own argument parsing in `sysutils/pfSense-upgrade/files/pfSense-upgrade`:

```sh
# Set default action when no parameter is set
: ${action:="upgrade"}
```

A bare `pfSense-upgrade` therefore applies whatever release the box's branch offers and reboots afterwards unless `-R` is passed; the check-only and metadata-only behaviours are the explicit `-c` and `-u` forms. `pfSense-repoc` and `pfSense-repo-setup` rebuild repository configuration and are cheap and local. Sending a user with a broken pkg setup straight into a release upgrade is a much larger action than the failure warrants.

Before:

```
install.sh: if this box's own pkg setup is at fault, rebuild it, then re-run this script:
install.sh:   pfSense-repoc
install.sh:   pfSense-repo-setup
install.sh:   pfSense-upgrade
```

After:

```
install.sh: if this box's own pkg setup is at fault, rebuild it and re-run this script:
install.sh:   pfSense-repoc
install.sh:   pfSense-repo-setup
install.sh: only if the re-run still fails, escalate to pfSense-upgrade — it applies any
install.sh: pfSense release upgrade the box's branch offers, and reboots when it does.
```

`usage()` carries the same escalation.

## Verification

Two tests pin the shape, not just the vocabulary: both gates partition at `pfSense-upgrade`, require the retry and the condition in the region between the repair commands and the escalation, require the reboot warning after the command, and reject an indented bare command outright. Shipped bytes executed RED against `devel`'s `install.sh`, then GREEN, byte-identical across both:

| Frozen RED test | git hash-object | RED run tail |
| --- | --- | --- |
| `tests/test_channel_install.py` | `4a36c86fbc8bb496cf04450f3a1b9328f6bcb3cb` | `2 failed in 0.78s` |

```
9 passed in 2.09s
```

The regression the issue names — flattening the escalation back into a third list item while keeping the words — now fails both gates:

```
--- mutation: flattened back into a list ---
2 failed in 0.78s
```

Full gates on the rebased branch:

```
GATE PASS: python3 scripts/check_coverage_pairing.py --name-status-z
GATE PASS: uv run --locked pytest
GATE PASS: uv run --locked ruff check .
GATE PASS: uv run --locked ruff format --check .
GATE PASS: uv run --locked mypy tests/
GATE PASS: sh -n scripts/install.sh
GATE PASS: shellcheck scripts/install.sh
GATE PASS: shellspec --shell $(command -v dash || command -v sh)
GATES: PASS
```

## Review

Reviewed independently per `.agents/policy/landing.md`. The reviewer confirmed the factual claim against upstream (bare invocation reaches `pkg_upgrade`, sets `need_reboot=1`, and calls `do_reboot` unless `-R`; on an interrupted upgrade it resumes stage 2 and reboots without prompting), and confirmed that `pfSense-upgrade -u` would be the weaker third step — the bare form already runs `pfSense-repo-setup` plus a forced `pkg update` before prompting, so it is a superset of `-u` and the only form that fixes the version-mismatch class.

It also returned two blockers, both valid: the original gates sliced from `pfSense-repo-setup`, so a flattened list kept every keyword and stayed green, and the usage gate had no between-region assertion at all. Both are fixed in the second commit, with the flattening mutation now proven to fail. Two nits are addressed as well: a stale "these three commands" in the rewritten comment, and the run-on "Run bare it applies" in the help text.

Authored by an OMP agent session; no `coauthor.omp.*` identity is configured in this checkout, so the commits carry no co-author trailer.
