### PR TITLE
download: refuse an XLSX extraction that finds no address

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.sh
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.sh
@@ -2061,9 +2061,7 @@ processxlsx() {
 
 	# Nothing here is piped: POSIX sh has no pipefail, so a pipeline reports only
 	# its last command's status -- `grep`'s no-match exit 1 (issue #2682) and a
-	# child killed at the ceiling would both be lost. `tar -xOf` therefore writes
-	# the shared-strings part to a file, and `grep` stages its matches for
-	# `sort -u -o` to rewrite in place (POSIX permits -o's file among its inputs).
+	# ceiling kill would both be lost. (POSIX permits sort -o's file among its inputs.)
 	# `set --` names ONE workbook: the glob splats into tar's argument list, where
 	# every match after the first is a member selector, not a second archive.
 	# `chmod` before the rename because published feeds have unprivileged readers

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.sh
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.sh
@@ -2060,14 +2060,10 @@ processxlsx() {
 	xlsxstage="${pfborig}${alias}.orig.tmp"
 
 	# Nothing here is piped: POSIX sh has no pipefail, so a pipeline reports only
-	# its last command's status. `tar -xOf` writes the shared-strings part to a
-	# file, and `grep` stages its matches for `sort -u -o` to rewrite in place
-	# (POSIX permits -o's output file among its inputs).
-	# issue #2682: that is what lets `grep`'s exit 1 -- a workbook that parses with
-	# no IPv4 literal in it -- refuse the feed. Through a pipe the status was lost,
-	# so zero bytes went out over the last-good '.orig' and read as a success: an
-	# empty file probes as the allow-listed `inode/x-empty`, so pfb_download()'s
-	# inner-content MIME gate passed the publication too.
+	# its last command's status -- `grep`'s no-match exit 1 (issue #2682) and a
+	# child killed at the ceiling would both be lost. `tar -xOf` therefore writes
+	# the shared-strings part to a file, and `grep` stages its matches for
+	# `sort -u -o` to rewrite in place (POSIX permits -o's file among its inputs).
 	# `set --` names ONE workbook: the glob splats into tar's argument list, where
 	# every match after the first is a member selector, not a second archive.
 	# `chmod` before the rename because published feeds have unprivileged readers

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.sh
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.sh
@@ -2040,6 +2040,9 @@ processet() {
 # issue #2666: the exit contract pfb_download() gates on. A failing status is
 # returned verbatim rather than collapsed to 1, so a child killed at issue
 # #2658's extraction ceiling reaches the caller as the 153 that names it.
+#
+# issue #2682: an extraction that parses but yields no address is part of that
+# contract -- it refuses the refresh instead of publishing an empty feed.
 processxlsx() {
 	if [ ! -x "${pathtar}" ]; then
 		log='Application [ TAR ] Not found, cannot proceed.'
@@ -2056,8 +2059,15 @@ processxlsx() {
 	xlsxshared="${tmpxlsx}sharedStrings.xml"
 	xlsxstage="${pfborig}${alias}.orig.tmp"
 
-	# `tar -xOf` writes to a file, not into the pipe: POSIX sh has no pipefail, so
-	# piped it would report only the trailing `sort`'s status.
+	# Nothing here is piped: POSIX sh has no pipefail, so a pipeline reports only
+	# its last command's status. `tar -xOf` writes the shared-strings part to a
+	# file, and `grep` stages its matches for `sort -u -o` to rewrite in place
+	# (POSIX permits -o's output file among its inputs).
+	# issue #2682: that is what lets `grep`'s exit 1 -- a workbook that parses with
+	# no IPv4 literal in it -- refuse the feed. Through a pipe the status was lost,
+	# so zero bytes went out over the last-good '.orig' and read as a success: an
+	# empty file probes as the allow-listed `inode/x-empty`, so pfb_download()'s
+	# inner-content MIME gate passed the publication too.
 	# `set --` names ONE workbook: the glob splats into tar's argument list, where
 	# every match after the first is a member selector, not a second archive.
 	# `chmod` before the rename because published feeds have unprivileged readers
@@ -2065,7 +2075,8 @@ processxlsx() {
 	"${pathtar}" -xf "${pfborig}${alias}.raw" -C "${tmpxlsx}" &&
 		set -- "${tmpxlsx}"*.[xX][lL][sS][xX] &&
 		"${pathtar}" -xOf "$1" "xl/sharedStrings.xml" > "${xlsxshared}" &&
-		grep -aoEw "(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)" "${xlsxshared}" | LC_ALL=C sort -u > "${xlsxstage}" &&
+		grep -aoEw "(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)" "${xlsxshared}" > "${xlsxstage}" &&
+		LC_ALL=C sort -u -o "${xlsxstage}" "${xlsxstage}" &&
 		chmod 644 "${xlsxstage}" &&
 		mv -f "${xlsxstage}" "${pfborig}${alias}.orig"
 	xlsxrc=$?

--- a/tests/php/DownloadExtractionExitCodeTest.php
+++ b/tests/php/DownloadExtractionExitCodeTest.php
@@ -560,6 +560,36 @@ final class DownloadExtractionExitCodeTest extends TestCase
 	}
 
 	/**
+	 * Issue #2682: an extraction that parses but yields no address is refused by the
+	 * helper, and the refusal has to stop the pass. The content-hash sidecar is
+	 * refreshed by pfb_download_finalize_text() further down the same function, so a
+	 * gate that logged and fell through would persist a digest for bytes that were
+	 * never ingested — and the next cron would then read the feed as unchanged.
+	 */
+	public function testXlsxRefusalReturnsBeforeTheSidecarRefresh(): void
+	{
+		$xlsx = strpos(self::$source, "if (strpos(\$xlsxtest, '.xlsx') !== FALSE) {");
+		$this->assertNotFalse($xlsx);
+		$zipBranch = strpos(self::$source, '} else {', $xlsx);
+		$this->assertNotFalse($zipBranch);
+		// Bounded by the branch, so a neutered xlsx gate cannot be satisfied by the
+		// ET branch's identical one further down the function.
+		$scope = substr(self::$source, $xlsx, $zipBranch - $xlsx);
+		$gate = strpos($scope, 'if (!pfb_download_extraction_succeeded($retval)) {');
+		$this->assertNotFalse($gate, 'the xlsx branch must gate on the helper exit status');
+		$refusal = substr($scope, $gate,
+			self::closingBraceExclusive($scope, strpos($scope, '{', $gate)) - $gate);
+		$this->assertStringContainsString('return PfbDownloadResult::failure();', $refusal,
+			'the xlsx refusal must return, not fall through into the text pipeline');
+		$this->assertStringNotContainsString('pfb_download_finalize_text', $refusal);
+		// Searched from the end of the branch, so the helper's own definition (far
+		// earlier in the file) cannot satisfy it: moving the refresh ahead of the
+		// archive branch leaves no later occurrence and this fails.
+		$this->assertNotFalse(strpos(self::$source, 'pfb_download_finalize_text(', $zipBranch),
+			'the sidecar refresh must sit downstream of the xlsx refusal, never ahead of it');
+	}
+
+	/**
 	 * pfb_download() hands the ET IQRisk feed to the shell helper, which splits it
 	 * into per-category files and republishes the feed from the selected ones;
 	 * issue #2683 gave that helper an exit contract, so this branch is pinned like

--- a/tests/php/PfbMimeAllowlistTest.php
+++ b/tests/php/PfbMimeAllowlistTest.php
@@ -138,12 +138,9 @@ final class PfbMimeAllowlistTest extends TestCase
 
 	public function test_shipped_allowlist_accepts_empty_bodies(): void
 	{
-		// issue #2682 asked whether 'inode/x-empty' is still justified once the XLSX
-		// path refuses an extraction that yields no address. It is, and this pins it:
-		// the entry is not the XLSX defect (which was a helper manufacturing an empty
-		// payload and reporting success), and this one list also gates the OUTER
-		// download of EVERY feed type, so dropping it would reject any legitimately
-		// empty body -- ADR-49's same ruling, that an empty body is its own signal.
+		// issue #2682 / ADR-49: an empty body is its own signal, and this one list
+		// gates the OUTER download of every feed type -- dropping the entry rejects
+		// legitimately empty bodies of every kind.
 		$shipped = $GLOBALS['pfb_shipped_mime_types'] ?? [];
 
 		$this->assertNotEmpty($shipped, 'shipped mime_types snapshot is empty — bootstrap capture broke');

--- a/tests/php/PfbMimeAllowlistTest.php
+++ b/tests/php/PfbMimeAllowlistTest.php
@@ -135,4 +135,21 @@ final class PfbMimeAllowlistTest extends TestCase
 			'application/x-7z-compressed must NOT be in the shipped allow-list'
 		);
 	}
+
+	public function test_shipped_allowlist_accepts_empty_bodies(): void
+	{
+		// issue #2682 asked whether 'inode/x-empty' is still justified once the XLSX
+		// path refuses an extraction that yields no address. It is, and this pins it:
+		// the entry is not the XLSX defect (which was a helper manufacturing an empty
+		// payload and reporting success), and this one list also gates the OUTER
+		// download of EVERY feed type, so dropping it would reject any legitimately
+		// empty body -- ADR-49's same ruling, that an empty body is its own signal.
+		$shipped = $GLOBALS['pfb_shipped_mime_types'] ?? [];
+
+		$this->assertNotEmpty($shipped, 'shipped mime_types snapshot is empty — bootstrap capture broke');
+		$this->assertTrue(
+			pfb_mime_in_allowlist('inode/x-empty', $shipped),
+			'an empty body must still reach the download gates, not be rejected as a MIME violation'
+		);
+	}
 }

--- a/tests/shell/pfblockerng_adr26_locale_spec.sh
+++ b/tests/shell/pfblockerng_adr26_locale_spec.sh
@@ -79,8 +79,6 @@ Describe 'ADR-26 — pfblockerng.sh locale/portability source invariants (Phases
   # success. Same sink, same collation requirement, one filename earlier.
   # issue #2682 took it off the pipe as well -- `grep` stages its matches and this
   # `sort` rewrites that file in place -- so grep's no-match status is readable.
-  # The collation requirement is unchanged; only the sink's form moved to `-o`,
-  # the same in-place idiom the masterfile sink below already uses.
   It 'prefixes the extracted-IP .orig sink with LC_ALL=C'
     When call has 'LC_ALL=C sort -u -o "${xlsxstage}" "${xlsxstage}"'
     The status should be success

--- a/tests/shell/pfblockerng_adr26_locale_spec.sh
+++ b/tests/shell/pfblockerng_adr26_locale_spec.sh
@@ -77,8 +77,12 @@ Describe 'ADR-26 — pfblockerng.sh locale/portability source invariants (Phases
   # issue #2666 staged this sink: the addresses are sorted onto "${xlsxstage}" and
   # only moved onto "${pfborig}${alias}.orig" once every extraction step reported
   # success. Same sink, same collation requirement, one filename earlier.
+  # issue #2682 took it off the pipe as well -- `grep` stages its matches and this
+  # `sort` rewrites that file in place -- so grep's no-match status is readable.
+  # The collation requirement is unchanged; only the sink's form moved to `-o`,
+  # the same in-place idiom the masterfile sink below already uses.
   It 'prefixes the extracted-IP .orig sink with LC_ALL=C'
-    When call has 'LC_ALL=C sort -u > "${xlsxstage}"'
+    When call has 'LC_ALL=C sort -u -o "${xlsxstage}" "${xlsxstage}"'
     The status should be success
   End
   It 'prefixes the masterfile order (sort -o) with LC_ALL=C'

--- a/tests/shell/pfblockerng_processxlsx_exit_spec.sh
+++ b/tests/shell/pfblockerng_processxlsx_exit_spec.sh
@@ -10,6 +10,10 @@
 # ".orig" already in service byte-unchanged instead of overwriting it with the
 # empty or partial remains of the attempt.
 #
+# issue #2682: an extraction that parses but yields no address is one of those
+# failing steps. `grep` reports it (exit 1, no lines selected) and that status is
+# now read, so the feed is refused rather than published as zero bytes.
+#
 # Fixture shape: the downloaded ".raw" container holds one "*.xlsx" member, and
 # that member is itself an archive holding "xl/sharedStrings.xml" -- the two
 # layers processxlsx() opens. Real feeds ship ZIP containers; these fixtures are
@@ -66,6 +70,17 @@ RUNNER
 		( cd "${work}/build" && tar -cf "${orig}${alias}.raw" "${alias}.xlsx" )
 	}
 
+	# A container whose workbook PARSES but carries no IPv4 literal at all: the
+	# shape issue #2682 names -- an address column that came up empty, or a
+	# workbook whose addresses live in an inline-string part instead of the
+	# shared-strings table.
+	plant_addressless_raw() {
+		printf '<sst><si><t>Hostname</t></si><si><t>example.invalid</t></si><si><t>2001:db8::1</t></si></sst>\n' \
+			> "${work}/inner/xl/sharedStrings.xml"
+		( cd "${work}/inner" && tar -cf "${work}/build/${alias}.xlsx" xl )
+		( cd "${work}/build" && tar -cf "${orig}${alias}.raw" "${alias}.xlsx" )
+	}
+
 	# A live publication left by a previous, successful run.
 	plant_prior_publication() {
 		printf '%s\n' "${prior}" > "${orig}${alias}.orig"
@@ -81,6 +96,65 @@ RUNNER
 			# The one context where this can fail: the staged file really was
 			# written here, so a publish that copied instead of renaming, or
 			# forgot to clean up, would leave it behind.
+			The path "${orig}${alias}.orig.tmp" should not be exist
+			The output should include 'Final count'
+		End
+	End
+
+	Context 'on a workbook that parses but carries no IPv4 literal'
+		# issue #2682: `grep` exits 1 when nothing matched, but piped into `sort`
+		# that status was lost -- a pipeline reports only its last command -- so
+		# such a workbook staged zero bytes at status 0 and published them over
+		# the last-good ".orig". Nothing downstream caught it either: an empty
+		# file probes as "inode/x-empty", which pfb_download()'s inner-content
+		# MIME gate allow-lists, so the ingest reported success and refreshed the
+		# feed's content-hash sidecar for it.
+		Before 'plant_prior_publication'
+		Before 'plant_addressless_raw'
+
+		It 'refuses the refresh and keeps the live publication byte-unchanged'
+			When run sh "${runner}"
+			The status should be failure
+			The contents of file "${orig}${alias}.orig" should equal "${prior}"
+			The path "${orig}${alias}.orig.tmp" should not be exist
+			The output should include 'XLSX processing failed'
+			# The sibling refusal line, verbatim: the operator reads the refusal
+			# and that the previous publication is what stayed in service.
+			The contents of file "${errorlog}" should include " [ ${alias} ] XLSX processing failed, exit 1; keeping existing [ 2026-01-01 00:00:00 ]"
+		End
+	End
+
+	Context 'on an addressless workbook with no publication yet'
+		# issue #2682, first fetch: with no ".orig" to keep, the refusal must
+		# leave the feed absent rather than publish zero bytes as its content.
+		Before 'plant_addressless_raw'
+
+		It 'refuses without manufacturing an empty publication'
+			When run sh "${runner}"
+			The status should be failure
+			The path "${orig}${alias}.orig" should not be exist
+			The path "${orig}${alias}.orig.tmp" should not be exist
+			The output should include 'XLSX processing failed'
+		End
+	End
+
+	Context 'on a workbook whose addresses repeat and are out of order'
+		# issue #2682 moved the de-duplication off the pipe: `grep` stages its
+		# matches and `sort -u -o` rewrites that file in place. The bytes that
+		# reach the feed are pinned here, so a mis-wired rewrite cannot pass as
+		# "the extraction still exits 0".
+		plant_repeated_raw() {
+			printf '<sst><si><t>198.51.100.20</t></si><si><t>192.0.2.10</t></si><si><t>198.51.100.20</t></si></sst>\n' \
+				> "${work}/inner/xl/sharedStrings.xml"
+			( cd "${work}/inner" && tar -cf "${work}/build/${alias}.xlsx" xl )
+			( cd "${work}/build" && tar -cf "${orig}${alias}.raw" "${alias}.xlsx" )
+		}
+		Before 'plant_repeated_raw'
+
+		It 'publishes each address once, in LC_ALL=C order'
+			When run sh "${runner}"
+			The status should be success
+			The contents of file "${orig}${alias}.orig" should equal "${expected}"
 			The path "${orig}${alias}.orig.tmp" should not be exist
 			The output should include 'Final count'
 		End

--- a/tests/shell/pfblockerng_processxlsx_exit_spec.sh
+++ b/tests/shell/pfblockerng_processxlsx_exit_spec.sh
@@ -62,9 +62,11 @@ RUNNER
 	After 'cleanup'
 
 	# A healthy container: outer archive holding an inner archive holding the
-	# shared-strings part the addresses are read out of.
+	# shared-strings part the addresses are read out of. The payload repeats one
+	# address and lists them out of order, so every example that asserts
+	# "${expected}" also pins the staging sort and its de-duplication.
 	plant_healthy_raw() {
-		printf '<si><t>192.0.2.10</t></si><si><t>198.51.100.20</t></si>\n' \
+		printf '<si><t>198.51.100.20</t></si><si><t>192.0.2.10</t></si><si><t>198.51.100.20</t></si>\n' \
 			> "${work}/inner/xl/sharedStrings.xml"
 		( cd "${work}/inner" && tar -cf "${work}/build/${alias}.xlsx" xl )
 		( cd "${work}/build" && tar -cf "${orig}${alias}.raw" "${alias}.xlsx" )
@@ -135,28 +137,6 @@ RUNNER
 			The path "${orig}${alias}.orig" should not be exist
 			The path "${orig}${alias}.orig.tmp" should not be exist
 			The output should include 'XLSX processing failed'
-		End
-	End
-
-	Context 'on a workbook whose addresses repeat and are out of order'
-		# issue #2682 moved the de-duplication off the pipe: `grep` stages its
-		# matches and `sort -u -o` rewrites that file in place. The bytes that
-		# reach the feed are pinned here, so a mis-wired rewrite cannot pass as
-		# "the extraction still exits 0".
-		plant_repeated_raw() {
-			printf '<sst><si><t>198.51.100.20</t></si><si><t>192.0.2.10</t></si><si><t>198.51.100.20</t></si></sst>\n' \
-				> "${work}/inner/xl/sharedStrings.xml"
-			( cd "${work}/inner" && tar -cf "${work}/build/${alias}.xlsx" xl )
-			( cd "${work}/build" && tar -cf "${orig}${alias}.raw" "${alias}.xlsx" )
-		}
-		Before 'plant_repeated_raw'
-
-		It 'publishes each address once, in LC_ALL=C order'
-			When run sh "${runner}"
-			The status should be success
-			The contents of file "${orig}${alias}.orig" should equal "${expected}"
-			The path "${orig}${alias}.orig.tmp" should not be exist
-			The output should include 'Final count'
 		End
 	End
 


### PR DESCRIPTION
## What this fixes

`processxlsx()` staged its extraction with `grep -aoEw … | LC_ALL=C sort -u > "${xlsxstage}"`. A POSIX pipeline reports only its last command's status, so `grep`'s exit 1 — *no lines selected* — was thrown away. A workbook that parses but carries no IPv4 literal therefore staged zero bytes at status 0, and the chain renamed those zero bytes over the last-good `.orig`.

Nothing downstream noticed: an empty file probes as `inode/x-empty`, which the ZIP inner-content MIME gate allow-lists, so `pfb_download()` reported success and `pfb_download_finalize_text()` refreshed the feed's content-hash sidecar for it.

`grep` now writes the staged file directly and `LC_ALL=C sort -u -o` rewrites it in place (POSIX permits `-o`'s output file among its inputs), so grep's status rides the same `&&` chain as every other step. The rename never runs on a refusal, which is what leaves the previous publication in service.

Fixes #2682

## The discriminating probe (executed at base, then at HEAD)

Two hypotheses for why the empty publication reported success:

* **H1** — `processxlsx()` itself returns 0: the staging pipeline masks `grep`'s no-match status.
* **H2** — `processxlsx()` does refuse, and the refusal is swallowed downstream (the caller's gate or the `inode/x-empty` allow-list).

Probe: call `processxlsx()` against a workbook whose `xl/sharedStrings.xml` parses but holds no IPv4 literal, with a prior publication in place; read the exit status and the `.orig` bytes.

At base (`b9903f00`):

```
=== processxlsx() exit status: 0
=== .orig size after run:        0 bytes
=== .orig hash before: c32613099802bca3fd8007cc1b0f4d69
=== .orig hash after : d41d8cd98f00b204e9800998ecf8427e
=== VERDICT: prior publication OVERWRITTEN
=== stdout:

Final count [ 0 ]
=== errorlog:
(no errorlog written)
=== file -b --mime-type of published .orig:
inode/x-empty
```

H1 confirmed, H2 refuted — the shell helper reports success, so nothing downstream ever had a refusal to swallow. The masking itself, probed directly under `dash`:

```
grep alone rc=1
pipeline rc=0 stage bytes=       0
in-place sort rc=0
```

At HEAD, the same probe:

```
=== processxlsx() exit status: 1
=== .orig size after run:       25 bytes
=== VERDICT: prior publication PRESERVED
=== stdout:
XLSX processing failed
=== errorlog:
 [ XlsxFeed ] XLSX processing failed, exit 1; keeping existing [ 2026-01-01 00:00:00 ]
=== file -b --mime-type of published .orig:
text/plain
```

## The policy decision

**"Extraction succeeded but produced no address" is a refusal.** `processxlsx()` returns non-zero, logs it in the shape its sibling refusal paths use, and the previous publication stays in service through the staged rename.

The mechanism matters as much as the verdict: **this is a status-masking fix, not an output-validity policy.** `grep` *does* report "no lines selected"; the pipeline discarded it. That distinction is what keeps this consistent with the ruling on issue #2668 (`7e4204f1`, contract leg, blocking), where an empty *staged tree* refusal was removed because "adding output validity semantics to a clean extractor exit is a different policy". Here the extractor exit is not clean — reading it is exactly issue #2666's own contract, "every failing step reports non-zero".

A stage-emptiness test (`[ -s "${xlsxstage}" ]`) would have been that rejected policy, and it is also strictly weaker. Executed comparison of the two shapes under both shells:

```
old pipeline shape: rc=0 with partial bytes <192.0.2.10>
new direct-writer shape: rc=153 with the same partial bytes
```

A `grep` killed mid-write at issue #2658's extraction ceiling leaves a *partial* stage, which an emptiness test publishes and a status check refuses.

Refusing an extraction that landed nothing is in any case already a live contract on the sibling branch of the same download path — `pfb_blacklist_tar_finalize_staged()` returns failure for an empty file list with the extractor's status still 0.

**Log wording:** the refusal reuses the existing sibling line (`XLSX processing failed, exit 1; keeping existing`) rather than a new string. The aggregate `xlsxrc` this block reads cannot tell a distinct reason apart — `tar`, `chmod` and `mv` all exit 1 too, and the shell's own failed-redirection status differs by shell, which the hostile-input matrix confirmed live: a crash-leftover DIRECTORY at the stage path gives

```
dash: RUN debris rc=2 … log=< [ XlsxFeed ] XLSX processing failed, exit 2; keeping existing …
sh:   RUN debris rc=1 … log=< [ XlsxFeed ] XLSX processing failed, exit 1; keeping existing …
```

so an `rc == 1` test would mislabel that path on one of the two shells. Naming the refusal would therefore take corroborating grep's status against the staged file's size, which is the emptiness policy this fix deliberately avoids. If a reviewer wants the wording anyway, say so and it lands with that corroboration.

## The `inode/x-empty` allow-list decision

**The entry stays, and a test now pins it.**

* It is one shared list (`$pfb['mime_types']`, `pfblockerng.inc:480`) and the **outer** download gate for *every* feed type reads it (`pfblockerng.inc:14514`). Dropping the entry would reject any legitimately empty body on every feed type — far outside this issue — and would convert a data condition into a misleading `mime_not_allowed` diagnostic.
* ADR-49 already ruled on the same question for the plain-text sanity scan: "`inode/x-empty` (an empty body is its own signal; rejecting it is a behaviour change beyond …)".
* The entry was never the defect. The defect was the XLSX helper *manufacturing* an empty payload and calling it success. With the refusal in place no empty payload reaches the inner gate on the XLSX path at all.

New pin: `PfbMimeAllowlistTest::test_shipped_allowlist_accepts_empty_bodies`, asserted against the real shipped list captured at bootstrap (not the hand-mirror), so removing the entry fails a named test.

## Sidecar: not refreshed on refusal

`pfb_download_finalize_text()` (`pfblockerng.inc:15314`) sits downstream of the XLSX branch, which returns `PfbDownloadResult::failure()` at `15031`, so a refusal never reaches it. The ET path needed an explicit sidecar drop because `processet()` publishes in place *before* that call; the XLSX path publishes nothing, so there is nothing to undo — no dead unlink loop was added.

The conditional-GET validators (`.etag` / `.lastmod`) are written by the cron detector at probe time (`pfblockerng_cron.inc:186/207/219`), unchanged by this fix and identical to every other `processxlsx()` refusal: the last-good `.orig` stays served, and a fixed workbook re-ingests as soon as the remote's validator or body hash changes.

## Test-first evidence

Frozen reproduction test — `git hash-object` at RED time, unchanged at GREEN and as committed. The reproduction was re-executed at the current bytes each time a review round moved them:

| File | Hash at head | Role |
| --- | --- | --- |
| `tests/shell/pfblockerng_processxlsx_exit_spec.sh` | `6d04e3696b1a9d195614d448110a0eeaa0dbb94e` | reproduction, executed RED before the production edit |
| `tests/php/DownloadExtractionExitCodeTest.php` | `74c89a1f3d3db5acf06357c4fa23a6c6cdc93535` | guard (green both ways), mutation-proven — M4 / M4b |
| `tests/php/PfbMimeAllowlistTest.php` | `2fe59e9286539f328293ae2dfb1a85b9a8cab789` | guard (green both ways), mutation-proven — M5 |
| `tests/shell/pfblockerng_adr26_locale_spec.sh` | `3cd5cafd42a08ac5a3b431d96dd96499310d7f6d` | ADR-26 sink pin, realigned to the new literal |

RED at the first commit's bytes (`518b7bf308b5bc777fe34988e791596ce049cb7e`), production untouched, `shellspec --shell /bin/dash`:

```
     1.1) The status should be failure
            expected: failure (non-zero)
                 got: success (zero) [status: 0]
     1.2) The contents of file …/orig/XlsxFeed.orig should equal 203.0.113.7
PRIOR-MARKER
            expected: "203.0.113.7
            PRIOR-MARKER"
                 got: ""
     1.4) The contents of file …/error.log should include  [ XlsxFeed ] XLSX processing failed, exit 1; keeping existing [ 2026-01-01 00:00:00 ]
            expected <unset> to include " [ XlsxFeed ] XLSX processing failed, exit 1; keeping existing [ 2026-01-01 00:00:00 ]"
     2.2) The path …/orig/XlsxFeed.orig should not be exist
            The specified path exists

16 examples, 2 failures
```

RED and GREEN re-executed at the CURRENT bytes (`6d04e369…`), in an isolated clone with only the production file reverted to `dff7c4f9~3`:

```
=== RED (production reverted, tests kept) ===
            expected: failure (non-zero)
                 got: success (zero) [status: 0]
            expected: "203.0.113.7
                 got: ""
            expected <unset> to include " [ XlsxFeed ] XLSX processing failed, exit 1; keeping existing [ 2026-01-01 00:00:00 ]"
15 examples, 2 failures
  …spec:117 refuses the refresh and keeps the live publication byte-unchanged FAILED
  …spec:134 refuses without manufacturing an empty publication FAILED
=== hashes at RED ===
6d04e3696b1a9d195614d448110a0eeaa0dbb94e
=== GREEN ===
15 examples, 0 failures
6d04e3696b1a9d195614d448110a0eeaa0dbb94e
```

Executed-example count, not file inspection (the #2749 lesson) — same spec file, base versus head:

```
=== base b91b95c ===  13 examples, 0 failures
=== head cd9b2a13 === 15 examples, 0 failures
```

Two net new examples (three were added, one folded away in the review rounds below). The reproduction was re-executed once more at `cd9b2a13`, unchanged: `15 examples, 2 failures` at `spec:117` and `spec:134` with the production file reverted, `15 examples, 0 failures` restored, spec blob `6d04e369…` both times.

## Mutation kills

Run in an isolated clone detached at the head; each mutant asserts a unique needle and a non-empty diff before its test runs, and reverts to a clean tree after. Every row below was also re-derived independently, by hand, by the test-honesty leg.

| # | Mutant | Named test that fails |
| --- | --- | --- |
| M1 | restore the masked pipeline (`grep \| sort -u`) — returns 0 on the empty result | `spec:117` *refuses the refresh and keeps the live publication byte-unchanged*; `spec:134` *refuses without manufacturing an empty publication* |
| M2 | publish before the refusal (grep's status ignored with `;`) | the same two |
| M3 | log without failing (`return 0` from the refusal block) | 8 failures: `spec:117`, `spec:134`, plus the six pre-existing failure-path examples at `spec:151` corrupt outer, `spec:172` truncated, `spec:192` inner not an archive, `spec:210` stage unwritable, `spec:246` killed stage (153), `spec:330` extraction ceiling |
| M4 | keep the sidecar refresh on refusal (xlsx gate neutered to `if (FALSE)`) | `DownloadExtractionExitCodeTest::testXlsxRefusalReturnsBeforeTheSidecarRefresh` (and `testXlsxBodyCapturesAndChecksHelperExit`) |
| M4b | keep the sidecar refresh on refusal (refusal falls through — `return` removed) | `DownloadExtractionExitCodeTest::testXlsxRefusalReturnsBeforeTheSidecarRefresh` |
| M5 | drop the `inode/x-empty` allow-list entry | `PfbMimeAllowlistTest::test_shipped_allowlist_accepts_empty_bodies` |
| M6 | drop `-u` from the in-place sort | 3 failures: `spec:94` healthy, `spec:218` debris-cleared, `spec:294` two-workbooks |
| M7 | refuse without cleaning the stage (`rm -rf "${xlsxstage}"` dropped) | 4 failures: `spec:117`, `spec:134`, `spec:218`, `spec:246` |
| M8 | `touch "${pfborig}${alias}.orig"` on refusal (manufacture an empty publication) | 1 failure, `spec:134` **only** |

Sample kill output:

```
### M2: publish before the refusal (grep status ignored with ;)
15 examples, 2 failures
shellspec …:117 # 1) … refuses the refresh and keeps the live publication byte-unchanged FAILED
shellspec …:134 # 2) … refuses without manufacturing an empty publication FAILED

### M4b: keep the sidecar refresh on refusal (xlsx refusal falls through)
1) DownloadExtractionExitCodeTest::testXlsxRefusalReturnsBeforeTheSidecarRefresh
the xlsx refusal must return, not fall through into the text pipeline
Failed asserting that 'if (!pfb_download_extraction_succeeded($retval)) { … unlink_if_exists($file_download); }' contains "return PfbDownloadResult::failure();".

### M5: drop the inode/x-empty allow-list entry
1) PfbMimeAllowlistTest::test_shipped_allowlist_accepts_empty_bodies
an empty body must still reach the download gates, not be rejected as a MIME violation
Failed asserting that false is true.

### M8: touch the publication on refusal (empty .orig manufactured on a first fetch)
15 examples, 1 failure
shellspec …:134 # 1) … refuses without manufacturing an empty publication FAILED

### ALL MUTANTS REVERTED; tree clean: yes
```

M8 is why the `on an addressless workbook with no publication yet` example survived the over-engineering leg's cut request: it is the only example that kills it.

## Hostile-input matrix (executed under both `/bin/dash` and `/bin/sh`)

Through the real `processxlsx()`, against a nested-tar fixture with a live prior publication:

| Input | rc | `.orig` after | stage / scratch |
| --- | --- | --- | --- |
| crash-leftover DIRECTORY at the stage path | 2 (dash) / 1 (sh) | prior preserved, mode 600 | absent / 0, and the next run recovers (rc=0, mode 644) |
| `ulimit -f 1` (issue #2658's ceiling) | 153 both shells | prior preserved | absent / 0 |
| `<sst></sst>` (parses, no address) | 1 | prior preserved | absent / 0 |
| zero-byte shared-strings part | 1 | prior preserved | absent / 0 |
| address embedded in a longer token (`x4.4.4.4y`) | 1 | prior preserved | absent / 0 |
| `xl/sharedStrings.xml` missing from the workbook | 1 | prior preserved | absent / 0 |
| NUL bytes around an address | 0 | `4.4.4.4` published | absent / 0 |
| CRLF line endings | 0 | `4.4.4.4` published | absent / 0 |
| 500,000-line address list | 0 | the two unique addresses | absent / 0 |

`sort -u -o FILE FILE` was probed on both implementations the code can meet, including a forced external merge (`-S 1K -T`, temp-space failure used as the spill discriminator):

```
SORT BSD small_rc=0 small=<a,b,> external_rc=0 lines=10000 first=00000001 last=00010000
SORT GNU small_rc=0 small=<a,b,> external_rc=0 lines=10000 first=00000001 last=00010000
```

POSIX `sort`: "`-o output` … This file can be the same as one of the input files"; FreeBSD `sort(1)` declares IEEE Std 1003.1-2008 compliance and does not list `-o` among its extensions. The idiom is also already shipped two examples below the ADR-26 pin this branch updates — `LC_ALL=C sort -o "${masterfile}" "${masterfile}"`.

## Success path unregressed

Every pre-existing example that pins publication, mode, verbatim status propagation and cleanup still passes (13 → 15, zero failures). The shared healthy fixture now carries a repeated, out-of-order payload, so those same examples also pin the staging sort and its de-duplication — which is what M6 kills three times over.

`tests/shell/pfblockerng_adr26_locale_spec.sh` needed one update, caught by the canonical gates and independently by the verifier leg: the ADR-26 gate pins that sink by its literal text, which this fix moved off the pipe. The invariant it enforces is unchanged (`pfblockerng.sh:2079` still carries `LC_ALL=C`); only the needle moved to the `-o` form.

## Scope

`src/usr/local/pkg/pfblockerng/pfblockerng.sh` (`processxlsx()` staging chain and its docblock) plus four test files. No `.inc` production change: the caller-side gate that decides the ingest on the helper's exit status already exists (#2666) and already returns before the sidecar refresh — proven above and now pinned. Shell stays strict POSIX `sh`; `sh -n`, `dash -n` and `shellcheck` clean.

Canonical gates at this head: every gate PASS except `vendor/bin/phpunit`, whose sole failure is the known Darwin-only `DownloadSizeCeilingTest::test_extract_cmd_ceiling_stops_a_child_that_writes_past_it` (#2765) — green on both CI PHPUnit legs.

## Review rounds

Round 1 at `c6be4f6f`, four legs: contract conformance (no blocking, two prose nitpicks), correctness + hostile inputs (pass, no findings, dual-shell executed matrix above), test honesty (pass, one nitpick), over-engineering (no blocking, five nitpicks, −55 lines claimed). The independent verifier and the canonical-gates run both caught the stale ADR-26 needle, fixed in `5fe07df5`.

Round 2 at `dff7c4f9`, three legs (correctness sat out: `git diff c6be4f6f..dff7c4f9 -- pfblockerng.sh` leaves the executable chain byte-identical, comments only, which that leg verified itself).

| # | Finding | Outcome |
| --- | --- | --- |
| 1 | ADR-26 sink pin still carried the old literal — branch RED on the full shellspec suite | fixed@`5fe07df5` |
| 2 | Repeat/out-of-order Context is the fixture, not an example | fixed@`dff7c4f9` — folded into `plant_healthy_raw`, M6 now kills three examples instead of one |
| 3 | Nine-line paragraph above the staging chain | fixed@`dff7c4f9`, trimmed again@`cd9b2a13` — three lines, only the two facts not readable off the code |
| 4 | Six-line allow-list comment restated ADR-49 | fixed@`dff7c4f9` — three-line pointer |
| 5 | Two restatement lines in the ADR-26 comment | fixed@`cd9b2a13` |
| 6 | `sort -u -o` in-place — is it needed? | skipped: the leg's own ruling, upheld in round 2 — the alternatives are the masked pipeline (the bug) or a second scratch path; two chain links is the shortest correct form with no pipefail |
| 7 | Parameterise the planter | skipped: two payload planters remain after finding 2, under the rule of three; leg withdrew it in round 2 |
| 8 | Delete the no-prior-publication Context | skipped with executed evidence: mutant M8 fails that example and only that example; leg withdrew the finding in round 2 |
| 9 | Mutation table said "five pre-existing failures" where the arithmetic needs six | fixed in this body, with the six line numbers named |
| 10 | Log-wording rationale claimed too broadly that no distinct reason could be derived | fixed in this body — the claim is now bounded to the aggregate `xlsxrc` this block reads, and the dual-shell debris rows show why an `rc == 1` label would mislabel one shell |
| 11 | Body evidence was stale for the current head (hashes, counts, missing M7/M8) | fixed in this body |
| 12 | The `/tmp` mutation driver's helpers pipe through `grep`/`head`, so a surviving mutant could read as a run | skipped: scratch harness, not PR code; every row was re-derived by hand by the test-honesty leg and cross-checked against the driver's own unique-needle and non-empty-diff assertions |

No blocking finding remains open.

🤖 Generated by Oh My Pi and posted on behalf of @andrebrait.
