### PR TITLE
agent: teach ast-grep and semgrep that .inc is PHP

### DIFF
--- a/.agents/context/repository-intelligence.md
+++ b/.agents/context/repository-intelligence.md
@@ -64,8 +64,7 @@ Load when: every agent session, from `AGENTS.md`.
   runs `serena project index <root>` when Serena is available. Under OMP (`OMP_CLI`
   or `PI_CLI`), it skips Serena because OMP provides native LSP tooling.
 - PHP includes are named `.inc`, and a tool that infers language from the extension
-  silently skips them until told otherwise — the result is indistinguishable from a clean
-  no-match (issue #2807). `phpcs.xml.dist`, `phpstan.neon`, `.editorconfig`,
-  `.vscode/settings.json`, and `sgconfig.yml` carry the association; semgrep has no
-  configuration equivalent, so always pass `semgrep --scan-unknown-extensions`.
+  silently skips them — indistinguishable from a clean no-match (issue #2807). The
+  tracked `sgconfig.yml` fixes ast-grep; semgrep has no configuration equivalent, so
+  always pass `semgrep --scan-unknown-extensions`.
 - Compiler, static analysis, tests, CI, and live smoke remain final.

--- a/.agents/context/repository-intelligence.md
+++ b/.agents/context/repository-intelligence.md
@@ -63,4 +63,11 @@ Load when: every agent session, from `AGENTS.md`.
   call/type hierarchy, diagnostics, and diagnostic-aware refactoring. The initializer
   runs `serena project index <root>` when Serena is available. Under OMP (`OMP_CLI`
   or `PI_CLI`), it skips Serena because OMP provides native LSP tooling.
+- PHP include files carry the `.inc` extension, and every tool that infers language
+  from the extension has to be told so, or it reports zero matches with exit status 0 —
+  indistinguishable from a genuine "no matches" (issue #2807). `phpcs.xml.dist`,
+  `phpstan.neon`, `.editorconfig`, `.vscode/settings.json`, and the tracked
+  `sgconfig.yml` (ast-grep) already carry the association. Semgrep exposes no
+  configuration-file or environment-variable equivalent, so always pass
+  `semgrep --scan-unknown-extensions` when a scan may reach a `.inc` file.
 - Compiler, static analysis, tests, CI, and live smoke remain final.

--- a/.agents/context/repository-intelligence.md
+++ b/.agents/context/repository-intelligence.md
@@ -63,11 +63,9 @@ Load when: every agent session, from `AGENTS.md`.
   call/type hierarchy, diagnostics, and diagnostic-aware refactoring. The initializer
   runs `serena project index <root>` when Serena is available. Under OMP (`OMP_CLI`
   or `PI_CLI`), it skips Serena because OMP provides native LSP tooling.
-- PHP include files carry the `.inc` extension, and every tool that infers language
-  from the extension has to be told so, or it reports zero matches with exit status 0 —
-  indistinguishable from a genuine "no matches" (issue #2807). `phpcs.xml.dist`,
-  `phpstan.neon`, `.editorconfig`, `.vscode/settings.json`, and the tracked
-  `sgconfig.yml` (ast-grep) already carry the association. Semgrep exposes no
-  configuration-file or environment-variable equivalent, so always pass
-  `semgrep --scan-unknown-extensions` when a scan may reach a `.inc` file.
+- PHP includes are named `.inc`, and a tool that infers language from the extension
+  silently skips them until told otherwise — the result is indistinguishable from a clean
+  no-match (issue #2807). `phpcs.xml.dist`, `phpstan.neon`, `.editorconfig`,
+  `.vscode/settings.json`, and `sgconfig.yml` carry the association; semgrep has no
+  configuration equivalent, so always pass `semgrep --scan-unknown-extensions`.
 - Compiler, static analysis, tests, CI, and live smoke remain final.

--- a/sgconfig.yml
+++ b/sgconfig.yml
@@ -1,0 +1,15 @@
+# ast-grep project configuration (issue #2807).
+#
+# pfSense packages name PHP include files `.inc`, and ast-grep resolves a target's
+# language from its extension before applying `--lang`. Without this mapping every
+# `.inc` file -- including pfblockerng.inc, the largest production file in the package
+# -- yields zero matches with exit status 0, which is indistinguishable from a genuine
+# "no matches" result. PHPCS (`phpcs.xml.dist`: extensions="php,inc"), PHPStan
+# (`phpstan.neon`: fileExtensions), `.editorconfig`, and the VS Code workspace already
+# carry the same association.
+#
+# `ruleDirs` is deliberately absent: this repository ships no ast-grep rule packs, and
+# `ast-grep scan` exits 0 without it.
+languageGlobs:
+  php:
+    - "*.inc"

--- a/sgconfig.yml
+++ b/sgconfig.yml
@@ -1,15 +1,6 @@
-# ast-grep project configuration (issue #2807).
-#
-# pfSense packages name PHP include files `.inc`, and ast-grep resolves a target's
-# language from its extension before applying `--lang`. Without this mapping every
-# `.inc` file -- including pfblockerng.inc, the largest production file in the package
-# -- yields zero matches with exit status 0, which is indistinguishable from a genuine
-# "no matches" result. PHPCS (`phpcs.xml.dist`: extensions="php,inc"), PHPStan
-# (`phpstan.neon`: fileExtensions), `.editorconfig`, and the VS Code workspace already
-# carry the same association.
-#
-# `ruleDirs` is deliberately absent: this repository ships no ast-grep rule packs, and
-# `ast-grep scan` exits 0 without it.
+# issue #2807: pfSense names PHP includes `.inc`, and ast-grep resolves a target's
+# language from its extension before applying `--lang`, so an unmapped `.inc` is
+# indistinguishable from a clean no-match. No `ruleDirs`: no rule packs ship here.
 languageGlobs:
   php:
     - "*.inc"

--- a/tests/skip-allowlist.txt
+++ b/tests/skip-allowlist.txt
@@ -45,6 +45,8 @@ pytest:tests.test_build_pkg_origins::test_print_build_origins_includes_expected_
 pytest:tests.test_build_pkg_origins::test_sparse_build_byte_identical_to_full_build  # FreeBSD-ports checkout not present on the runner
 pytest:tests.test_build_pkg_portable::test_output_macos_os_alias_is_allowed[/tmp-/private/tmp]  # macOS-only alias case; the runner is Linux
 pytest:tests.test_build_pkg_portable::test_output_macos_os_alias_is_allowed[/var-/private/var]  # macOS-only alias case; the runner is Linux
+pytest:tests.test_cross_agent_tooling::test_ast_grep_parses_a_php_inc_file_as_php  # ast-grep is an agent-host uv tool, not in CI's locked dev group
+pytest:tests.test_cross_agent_tooling::test_semgrep_scans_a_php_inc_file_only_with_the_documented_flag  # semgrep is an agent-host uv tool, not in CI's locked dev group
 
 # ui -- the live-VM Tier-B browser legs. Whether any pre-defined feed exposes an
 # Alternate-URL radio is feed-data dependent, so the case has always skipped cleanly when

--- a/tests/test_cross_agent_tooling.py
+++ b/tests/test_cross_agent_tooling.py
@@ -8,6 +8,7 @@ import shutil
 import subprocess
 from pathlib import Path
 
+import pytest
 import yaml
 
 from tests._workflow_steps import extract_between
@@ -312,66 +313,50 @@ def test_copilot_roles_are_pinned_and_defined() -> None:
     assert {f"{name}.agent.md" for name in codex_agents} == agents, "Copilot role coverage diverges from Codex"
 
 
-# A real production include, so the probes prove the tools read this package's own
-# PHP rather than a synthetic fixture. `return $$$X;` is chosen over a named symbol
-# because ~875 of them exist in this file: no refactor can quietly empty the probe.
+# A real production include, so the probes prove the tools read this package's own PHP.
 PHP_INCLUDE_PROBE = "src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc"
+AST_GREP = shutil.which("ast-grep") or ""
+SEMGREP = shutil.which("semgrep") or ""
 
 
-def test_structural_and_static_analysis_tools_read_php_inc_files(tmp_path: Path) -> None:
-    # issue #2807: ast-grep and semgrep both key language detection off the file
-    # extension, so an unconfigured run over a `.inc` reports zero matches with exit
-    # status 0 -- indistinguishable from a genuine "no matches" and therefore worse
-    # than a parse error. PHPCS (`extensions="php,inc"`), PHPStan (`fileExtensions`),
-    # and `.editorconfig` already carry the association; these two did not.
+def test_php_inc_files_are_declared_php_to_extension_driven_tools() -> None:
+    # issue #2807: an unmapped `.inc` is skipped, and the result is indistinguishable
+    # from a clean no-match on a file the tool did read.
     config = yaml.safe_load((ROOT / "sgconfig.yml").read_text(encoding="utf-8"))
-    assert "*.inc" in config["languageGlobs"]["php"], "ast-grep must be told .inc is PHP"
+    assert config == {"languageGlobs": {"php": ["*.inc"]}}, "ast-grep rejects a scalar glob"
 
-    # semgrep exposes no configuration-file or environment-variable equivalent, so the
-    # flag can only be a documented invocation rule.
     routing = (ROOT / ".agents/context/repository-intelligence.md").read_text(encoding="utf-8")
-    assert "--scan-unknown-extensions" in routing, "the semgrep remedy must be routed"
+    assert "--scan-unknown-extensions" in routing, "semgrep's only surface is the documented flag"
 
-    # Neither binary is installed in CI (only `scripts/agent/setup-agent-tools.sh`
-    # installs them), so the behavioural halves are host-conditional while the
-    # configuration assertions above always run.
-    ast_grep = shutil.which("ast-grep")
-    if ast_grep is not None:
-        matches = subprocess.run(
-            [ast_grep, "run", "--pattern", "return $$$X;", PHP_INCLUDE_PROBE],
+
+@pytest.mark.skipif(not AST_GREP, reason="ast-grep is an agent-host tool, absent from CI")
+def test_ast_grep_parses_a_php_inc_file_as_php() -> None:
+    # The reported language, not a match count: any language ast-grep assigns matches
+    # `return $$$X;`, so a count alone passes under a decoy mapping.
+    stream = subprocess.run(
+        [AST_GREP, "run", "--pattern", "return $$$X;", "--json=stream", PHP_INCLUDE_PROBE],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.splitlines()
+    languages = {json.loads(line)["language"] for line in stream}
+    assert languages == {"Php"}, f"ast-grep read {PHP_INCLUDE_PROBE} as {languages or 'no language'}"
+
+
+@pytest.mark.skipif(not SEMGREP, reason="semgrep is an agent-host tool, absent from CI")
+def test_semgrep_scans_a_php_inc_file_only_with_the_documented_flag() -> None:
+    def findings(*flags: str) -> int:
+        scan = subprocess.run(
+            [SEMGREP, "scan", "--quiet", "--json", "-e", "return $X;", "-l", "php", *flags, PHP_INCLUDE_PROBE],
             cwd=ROOT,
             capture_output=True,
             text=True,
             check=True,
-        ).stdout
-        hits = [line for line in matches.splitlines() if line.startswith(f"{PHP_INCLUDE_PROBE}:")]
-        assert len(hits) > 100, f"ast-grep parsed no PHP out of {PHP_INCLUDE_PROBE}"
-
-    semgrep = shutil.which("semgrep")
-    if semgrep is not None:
-        # Not under ROOT: in a worktree `.git` is a file, and semgrep would otherwise
-        # also have to be told to ignore its own rule file as a scan target.
-        rule = tmp_path / "pfb-inc-probe.yml"
-        rule.write_text(
-            "rules:\n"
-            "  - id: pfb-inc-probe\n"
-            "    languages: [php]\n"
-            "    message: probe\n"
-            "    severity: INFO\n"
-            "    pattern: return $X;\n",
-            encoding="utf-8",
         )
+        report = json.loads(scan.stdout)
+        assert report["errors"] == [], f"semgrep errored: {report['errors']}"
+        return len(report["results"])
 
-        def probe(*flags: str) -> int:
-            completed = subprocess.run(
-                [semgrep, "scan", "--quiet", "--json", "--config", str(rule), *flags, PHP_INCLUDE_PROBE],
-                cwd=ROOT,
-                capture_output=True,
-                text=True,
-                check=False,
-            )
-            assert completed.stdout, f"semgrep produced no report: {completed.stderr}"
-            return len(json.loads(completed.stdout)["results"])
-
-        assert probe() == 0, "semgrep gained .inc support; the documented flag is now misleading"
-        assert probe("--scan-unknown-extensions") > 0, "the documented semgrep flag does not work"
+    assert findings() == 0, "semgrep gained .inc support; the documented flag is now misleading"
+    assert findings("--scan-unknown-extensions") > 0, "the documented semgrep flag does not work"

--- a/tests/test_cross_agent_tooling.py
+++ b/tests/test_cross_agent_tooling.py
@@ -315,8 +315,6 @@ def test_copilot_roles_are_pinned_and_defined() -> None:
 
 # A real production include, so the probes prove the tools read this package's own PHP.
 PHP_INCLUDE_PROBE = "src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc"
-AST_GREP = shutil.which("ast-grep") or ""
-SEMGREP = shutil.which("semgrep") or ""
 
 
 def test_php_inc_files_are_declared_php_to_extension_driven_tools() -> None:
@@ -329,12 +327,12 @@ def test_php_inc_files_are_declared_php_to_extension_driven_tools() -> None:
     assert "--scan-unknown-extensions" in routing, "semgrep's only surface is the documented flag"
 
 
-@pytest.mark.skipif(not AST_GREP, reason="ast-grep is an agent-host tool, absent from CI")
+@pytest.mark.skipif(shutil.which("ast-grep") is None, reason="agent-host tool, absent from CI")
 def test_ast_grep_parses_a_php_inc_file_as_php() -> None:
     # The reported language, not a match count: any language ast-grep assigns matches
     # `return $$$X;`, so a count alone passes under a decoy mapping.
     stream = subprocess.run(
-        [AST_GREP, "run", "--pattern", "return $$$X;", "--json=stream", PHP_INCLUDE_PROBE],
+        ["ast-grep", "run", "--pattern", "return $$$X;", "--json=stream", PHP_INCLUDE_PROBE],
         cwd=ROOT,
         capture_output=True,
         text=True,
@@ -344,16 +342,17 @@ def test_ast_grep_parses_a_php_inc_file_as_php() -> None:
     assert languages == {"Php"}, f"ast-grep read {PHP_INCLUDE_PROBE} as {languages or 'no language'}"
 
 
-@pytest.mark.skipif(not SEMGREP, reason="semgrep is an agent-host tool, absent from CI")
+@pytest.mark.skipif(shutil.which("semgrep") is None, reason="agent-host tool, absent from CI")
 def test_semgrep_scans_a_php_inc_file_only_with_the_documented_flag() -> None:
     def findings(*flags: str) -> int:
         scan = subprocess.run(
-            [SEMGREP, "scan", "--quiet", "--json", "-e", "return $X;", "-l", "php", *flags, PHP_INCLUDE_PROBE],
+            ["semgrep", "scan", "--quiet", "--json", "-e", "return $X;", "-l", "php", *flags, PHP_INCLUDE_PROBE],
             cwd=ROOT,
             capture_output=True,
             text=True,
-            check=True,
+            check=False,
         )
+        assert scan.returncode == 0, f"semgrep exited {scan.returncode}: {scan.stdout}{scan.stderr}"
         report = json.loads(scan.stdout)
         assert report["errors"] == [], f"semgrep errored: {report['errors']}"
         return len(report["results"])

--- a/tests/test_cross_agent_tooling.py
+++ b/tests/test_cross_agent_tooling.py
@@ -4,8 +4,11 @@ from __future__ import annotations
 
 import hashlib
 import json
+import shutil
 import subprocess
 from pathlib import Path
+
+import yaml
 
 from tests._workflow_steps import extract_between
 
@@ -307,3 +310,68 @@ def test_copilot_roles_are_pinned_and_defined() -> None:
     agents = {path.name for path in (ROOT / ".github/agents").glob("*.agent.md")}
     codex_agents = {path.stem for path in (ROOT / ".codex/agents").glob("*.toml")}
     assert {f"{name}.agent.md" for name in codex_agents} == agents, "Copilot role coverage diverges from Codex"
+
+
+# A real production include, so the probes prove the tools read this package's own
+# PHP rather than a synthetic fixture. `return $$$X;` is chosen over a named symbol
+# because ~875 of them exist in this file: no refactor can quietly empty the probe.
+PHP_INCLUDE_PROBE = "src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc"
+
+
+def test_structural_and_static_analysis_tools_read_php_inc_files(tmp_path: Path) -> None:
+    # issue #2807: ast-grep and semgrep both key language detection off the file
+    # extension, so an unconfigured run over a `.inc` reports zero matches with exit
+    # status 0 -- indistinguishable from a genuine "no matches" and therefore worse
+    # than a parse error. PHPCS (`extensions="php,inc"`), PHPStan (`fileExtensions`),
+    # and `.editorconfig` already carry the association; these two did not.
+    config = yaml.safe_load((ROOT / "sgconfig.yml").read_text(encoding="utf-8"))
+    assert "*.inc" in config["languageGlobs"]["php"], "ast-grep must be told .inc is PHP"
+
+    # semgrep exposes no configuration-file or environment-variable equivalent, so the
+    # flag can only be a documented invocation rule.
+    routing = (ROOT / ".agents/context/repository-intelligence.md").read_text(encoding="utf-8")
+    assert "--scan-unknown-extensions" in routing, "the semgrep remedy must be routed"
+
+    # Neither binary is installed in CI (only `scripts/agent/setup-agent-tools.sh`
+    # installs them), so the behavioural halves are host-conditional while the
+    # configuration assertions above always run.
+    ast_grep = shutil.which("ast-grep")
+    if ast_grep is not None:
+        matches = subprocess.run(
+            [ast_grep, "run", "--pattern", "return $$$X;", PHP_INCLUDE_PROBE],
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout
+        hits = [line for line in matches.splitlines() if line.startswith(f"{PHP_INCLUDE_PROBE}:")]
+        assert len(hits) > 100, f"ast-grep parsed no PHP out of {PHP_INCLUDE_PROBE}"
+
+    semgrep = shutil.which("semgrep")
+    if semgrep is not None:
+        # Not under ROOT: in a worktree `.git` is a file, and semgrep would otherwise
+        # also have to be told to ignore its own rule file as a scan target.
+        rule = tmp_path / "pfb-inc-probe.yml"
+        rule.write_text(
+            "rules:\n"
+            "  - id: pfb-inc-probe\n"
+            "    languages: [php]\n"
+            "    message: probe\n"
+            "    severity: INFO\n"
+            "    pattern: return $X;\n",
+            encoding="utf-8",
+        )
+
+        def probe(*flags: str) -> int:
+            completed = subprocess.run(
+                [semgrep, "scan", "--quiet", "--json", "--config", str(rule), *flags, PHP_INCLUDE_PROBE],
+                cwd=ROOT,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            assert completed.stdout, f"semgrep produced no report: {completed.stderr}"
+            return len(json.loads(completed.stdout)["results"])
+
+        assert probe() == 0, "semgrep gained .inc support; the documented flag is now misleading"
+        assert probe("--scan-unknown-extensions") > 0, "the documented semgrep flag does not work"


### PR DESCRIPTION
## Summary

`ast-grep` and `semgrep` both resolve a target's language from its file extension, and neither
recognises `.inc`, the extension pfSense packages use for PHP include files. An unconfigured run
reported zero matches with exit status 0 — indistinguishable from a genuine "no matches" — so
structural searches and static-analysis rule packs silently skipped every include in the package,
including `pfblockerng.inc`, its largest production file.

This is the same class of defect as #2802 (OMP language servers) but a different cause and a
different remedy.

## Change

- `sgconfig.yml` (new, tracked): maps `*.inc` to PHP for ast-grep. `ruleDirs` is deliberately
  absent — this repository ships no ast-grep rule packs, and `ast-grep scan` exits 0 without it.
- `.agents/context/repository-intelligence.md`: routes the `semgrep --scan-unknown-extensions`
  invocation. Semgrep exposes no configuration-file or environment-variable equivalent, so a
  documented invocation rule is the only available surface.

Nothing else needed a change. PHPCS (`extensions="php,inc"`), PHPStan (`fileExtensions`),
`.editorconfig`, and `.vscode/settings.json` already carried the association; CodeGraph already
classifies `.inc` as PHP. GitHub Linguist needs no `.gitattributes` override either: its
`heuristics.yml` disambiguates `.inc` to PHP on the pattern `^<\?(?:php)?`, every `.inc` here opens
with `<?php`, and the rule evaluated ahead of it (Motorola 68K Assembly) matches only
`moveq`/`move.[bwl]` operand forms. Graphify's equivalent defect has a third cause and stays
tracked upstream in Graphify-Labs/graphify#2961.

## Test-first proof

`tests/test_cross_agent_tooling.py::test_structural_and_static_analysis_tools_read_php_inc_files`,
byte-identical across both runs (`md5 55eabba4afe3244e096c542af89cd9f4`):

- RED, configuration withheld: `1 failed, 12 passed`.
- GREEN, configuration in place: `13 passed`.

The behavioural halves were confirmed load-bearing rather than incidental. Running the exact
ast-grep command the test runs, against `src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc`:

| `sgconfig.yml` | matches for `return $$$X;` |
| --- | --- |
| absent | 0 |
| present | 875 |
| removed again | 0 |

The semgrep half asserts in both directions — no findings without the flag, findings with it — so
the test also fails if a future semgrep release makes the documented flag unnecessary.

Both behavioural halves are host-conditional (`shutil.which`), because neither binary is installed
in CI; only `scripts/agent/setup-agent-tools.sh` installs them. The configuration assertions run
unconditionally. Tool versions probed: `ast-grep 0.45.2`, `semgrep 1.175.0`.

## Gates

`scripts/agent/run-gates.sh`: all six gates PASS (`check_coverage_pairing`, `pytest`,
`ruff check`, `ruff format --check`, `mypy tests/`, `markdownlint-cli2`).

## Note for review order

PR #2804 (issue #2802) also appends to `tests/test_cross_agent_tooling.py`. Whichever lands second
rebases; the two tests are independent.

Fixes #2807


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recognition of PHP include files using the `.inc` extension.
  * Cross-tool analysis now correctly identifies `.inc` files as PHP where supported.

* **Tests**
  * Added coverage verifying PHP language detection and extension-based scanning behavior.
  * Added safeguards for environments where optional analysis tools are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->