### PR TITLE
install.sh: collapse the cheap repair to pfSense-upgrade -u

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -98,10 +98,13 @@ die() {
 # interrupted upgrade, leave pkg unable to refresh ANY catalogue, and no conf this script
 # writes can repair that. Guidance only, never run for the user.
 #
-# `pfSense-upgrade -u` is the whole cheap repair in one command (issue #2808): upstream
-# runs pfSense-repo-setup before dispatching any action, that script runs
-# pfSense-repoc-static itself, and `-u` then forces `pkg update -f`, upgrading pkg and
-# bootstrapping it when the repository moved to metadata version 2. A BARE
+# `pfSense-upgrade -u` is the whole cheap repair in one command whenever it reaches its
+# work (issue #2808): upstream runs pfSense-repo-setup before dispatching any action,
+# that script runs pfSense-repoc-static itself, and `-u` then forces `pkg update -f`,
+# upgrading pkg and bootstrapping it when the repository moved to metadata version 2. Two
+# early exits precede all of that: the pid lock, which refuses while a boot-time metadata
+# refresh runs, and the block_external_services flag, which exits 0 without doing
+# anything. A BARE
 # `pfSense-upgrade` is NOT a second item beside it: upstream sets
 # `: ${action:="upgrade"}` when no action flag is given, so it applies whatever release
 # the box's branch offers and reboots afterwards. It is the escalation for a mismatch the
@@ -122,7 +125,7 @@ pfb_pkg_die() {
     cat >&2 <<'HINT'
 install.sh: if this box's own pkg setup is at fault, rebuild it and re-run this script:
 install.sh:   pfSense-upgrade -u
-install.sh: only if the re-run still fails, escalate to a bare pfSense-upgrade: it applies
+install.sh: only if the re-run still fails, escalate to a bare pfSense-upgrade — it applies
 install.sh: any pfSense release upgrade the box's branch offers, and reboots when it does.
 HINT
     exit "${_pkg_die_code}"
@@ -374,7 +377,9 @@ conf: rebuild it, then re-run this script.
   pfSense-upgrade -u
 
 That one command re-fetches the repository settings (it runs pfSense-repo-setup, which
-runs pfSense-repoc) and then forces a catalogue refresh.
+runs pfSense-repoc-static) and then forces a catalogue refresh, upgrading or
+re-bootstrapping pkg itself if the repository requires it. "Another instance is already
+running" means a boot-time metadata refresh holds the lock; wait for it and retry.
 
 Only if the re-run still fails, escalate to a bare pfSense-upgrade. With no arguments it
 applies any pfSense release upgrade the box's branch offers, and reboots when it does, so

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -98,12 +98,15 @@ die() {
 # interrupted upgrade, leave pkg unable to refresh ANY catalogue, and no conf this script
 # writes can repair that. Guidance only, never run for the user.
 #
-# The two repository-rebuild commands come first and are cheap and local. A bare
-# `pfSense-upgrade` is NOT a third item beside them: upstream sets
+# `pfSense-upgrade -u` is the whole cheap repair in one command (issue #2808): upstream
+# runs pfSense-repo-setup before dispatching any action, that script runs
+# pfSense-repoc-static itself, and `-u` then forces `pkg update -f`, upgrading pkg and
+# bootstrapping it when the repository moved to metadata version 2. A BARE
+# `pfSense-upgrade` is NOT a second item beside it: upstream sets
 # `: ${action:="upgrade"}` when no action flag is given, so it applies whatever release
-# the box's branch offers and reboots afterwards. It is the escalation for a mismatch
-# rebuilding the repository files did not fix, and it is stated as such, with the reboot
-# named where it is proposed (issue #2803).
+# the box's branch offers and reboots afterwards. It is the escalation for a mismatch the
+# repository rebuild did not fix, and it is stated as such, with the reboot named where
+# it is proposed (issue #2803).
 #
 # The diagnosis prints FIRST: the remedy is conditional on it, and a reader who has not
 # yet been told what failed cannot judge whether this sequence is their answer.
@@ -118,10 +121,9 @@ pfb_pkg_die() {
     printf 'install.sh: %s\n' "$*" >&2
     cat >&2 <<'HINT'
 install.sh: if this box's own pkg setup is at fault, rebuild it and re-run this script:
-install.sh:   pfSense-repoc
-install.sh:   pfSense-repo-setup
-install.sh: only if the re-run still fails, escalate to pfSense-upgrade — it applies any
-install.sh: pfSense release upgrade the box's branch offers, and reboots when it does.
+install.sh:   pfSense-upgrade -u
+install.sh: only if the re-run still fails, escalate to a bare pfSense-upgrade: it applies
+install.sh: any pfSense release upgrade the box's branch offers, and reboots when it does.
 HINT
     exit "${_pkg_die_code}"
 }
@@ -369,12 +371,14 @@ Exit codes:
 A failed pkg step is often this box's own repository setup rather than the pfBlockerNG
 conf: rebuild it, then re-run this script.
 
-  pfSense-repoc
-  pfSense-repo-setup
+  pfSense-upgrade -u
 
-Only if the re-run still fails, escalate to pfSense-upgrade. With no arguments it applies
-any pfSense release upgrade the box's branch offers, and reboots when it does, so it is
-a deliberate last step rather than part of the sequence above.
+That one command re-fetches the repository settings (it runs pfSense-repo-setup, which
+runs pfSense-repoc) and then forces a catalogue refresh.
+
+Only if the re-run still fails, escalate to a bare pfSense-upgrade. With no arguments it
+applies any pfSense release upgrade the box's branch offers, and reboots when it does, so
+it is a deliberate last step rather than part of the repair above.
 USAGE_TAIL
 }
 

--- a/tests/test_channel_install.py
+++ b/tests/test_channel_install.py
@@ -1761,25 +1761,27 @@ def test_output_reader_does_not_outlive_the_run() -> None:
 
 
 # --------------------------------------------------------------------------- #
-# 22. pkg-setup repair hint (issue #2789): a failed pkg step is frequently the
-#     box's own repository setup, not our conf. The three recovery commands ride
-#     the failure output, but only where that setup can be the cause.
+# 22. pkg-setup repair hint (issues #2789, #2803, #2808): a failed pkg step is
+#     frequently the box's own repository setup, not our conf. `pfSense-upgrade -u`
+#     rebuilds that setup and refreshes the catalogue in one command; the bare form
+#     is the escalation behind a retry, because it upgrades the release and reboots.
+#     The hint rides the failure output, but only where that setup can be the cause.
 # --------------------------------------------------------------------------- #
 
-_REPAIR_COMMANDS = ("pfSense-repoc", "pfSense-repo-setup", "pfSense-upgrade")
+_REPAIR_COMMAND = "pfSense-upgrade -u"
+_BARE_UPGRADE_LIST_ITEM = "install.sh:   pfSense-upgrade\n"
 
 
 def _repair_hint_on_stderr(proc: subprocess.CompletedProcess[str]) -> bool:
     """The hint rides stderr beside die()'s diagnosis: a user who captures only stderr
     for a bug report still gets the remedy."""
-    return all(command in proc.stderr for command in _REPAIR_COMMANDS)
+    return _REPAIR_COMMAND in proc.stderr
 
 
 def _repair_hint_shown(proc: subprocess.CompletedProcess[str]) -> bool:
-    """Either stream — strictly stronger than the stderr check, so the negative cases
-    cannot pass merely because the hint went to stdout."""
-    combined = proc.stdout + proc.stderr
-    return any(command in combined for command in _REPAIR_COMMANDS)
+    """Either stream, and either form of the command — strictly stronger than the stderr
+    check, so a negative case cannot pass merely because the hint went to stdout."""
+    return "pfSense-upgrade" in proc.stdout + proc.stderr
 
 
 def test_pkg_update_failure_prints_the_repository_repair_sequence() -> None:
@@ -1788,47 +1790,49 @@ def test_pkg_update_failure_prints_the_repository_repair_sequence() -> None:
 
         assert proc.returncode == 4, proc.stdout + proc.stderr
         assert _repair_hint_on_stderr(proc), proc.stdout + proc.stderr
-        assert proc.stderr.index("failed") < proc.stderr.index("pfSense-repoc"), (
+        assert proc.stderr.index("failed") < proc.stderr.index(_REPAIR_COMMAND), (
             f"the diagnosis must precede the remedy:\n{proc.stderr}"
         )
 
 
-def test_repair_hint_gates_pfsense_upgrade_behind_a_retry() -> None:
-    """issue #2803: a bare `pfSense-upgrade` applies the box's pending release upgrade
-    and reboots (upstream sets `: ${action:="upgrade"}` when no action flag is given),
-    so it is the escalation after rebuilding the repository files and retrying — never
-    the third item of a flat list the user works through in order."""
+def test_repair_hint_gates_the_bare_upgrade_behind_a_retry() -> None:
+    """issues #2803/#2808: `pfSense-upgrade -u` rebuilds the repository setup and
+    refreshes the catalogue, and is safe. The BARE form applies the box's pending
+    release upgrade and reboots (upstream sets `: ${action:="upgrade"}` when no action
+    flag is given), so it sits behind a retry — never beside `-u` as a second list
+    item the user works through in order."""
     with tempfile.TemporaryDirectory() as root:
         proc = _run_install(root, "testing", update_fails=True)
 
         assert proc.returncode == 4, proc.stdout + proc.stderr
         hint = proc.stderr
-        before, _, escalation = hint.partition("pfSense-upgrade")
-        assert escalation, f"the escalation command is missing entirely:\n{hint}"
-        between = before.split("pfSense-repo-setup", 1)[1]
-        # Shape, not just vocabulary: an indented bare command is a third list item, which
-        # is the regression this gate exists to catch — the words alone all survive it.
-        assert "install.sh:   pfSense-upgrade" not in hint, (
-            f"pfSense-upgrade must not be a list item beside the two repair commands:\n{hint}"
-        )
-        assert "re-run" in between, f"the retry must sit before the escalation:\n{hint}"
-        assert "only if" in between, f"pfSense-upgrade must be conditional:\n{hint}"
+        before, _, escalation = hint.partition(_REPAIR_COMMAND)
+        assert escalation, f"the one-command repair is missing entirely:\n{hint}"
+        # Shape, not just vocabulary: a bare `pfSense-upgrade` on its own indented line is
+        # a second list item, the regression this gate exists to catch — every keyword
+        # below survives that flattening.
+        assert _BARE_UPGRADE_LIST_ITEM not in hint, f"the bare upgrade must not be a list item beside `-u`:\n{hint}"
+        assert "re-run" in escalation, f"the retry must sit before the escalation:\n{hint}"
+        assert "only if" in escalation, f"the bare upgrade must be conditional:\n{hint}"
         assert "reboot" in escalation, f"the reboot must be stated where it is proposed:\n{hint}"
+        assert escalation.index("only if") < escalation.index("reboot"), (
+            f"the condition must precede the consequence:\n{hint}"
+        )
 
 
-def test_usage_gates_pfsense_upgrade_behind_a_retry() -> None:
+def test_usage_gates_the_bare_upgrade_behind_a_retry() -> None:
     proc = _run_argv("--help")
 
     assert proc.returncode == 0, proc.stdout + proc.stderr
     text = proc.stdout
-    before, _, escalation = text.partition("pfSense-upgrade")
+    before, _, escalation = text.partition(_REPAIR_COMMAND)
     assert escalation, text
+    assert "\n  pfSense-upgrade\n" not in text, f"the bare upgrade must not be a list item:\n{text}"
     # Help text is prose, so the gate words may open a sentence.
-    between = before.split("pfSense-repo-setup", 1)[1].casefold()
-    assert "\n  pfSense-upgrade" not in text, f"pfSense-upgrade must not be a list item:\n{text}"
-    assert "re-run" in between, text
-    assert "only if" in between, text
-    assert "reboot" in escalation.casefold(), text
+    folded = escalation.casefold()
+    assert "re-run" in folded, text
+    assert "only if" in folded, text
+    assert "reboot" in folded, text
 
 
 def test_empty_catalogue_failure_prints_the_repository_repair_sequence() -> None:
@@ -1903,5 +1907,4 @@ def test_usage_documents_the_repository_repair_sequence() -> None:
     proc = _run_argv("--help")
 
     assert proc.returncode == 0, proc.stdout + proc.stderr
-    for command in _REPAIR_COMMANDS:
-        assert command in proc.stdout, proc.stdout
+    assert _REPAIR_COMMAND in proc.stdout, proc.stdout

--- a/tests/test_channel_install.py
+++ b/tests/test_channel_install.py
@@ -1806,7 +1806,7 @@ def test_repair_hint_gates_the_bare_upgrade_behind_a_retry() -> None:
 
         assert proc.returncode == 4, proc.stdout + proc.stderr
         hint = proc.stderr
-        before, _, escalation = hint.partition(_REPAIR_COMMAND)
+        _, _, escalation = hint.partition(_REPAIR_COMMAND)
         assert escalation, f"the one-command repair is missing entirely:\n{hint}"
         # Shape, not just vocabulary: a bare `pfSense-upgrade` on its own indented line is
         # a second list item, the regression this gate exists to catch — every keyword
@@ -1825,7 +1825,7 @@ def test_usage_gates_the_bare_upgrade_behind_a_retry() -> None:
 
     assert proc.returncode == 0, proc.stdout + proc.stderr
     text = proc.stdout
-    before, _, escalation = text.partition(_REPAIR_COMMAND)
+    _, _, escalation = text.partition(_REPAIR_COMMAND)
     assert escalation, text
     assert "\n  pfSense-upgrade\n" not in text, f"the bare upgrade must not be a list item:\n{text}"
     # Help text is prose, so the gate words may open a sentence.
@@ -1833,6 +1833,7 @@ def test_usage_gates_the_bare_upgrade_behind_a_retry() -> None:
     assert "re-run" in folded, text
     assert "only if" in folded, text
     assert "reboot" in folded, text
+    assert folded.index("only if") < folded.index("reboot"), f"the condition must precede the consequence:\n{text}"
 
 
 def test_empty_catalogue_failure_prints_the_repository_repair_sequence() -> None:


### PR DESCRIPTION
Closes #2808.

The hint named two commands for the cheap repair. One supported invocation already contains both.

- `pfSense-upgrade` runs `pfSense-repo-setup` before it dispatches on the requested action.
- `pfSense-repo-setup` runs `pfSense-repoc-static` itself unless `-U` suppresses it, then validates the resulting conf and runs `abi_setup`.
- `-u` dispatches to `pkg_update force`: `pkg-static update -f`, upgrading `pkg` when the local one is older, with a `pkg bootstrap -f` fallback when the remote repository has moved to metadata version 2.
- `pfSense-upgrade` also acts on repo-setup's signal exit codes — 11 reinstall pkg, 12/13 new OS major, 14 newer pkg available — which a hand-run pair discards.

Failure output now:

```
install.sh: if this box's own pkg setup is at fault, rebuild it and re-run this script:
install.sh:   pfSense-upgrade -u
install.sh: only if the re-run still fails, escalate to a bare pfSense-upgrade — it applies
install.sh: any pfSense release upgrade the box's branch offers, and reboots when it does.
```

`usage()` carries the same, plus a paragraph naming what `-u` covers, that it can upgrade or re-bootstrap `pkg` itself, and what the `Another instance is already running` refusal means.

### On the pid lock

An earlier draft justified the collapse by claiming the pair needs the same lock. That is wrong and the review caught it: `pfSense-repo-setup` has no pid or lockf logic and only reads the local pkg database in `abi_setup()`, so the pair does run while `pfSense-upgrade` refuses. The collapse stands on the accurate argument instead — the forced catalogue refresh that both routes exist to enable is exactly what the lock blocks, so the pair cannot get a locked box further either. Since the refusal is common and lasts as long as a boot-time metadata refresh, the help text now names it and tells the user to wait rather than escalate.

## Verification

The gates anchor on the `-u` form, require the retry, the condition and the reboot warning after it, require the condition to precede the consequence in **both** surfaces, and reject a bare `pfSense-upgrade` on its own indented line. Shipped bytes executed RED against `devel`'s `install.sh`, then GREEN, byte-identical across both:

| Frozen RED test | git hash-object | RED run tail |
| --- | --- | --- |
| `tests/test_channel_install.py` | `33485b404d1f36096da0e360f3b991bd37ccc287` | `6 failed, 3 passed in 2.34s` |

```
9 passed in 2.06s
```

Mutations that must fail, and do:

| mutation | result |
| --- | --- |
| bare upgrade flattened into a list item | 2 failed |
| `-u` dropped, leaving a bare command | red |
| reboot stated above the condition (stderr) | red |
| reboot stated above the condition (usage) | 1 failed, 1 passed |
| `-u` changed to `-U` ("do not update repository information") | red |

Full gates on the rebased branch:

```
GATE PASS: python3 scripts/check_coverage_pairing.py --name-status-z
GATE PASS: uv run --locked pytest
GATE PASS: uv run --locked ruff check .
GATE PASS: uv run --locked ruff format --check .
GATE PASS: uv run --locked mypy tests/
GATE PASS: sh -n scripts/install.sh
GATE PASS: shellcheck scripts/install.sh
GATE PASS: shellspec --shell $(command -v dash || command -v sh)
GATES: PASS
```

## Review

Reviewed independently per `.agents/policy/landing.md`: APPROVE, no blockers, no majors. The reviewer confirmed the containment claim against upstream, reproduced red-before/green-after, and verified four mutations go red including the `-u`/`-U` typo. All six findings are addressed in the second commit: the pid-lock rationale, the understated `-u` gloss, `pfSense-repoc-static` naming, the missing usage ordering pin, two dead `before` bindings, the colon that could read as a second command list, and the comment's unconditional claim (the pid lock and `block_external_services` both return before repo-setup runs, the latter with a success status).

Authored by an OMP agent session; no `coauthor.omp.*` identity is configured in this checkout, so the commits carry no co-author trailer.
