### PR TITLE
pfblockerng: register the 17 on/off toggles whose default still lived in the page

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -231,6 +231,23 @@ if [ "$staged_php" = 1 ] || [ "$staged_xml" = 1 ]; then
 	fi
 fi
 
+# --- Forbid an on/off toggle declaring its default in the page (issue #2123):
+#     a PFB_FILTER_ON_OFF save into a registered section must name a registry entry,
+#     and a registered toggle's default must not be restated by the page. Relevant to
+#     the settings pages and to the registry itself, so it runs on staged PHP/.inc. ---
+if [ "$staged_php" = 1 ]; then
+	if exempted scripts/check_toggle_registry.py; then
+		exempt toggle-registry
+	elif [ -n "$py_bin" ]; then
+		step 'toggle-registry (on/off default belongs to pfb_cfg_registry())'
+		"$py_bin" scripts/check_toggle_registry.py --self-test > /dev/null \
+			|| failed 'toggle-registry (red canary)'
+		"$py_bin" scripts/check_toggle_registry.py || failed 'toggle-registry'
+	else
+		skip toggle-registry
+	fi
+fi
+
 # --- Forbid direct Python interpreter paths ON the pfSense appliance. Consumers
 #     invoke pfb_python.sh, the sole dependency-derived resolver. ---
 if [ "$staged_py" = 1 ] || [ "$staged_php" = 1 ] || [ "$staged_sh" = 1 ]; then

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -313,6 +313,16 @@ jobs:
         # .php/.inc/.xml (the checker's defaults). ubuntu-latest ships python3.
         run: python3 scripts/check_noopener.py
 
+      - name: Forbid an on/off toggle declaring its default in the page
+        # issue #2123: a PFB_FILTER_ON_OFF save into a registered config section must
+        # name a pfb_cfg_registry() entry, and a registered toggle's default must not be
+        # restated by the page. The --self-test run is this gate's red canary: it feeds a
+        # known-violating synthetic page through the same matchers and fails if either
+        # rule stops firing, so a matcher that rots cannot green the real scan.
+        run: |
+          python3 scripts/check_toggle_registry.py --self-test
+          python3 scripts/check_toggle_registry.py
+
       - name: Forbid direct Python paths on the pfSense appliance
         # pfb_python.sh alone constructs the dependency-derived versioned path; all
         # appliance consumers invoke that wrapper. Scans tracked src/ + tests.

--- a/docs/misc/config-gateway.md
+++ b/docs/misc/config-gateway.md
@@ -18,12 +18,19 @@ or checking foreign-key exclusions.
   sniff's `$registeredPaths`).
 - **Path addressing (issue #1931):** registry keys = `'<alias>/<config-key>'` path
   strings — `'gen/pfb_keep'`, `'ip/suppression'` — alias resolved through
-  `PFB_SECTIONS` map (`gen`/`dnsbl`/`ss`/`ip`/`rep`), single home of five real
-  section paths. Same-named keys in different sections cannot collide. Bare-name
-  lookups throw (`InvalidArgumentException`) — no dual addressing. Entries carry no
-  `section` attribute; key prefix outside `PFB_SECTIONS` fails `CfgGatewayTest`'s
-  alias gate. Pre-change tuple parity pinned by
+  `PFB_SECTIONS` map (`gen`/`dnsbl`/`ss`/`ip`/`rep`, plus `global`/`sync` since
+  issue #2123), single home of seven real section paths. Same-named keys in different
+  sections cannot collide — which is what lets #2123 register the DNSBL page's
+  `dnsbl/auto*` scalars while the identically named per-feed-row and per-continent keys
+  stay foreign. Bare-name lookups throw (`InvalidArgumentException`) — no dual
+  addressing. Entries carry no `section` attribute; key prefix outside `PFB_SECTIONS`
+  fails `CfgGatewayTest`'s alias gate. Pre-change tuple parity pinned by
   `tests/php/fixtures/cfg_registry_pre1931_parity.json`.
+  `global` (`installedpackages/pfblockerngglobal`) and `sync`
+  (`installedpackages/pfblockerngsync/config/0`) each hold ONE registered key beside
+  otherwise-foreign siblings — the same arrangement `rep` has: an unregistered sibling
+  passes a section write through byte-identical, and adding an alias does not register
+  the section.
 - Section helpers (`readSection`/`writeSection`/`deleteSection`) for whole-section,
   non-per-field access. Unregistered key → `InvalidArgumentException`.
 - **No `write_config()` inside gateway** — caller decide when to flush. Registry
@@ -123,9 +130,21 @@ Authorization = property of **write**, not call site (generalises
     `pfb_noaaaa`, `pfb_gp`, `pfb_py_nolog`, `tld_wildcard`, `top1m_enable`)
     keep raw `{'on', ''}` storage until they adopt pair — field joining
     adapter set moves all its consumers in same commit (see below).
-  - **Nine adapter-bearing toggles default On:** `pfb_keep`, `pfb_software_check`,
+  - **The seventeen #2123 relocations.** `PFB_FILTER_ON_OFF` save sites whose default,
+    stored vocabulary and render comparison were still declared in the page (the 3.2
+    arrangement) now read through the registry: `ip/{enable_dup,enable_agg,enable_log,`
+    `enable_rdns,database_cc,enable_float,killstates}`,
+    `dnsbl/auto{addrnot,ports,addr,not}_{in,out}` (the DNSBL page's two Advanced
+    Firewall Rule panels), `sync/syncinterfaces`, and `global/alertrefresh`. Sixteen
+    default `''`; `alertrefresh` defaults `'on'`, so absence reads On while an
+    operator's stored `''` reads Off — the same shape as the nine below. Each save site
+    keeps its `pfb_filter(…, PFB_FILTER_ON_OFF, …) ?: ''` (transport normalisation of a
+    POST-absent checkbox, re-normalised by `writeSection()`); what moved is the READ
+    default. Regrowth blocked by `scripts/check_toggle_registry.py` (below).
+  - **Ten adapter-bearing toggles default On:** `pfb_keep`, `pfb_software_check`,
     `pfb_feed_internal_filter`, `pfb_syntax_highlight`, `pfb_cache`, `pfb_py_reply`,
-    `pfb_hsts`, `pfb_idn_block_malicious`, and ip-section `suppression`. For all nine,
+    `pfb_hsts`, `pfb_idn_block_malicious`, ip-section `suppression`, and (since #2123)
+    `global/alertrefresh`. For all ten,
     absence reads On while stored `''` reads Off. Six former `'' => 'off'`
     grandfather arms (`pfb_keep`, `pfb_cache`, `pfb_py_reply`, `pfb_hsts`,
     `pfb_idn_block_malicious`, `suppression`) retired by #2120 because runtime
@@ -209,6 +228,30 @@ Authorization = property of **write**, not call site (generalises
 
 When adding registered key, also add its full path to `$registeredPaths` property in
 `tests/phpcs/PfBlockerNG/Sniffs/Config/RequireConfigGatewaySniff.php` (enforcement sniff).
+
+### The toggle-contract gate (issue #2123)
+
+`scripts/check_toggle_registry.py` keeps the on/off contract from growing back into the
+pages. Wired into `.github/workflows/test.yml`, `.githooks/pre-commit` and
+`scripts/agent/run-gates.sh`; covered by `tests/test_toggle_registry_check.py`.
+
+- **RULE 1** — a `$pfb['<mirror>']['<key>'] = … PFB_FILTER_ON_OFF …` save into a section
+  that `PFB_SECTIONS` knows MUST name a registered key. So a new settings checkbox
+  cannot land without a registry entry.
+- **RULE 2** — a registered **toggle**'s default MUST NOT be restated by the page: no
+  `$pconfig[…] = $pfb['<mirror>']['<key>'] ?: '<literal>'` and no
+  `isset($pfb['<mirror>']['<key>']) ? … : '<literal>'`. Read it with `PfbConfig::read()`.
+  Scoped to toggles on purpose — several registered plain scalars carry a page default
+  their registry entry does not, so widening the rule would push a behaviour change
+  through a lint (issue #2812).
+- The mirror → alias mapping is DERIVED from each page's own
+  `$pfb['<mirror>'] = PfbConfig::readSection('<path>')`, so a new page needs no edit here.
+- Fails CLOSED: an unreadable registry, an unparseable `PFB_SECTIONS`, or fewer than 100
+  parsed keys exits 2 rather than reporting clean.
+- `--self-test` is the red canary — a synthetic violating page must trip BOTH rules — and
+  runs before the real scan in every wiring.
+- Exemptions live in the checker's `EXEMPT` table, each with a reason;
+  `test_every_exempt_row_still_names_a_live_site` fails on a stale row.
 
 `tld_allow_sort` and `tld_allow_{gtld,cctld,itld,bgtld}` = plain registered scalars (`NULL`/
 `NULL` adapters) since issue #1921 — previously on foreign-key exclusion list
@@ -433,6 +476,11 @@ registered path set). Each annotation committed in relevant source file.
 | `pfblockerngdnsblsettings/config/0/dnsbl_webpage` | Out-of-scope foreign key (ADR-29 §2.5); written directly by `pfblockerng_dnsbl.php`, read via `pfb_dnsbl_webpage()` (issue #713 removed the never-written `dnsblwebpage` registry mis-spelling) |
 | `pfblockerngdnsbl` / `pfblockernglistsv4/v6` (section-level reads) | Dynamic list sections |
 | `aliases/alias`, `filter/rule`, `system/*`, `interfaces`, `unbound/*` | pfSense core sections |
+| `pfblockernglistsv4/v6/config/{row}/auto{addrnot,ports,addr,not}_{in,out}` | Dynamic per-row keys (issue #2123: same bare names as the registered `dnsbl/auto*` scalars; `pfblockerng_category_edit.php` writes them at `installedpackages/{$conf_type}/config/{$rowid}/…`, a path no exact-path registry entry can address) |
+| `pfblockernglistsv4/v6/config/{row}/whois_convert` + `filter_top1m` | Dynamic per-row `PFB_FILTER_ON_OFF` keys, same reason |
+| `pfblockerng{continent}/config/0/auto*` | Dynamic per-continent structure (issue #2123: `pfblockerng_geoip.inc` writes the same bare names per continent) |
+| `pfblockerngsync/config/0/{varsynconchanges,varsynctimeout}` | Foreign siblings of the registered `sync/syncinterfaces` |
+| `pfblockerngglobal/*` except `alertrefresh` | Foreign siblings of the registered `global/alertrefresh` (display prefs, `pfbextdns`, and the dynamic `feed_*`/`widget-*` keys) |
 
 ## Sniff file-scope exclusion — `pfblockerng_extra.inc` / `pfblockerng_migrate.inc`
 

--- a/scripts/agent/run-gates.sh
+++ b/scripts/agent/run-gates.sh
@@ -82,6 +82,9 @@ gates_for() {
 	fi
 	if printf '%s\n' "$files" | grep -Eq '\.(php|inc)$'; then
 		out="${out}uv run --locked python scripts/check_composer_vendor.py${nl}"
+		# issue #2123: the on/off toggle contract belongs to pfb_cfg_registry(), not to
+		# the page. --self-test is the gate's own red canary and runs first.
+		out="${out}uv run --locked python scripts/check_toggle_registry.py --self-test && uv run --locked python scripts/check_toggle_registry.py${nl}"
 		for f in $(printf '%s\n' "$files" | grep -E '\.(php|inc)$'); do
 			out="${out}php -l $f${nl}"
 		done

--- a/scripts/check_toggle_registry.py
+++ b/scripts/check_toggle_registry.py
@@ -170,7 +170,9 @@ def find_violations(
             # The mirror is not a registered section at all (no PFB_SECTIONS alias):
             # a foreign section, outside the registry's scope.
             continue
-        if (alias, key) in registry_keys or (basename, key) in EXEMPT:
+        # EXEMPT is a RULE 2 record only: one backlog row must never license an
+        # unregistered save of that key name forever.
+        if (alias, key) in registry_keys:
             continue
         lineno, snippet = site(match.start())
         if snippet.startswith(("//", "*", "/*", "#")):
@@ -311,8 +313,13 @@ def main(argv: list[str] | None = None) -> int:
             candidate = root / path
         try:
             text = candidate.read_text(encoding="utf-8", errors="replace")
-        except OSError:
-            continue
+        except OSError as exc:
+            # Fail CLOSED: a page the gate cannot read is not a clean page.
+            print(
+                f"check_toggle_registry: cannot read {path} ({exc}) -- failing closed rather than reporting clean.",
+                file=sys.stderr,
+            )
+            return 2
         violations.extend(find_violations(text, path, sections_by_path, registry_keys))
 
     for v in violations:

--- a/scripts/check_toggle_registry.py
+++ b/scripts/check_toggle_registry.py
@@ -67,22 +67,22 @@ _SECTIONS_BLOCK_RE = re.compile(r"const PFB_SECTIONS\s*=\s*\[(.*?)^\];", re.DOTA
 _SECTIONS_ROW_RE = re.compile(r"'([a-z]+)'\s*=>\s*'([^']+)'")
 
 # A page's own mirror declaration: `$pfb['iconfig'] = PfbConfig::readSection('...');`.
-_MIRROR_RE = re.compile(r"\$pfb\['(\w+)'\]\s*=\s*PfbConfig::readSection\(\s*'([^']+)'")
+_MIRROR_RE = re.compile(r"\$pfb\s*\[\s*'(\w+)'\s*\]\s*=\s*PfbConfig::readSection\(\s*'([^']+)'")
 
 # A save into a section mirror through the on/off form filter. Matched over the whole
 # file, not line by line: `[^;]*?` cannot cross a statement terminator, so a save
 # wrapped across lines is still one match and cannot slip past the gate by being
 # reformatted.
 _SAVE_RE = re.compile(
-    r"\$pfb\['(\w+)'\]\['(\w+)'\]\s*=[^;]*?\bPFB_FILTER_ON_OFF\b",
+    r"\$pfb\s*\[\s*'(\w+)'\s*\]\s*\[\s*'(\w+)'\s*\]\s*=[^;]*?\bPFB_FILTER_ON_OFF\b",
     re.DOTALL,
 )
 
 # A read of a section mirror carrying its own default. Two spellings:
 #   $x = $pfb['iconfig']['enable_dup'] ?: '';
 #   $x = isset($pfb['aglobal']['alertrefresh']) ? $pfb['aglobal']['alertrefresh'] : 'on';
-_READ_COALESCE_RE = re.compile(r"=\s*\$pfb\['(\w+)'\]\['(\w+)'\]\s*\?[:?]")
-_READ_ISSET_RE = re.compile(r"isset\(\s*\$pfb\['(\w+)'\]\['(\w+)'\]\s*\)\s*\?[^?:]*:")
+_READ_COALESCE_RE = re.compile(r"=\s*\$pfb\s*\[\s*'(\w+)'\s*\]\s*\[\s*'(\w+)'\s*\]\s*\?[:?]")
+_READ_ISSET_RE = re.compile(r"isset\(\s*\$pfb\s*\[\s*'(\w+)'\s*\]\s*\[\s*'(\w+)'\s*\]\s*\)\s*\?[^?:]*:")
 
 # Sanity floor: the registry has had >100 entries since issue #1920's audit. A parse
 # that finds fewer has broken, and a broken parse must fail the gate rather than

--- a/scripts/check_toggle_registry.py
+++ b/scripts/check_toggle_registry.py
@@ -1,0 +1,335 @@
+#!/usr/bin/env python3
+"""Keep the on/off toggle contract in the configuration registry, not in the page.
+
+issue #2123 moved seventeen `PFB_FILTER_ON_OFF` toggle keys off the 3.2 arrangement --
+default declared at the top of the page, stored vocabulary decided at the save site,
+comparison written inline at the render -- and onto `pfb_cfg_registry()`. Without a
+mechanical gate that sweep is a one-off: the next settings checkbox someone adds gets
+its own page-level `?: ''` and the drift is back.
+
+Two rules, both scoped to a SECTION-MIRROR save (`$pfb['<mirror>']['<key>'] = ...`),
+which is the shape a registered scalar takes:
+
+  RULE 1 -- REGISTERED. A `PFB_FILTER_ON_OFF` save into a section mirror must name a key
+  that `pfb_cfg_registry()` knows, under the alias the mirror's own section resolves to.
+
+  RULE 2 -- NO PAGE DEFAULT. Once a key IS registered, the page must not restate its
+  default: a READ of `$pfb['<mirror>']['<key>']` may not carry a `?:` fallback or sit
+  inside an `isset(...) ? ... : <literal>`. The default belongs to the registry entry.
+  Reads are distinguished from saves by side: a save has the mirror expression on the
+  LEFT of `=`, a read has it on the right. The save site's own `?: ''` is left alone on
+  purpose -- it is transport normalisation of an absent checkbox, not a default, and
+  `PfbConfig::writeSection()` re-normalises it through the registered adapter anyway.
+
+The mirror -> section mapping is DERIVED, never listed: each page declares it itself
+with `$pfb['<mirror>'] = PfbConfig::readSection('<section path>')`, and the section path
+is resolved to a registry alias through `PFB_SECTIONS`. So a page that introduces a new
+mirror is covered the moment it is written, with nothing to keep in sync here.
+
+Exemptions live in `EXEMPT` below and each carries a reason. An unregisterable key --
+a genuinely dynamic per-row or per-continent path -- never reaches these rules in the
+first place: it is not a section-mirror save.
+
+Usage:
+    check_toggle_registry.py [PATH ...]
+    check_toggle_registry.py --self-test
+
+With no PATH, scans every tracked `src/usr/local/www/pfblockerng/*.php`. Exit 0 clean,
+1 on violations, 2 when the scan set or the registry could not be established (fail
+closed -- a gate that cannot read the registry must not report "clean").
+
+`--self-test` is the red canary the testing policy requires for a newly wired blocking
+gate: it feeds a known-violating synthetic page through the same matchers and exits 0
+only if BOTH rules fire. It does not touch the repository.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import NamedTuple
+
+REGISTRY_FILE = "src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc"
+WWW_DIR = "src/usr/local/www/pfblockerng"
+
+# A registry entry: its path key plus enough of the entry body to see which read
+# adapter it declares. Non-greedy to the entry's own closing `],`.
+_REGISTRY_ENTRY_RE = re.compile(
+    r"^\s*'([a-z]+)/([A-Za-z0-9_]+)'\s*=>\s*\[(.*?)^\t\t\],",
+    re.DOTALL | re.MULTILINE,
+)
+_TOGGLE_ADAPTER = "pfb_cfg_toggle_read"
+
+# One `PFB_SECTIONS` row: `'ip' => 'installedpackages/pfblockerngipsettings/config/0',`.
+_SECTIONS_BLOCK_RE = re.compile(r"const PFB_SECTIONS\s*=\s*\[(.*?)^\];", re.DOTALL | re.MULTILINE)
+_SECTIONS_ROW_RE = re.compile(r"'([a-z]+)'\s*=>\s*'([^']+)'")
+
+# A page's own mirror declaration: `$pfb['iconfig'] = PfbConfig::readSection('...');`.
+_MIRROR_RE = re.compile(r"\$pfb\['(\w+)'\]\s*=\s*PfbConfig::readSection\(\s*'([^']+)'")
+
+# A save into a section mirror through the on/off form filter. Matched over the whole
+# file, not line by line: `[^;]*?` cannot cross a statement terminator, so a save
+# wrapped across lines is still one match and cannot slip past the gate by being
+# reformatted.
+_SAVE_RE = re.compile(
+    r"\$pfb\['(\w+)'\]\['(\w+)'\]\s*=[^;]*?\bPFB_FILTER_ON_OFF\b",
+    re.DOTALL,
+)
+
+# A read of a section mirror carrying its own default. Two spellings:
+#   $x = $pfb['iconfig']['enable_dup'] ?: '';
+#   $x = isset($pfb['aglobal']['alertrefresh']) ? $pfb['aglobal']['alertrefresh'] : 'on';
+_READ_COALESCE_RE = re.compile(r"=\s*\$pfb\['(\w+)'\]\['(\w+)'\]\s*\?[:?]")
+_READ_ISSET_RE = re.compile(r"isset\(\s*\$pfb\['(\w+)'\]\['(\w+)'\]\s*\)\s*\?[^?:]*:")
+
+# Sanity floor: the registry has had >100 entries since issue #1920's audit. A parse
+# that finds fewer has broken, and a broken parse must fail the gate rather than
+# declare every save site unregistered (or, worse, every key registered).
+_MIN_REGISTRY_KEYS = 100
+
+# (page basename, bare key) -> reason. Every entry is a deliberate, recorded decision.
+#
+# RULE 2's pre-existing backlog, tracked by issue #2812. Every key here was registered
+# BEFORE issue #2123 and is therefore outside its key set, and every one was checked on
+# #2123's branch to be behaviour-equivalent today: six declare the same token twice, and
+# `pfb_dnsbl_lenient` declares `''` in the page against `'off'` in the registry, which
+# the #2120 toggle contract resolves to the same Off. Recorded as a documented set with
+# a tracking issue, so this gate stays BLOCKING for anything new instead of being
+# downgraded to advisory. An entry whose site is gone is dead weight -- delete it.
+EXEMPT: dict[tuple[str, str], str] = {
+    ("pfblockerng_dnsbl.php", "pfb_dnsbl"): "#2812 pre-registered toggle, page and registry defaults agree",
+    ("pfblockerng_dnsbl.php", "pfb_dnsvip_auto"): "#2812 pre-registered toggle, page and registry defaults agree",
+    ("pfblockerng_dnsbl.php", "pfb_dnsbl_nonat"): "#2812 pre-registered toggle, page and registry defaults agree",
+    ("pfblockerng_dnsbl.php", "pfb_idn_escalate_suspicious"): (
+        "#2812 pre-registered toggle, page and registry defaults agree"
+    ),
+    ("pfblockerng_dnsbl.php", "pfb_regex_cap"): "#2812 pre-registered toggle, page and registry defaults agree",
+    ("pfblockerng_dnsbl.php", "pfb_dnsbl_lenient"): (
+        "#2812 pre-registered toggle, page '' vs registry 'off' -- both read Off under #2120"
+    ),
+    ("pfblockerng_general.php", "enable_cb"): "#2812 pre-registered toggle, page and registry defaults agree",
+}
+
+
+class Violation(NamedTuple):
+    """One page site that keeps a toggle contract the registry should own."""
+
+    source: str
+    line: int
+    rule: str
+    detail: str
+    snippet: str
+
+
+def parse_sections(registry_text: str) -> dict[str, str]:
+    """Map config.xml section path -> registry alias, from `PFB_SECTIONS`."""
+    block = _SECTIONS_BLOCK_RE.search(registry_text)
+    if block is None:
+        return {}
+    return {path: alias for alias, path in _SECTIONS_ROW_RE.findall(block.group(1))}
+
+
+def parse_registry_keys(registry_text: str) -> dict[tuple[str, str], bool]:
+    """Every `(alias, bare key)` pair `pfb_cfg_registry()` declares literally, mapped
+    to whether the entry carries the on/off toggle read adapter."""
+    return {
+        (alias, key): (f"'{_TOGGLE_ADAPTER}'" in body) for alias, key, body in _REGISTRY_ENTRY_RE.findall(registry_text)
+    }
+
+
+def find_violations(
+    text: str,
+    source: str,
+    sections_by_path: dict[str, str],
+    registry_keys: dict[tuple[str, str], bool],
+) -> list[Violation]:
+    """Apply both rules to one page's source."""
+    basename = Path(source).name
+    lines = text.splitlines()
+    # The page's own mirror -> alias map, derived from its readSection() calls.
+    alias_by_mirror: dict[str, str] = {}
+    for mirror, path in _MIRROR_RE.findall(text):
+        alias = sections_by_path.get(path)
+        if alias is not None:
+            alias_by_mirror[mirror] = alias
+
+    def site(offset: int) -> tuple[int, str]:
+        """(1-based line, trimmed line) for a match offset."""
+        lineno = text.count("\n", 0, offset) + 1
+        return lineno, lines[lineno - 1].strip() if lineno <= len(lines) else ""
+
+    violations: list[Violation] = []
+
+    # RULE 1 -- every on/off save into a registered section must name a registered key.
+    for match in _SAVE_RE.finditer(text):
+        mirror, key = match.group(1), match.group(2)
+        alias = alias_by_mirror.get(mirror)
+        if alias is None:
+            # The mirror is not a registered section at all (no PFB_SECTIONS alias):
+            # a foreign section, outside the registry's scope.
+            continue
+        if (alias, key) in registry_keys or (basename, key) in EXEMPT:
+            continue
+        lineno, snippet = site(match.start())
+        if snippet.startswith(("//", "*", "/*", "#")):
+            continue
+        violations.append(
+            Violation(
+                source,
+                lineno,
+                "unregistered-toggle",
+                f"PFB_FILTER_ON_OFF save of '{alias}/{key}' has no pfb_cfg_registry() entry",
+                snippet,
+            )
+        )
+
+    # RULE 2 -- scoped to TOGGLE entries. A registered plain scalar whose page still
+    # carries a `?:` fallback is a separate backlog (issue #2812), not this rule: several
+    # of those page defaults genuinely disagree with their registry entry, so deleting
+    # them would change behaviour and needs its own evidence.
+    seen: set[int] = set()
+    for matcher in (_READ_COALESCE_RE, _READ_ISSET_RE):
+        for match in matcher.finditer(text):
+            mirror, key = match.group(1), match.group(2)
+            alias = alias_by_mirror.get(mirror)
+            if alias is None or not registry_keys.get((alias, key), False):
+                continue
+            if (basename, key) in EXEMPT:
+                continue
+            lineno, snippet = site(match.start())
+            if lineno in seen or snippet.startswith(("//", "*", "/*", "#")):
+                continue
+            seen.add(lineno)
+            violations.append(
+                Violation(
+                    source,
+                    lineno,
+                    "page-level-default",
+                    f"'{alias}/{key}' is a registered toggle, so its default belongs to "
+                    "the registry entry -- read it with PfbConfig::read()",
+                    snippet,
+                )
+            )
+
+    return sorted(violations, key=lambda v: (v.line, v.rule))
+
+
+def _git_tracked_pages(root: Path) -> list[str]:
+    """Tracked `src/usr/local/www/pfblockerng/*.php` paths (sorted)."""
+    try:
+        out = subprocess.run(
+            ["git", "-C", str(root), "ls-files", "-z", WWW_DIR],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout
+    except (OSError, subprocess.CalledProcessError):
+        return []
+    return sorted(p for p in out.split("\0") if p.endswith(".php"))
+
+
+_SELF_TEST_PAGE = """<?php
+$pfb['iconfig'] = PfbConfig::readSection('installedpackages/pfblockerngipsettings/config/0');
+$pconfig['suppression'] = $pfb['iconfig']['suppression'] ?: 'on';
+if ($_POST) {
+    $pfb['iconfig']['pfb_brand_new_toggle'] = pfb_filter(
+        $_POST['pfb_brand_new_toggle'] ?? '', PFB_FILTER_ON_OFF, 'ip') ?: '';
+    $pfb['iconfig']['suppression'] = pfb_filter($_POST['suppression'] ?? '', PFB_FILTER_ON_OFF, 'ip') ?: '';
+}
+"""
+
+
+def _self_test(sections_by_path: dict[str, str], registry_keys: dict[tuple[str, str], bool]) -> int:
+    """Red canary: prove both rules fire on a known-violating synthetic page."""
+    found = find_violations(_SELF_TEST_PAGE, "self-test/pfblockerng_ip.php", sections_by_path, registry_keys)
+    rules = {v.rule for v in found}
+    missing = {"unregistered-toggle", "page-level-default"} - rules
+    if missing:
+        print(
+            f"check_toggle_registry --self-test: rule(s) did not fire: {sorted(missing)}. "
+            "The gate cannot detect the drift it exists to detect.",
+            file=sys.stderr,
+        )
+        for v in found:
+            print(f"    fired: {v.rule} at line {v.line}", file=sys.stderr)
+        return 1
+    print(
+        "check_toggle_registry --self-test: both rules fired on the violating page "
+        f"({len(found)} finding(s)) -- gate wiring proven.",
+    )
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point. 0 clean, 1 violations, 2 fail-closed."""
+    args = list(sys.argv[1:] if argv is None else argv)
+    root = Path(__file__).resolve().parent.parent
+
+    try:
+        registry_text = (root / REGISTRY_FILE).read_text(encoding="utf-8")
+    except OSError as exc:
+        print(
+            f"check_toggle_registry: cannot read {REGISTRY_FILE} ({exc}) -- failing "
+            "closed rather than reporting clean.",
+            file=sys.stderr,
+        )
+        return 2
+
+    sections_by_path = parse_sections(registry_text)
+    registry_keys = parse_registry_keys(registry_text)
+    if not sections_by_path or len(registry_keys) < _MIN_REGISTRY_KEYS:
+        print(
+            f"check_toggle_registry: parsed {len(sections_by_path)} section alias(es) and "
+            f"{len(registry_keys)} registry key(s) from {REGISTRY_FILE} -- below the "
+            f"{_MIN_REGISTRY_KEYS}-key floor, so the parse is broken. Failing closed.",
+            file=sys.stderr,
+        )
+        return 2
+
+    if args == ["--self-test"]:
+        return _self_test(sections_by_path, registry_keys)
+
+    if args:
+        paths = args
+    else:
+        paths = _git_tracked_pages(root)
+        if not paths:
+            print(
+                f"check_toggle_registry: `git ls-files {WWW_DIR}` returned nothing "
+                "(git unavailable or not a checkout) -- failing closed rather than "
+                "skipping the gate.",
+                file=sys.stderr,
+            )
+            return 2
+
+    violations: list[Violation] = []
+    for path in paths:
+        candidate = Path(path)
+        if not candidate.is_absolute():
+            candidate = root / path
+        try:
+            text = candidate.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        violations.extend(find_violations(text, path, sections_by_path, registry_keys))
+
+    for v in violations:
+        print(f"{v.source}:{v.line}: [{v.rule}] {v.detail}", file=sys.stderr)
+        print(f"    {v.snippet}", file=sys.stderr)
+
+    if violations:
+        print(
+            f"\n{len(violations)} toggle-contract violation(s). Add the key to "
+            "pfb_cfg_registry() (see docs/misc/config-gateway.md -> 'Adding a new "
+            "registered field'), read it through PfbConfig::read(), or record a "
+            "reasoned exemption in scripts/check_toggle_registry.py's EXEMPT table.",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -19669,8 +19669,10 @@ function pfblockerng_do_xmlrpc_sync($sync_to_ip, $port, $protocol, $username, $p
 		$sync_to_ip = "[{$sync_to_ip}]";
 	}
 
-	// If User Disabled, remove 'General/IP/DNSBL Tab Customizations' from Sync
-	$sections = pfblockerng_sync_sections(config_get_path('installedpackages/pfblockerngsync/config/0/syncinterfaces') != 'on');
+	// If User Disabled, remove 'General/IP/DNSBL Tab Customizations' from Sync.
+	// issue #2123: read through the gateway, so the registered default and the
+	// case-insensitive toggle vocabulary apply here as on the Sync page.
+	$sections = pfblockerng_sync_sections(PfbConfig::read('sync/syncinterfaces') !== PfbToggle::On);
 
 	/* xml will hold the sections to sync */
 	$xml = array();
@@ -19712,8 +19714,8 @@ function pfblockerng_plugin_xmlrpc_send() {
 	$section_paths_temp = [
 		'installedpackages/pfblockerngsync/config/0/varsynconchanges'
 	];
-	// If User Disabled, remove 'General/IP/DNSBL Tab Customizations' from Sync
-	$sections = pfblockerng_sync_sections(config_get_path('installedpackages/pfblockerngsync/config/0/syncinterfaces') != 'on');
+	// If User Disabled, remove 'General/IP/DNSBL Tab Customizations' from Sync (#2123).
+	$sections = pfblockerng_sync_sections(PfbConfig::read('sync/syncinterfaces') !== PfbToggle::On);
 	foreach ($sections as $section) {
 		$section_paths_temp[] = "installedpackages/{$section}";
 	}

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -1785,13 +1785,14 @@ function pfb_cfg_registry(): array
 		// setting keeps the historical always-on behaviour through pfb_rdns_seed_value(),
 		// a CROSS-SECTION seed (it reads the General section to decide) that the registry
 		// pass cannot express as a per-section grandfather map. It stays hand-written in
-		// pfblockerng_install.inc and runs BEFORE the pass, which then sees the key
-		// present and leaves it alone -- so this entry's default governs new installs only.
+		// pfblockerng_install.inc, runs BEFORE the pass, and corrects the captured IP mode
+		// to OLDCFG -- without that correction the pass's NEWCFG branch would assign this
+		// default over the seed. So this default governs new installs only.
 		'ip/enable_rdns' => [
 			'default'       => '',
 			'read_adapter'  => 'pfb_cfg_toggle_read',
 			'write_adapter' => 'pfb_cfg_toggle_write',
-			'no_grandfather' => '#336 upgrade preservation is the cross-section pfb_rdns_seed_value() seed, ordered before the registry pass; a per-section map cannot see the General section it keys on',
+			'no_grandfather' => '#336 upgrade preservation is the cross-section pfb_rdns_seed_value() seed, ordered before the registry pass and protected by the installer correcting the captured IP mode to OLDCFG; a per-section map cannot see the General section it keys on',
 		],
 
 		'ip/database_cc' => [

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -729,11 +729,17 @@ function pfb_cfg_top1m_source_write(PfbTop1mSource|string $source): string
 // issue #1931: the one greppable home of every real config.xml section path. Registry
 // keys below are '<alias>/<bare-key>'; PfbConfig resolves the alias through this map.
 const PFB_SECTIONS = [
-	'gen'   => 'installedpackages/pfblockerng/config/0',
-	'dnsbl' => 'installedpackages/pfblockerngdnsblsettings/config/0',
-	'ss'    => 'installedpackages/pfblockerngsafesearch',
-	'ip'    => 'installedpackages/pfblockerngipsettings/config/0',
-	'rep'   => 'installedpackages/pfblockerngreputation/config/0',
+	'gen'    => 'installedpackages/pfblockerng/config/0',
+	'dnsbl'  => 'installedpackages/pfblockerngdnsblsettings/config/0',
+	'ss'     => 'installedpackages/pfblockerngsafesearch',
+	'ip'     => 'installedpackages/pfblockerngipsettings/config/0',
+	'rep'    => 'installedpackages/pfblockerngreputation/config/0',
+	// issue #2123: two sections that already hold static page scalars beside their
+	// dynamic/foreign siblings, the same arrangement 'rep' has -- registering one key
+	// in them does not make the rest of the section registered, and every unregistered
+	// sibling still passes a section write through byte-identical.
+	'global' => 'installedpackages/pfblockerngglobal',
+	'sync'   => 'installedpackages/pfblockerngsync/config/0',
 ];
 
 // issue #1921: dedicated map key standing for "key genuinely absent" inside a
@@ -1591,6 +1597,71 @@ function pfb_cfg_registry(): array
 			'no_grandfather' => 'ADR-37 companion; inert while dnsbl_dot_block is off',
 		],
 
+		// issue #2123 -- the eight "DNSBL IPs - Advanced In/Outbound Firewall Rule
+		// Settings" checkboxes. The page renders them with a dynamic field name
+		// ('autoaddrnot_' . $advmode) over a STATIC stored key, so each direction is an
+		// ordinary dnsbl-section scalar and path addressing keeps it distinct from the
+		// per-feed-row and per-continent keys of the same bare name (those live under
+		// dynamic config paths and stay on the foreign-key exclusion list). All eight
+		// were off-by-default in pfblockerng_dnsbl.php's own `?: ''`, so the registered
+		// '' reproduces the page exactly. pfb_determine_list_detail() reads them off the
+		// section blob through a dynamic path, which registration leaves untouched.
+		'dnsbl/autoaddrnot_in' => [
+			'default'       => '',
+			'read_adapter'  => 'pfb_cfg_toggle_read',
+			'write_adapter' => 'pfb_cfg_toggle_write',
+			'no_grandfather' => '#2123 relocated pfblockerng_dnsbl.php:111\'s own off default into the registry; absent behaviour unchanged',
+		],
+
+		'dnsbl/autoports_in' => [
+			'default'       => '',
+			'read_adapter'  => 'pfb_cfg_toggle_read',
+			'write_adapter' => 'pfb_cfg_toggle_write',
+			'no_grandfather' => '#2123 relocated pfblockerng_dnsbl.php:112\'s own off default into the registry; absent behaviour unchanged',
+		],
+
+		'dnsbl/autoaddr_in' => [
+			'default'       => '',
+			'read_adapter'  => 'pfb_cfg_toggle_read',
+			'write_adapter' => 'pfb_cfg_toggle_write',
+			'no_grandfather' => '#2123 relocated pfblockerng_dnsbl.php:114\'s own off default into the registry; absent behaviour unchanged',
+		],
+
+		'dnsbl/autonot_in' => [
+			'default'       => '',
+			'read_adapter'  => 'pfb_cfg_toggle_read',
+			'write_adapter' => 'pfb_cfg_toggle_write',
+			'no_grandfather' => '#2123 relocated pfblockerng_dnsbl.php:115\'s own off default into the registry; absent behaviour unchanged',
+		],
+
+		'dnsbl/autoaddrnot_out' => [
+			'default'       => '',
+			'read_adapter'  => 'pfb_cfg_toggle_read',
+			'write_adapter' => 'pfb_cfg_toggle_write',
+			'no_grandfather' => '#2123 relocated pfblockerng_dnsbl.php:120\'s own off default into the registry; absent behaviour unchanged',
+		],
+
+		'dnsbl/autoports_out' => [
+			'default'       => '',
+			'read_adapter'  => 'pfb_cfg_toggle_read',
+			'write_adapter' => 'pfb_cfg_toggle_write',
+			'no_grandfather' => '#2123 relocated pfblockerng_dnsbl.php:121\'s own off default into the registry; absent behaviour unchanged',
+		],
+
+		'dnsbl/autoaddr_out' => [
+			'default'       => '',
+			'read_adapter'  => 'pfb_cfg_toggle_read',
+			'write_adapter' => 'pfb_cfg_toggle_write',
+			'no_grandfather' => '#2123 relocated pfblockerng_dnsbl.php:123\'s own off default into the registry; absent behaviour unchanged',
+		],
+
+		'dnsbl/autonot_out' => [
+			'default'       => '',
+			'read_adapter'  => 'pfb_cfg_toggle_read',
+			'write_adapter' => 'pfb_cfg_toggle_write',
+			'no_grandfather' => '#2123 relocated pfblockerng_dnsbl.php:124\'s own off default into the registry; absent behaviour unchanged',
+		],
+
 		// -------------------------------------------------------------------
 		// ADR-38: syslog export settings (General / Log Settings section, $gen)
 		// -------------------------------------------------------------------
@@ -1682,6 +1753,68 @@ function pfb_cfg_registry(): array
 			'no_grandfather' => 'v3.2 deliberate empty checkbox state is preserved by the owner-ruled storage contract',
 		],
 
+		// issue #2123 -- the seven IP-page checkboxes whose default used to be declared
+		// by pfblockerng_ip.php's own `?: ''` at the top of the file and whose stored
+		// vocabulary was decided at its save site. All seven were off-by-default there,
+		// so the registered '' reproduces the page exactly: absent reads Off, a stored
+		// '' reads Off, only 'on' reads On. Their runtime consumers read the ip section
+		// blob (pfblockerng_apply.inc's $pfb['ipconfig'] mirrors), which registration
+		// leaves untouched.
+		'ip/enable_dup' => [
+			'default'       => '',
+			'read_adapter'  => 'pfb_cfg_toggle_read',
+			'write_adapter' => 'pfb_cfg_toggle_write',
+			'no_grandfather' => '#2123 relocated pfblockerng_ip.php:39\'s own off default into the registry; absent behaviour unchanged',
+		],
+
+		'ip/enable_agg' => [
+			'default'       => '',
+			'read_adapter'  => 'pfb_cfg_toggle_read',
+			'write_adapter' => 'pfb_cfg_toggle_write',
+			'no_grandfather' => '#2123 relocated pfblockerng_ip.php:40\'s own off default into the registry; absent behaviour unchanged',
+		],
+
+		'ip/enable_log' => [
+			'default'       => '',
+			'read_adapter'  => 'pfb_cfg_toggle_read',
+			'write_adapter' => 'pfb_cfg_toggle_write',
+			'no_grandfather' => '#2123 relocated pfblockerng_ip.php:59\'s own off default into the registry; absent behaviour unchanged',
+		],
+
+		// Reverse DNS lookups. Off for a new install; an install that predates the
+		// setting keeps the historical always-on behaviour through pfb_rdns_seed_value(),
+		// a CROSS-SECTION seed (it reads the General section to decide) that the registry
+		// pass cannot express as a per-section grandfather map. It stays hand-written in
+		// pfblockerng_install.inc and runs BEFORE the pass, which then sees the key
+		// present and leaves it alone -- so this entry's default governs new installs only.
+		'ip/enable_rdns' => [
+			'default'       => '',
+			'read_adapter'  => 'pfb_cfg_toggle_read',
+			'write_adapter' => 'pfb_cfg_toggle_write',
+			'no_grandfather' => '#336 upgrade preservation is the cross-section pfb_rdns_seed_value() seed, ordered before the registry pass; a per-section map cannot see the General section it keys on',
+		],
+
+		'ip/database_cc' => [
+			'default'       => '',
+			'read_adapter'  => 'pfb_cfg_toggle_read',
+			'write_adapter' => 'pfb_cfg_toggle_write',
+			'no_grandfather' => '#2123 relocated pfblockerng_ip.php:65\'s own off default into the registry; absent behaviour unchanged',
+		],
+
+		'ip/enable_float' => [
+			'default'       => '',
+			'read_adapter'  => 'pfb_cfg_toggle_read',
+			'write_adapter' => 'pfb_cfg_toggle_write',
+			'no_grandfather' => '#2123 relocated pfblockerng_ip.php:75\'s own off default into the registry; absent behaviour unchanged',
+		],
+
+		'ip/killstates' => [
+			'default'       => '',
+			'read_adapter'  => 'pfb_cfg_toggle_read',
+			'write_adapter' => 'pfb_cfg_toggle_write',
+			'no_grandfather' => '#2123 relocated pfblockerng_ip.php:78\'s own off default into the registry; absent behaviour unchanged',
+		],
+
 		// -------------------------------------------------------------------
 		// Reputation section (pfblockerngreputation/config/0)
 		// -------------------------------------------------------------------
@@ -1710,6 +1843,42 @@ function pfb_cfg_registry(): array
 			'read_adapter'  => 'pfb_cfg_toggle_read',
 			'write_adapter' => 'pfb_cfg_toggle_write',
 			'no_grandfather' => 'v3.2.16 absent-key fallback equals current default',
+		],
+
+		// -------------------------------------------------------------------
+		// Alerts display section (pfblockerngglobal — flat, no /config/0)
+		// -------------------------------------------------------------------
+
+		// issue #2123: the last toggle still arranged the 3.2 way -- default declared by
+		// pfblockerng_alerts.php:41's `isset(...) ? ... : 'on'`, stored vocabulary decided
+		// at its save site, comparison written inline at four render sites. Default ON,
+		// which is the reason this one mattered: an `isset()` fallback treats a stored ''
+		// as SET, so an operator's uncheck read Off while a never-configured install read
+		// On. The registry reproduces both -- absence takes this default, a present ''
+		// reaches the toggle adapter (issue #2120) -- and getting the default wrong here
+		// would invert the Alerts page's auto-refresh for every untouched install.
+		// Its dynamic siblings in this section (feed_*, feed_alt_*, widget-*) stay
+		// foreign and pass a section write through byte-identical.
+		'global/alertrefresh' => [
+			'default'       => 'on',
+			'read_adapter'  => 'pfb_cfg_toggle_read',
+			'write_adapter' => 'pfb_cfg_toggle_write',
+			'no_grandfather' => '#2123 relocated pfblockerng_alerts.php:41\'s own ON default into the registry; absent still reads On and a stored \'\' still reads Off',
+		],
+
+		// -------------------------------------------------------------------
+		// XMLRPC sync section (pfblockerngsync/config/0)
+		// -------------------------------------------------------------------
+
+		// issue #2123: "Sync interfaces" -- when On, the XMLRPC replication set drops the
+		// interface-bearing sections (pfblockerng_sync_sections()). Off by default, which
+		// pfblockerng_sync.php:35 declared with its own `?: ''`. The section's dynamic
+		// destination row blob (row/*) and its credentials stay foreign and unregistered.
+		'sync/syncinterfaces' => [
+			'default'       => '',
+			'read_adapter'  => 'pfb_cfg_toggle_read',
+			'write_adapter' => 'pfb_cfg_toggle_write',
+			'no_grandfather' => '#2123 relocated pfblockerng_sync.php:35\'s own off default into the registry; absent behaviour unchanged',
 		],
 	];
 

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_install.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_install.inc
@@ -613,6 +613,12 @@ if ($has_migratable && empty($pfb_ip_section)) {
 	// byte-identical for pfb_registry_pass()'s rename/grandfather decisions.
 	PfbConfig::writeSectionRawSystem('installedpackages/pfblockerngipsettings/config/0', $pfb['iconfig']);
 	PfbConfig::writeSectionRawSystem('installedpackages/pfblockerng/config/0', $pfb['gconfig']);
+	// issue #2123: this branch fires only when the IP section was EMPTY, which is exactly
+	// when the mode captured above reads NEWCFG -- and the pass's NEWCFG branch assigns
+	// every registered key its default unconditionally, so it would erase the operator
+	// values just migrated here (six of the fourteen are registered IP toggles). A section
+	// that has received migrated operator data IS an existing install: correct the mode.
+	$pfb_registry_modes[PFB_SECTIONS['ip']] = 'OLDCFG';
 	update_status(" saving new changes ... done.\n");
 }
 else {
@@ -634,6 +640,10 @@ if ($pfb_rdns_seed !== null) {
 	// the gateway's system writer (no web session here). The pass below then sees the
 	// key present and leaves this cross-section decision alone.
 	PfbConfig::writeSystem('ip/enable_rdns', $pfb_rdns_seed);
+	// issue #2123: same reason as the reshape above -- this seed exists to preserve the
+	// historical always-on behaviour, and a captured NEWCFG (General configured, IP tab
+	// never saved) would let the pass overwrite it with the registered ''.
+	$pfb_registry_modes[PFB_SECTIONS['ip']] = 'OLDCFG';
 	update_status(" saving new changes ... done.\n");
 } else {
 	update_status(" no changes required ... done.\n");

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_install.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_install.inc
@@ -637,8 +637,9 @@ $pfb_rdns_seed = pfb_rdns_seed_value(
 );
 if ($pfb_rdns_seed !== null) {
 	// issue #2123: 'ip/enable_rdns' is a registered key now, so the seed goes through
-	// the gateway's system writer (no web session here). The pass below then sees the
-	// key present and leaves this cross-section decision alone.
+	// the gateway's system writer (no web session here). A present key alone is NOT
+	// enough to survive the pass -- its NEWCFG branch assigns the registered default
+	// regardless -- so the mode correction below is what preserves this decision.
 	PfbConfig::writeSystem('ip/enable_rdns', $pfb_rdns_seed);
 	// issue #2123: same reason as the reshape above -- this seed exists to preserve the
 	// historical always-on behaviour, and a captured NEWCFG (General configured, IP tab

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_install.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_install.inc
@@ -630,7 +630,10 @@ $pfb_rdns_seed = pfb_rdns_seed_value(
 	PfbConfig::readSection('installedpackages/pfblockerngipsettings/config/0')
 );
 if ($pfb_rdns_seed !== null) {
-	config_set_path('installedpackages/pfblockerngipsettings/config/0/enable_rdns', $pfb_rdns_seed);
+	// issue #2123: 'ip/enable_rdns' is a registered key now, so the seed goes through
+	// the gateway's system writer (no web session here). The pass below then sees the
+	// key present and leaves this cross-section decision alone.
+	PfbConfig::writeSystem('ip/enable_rdns', $pfb_rdns_seed);
 	update_status(" saving new changes ... done.\n");
 } else {
 	update_status(" no changes required ... done.\n");

--- a/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
@@ -38,7 +38,10 @@ $aglobal_array = array(	'pfbunicnt' => 200, 'pfbdenycnt' => 25, 'pfbpermitcnt' =
 
 $pfb['aglobal'] = PfbConfig::readSection('installedpackages/pfblockerngglobal');
 
-$alertrefresh	= isset($pfb['aglobal']['alertrefresh'])	? $pfb['aglobal']['alertrefresh']	: 'on';
+// issue #2123: the ON default and the stored vocabulary now live in the registry
+// (ADR-29) instead of this page. PfbConfig::read() applies the default only for a
+// genuinely absent key, so an operator's unchecked '' still reads Off.
+$alertrefresh	= PfbConfig::read('global/alertrefresh');
 $pfbpageload	= $pfb['aglobal']['pfbpageload']	!= ''	? $pfb['aglobal']['pfbpageload']	: 'unified';
 $pfbmaxtable	= $pfb['aglobal']['pfbmaxtable']	!= ''	? $pfb['aglobal']['pfbmaxtable']	: '1000';
 $pfbreplytypes	= pfb_csv_list($pfb['aglobal']['pfbreplytypes'] ?? NULL);
@@ -600,7 +603,10 @@ if (isset($_POST) && !empty($_POST)) {
 			$pfb['aglobal']['pfbchart2'] = pfb_filter($_POST['pfbchart2'], PFB_FILTER_HEX_COLOR, 'alerts hex', '#7A7A7A');
 		}
 
-		$pfb['aglobal']['alertrefresh']		= pfb_filter($_POST['alertrefresh'], PFB_FILTER_ON_OFF, 'alerts alertrefresh');
+		// issue #2123: an unchecked checkbox is absent from $_POST; PFB_FILTER_ON_OFF
+		// emits the owner-ruled empty Off token for it, and writeSection() below
+		// normalises the value through the key's registered adapter.
+		$pfb['aglobal']['alertrefresh']		= pfb_filter($_POST['alertrefresh'] ?? '', PFB_FILTER_ON_OFF, 'alerts alertrefresh');
 
 		$pfb['aglobal']['pfbpageload']		= $_POST['pfbpageload']					?: 'unified';
 		$pfb['aglobal']['pfbmaxtable']		= $_POST['pfbmaxtable']					?: '1000';
@@ -3463,7 +3469,7 @@ $group->add(new Form_Checkbox(
 	'alertrefresh',
 	'Auto-Refresh',
 	NULL,
-	pfb_cfg_toggle_read($alertrefresh) === PfbToggle::On,
+	$alertrefresh === PfbToggle::On,
 	'on'
 ))->setHelp('Auto&nbsp;Refresh')->setAttribute('title', 'Select to \'Auto-Refresh\' Alerts page every 60 seconds.');
 
@@ -4188,7 +4194,7 @@ if (!$alert_summary):
 <div class="panel panel-default" style="width: 100%;">
 	<div class="panel-heading">
 		<h2 class="panel-title">
-			<? if (pfb_cfg_toggle_read($alertrefresh) === PfbToggle::On): ?>
+			<? if ($alertrefresh === PfbToggle::On): ?>
 			<i class="fa-solid fa-pause-circle" id="PauseRefresh" " title="Pause Alerts Refresh"></i>&nbsp;
 			<? endif; ?>
 			<?=gettext($logtype)?><small>-&nbsp;<?=gettext('Last')?>&nbsp;<?=$pfbentries?>&nbsp;<?=gettext('Alert Entries')?></small>
@@ -4762,7 +4768,7 @@ foreach ($stats as $stat_type => $stype):
 <div class="panel panel-default" id="Alert_Stats_<?=$stat_type?>" style="display: inline-block; width: 100%;">
 	<div class="panel-heading">
 		<h2 class="panel-title">
-			<? if (pfb_cfg_toggle_read($alertrefresh) === PfbToggle::On): ?>
+			<? if ($alertrefresh === PfbToggle::On): ?>
 			<i class="fa-solid fa-pause-circle" id="PauseRefresh" " title="Pause Alerts Refresh"></i>&nbsp;
 			<? endif; ?>
 
@@ -5033,7 +5039,7 @@ foreach ($stats as $stat_type => $stype):
 endif;
 
 // Refresh page every 60 secs
-if (pfb_cfg_toggle_read($alertrefresh) === PfbToggle::On) {
+if ($alertrefresh === PfbToggle::On) {
 
 	$pageview = '?';
 	if ($pfb['filterlogentries']) {

--- a/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
@@ -108,20 +108,24 @@ $pconfig['pfb_gp_bypass_list']	= pfb_b64_text($pfb['dconfig']['pfb_gp_bypass_lis
 $pconfig['action']		= $pfb['dconfig']['action']				?: 'Disabled';
 $pconfig['aliaslog']		= $pfb['dconfig']['aliaslog']				?: 'enabled';
 
-$pconfig['autoaddrnot_in']	= $pfb['dconfig']['autoaddrnot_in']			?: '';
-$pconfig['autoports_in']	= $pfb['dconfig']['autoports_in']			?: '';
+// issue #2123: the eight Advanced In/Outbound rule checkbox defaults are owned by the
+// registry (ADR-29), not restated here. A validation-error redisplay replaces $pconfig
+// with raw $_POST (:1019), so the renders still run the value through the toggle read
+// adapter -- that call is the POST-redisplay adapter, not a second default.
+$pconfig['autoaddrnot_in']	= PfbConfig::read('dnsbl/autoaddrnot_in');
+$pconfig['autoports_in']	= PfbConfig::read('dnsbl/autoports_in');
 $pconfig['aliasports_in']	= $pfb['dconfig']['aliasports_in']			?: '';
-$pconfig['autoaddr_in']		= $pfb['dconfig']['autoaddr_in']			?: '';
-$pconfig['autonot_in']		= $pfb['dconfig']['autonot_in']				?: '';
+$pconfig['autoaddr_in']		= PfbConfig::read('dnsbl/autoaddr_in');
+$pconfig['autonot_in']		= PfbConfig::read('dnsbl/autonot_in');
 $pconfig['aliasaddr_in']	= $pfb['dconfig']['aliasaddr_in']			?: '';
 $pconfig['autoproto_in']	= $pfb['dconfig']['autoproto_in']			?: 'any';
 $pconfig['agateway_in']		= $pfb['dconfig']['agateway_in']			?: 'default';
 
-$pconfig['autoaddrnot_out']	= $pfb['dconfig']['autoaddrnot_out']			?: '';
-$pconfig['autoports_out']	= $pfb['dconfig']['autoports_out']			?: '';
+$pconfig['autoaddrnot_out']	= PfbConfig::read('dnsbl/autoaddrnot_out');
+$pconfig['autoports_out']	= PfbConfig::read('dnsbl/autoports_out');
 $pconfig['aliasports_out']	= $pfb['dconfig']['aliasports_out']			?: '';
-$pconfig['autoaddr_out']	= $pfb['dconfig']['autoaddr_out']			?: '';
-$pconfig['autonot_out']		= $pfb['dconfig']['autonot_out']			?: '';
+$pconfig['autoaddr_out']	= PfbConfig::read('dnsbl/autoaddr_out');
+$pconfig['autonot_out']		= PfbConfig::read('dnsbl/autonot_out');
 $pconfig['aliasaddr_out']	= $pfb['dconfig']['aliasaddr_out']			?: '';
 $pconfig['autoproto_out']	= $pfb['dconfig']['autoproto_out']			?: 'any';
 $pconfig['agateway_out']	= $pfb['dconfig']['agateway_out']			?: 'default';
@@ -900,22 +904,22 @@ if ($_POST) {
 			$pfb['dconfig']['action']		= $_POST['action']							?: 'Disabled';
 			$pfb['dconfig']['aliaslog']		= $_POST['aliaslog']							?: 'enabled';
 
-			$pfb['dconfig']['autoaddrnot_in']	= pfb_filter($_POST['autoaddrnot_in'], PFB_FILTER_ON_OFF, 'dnsbl')	?: '';
-			$pfb['dconfig']['autoports_in']		= pfb_filter($_POST['autoports_in'], PFB_FILTER_ON_OFF, 'dnsbl')	?: '';
+			$pfb['dconfig']['autoaddrnot_in']	= pfb_filter($_POST['autoaddrnot_in'] ?? '', PFB_FILTER_ON_OFF, 'dnsbl')	?: '';
+			$pfb['dconfig']['autoports_in']		= pfb_filter($_POST['autoports_in'] ?? '', PFB_FILTER_ON_OFF, 'dnsbl')	?: '';
 			// issue #1723: aliasaddr_in/out, aliasports_in/out already sanitized by the
 			// ingestion prologue above -- plain read.
 			$pfb['dconfig']['aliasports_in']	= $_POST['aliasports_in']						?: '';
-			$pfb['dconfig']['autoaddr_in']		= pfb_filter($_POST['autoaddr_in'], PFB_FILTER_ON_OFF, 'dnsbl')		?: '';
-			$pfb['dconfig']['autonot_in']		= pfb_filter($_POST['autonot_in'], PFB_FILTER_ON_OFF, 'dnsbl')		?: '';
+			$pfb['dconfig']['autoaddr_in']		= pfb_filter($_POST['autoaddr_in'] ?? '', PFB_FILTER_ON_OFF, 'dnsbl')		?: '';
+			$pfb['dconfig']['autonot_in']		= pfb_filter($_POST['autonot_in'] ?? '', PFB_FILTER_ON_OFF, 'dnsbl')		?: '';
 			$pfb['dconfig']['aliasaddr_in']		= $_POST['aliasaddr_in']						?: '';
 			$pfb['dconfig']['autoproto_in']		= $_POST['autoproto_in']						?: 'any';
 			$pfb['dconfig']['agateway_in']		= $_POST['agateway_in']							?: 'default';
 
-			$pfb['dconfig']['autoaddrnot_out']	= pfb_filter($_POST['autoaddrnot_out'], PFB_FILTER_ON_OFF, 'dnsbl')	?: '';
-			$pfb['dconfig']['autoports_out']	= pfb_filter($_POST['autoports_out'], PFB_FILTER_ON_OFF, 'dnsbl')	?: '';
+			$pfb['dconfig']['autoaddrnot_out']	= pfb_filter($_POST['autoaddrnot_out'] ?? '', PFB_FILTER_ON_OFF, 'dnsbl')	?: '';
+			$pfb['dconfig']['autoports_out']	= pfb_filter($_POST['autoports_out'] ?? '', PFB_FILTER_ON_OFF, 'dnsbl')	?: '';
 			$pfb['dconfig']['aliasports_out']	= $_POST['aliasports_out']						?: '';
-			$pfb['dconfig']['autoaddr_out']		= pfb_filter($_POST['autoaddr_out'], PFB_FILTER_ON_OFF, 'dnsbl')	?: '';
-			$pfb['dconfig']['autonot_out']		= pfb_filter($_POST['autonot_out'], PFB_FILTER_ON_OFF, 'dnsbl')		?: '';
+			$pfb['dconfig']['autoaddr_out']		= pfb_filter($_POST['autoaddr_out'] ?? '', PFB_FILTER_ON_OFF, 'dnsbl')	?: '';
+			$pfb['dconfig']['autonot_out']		= pfb_filter($_POST['autonot_out'] ?? '', PFB_FILTER_ON_OFF, 'dnsbl')		?: '';
 			$pfb['dconfig']['aliasaddr_out']	= $_POST['aliasaddr_out']						?: '';
 			$pfb['dconfig']['autoproto_out']	= $_POST['autoproto_out']						?: 'any';
 			$pfb['dconfig']['agateway_out']		= $_POST['agateway_out']						?: 'default';
@@ -3602,7 +3606,7 @@ foreach (array( 'In' => 'Source', 'Out' => 'Destination') as $adv_mode => $adv_t
 		'autoaddrnot_' . $advmode,
 		"Invert {$adv_type}",
 		NULL,
-		pfb_cfg_toggle_read($pconfig['autoaddrnot_' . $advmode]) === PfbToggle::On,
+		pfb_cfg_toggle_read($pconfig['autoaddrnot_' . $advmode] ?? NULL) === PfbToggle::On,
 		'on'
 	))->setHelp("Option to invert the sense of the match. ie - Not (!) {$adv_type} Address(es)")
 	  ->addClass('dnsbl_ip');
@@ -3612,7 +3616,7 @@ foreach (array( 'In' => 'Source', 'Out' => 'Destination') as $adv_mode => $adv_t
 		'autoports_' . $advmode,
 		'Custom DST Port',
 		NULL,
-		pfb_cfg_toggle_read($pconfig['autoports_' . $advmode]) === PfbToggle::On,
+		pfb_cfg_toggle_read($pconfig['autoports_' . $advmode] ?? NULL) === PfbToggle::On,
 		'on'
 	))->setHelp('Enable')
 	  ->setWidth(2)
@@ -3640,7 +3644,7 @@ foreach (array( 'In' => 'Source', 'Out' => 'Destination') as $adv_mode => $adv_t
 		'autoaddr_' . $advmode,
 		"Custom {$custom_location}",
 		NULL,
-		pfb_cfg_toggle_read($pconfig["autoaddr_{$advmode}"]) === PfbToggle::On,
+		pfb_cfg_toggle_read($pconfig["autoaddr_{$advmode}"] ?? NULL) === PfbToggle::On,
 		'on'
 	))->setHelp('Enable')->setWidth(1)
 	  ->addClass('dnsbl_ip');
@@ -3649,7 +3653,7 @@ foreach (array( 'In' => 'Source', 'Out' => 'Destination') as $adv_mode => $adv_t
 		'autonot_' . $advmode,
 		NULL,
 		NULL,
-		pfb_cfg_toggle_read($pconfig["autonot_{$advmode}"]) === PfbToggle::On,
+		pfb_cfg_toggle_read($pconfig["autonot_{$advmode}"] ?? NULL) === PfbToggle::On,
 		'on'
 	))->setHelp('Invert')->setWidth(1)
 	  ->addClass('dnsbl_ip');

--- a/src/usr/local/www/pfblockerng/pfblockerng_ip.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_ip.php
@@ -36,8 +36,14 @@ $pfb_syntaxhl_on = pfb_editor_enabled();
 $pfb_ip_editor = pfb_ip_editor_render($pfb_syntaxhl_on);
 
 $pconfig = array();
-$pconfig['enable_dup']		= $pfb['iconfig']['enable_dup']				?: '';
-$pconfig['enable_agg']		= $pfb['iconfig']['enable_agg']				?: '';
+// issue #2123: the seven checkbox defaults below are owned by the registry (ADR-29),
+// not restated here; PfbConfig::read() applies each one when the key is absent and
+// returns the PfbToggle the render compares. A validation-error redisplay replaces
+// $pconfig with raw $_POST (see below), so the renders still run the value through
+// the toggle read adapter -- that call is the POST-redisplay adapter, not a second
+// declaration of the default.
+$pconfig['enable_dup']		= PfbConfig::read('ip/enable_dup');
+$pconfig['enable_agg']		= PfbConfig::read('ip/enable_agg');
 
 // ADR-11: opt-in per-type aggregate ("Uber") aliases. CSV scalar, gateway-registered
 // (general section); presented here beside CIDR Aggregation. Default none -> [''] selects
@@ -56,13 +62,13 @@ $pconfig['pfb_alias_delta_batch']	= pfb_alias_delta_batch_clamp((string) PfbConf
 // when absent.
 $pconfig['suppression']		= PfbConfig::read('ip/suppression');
 
-$pconfig['enable_log']		= $pfb['iconfig']['enable_log']				?: '';
-$pconfig['enable_rdns']		= $pfb['iconfig']['enable_rdns']				?: '';
+$pconfig['enable_log']		= PfbConfig::read('ip/enable_log');
+$pconfig['enable_rdns']		= PfbConfig::read('ip/enable_rdns');
 $pconfig['ip_placeholder']	= $pfb['iconfig']['ip_placeholder']			?: '127.1.7.7';
 $pconfig['maxmind_locale']	= $pfb['iconfig']['maxmind_locale']			?: 'en';
 $pconfig['asn_reporting']	= $pfb['iconfig']['asn_reporting']			?: 'disabled';
 $pconfig['asn_token']		= $pfb['iconfig']['asn_token']				?: '';
-$pconfig['database_cc']		= $pfb['iconfig']['database_cc']			?: '';
+$pconfig['database_cc']		= PfbConfig::read('ip/database_cc');
 $pconfig['maxmind_account']	= $pfb['iconfig']['maxmind_account']			?: '';
 // issue #924: maxmind_key is masked/write-only -- never populate it from the stored value.
 // A GET renders blank; a validation-error redisplay preserves the just-typed $_POST value
@@ -72,10 +78,10 @@ $pconfig['inbound_interface']	= pfb_csv_list($pfb['iconfig']['inbound_interface'
 $pconfig['inbound_deny_action']	= $pfb['iconfig']['inbound_deny_action']		?: 'block';
 $pconfig['outbound_interface']	= pfb_csv_list($pfb['iconfig']['outbound_interface'] ?? NULL);
 $pconfig['outbound_deny_action']= $pfb['iconfig']['outbound_deny_action']		?: 'reject';
-$pconfig['enable_float']	= $pfb['iconfig']['enable_float']			?: '';
+$pconfig['enable_float']	= PfbConfig::read('ip/enable_float');
 $pconfig['pass_order']		= $pfb['iconfig']['pass_order']				?: 'order_0';
 $pconfig['autorule_suffix']	= $pfb['iconfig']['autorule_suffix']			?: 'autorule';
-$pconfig['killstates']		= $pfb['iconfig']['killstates']				?: '';
+$pconfig['killstates']		= PfbConfig::read('ip/killstates');
 $pconfig['v4suppression']	= pfb_b64_text($pfb['iconfig']['v4suppression'] ?? NULL);
 // ADR-53 review finding B: '?? ""' on the array read -- v6suppression (unlike
 // v4suppression) is NEVER install-migrated, so it is absent from config.xml
@@ -244,15 +250,18 @@ if ($_POST) {
 
 		if (!$input_errors) {
 
-			$pfb['iconfig']['enable_dup']		= pfb_filter($_POST['enable_dup'], PFB_FILTER_ON_OFF, 'ip')	?: '';
-			$pfb['iconfig']['enable_agg']		= pfb_filter($_POST['enable_agg'], PFB_FILTER_ON_OFF, 'ip')	?: '';
-			// issue #1907: checkbox-absent is the owner-ruled empty Off token.
+			// issue #1907/#2123: an unchecked checkbox is absent from $_POST, and the
+			// owner-ruled empty token is what PFB_FILTER_ON_OFF already emits for it;
+			// writeSection() then normalises every registered key below through its
+			// registered adapter.
+			$pfb['iconfig']['enable_dup']		= pfb_filter($_POST['enable_dup'] ?? '', PFB_FILTER_ON_OFF, 'ip') ?: '';
+			$pfb['iconfig']['enable_agg']		= pfb_filter($_POST['enable_agg'] ?? '', PFB_FILTER_ON_OFF, 'ip') ?: '';
 			$pfb['iconfig']['suppression']		= pfb_filter($_POST['suppression'] ?? '', PFB_FILTER_ON_OFF, 'ip') ?: '';
-			$pfb['iconfig']['enable_log']		= pfb_filter($_POST['enable_log'], PFB_FILTER_ON_OFF, 'ip')	?: '';
-			$pfb['iconfig']['enable_rdns']		= pfb_filter($_POST['enable_rdns'], PFB_FILTER_ON_OFF, 'ip')	?: '';
+			$pfb['iconfig']['enable_log']		= pfb_filter($_POST['enable_log'] ?? '', PFB_FILTER_ON_OFF, 'ip') ?: '';
+			$pfb['iconfig']['enable_rdns']		= pfb_filter($_POST['enable_rdns'] ?? '', PFB_FILTER_ON_OFF, 'ip') ?: '';
 			$pfb['iconfig']['ip_placeholder']	= $_POST['ip_placeholder']					?: '127.1.7.7';
 			$pfb['iconfig']['maxmind_locale']	= $_POST['maxmind_locale']					?: 'en';
-			$pfb['iconfig']['database_cc']		= pfb_filter($_POST['database_cc'], PFB_FILTER_ON_OFF, 'ip')	?: '';
+			$pfb['iconfig']['database_cc']		= pfb_filter($_POST['database_cc'] ?? '', PFB_FILTER_ON_OFF, 'ip') ?: '';
 			$pfb['iconfig']['maxmind_account']	= pfb_filter($_POST['maxmind_account'], PFB_FILTER_WORD, 'ip')	?: '';
 			// issue #924: blank keeps the existing stored key -- only overwrite on a non-empty
 			// submission, never clear it via a blank re-post ($pfb['iconfig']['maxmind_key']
@@ -266,10 +275,10 @@ if ($_POST) {
 			$pfb['iconfig']['inbound_deny_action']	= $_POST['inbound_deny_action']					?: '';
 			$pfb['iconfig']['outbound_interface']	= implode(',', (array)$_POST['outbound_interface'])		?: '';
 			$pfb['iconfig']['outbound_deny_action']	= $_POST['outbound_deny_action']				?: '';
-			$pfb['iconfig']['enable_float']		= pfb_filter($_POST['enable_float'], PFB_FILTER_ON_OFF, 'ip')	?: '';
+			$pfb['iconfig']['enable_float']		= pfb_filter($_POST['enable_float'] ?? '', PFB_FILTER_ON_OFF, 'ip') ?: '';
 			$pfb['iconfig']['pass_order']		= $_POST['pass_order']						?: 'order_0';
 			$pfb['iconfig']['autorule_suffix']	= $_POST['autorule_suffix']					?: 'autorule';
-			$pfb['iconfig']['killstates']		= pfb_filter($_POST['killstates'], PFB_FILTER_ON_OFF, 'ip')	?: '';
+			$pfb['iconfig']['killstates']		= pfb_filter($_POST['killstates'] ?? '', PFB_FILTER_ON_OFF, 'ip') ?: '';
 			// issue #1723: already sanitized by the ingestion prologue -- plain encode.
 			$pfb['iconfig']['v4suppression']	= base64_encode($_POST['v4suppression'] ?? '');
 			$pfb['iconfig']['v6suppression']	= base64_encode($_POST['v6suppression'] ?? '');
@@ -362,7 +371,7 @@ $section->addInput(new Form_Checkbox(
 	'enable_dup',
 	'De-Duplication',
 	'Enable',
-	pfb_cfg_toggle_read($pconfig['enable_dup']) === PfbToggle::On,
+	pfb_cfg_toggle_read($pconfig['enable_dup'] ?? NULL) === PfbToggle::On,
 	'on'
 ))->setHelp('Only used for IPv4 Deny Lists');
 
@@ -370,7 +379,7 @@ $section->addInput(new Form_Checkbox(
 	'enable_agg',
 	'CIDR Aggregation',
 	'Enable',
-	pfb_cfg_toggle_read($pconfig['enable_agg']) === PfbToggle::On,
+	pfb_cfg_toggle_read($pconfig['enable_agg'] ?? NULL) === PfbToggle::On,
 	'on'
 ))->setHelp('Optimise CIDRs - merge contiguous CIDRs into larger CIDR blocks.');
 
@@ -435,7 +444,7 @@ $section->addInput(new Form_Checkbox(
 	'enable_log',
 	'Force Global IP Logging',
 	'Enable',
-	pfb_cfg_toggle_read($pconfig['enable_log']) === PfbToggle::On,
+	pfb_cfg_toggle_read($pconfig['enable_log'] ?? NULL) === PfbToggle::On,
 	'on'
 ))->setHelp('The global logging option is only used to force logging for all IP Aliases, and not to disable the logging of all IP Aliases.<br />'
 		. 'This overrides any logging settings in the GeoIP/IPv4/v6 tabs.'
@@ -445,7 +454,7 @@ $section->addInput(new Form_Checkbox(
 	'enable_rdns',
 	'Reverse DNS Lookups',
 	'Enable',
-	pfb_cfg_toggle_read($pconfig['enable_rdns']) === PfbToggle::On,
+	pfb_cfg_toggle_read($pconfig['enable_rdns'] ?? NULL) === PfbToggle::On,
 	'on'
 ))->setHelp('Perform a reverse DNS (PTR) lookup to resolve the hostname of each blocked IP address shown in the Alerts and logs.<br />'
 		. 'Enabling this increases the number of DNS queries performed, though the impact is usually negligible.');
@@ -541,7 +550,7 @@ $section->addInput(new Form_Checkbox(
 	'database_cc',
 	'MaxMind CSV Updates',
 	'Check to disable MaxMind CSV updates',
-	pfb_cfg_toggle_read($pconfig['database_cc']) === PfbToggle::On,
+	pfb_cfg_toggle_read($pconfig['database_cc'] ?? NULL) === PfbToggle::On,
 	'on'
 ))->setHelp('This will disable the MaxMind monthly CSV GeoIP database cron update. This does not affect the MaxMind binary cron update that is used for other GeoIP funcionality in the package.');
 
@@ -657,7 +666,7 @@ $section->addInput(new Form_Checkbox(
 	'enable_float',
 	'Floating Rules',
 	'Enable',
-	pfb_cfg_toggle_read($pconfig['enable_float']) === PfbToggle::On,
+	pfb_cfg_toggle_read($pconfig['enable_float'] ?? NULL) === PfbToggle::On,
 	'on'
 ))->setHelp('<strong>Enabled:</strong> Auto-rules will be generated in the \'Floating Rules\' tab.<br />'
 		. '<strong>Disabled:</strong> Auto-rules will be generated in the selected Inbound/Outbound interfaces.'
@@ -690,7 +699,7 @@ $section->addInput(new Form_Checkbox(
 	'killstates',
 	'Kill States',
 	'Enable',
-	pfb_cfg_toggle_read($pconfig['killstates']) === PfbToggle::On,
+	pfb_cfg_toggle_read($pconfig['killstates'] ?? NULL) === PfbToggle::On,
 	'on'
 ))->setHelp('When \'Enabled\', after a cron event or any \'Force\' commands, any blocked IPs found in the Firewall states will be cleared.');
 

--- a/src/usr/local/www/pfblockerng/pfblockerng_sync.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_sync.php
@@ -32,7 +32,10 @@ $pfb['sconfig'] = PfbConfig::readSection('installedpackages/pfblockerngsync/conf
 $pconfig = array();
 $pconfig['varsynconchanges']	= $pfb['sconfig']['varsynconchanges']	?: '';
 $pconfig['varsynctimeout']	= $pfb['sconfig']['varsynctimeout']	?: 150;
-$pconfig['syncinterfaces']	= $pfb['sconfig']['syncinterfaces']	?: '';
+// issue #2123: default owned by the registry (ADR-29). This page never replaces
+// $pconfig with raw $_POST -- a save either redirects or re-renders from the section
+// read above -- so the value stays a PfbToggle all the way to the render.
+$pconfig['syncinterfaces']	= PfbConfig::read('sync/syncinterfaces');
 
 // Select field options
 $options_varsynconchanges	= [ 'disabled' => 'Do not sync this package configuration', 'auto' => 'Sync to configured system backup server', 'manual' => 'Sync to host(s) defined below' ];
@@ -156,7 +159,7 @@ if ($_POST) {
 
 			$pfb['sconfig']['varsynconchanges']	= $_POST['varsynconchanges']						?: '';
 			$pfb['sconfig']['varsynctimeout']	= $_POST['varsynctimeout']						?: '';
-			$pfb['sconfig']['syncinterfaces']	= pfb_filter($_POST['syncinterfaces'], PFB_FILTER_ON_OFF, 'Sync')	?: '';
+			$pfb['sconfig']['syncinterfaces']	= pfb_filter($_POST['syncinterfaces'] ?? '', PFB_FILTER_ON_OFF, 'Sync')	?: '';
 
 			PfbConfig::writeSection('installedpackages/pfblockerngsync/config/0', $pfb['sconfig']);
 			write_config('[pfBlockerNG] save XMLRPC sync settings');
@@ -227,7 +230,7 @@ $section->addInput(new Form_Checkbox(
 	'syncinterfaces',
 	'Disable General/IP/DNSBL tab settings sync',
 	NULL,
-	pfb_cfg_toggle_read($pconfig['syncinterfaces']) === PfbToggle::On,
+	$pconfig['syncinterfaces'] === PfbToggle::On,
 	'on'
 ))->setHelp('When selected, the \'General\', \'IP\', and \'DNSBL\' tab customizations will not be sync\'d');
 $form->add($section);

--- a/tests/php/CfgGatewayTest.php
+++ b/tests/php/CfgGatewayTest.php
@@ -1189,29 +1189,25 @@ final class CfgGatewayTest extends TestCase
 			'pfbextdns',
 
 			// pfblockerngipsettings — section read + sub-keys.
-			// (v4suppression is registered -- ADR-53 -- and lives in the registry, not here.)
+			// (v4suppression is registered -- ADR-53 -- and lives in the registry, not here.
+			// issue #2123 moved enable_dup / enable_agg / enable_log / enable_rdns /
+			// database_cc / enable_float / killstates off this list into the registry.)
 			'maxmind_key',
 			'maxmind_locale',
-			'database_cc',
 			'asn_reporting',
 			'asn_token',
 			'maxmind_account',
 			'inbound_deny_action',
 			'outbound_deny_action',
-			'enable_float',
-			'enable_dup',
-			'enable_agg',
 			'pass_order',
-			'enable_log',
 			'autorule_suffix',
-			'killstates',
 			'ip_placeholder',
 
 			// pfblockerngreputation sub-keys.
 			'et_header',
 
-			// pfblockerngsync sub-keys.
-			'syncinterfaces',
+			// pfblockerngsync sub-keys. (issue #2123 registered 'syncinterfaces' as
+			// 'sync/syncinterfaces'; its siblings here stay foreign.)
 			'varsynconchanges',
 			'varsynctimeout',
 			'varsyncdestinenable',

--- a/tests/php/CfgToggleRegistryPageParityTest.php
+++ b/tests/php/CfgToggleRegistryPageParityTest.php
@@ -1,0 +1,309 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * issue #2123 — the 17 PFB_FILTER_ON_OFF toggles whose default used to be declared in
+ * the page rather than in pfb_cfg_registry().
+ *
+ * The claim these tests have to make checkable is a PARITY claim, not a preference:
+ * reading each newly registered field through PfbConfig on a configuration that
+ * predates the registration must resolve to exactly the value the page produced
+ * before. So the deleted page expression is not described here, it is RE-EVALUATED:
+ * preRegistrationPageValue() below is a transcription of the two expression shapes
+ * the pages carried at b91b95cc, and every row compares the gateway against it.
+ *
+ * Two shapes, quoted from the pre-#2123 sources:
+ *
+ *   FALSY_EMPTY (16 fields) — e.g. pfblockerng_ip.php:39
+ *       $pconfig['enable_dup'] = $pfb['iconfig']['enable_dup'] ?: '';
+ *       ... rendered as pfb_cfg_toggle_read($pconfig['enable_dup']) === PfbToggle::On
+ *     so: absent and every falsy token collapse to '' and read Off.
+ *
+ *   ISSET_ON (1 field) — pfblockerng_alerts.php:41
+ *       $alertrefresh = isset($pfb['aglobal']['alertrefresh'])
+ *           ? $pfb['aglobal']['alertrefresh'] : 'on';
+ *       ... rendered as pfb_cfg_toggle_read($alertrefresh) === PfbToggle::On
+ *     so: ONLY a genuinely absent key falls back to 'on'; a stored '' is an operator
+ *     uncheck and reads Off. This is the dangerous one — a registered default of ''
+ *     would invert it for every install that never touched the checkbox, and a
+ *     registry that resolved '' to the default would invert it for every operator
+ *     who unchecked it. Both directions are pinned below.
+ *
+ * The matrix is deliberately wider than the two states pfSense itself writes: the
+ * supported producers of a foreign token are an area restore, an XMLRPC HA receive
+ * and a hand-edited config.xml (issue #2120's executed evidence), so legacy 'off',
+ * case variants and junk all carry a pinned expectation.
+ */
+final class CfgToggleRegistryPageParityTest extends TestCase
+{
+	/** $blob[$key] ?: '<default>' — absent and every falsy token collapse to the default. */
+	private const SHAPE_FALSY_EMPTY = 'falsy_empty';
+
+	/** isset($blob[$key]) ? $blob[$key] : 'on' — only genuine absence takes the default. */
+	private const SHAPE_ISSET_ON = 'isset_on';
+
+	/**
+	 * The 17 fields: registry path key => [config.xml section path, pre-#2123 page
+	 * expression site, expression shape].
+	 *
+	 * @var array<string,array{0:string,1:string,2:string}>
+	 */
+	private const FIELDS = [
+		// pfblockerng_ip.php — IP-settings section scalars.
+		'ip/enable_dup'   => ['installedpackages/pfblockerngipsettings/config/0', 'pfblockerng_ip.php:39', self::SHAPE_FALSY_EMPTY],
+		'ip/enable_agg'   => ['installedpackages/pfblockerngipsettings/config/0', 'pfblockerng_ip.php:40', self::SHAPE_FALSY_EMPTY],
+		'ip/enable_log'   => ['installedpackages/pfblockerngipsettings/config/0', 'pfblockerng_ip.php:59', self::SHAPE_FALSY_EMPTY],
+		'ip/enable_rdns'  => ['installedpackages/pfblockerngipsettings/config/0', 'pfblockerng_ip.php:60', self::SHAPE_FALSY_EMPTY],
+		'ip/database_cc'  => ['installedpackages/pfblockerngipsettings/config/0', 'pfblockerng_ip.php:65', self::SHAPE_FALSY_EMPTY],
+		'ip/enable_float' => ['installedpackages/pfblockerngipsettings/config/0', 'pfblockerng_ip.php:75', self::SHAPE_FALSY_EMPTY],
+		'ip/killstates'   => ['installedpackages/pfblockerngipsettings/config/0', 'pfblockerng_ip.php:78', self::SHAPE_FALSY_EMPTY],
+
+		// pfblockerng_dnsbl.php — DNSBL-settings section scalars behind the two
+		// "Advanced In/Outbound Firewall Rule Settings" panels (:3602, :3611, :3641,
+		// :3649 render them with a dynamic field name over a static stored key).
+		'dnsbl/autoaddrnot_in'  => ['installedpackages/pfblockerngdnsblsettings/config/0', 'pfblockerng_dnsbl.php:111', self::SHAPE_FALSY_EMPTY],
+		'dnsbl/autoports_in'    => ['installedpackages/pfblockerngdnsblsettings/config/0', 'pfblockerng_dnsbl.php:112', self::SHAPE_FALSY_EMPTY],
+		'dnsbl/autoaddr_in'     => ['installedpackages/pfblockerngdnsblsettings/config/0', 'pfblockerng_dnsbl.php:114', self::SHAPE_FALSY_EMPTY],
+		'dnsbl/autonot_in'      => ['installedpackages/pfblockerngdnsblsettings/config/0', 'pfblockerng_dnsbl.php:115', self::SHAPE_FALSY_EMPTY],
+		'dnsbl/autoaddrnot_out' => ['installedpackages/pfblockerngdnsblsettings/config/0', 'pfblockerng_dnsbl.php:120', self::SHAPE_FALSY_EMPTY],
+		'dnsbl/autoports_out'   => ['installedpackages/pfblockerngdnsblsettings/config/0', 'pfblockerng_dnsbl.php:121', self::SHAPE_FALSY_EMPTY],
+		'dnsbl/autoaddr_out'    => ['installedpackages/pfblockerngdnsblsettings/config/0', 'pfblockerng_dnsbl.php:123', self::SHAPE_FALSY_EMPTY],
+		'dnsbl/autonot_out'     => ['installedpackages/pfblockerngdnsblsettings/config/0', 'pfblockerng_dnsbl.php:124', self::SHAPE_FALSY_EMPTY],
+
+		// pfblockerng_sync.php — XMLRPC-sync section scalar.
+		'sync/syncinterfaces' => ['installedpackages/pfblockerngsync/config/0', 'pfblockerng_sync.php:35', self::SHAPE_FALSY_EMPTY],
+
+		// pfblockerng_alerts.php — the default-On survivor of the 3.2 arrangement.
+		'global/alertrefresh' => ['installedpackages/pfblockerngglobal', 'pfblockerng_alerts.php:41', self::SHAPE_ISSET_ON],
+	];
+
+	/**
+	 * Raw stored states a pre-registration configuration can present. NULL is the
+	 * genuinely absent key; every other row is a value physically present in
+	 * config.xml.
+	 *
+	 * @var array<string,mixed>
+	 */
+	private const RAW_STATES = [
+		'absent'      => NULL,
+		'empty'       => '',
+		'canonical'   => 'on',
+		'legacy_off'  => 'off',
+		'case_On'     => 'On',
+		'case_OFF'    => 'OFF',
+		'junk_yes'    => 'yes',
+		'junk_one'    => '1',
+		'junk_zero'   => '0',
+	];
+
+	protected function setUp(): void
+	{
+		$GLOBALS['config'] = [];
+	}
+
+	/**
+	 * The pre-#2123 page expression, transcribed. Given the RAW stored value, return
+	 * the PfbToggle the page's render comparison saw.
+	 */
+	private static function preRegistrationPageValue(string $shape, mixed $raw): PfbToggle
+	{
+		if ($shape === self::SHAPE_ISSET_ON) {
+			// isset($blob[$k]) ? $blob[$k] : 'on'  --  a stored '' is set, so it stays ''.
+			return pfb_cfg_toggle_read($raw === NULL ? 'on' : $raw);
+		}
+
+		// $blob[$k] ?: ''
+		return pfb_cfg_toggle_read($raw ?: '');
+	}
+
+	/** @return iterable<string,array{0:string,1:string,2:string,3:string,4:mixed}> */
+	public static function fieldRawMatrix(): iterable
+	{
+		foreach (self::FIELDS as $path_key => [$section, $site, $shape]) {
+			foreach (self::RAW_STATES as $state => $raw) {
+				yield "{$path_key} [{$state}]" => [$path_key, $section, $shape, $site, $raw];
+			}
+		}
+	}
+
+	/**
+	 * Scenario:
+	 *   Background: a configuration written before #2123 registered these keys.
+	 *   Given one of the 17 keys holds raw stored value v (or is absent).
+	 *   When PfbConfig::read('<alias>/<key>') resolves it.
+	 *   Then the result equals what the page's own pre-registration expression
+	 *        produced for the same v — the registry took over the declaration
+	 *        without taking over the behaviour.
+	 */
+	#[DataProvider('fieldRawMatrix')]
+	public function testGatewayReadReproducesThePreRegistrationPageValue(
+		string $path_key,
+		string $section,
+		string $shape,
+		string $site,
+		mixed $raw
+	): void {
+		$bare = substr($path_key, strpos($path_key, '/') + 1);
+		if ($raw !== NULL) {
+			config_set_path("{$section}/{$bare}", $raw);
+		}
+
+		// Before: the raw state is exactly what a pre-#2123 config presents.
+		$this->assertSame($raw, config_get_path("{$section}/{$bare}"),
+			"before: {$path_key} raw stored state");
+
+		$expected = self::preRegistrationPageValue($shape, $raw);
+
+		// When/Then.
+		$this->assertSame($expected, PfbConfig::read($path_key), sprintf(
+			'%s: gateway read must equal the pre-#2123 %s expression (%s) for raw %s',
+			$path_key, $shape, $site, var_export($raw, TRUE)
+		));
+	}
+
+	/**
+	 * The Alerts auto-refresh inversion, pinned in both directions.
+	 *
+	 * Scenario:
+	 *   Given the Alerts page defaulted alertrefresh to 'on' via isset() and stored
+	 *     '' for an operator's uncheck (pfblockerng_alerts.php:41 and :603).
+	 *   When the key is registered.
+	 *   Then an install that never touched the checkbox still reads On, and an
+	 *     operator who unchecked it still reads Off. A registered default of '',
+	 *     or a gateway that resolved a stored '' to the default, flips one of them.
+	 */
+	public function testAlertRefreshKeepsOnDefaultAndHonoursADeliberateUncheck(): void
+	{
+		$path = 'installedpackages/pfblockerngglobal/alertrefresh';
+
+		// Never configured -> On (the page's isset() fallback).
+		$this->assertNull(config_get_path($path), 'before: alertrefresh absent');
+		$this->assertSame(PfbToggle::On, PfbConfig::read('global/alertrefresh'),
+			'absent alertrefresh must read On — the registered default carries the '
+			. 'page-level default deleted from pfblockerng_alerts.php:41');
+
+		// Operator unchecked the box: PFB_FILTER_ON_OFF stored '' -> Off.
+		config_set_path($path, '');
+		$this->assertSame(PfbToggle::Off, PfbConfig::read('global/alertrefresh'),
+			"stored '' alertrefresh must read Off — an unchecked box is not "
+			. 'the default (issue #2120 owner ruling)');
+
+		// And the canonical On token still reads On.
+		config_set_path($path, 'on');
+		$this->assertSame(PfbToggle::On, PfbConfig::read('global/alertrefresh'),
+			"stored 'on' alertrefresh must read On");
+	}
+
+	/**
+	 * The one runtime consumer that compared the stored token by hand
+	 * (pfblockerng.inc's XMLRPC sync section chooser, twice) keeps its verdict.
+	 *
+	 * Scenario:
+	 *   Given the pre-#2123 test was config_get_path(...) != 'on'.
+	 *   When the same raw state is read through the gateway as
+	 *     PfbConfig::read('sync/syncinterfaces') !== PfbToggle::On.
+	 *   Then the boolean matches for every token pfSense or the package writes,
+	 *     and differs ONLY for a case variant of 'on' — which #1887 deliberately
+	 *     accepts so a hand-edited or HA-synced 'On' cannot silently disable a
+	 *     feature the operator enabled.
+	 */
+	public function testSyncInterfacesGatewayReadMatchesTheHandWrittenTokenTest(): void
+	{
+		$path = 'installedpackages/pfblockerngsync/config/0/syncinterfaces';
+
+		// [raw, pre-#2123 (raw != 'on'), gateway (read !== On)]
+		$rows = [
+			['absent',     NULL,  TRUE,  TRUE],
+			['empty',      '',    TRUE,  TRUE],
+			['canonical',  'on',  FALSE, FALSE],
+			['legacy_off', 'off', TRUE,  TRUE],
+			['junk',       'yes', TRUE,  TRUE],
+		];
+
+		foreach ($rows as [$label, $raw, $legacy, $gateway]) {
+			$GLOBALS['config'] = [];
+			if ($raw !== NULL) {
+				config_set_path($path, $raw);
+			}
+			$this->assertSame($legacy, config_get_path($path) != 'on',
+				"{$label}: pre-#2123 token comparison");
+			$this->assertSame($gateway, PfbConfig::read('sync/syncinterfaces') !== PfbToggle::On,
+				"{$label}: gateway read must agree with the pre-#2123 comparison");
+		}
+
+		// The single deliberate divergence, recorded rather than hidden.
+		$GLOBALS['config'] = [];
+		config_set_path($path, 'On');
+		$this->assertTrue(config_get_path($path) != 'on',
+			"pre-#2123: a hand-edited 'On' read as NOT enabled");
+		$this->assertSame(PfbToggle::On, PfbConfig::read('sync/syncinterfaces'),
+			"'On' now reads On — issue #1887's case-insensitive toggle read reaches "
+			. 'this consumer once the key is registered, deliberately');
+	}
+
+	/**
+	 * Every one of the 17 is registered, adapter-bearing, and classified. Guards the
+	 * shape of the entry, not just its presence: a plain-scalar entry would leave a
+	 * stored '' resolving to the default, which is the #2120 inversion again.
+	 */
+	public function testAllSeventeenAreRegisteredAsClassifiedToggles(): void
+	{
+		$registry = pfb_cfg_registry();
+
+		foreach (array_keys(self::FIELDS) as $path_key) {
+			$this->assertArrayHasKey($path_key, $registry,
+				"{$path_key} must be registered (issue #2123)");
+			$entry = $registry[$path_key];
+			$this->assertSame('pfb_cfg_toggle_read', $entry['read_adapter'],
+				"{$path_key} must carry the toggle read adapter");
+			$this->assertSame('pfb_cfg_toggle_write', $entry['write_adapter'],
+				"{$path_key} must carry the toggle write adapter");
+			$this->assertSame(
+				1,
+				(int) isset($entry['grandfather']) + (int) isset($entry['no_grandfather']),
+				"{$path_key} must carry exactly one of grandfather / no_grandfather"
+			);
+		}
+	}
+
+	/**
+	 * The registered defaults, spelled out. A silent flip of any of these is the
+	 * behaviour change #2123 exists to prevent, so the expected value is written
+	 * here as a literal rather than derived from the registry it is checking.
+	 */
+	public function testRegisteredDefaultsAreThePageDefaultsTheyReplaced(): void
+	{
+		$expected = [
+			'ip/enable_dup'         => '',
+			'ip/enable_agg'         => '',
+			'ip/enable_log'         => '',
+			'ip/enable_rdns'        => '',
+			'ip/database_cc'        => '',
+			'ip/enable_float'       => '',
+			'ip/killstates'         => '',
+			'dnsbl/autoaddrnot_in'  => '',
+			'dnsbl/autoports_in'    => '',
+			'dnsbl/autoaddr_in'     => '',
+			'dnsbl/autonot_in'      => '',
+			'dnsbl/autoaddrnot_out' => '',
+			'dnsbl/autoports_out'   => '',
+			'dnsbl/autoaddr_out'    => '',
+			'dnsbl/autonot_out'     => '',
+			'sync/syncinterfaces'   => '',
+			'global/alertrefresh'   => 'on',
+		];
+
+		$this->assertSame(array_keys(self::FIELDS), array_keys($expected),
+			'the default table must cover exactly the 17 fields under test');
+
+		$registry = pfb_cfg_registry();
+		foreach ($expected as $path_key => $default) {
+			$this->assertSame($default, $registry[$path_key]['default'] ?? NULL,
+				"{$path_key}: registered default must reproduce the deleted page default");
+		}
+	}
+}

--- a/tests/php/CfgToggleRegistryPageParityTest.php
+++ b/tests/php/CfgToggleRegistryPageParityTest.php
@@ -262,11 +262,17 @@ final class CfgToggleRegistryPageParityTest extends TestCase
 				"{$path_key} must carry the toggle read adapter");
 			$this->assertSame('pfb_cfg_toggle_write', $entry['write_adapter'],
 				"{$path_key} must carry the toggle write adapter");
-			$this->assertSame(
-				1,
-				(int) isset($entry['grandfather']) + (int) isset($entry['no_grandfather']),
-				"{$path_key} must carry exactly one of grandfather / no_grandfather"
-			);
+			$this->assertArrayNotHasKey('grandfather', $entry,
+				"{$path_key} must NOT carry a grandfather map -- the registered default IS "
+				. 'the page default it replaced, so there is nothing to map');
+			$this->assertArrayHasKey('no_grandfather', $entry,
+				"{$path_key} must carry a no_grandfather reason");
+			// The reason must identify WHY, not merely be non-empty: a gate that accepts
+			// any string lets a wrong reason ship (issue #2123 review finding).
+			$expected_marker = $path_key === 'ip/enable_rdns' ? '#336' : '#2123';
+			$this->assertStringContainsString($expected_marker, $entry['no_grandfather'],
+				"{$path_key}: the no_grandfather reason must cite the decision it records "
+				. "({$expected_marker})");
 		}
 	}
 

--- a/tests/php/InstallRdnsSeedAfterPassTest.php
+++ b/tests/php/InstallRdnsSeedAfterPassTest.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * issue #2123 review finding — the enable_rdns seed must be APPLIED after the registry
+ * pass, not before it.
+ *
+ * `pfb_rdns_seed_value()` preserves the historical always-on reverse-DNS behaviour for an
+ * install that predates the setting: General section non-empty, `enable_rdns` absent from
+ * the IP section. Its predicate is cross-section, so it must be EVALUATED before the pass
+ * (which seeds every registered key and would erase the "absent" evidence).
+ *
+ * Registering `ip/enable_rdns` made the WRITE order load-bearing too. The installer
+ * captures each section's mode before migrations (`pfblockerng_install.inc:42`), and an
+ * install whose General section is configured but whose IP section was never saved
+ * captures IP as NEWCFG. `pfb_registry_pass()`'s NEWCFG branch assigns the registered
+ * default unconditionally — so a seed written BEFORE the pass is overwritten with `''`,
+ * silently turning reverse-DNS lookups off for exactly the install the seed exists to
+ * protect. Before registration the pass ignored the key and the order did not matter.
+ *
+ * Same shape as `pfb_install_psl_feed_policy_seed()` (issue #2371), which captures its
+ * predicate early and applies its seed after `pfb_install_registry_writeback()` for the
+ * same reason.
+ */
+final class InstallRdnsSeedAfterPassTest extends TestCase
+{
+	private const INSTALLER = __DIR__ . '/../../src/usr/local/pkg/pfblockerng/pfblockerng_install.inc';
+
+	protected function setUp(): void
+	{
+		$GLOBALS['config'] = [];
+	}
+
+	/**
+	 * Why the order matters, as behaviour rather than as an assertion about source.
+	 *
+	 * Scenario:
+	 *   Given an install whose IP section was empty when the installer captured modes,
+	 *     so its captured mode is NEWCFG.
+	 *   And the cross-section rDNS seed has since written 'on' into that section.
+	 *   When pfb_registry_pass() runs with the captured modes.
+	 *   Then it returns '' for ip/enable_rdns — the registered default — which is why the
+	 *     seed cannot be written before the pass.
+	 */
+	public function testTheNewcfgBranchOverwritesASeedWrittenBeforeThePass(): void
+	{
+		$ip      = PFB_SECTIONS['ip'];
+		$modes   = pfb_registry_section_modes([]);
+		$this->assertSame('NEWCFG', $modes[$ip], 'before: an empty IP section captures NEWCFG');
+
+		$sections = [];
+		foreach (PFB_SECTIONS as $section) {
+			$sections[$section] = [];
+		}
+		// The pre-pass seed the installer used to write here.
+		$sections[$ip] = ['enable_rdns' => 'on'];
+
+		$changed = pfb_registry_pass($sections, NULL, $modes);
+		$after   = $changed[$ip] ?? $sections[$ip];
+
+		$this->assertSame('', $after['enable_rdns'] ?? NULL,
+			'a pre-pass enable_rdns seed is overwritten by the NEWCFG branch, so the '
+			. 'installer must apply that seed AFTER pfb_install_registry_writeback()');
+	}
+
+	/**
+	 * OLDCFG preserves what NEWCFG erases -- the other half of the pair, so green proves
+	 * the mode is the discriminator rather than that the pass happens to be gentle.
+	 */
+	public function testTheOldcfgBranchPreservesAPrePassSeedAndAMigratedValue(): void
+	{
+		$ip       = PFB_SECTIONS['ip'];
+		$sections = [];
+		foreach (PFB_SECTIONS as $section) {
+			$sections[$section] = [];
+		}
+		$sections[$ip] = ['enable_rdns' => 'on', 'enable_dup' => 'on', 'killstates' => 'on'];
+
+		$modes      = pfb_registry_section_modes([]);
+		$modes[$ip] = 'OLDCFG';
+
+		$changed = pfb_registry_pass($sections, NULL, $modes);
+		$after   = $changed[$ip] ?? $sections[$ip];
+
+		foreach (['enable_rdns', 'enable_dup', 'killstates'] as $key) {
+			$this->assertSame('on', $after[$key] ?? NULL,
+				"OLDCFG must leave a populated {$key} alone");
+		}
+	}
+
+	/**
+	 * And the installer forces that mode wherever it plants operator data into the IP
+	 * section before the pass runs.
+	 *
+	 * Two such places, both of which fire exactly when the captured mode is NEWCFG: the
+	 * General -> IP settings reshape (guarded by its own `empty($pfb_ip_section)`) and
+	 * the cross-section rDNS preservation seed. A section that has just received migrated
+	 * operator data, or a seed whose whole purpose is preserving historical behaviour, IS
+	 * an existing install -- so the captured mode must be corrected, not trusted.
+	 */
+	public function testTheInstallerForcesOldcfgWhereverItPlantsIpDataBeforeThePass(): void
+	{
+		$src = file_get_contents(self::INSTALLER);
+		$this->assertIsString($src, 'installer source must be readable');
+
+		$pattern = '/\\$pfb_registry_modes\\[PFB_SECTIONS\\[.ip.\\]\\]\\s*=\\s*.OLDCFG./';
+		$this->assertSame(2, preg_match_all($pattern, $src),
+			'both pre-pass IP writers -- the General -> IP reshape and the rDNS seed -- must '
+			. "correct the captured mode to OLDCFG, or the pass's NEWCFG branch overwrites "
+			. 'what they just planted');
+
+		$pass = strpos($src, 'pfb_install_registry_writeback(');
+		$this->assertNotFalse($pass, 'pfb_install_registry_writeback() call not found');
+		$this->assertSame(1, preg_match($pattern, $src, $m, PREG_OFFSET_CAPTURE));
+		$this->assertLessThan($pass, $m[0][1],
+			'the mode correction must happen before the pass consumes the mode map');
+	}
+}

--- a/tests/php/RegistryPassTest.php
+++ b/tests/php/RegistryPassTest.php
@@ -113,11 +113,14 @@ final class RegistryPassTest extends TestCase
 	public function testFreshEmptySectionsSeedEveryRegisteredFieldAtDefault(): void
 	{
 		$sections = [
-			self::GEN_SECTION   => [],
-			self::DNSBL_SECTION => [],
-			self::SS_SECTION    => [],
-			self::IP_SECTION    => [],
-			self::REP_SECTION   => [],
+			self::GEN_SECTION    => [],
+			self::DNSBL_SECTION  => [],
+			self::SS_SECTION     => [],
+			self::IP_SECTION     => [],
+			self::REP_SECTION    => [],
+			// issue #2123: the two sections that joined PFB_SECTIONS.
+			self::GLOBAL_SECTION => [],
+			self::SYNC_SECTION   => [],
 		];
 
 		$result = pfb_registry_pass($sections);
@@ -136,6 +139,12 @@ final class RegistryPassTest extends TestCase
 		$this->assertSame('Disable', $result[self::SS_SECTION]['safesearch_enable'] ?? NULL);
 		$this->assertSame('', $result[self::IP_SECTION]['v6suppression'] ?? NULL);
 		$this->assertSame('', $result[self::REP_SECTION]['enable_rep'] ?? NULL);
+		// issue #2123: alertrefresh is the only default-ON key among the seventeen, so a
+		// fresh install must seed 'on' there and '' for syncinterfaces.
+		$this->assertSame('on', $result[self::GLOBAL_SECTION]['alertrefresh'] ?? NULL);
+		$this->assertSame('', $result[self::SYNC_SECTION]['syncinterfaces'] ?? NULL);
+		$this->assertSame('', $result[self::IP_SECTION]['enable_dup'] ?? NULL);
+		$this->assertSame('', $result[self::DNSBL_SECTION]['autoaddrnot_in'] ?? NULL);
 
 		// settings_family is never written by the pass -- absent from input, absent from output.
 		$this->assertArrayNotHasKey('settings_family', $result[self::GEN_SECTION]);

--- a/tests/php/RegistryPassTest.php
+++ b/tests/php/RegistryPassTest.php
@@ -25,6 +25,9 @@ final class RegistryPassTest extends TestCase
 	private const SS_SECTION    = 'installedpackages/pfblockerngsafesearch';
 	private const IP_SECTION    = 'installedpackages/pfblockerngipsettings/config/0';
 	private const REP_SECTION   = 'installedpackages/pfblockerngreputation/config/0';
+	// issue #2123.
+	private const GLOBAL_SECTION = 'installedpackages/pfblockerngglobal';
+	private const SYNC_SECTION   = 'installedpackages/pfblockerngsync/config/0';
 
 	protected function setUp(): void
 	{
@@ -65,19 +68,24 @@ final class RegistryPassTest extends TestCase
 	public function testSectionModesUseOperatorViewAcrossEveryRegisteredSection(): void
 	{
 		$modes = pfb_registry_section_modes([
-			self::GEN_SECTION   => [],
-			self::DNSBL_SECTION => ['settings_family' => '4.0'],
-			self::SS_SECTION    => ['safesearch' => 'on'],
-			self::IP_SECTION    => 'not-an-array',
-			self::REP_SECTION   => ['enable_rep' => 'on'],
+			self::GEN_SECTION    => [],
+			self::DNSBL_SECTION  => ['settings_family' => '4.0'],
+			self::SS_SECTION     => ['safesearch' => 'on'],
+			self::IP_SECTION     => 'not-an-array',
+			self::REP_SECTION    => ['enable_rep' => 'on'],
+			// issue #2123: two sections joined PFB_SECTIONS. A supplied-but-empty blob
+			// and an absent one both read NEWCFG; real operator data reads OLDCFG.
+			self::GLOBAL_SECTION => ['pfbpageload' => 'unified'],
 		]);
 
 		$this->assertSame([
-			self::GEN_SECTION   => 'NEWCFG',
-			self::DNSBL_SECTION => 'NEWCFG',
-			self::SS_SECTION    => 'OLDCFG',
-			self::IP_SECTION    => 'NEWCFG',
-			self::REP_SECTION   => 'OLDCFG',
+			self::GEN_SECTION    => 'NEWCFG',
+			self::DNSBL_SECTION  => 'NEWCFG',
+			self::SS_SECTION     => 'OLDCFG',
+			self::IP_SECTION     => 'NEWCFG',
+			self::REP_SECTION    => 'OLDCFG',
+			self::GLOBAL_SECTION => 'OLDCFG',
+			self::SYNC_SECTION   => 'NEWCFG',
 		], $modes);
 	}
 

--- a/tests/phpcs/PfBlockerNG/Sniffs/Config/RequireConfigGatewaySniff.php
+++ b/tests/phpcs/PfBlockerNG/Sniffs/Config/RequireConfigGatewaySniff.php
@@ -244,6 +244,30 @@ class RequireConfigGatewaySniff implements Sniff
 		'installedpackages/pfblockerngreputation/config/0/enable_rep',
 		'installedpackages/pfblockerngreputation/config/0/enable_pdup',
 		'installedpackages/pfblockerngreputation/config/0/enable_dedup',
+		// issue #2123: the IP-page checkboxes whose default moved into the registry
+		'installedpackages/pfblockerngipsettings/config/0/enable_dup',
+		'installedpackages/pfblockerngipsettings/config/0/enable_agg',
+		'installedpackages/pfblockerngipsettings/config/0/enable_log',
+		'installedpackages/pfblockerngipsettings/config/0/enable_rdns',
+		'installedpackages/pfblockerngipsettings/config/0/database_cc',
+		'installedpackages/pfblockerngipsettings/config/0/enable_float',
+		'installedpackages/pfblockerngipsettings/config/0/killstates',
+		// issue #2123: the DNSBL "Advanced In/Outbound Firewall Rule Settings" checkboxes.
+		// The per-feed-row and per-continent keys of the same bare name live under
+		// DYNAMIC paths, so they are unreachable by this exact-path check and stay on the
+		// foreign-key exclusion list.
+		'installedpackages/pfblockerngdnsblsettings/config/0/autoaddrnot_in',
+		'installedpackages/pfblockerngdnsblsettings/config/0/autoports_in',
+		'installedpackages/pfblockerngdnsblsettings/config/0/autoaddr_in',
+		'installedpackages/pfblockerngdnsblsettings/config/0/autonot_in',
+		'installedpackages/pfblockerngdnsblsettings/config/0/autoaddrnot_out',
+		'installedpackages/pfblockerngdnsblsettings/config/0/autoports_out',
+		'installedpackages/pfblockerngdnsblsettings/config/0/autoaddr_out',
+		'installedpackages/pfblockerngdnsblsettings/config/0/autonot_out',
+		// issue #2123: installedpackages/pfblockerngglobal (flat section, no /config/0)
+		'installedpackages/pfblockerngglobal/alertrefresh',
+		// issue #2123: installedpackages/pfblockerngsync/config/0
+		'installedpackages/pfblockerngsync/config/0/syncinterfaces',
 	];
 
 	/**

--- a/tests/phpcs/fixtures/gateway_compliant.php
+++ b/tests/phpcs/fixtures/gateway_compliant.php
@@ -18,10 +18,12 @@
 
 function pfb_gateway_compliant_foreign_key()
 {
-	// Foreign section — pfblockerngipsettings/enable_dup is NOT in the registry.
-	// (v4suppression, the ADR-53 sibling in this same section, IS registered now —
-	// see pfb_gateway_compliant_v4suppression_via_gateway() below.)
-	$dup = config_get_path('installedpackages/pfblockerngipsettings/config/0/enable_dup');
+	// Foreign key — pfblockerngipsettings/ip_placeholder is NOT in the registry.
+	// (v4suppression, the ADR-53 sibling in this same section, IS registered — see
+	// pfb_gateway_compliant_v4suppression_via_gateway() below — and issue #2123
+	// registered the section's seven checkbox keys, so this example uses a key that
+	// is still genuinely foreign.)
+	$dup = config_get_path('installedpackages/pfblockerngipsettings/config/0/ip_placeholder');
 
 	// Foreign dynamic per-row key — not in the registered path set.
 	$row = 0;

--- a/tests/shell/agent_run_gates_spec.sh
+++ b/tests/shell/agent_run_gates_spec.sh
@@ -18,19 +18,22 @@ Describe 'run-gates.sh gates_for()'
     The lines of output should equal 4
   End
 
-  It 'maps PHP files to per-file lint plus the three suite gates'
+  It 'maps PHP files to per-file lint plus the toggle-registry gate and the three suite gates'
     Data
       #|src/a.inc
       #|src/b.php
     End
     When call gates_for
     The line 1 of output should equal 'uv run --locked python scripts/check_composer_vendor.py'
-    The line 2 of output should equal 'php -l src/a.inc'
-    The line 3 of output should equal 'php -l src/b.php'
-    The line 4 of output should equal 'vendor/bin/phpunit'
-    The line 5 of output should equal 'composer phpstan'
-    The line 6 of output should equal 'composer phpcs -- --standard=phpcs.xml.dist src/'
-    The lines of output should equal 6
+    # issue #2123: the red canary runs first in the same command, so a rotted matcher
+    # fails the gate instead of greening the real scan.
+    The line 2 of output should equal 'uv run --locked python scripts/check_toggle_registry.py --self-test && uv run --locked python scripts/check_toggle_registry.py'
+    The line 3 of output should equal 'php -l src/a.inc'
+    The line 4 of output should equal 'php -l src/b.php'
+    The line 5 of output should equal 'vendor/bin/phpunit'
+    The line 6 of output should equal 'composer phpstan'
+    The line 7 of output should equal 'composer phpcs -- --standard=phpcs.xml.dist src/'
+    The lines of output should equal 7
   End
 
   It 'maps shell files to per-file sh -n + shellcheck plus the dash-pinned shellspec'

--- a/tests/shell/precommit_githooks_exempt_spec.sh
+++ b/tests/shell/precommit_githooks_exempt_spec.sh
@@ -17,6 +17,7 @@ scripts/check_agent_roles.py
 scripts/check_context_budget.py
 scripts/check_composer_vendor.py
 scripts/check_url_encoding.py
+scripts/check_toggle_registry.py
 scripts/agent/check-agent-config-parity.sh'
   make_repo() {
     scrub_git_env

--- a/tests/smoke/ui/test_toggle_registry_default_render.py
+++ b/tests/smoke/ui/test_toggle_registry_default_render.py
@@ -1,0 +1,197 @@
+"""Tier-A ``ui_render`` coverage for issue #2123: the registry, not the page, decides
+what a toggle checkbox renders as when its key is absent from ``config.xml``.
+
+#2123 deleted seventeen page-level default declarations and replaced them with
+``PfbConfig::read('<alias>/<key>')``. The observable consequence is the rendered
+``checked`` state of a checkbox on a configuration that has never stored the key, so
+that is what these tests assert, against the real pages over the authenticated
+webConfigurator session.
+
+Two directions matter, and they are opposites:
+
+* the sixteen off-by-default keys (here: the IP page's ``enable_dup`` and the Sync
+  page's ``syncinterfaces``) must render UNCHECKED when absent;
+* ``alertrefresh`` must render CHECKED when absent — its page-level default was ``on``
+  (``pfblockerng_alerts.php:41``'s ``isset(...) ? ... : 'on'``), and a registered
+  default of ``''`` would silently switch the Alerts page's auto-refresh off for every
+  install that never touched the checkbox. The stored-``''`` half is asserted too: an
+  operator who unchecked the box must keep it unchecked, which is the inversion
+  issue #2120 ruled on.
+
+What this proves: the registered default, the gateway read, and the render agree on the
+real surface, for both an absent key and a stored empty token.
+What it cannot prove: the SAVE handler's persistence. ``pfblockerng_ip.php`` and the
+sibling settings pages run their save inside a top-level handler that PHPUnit cannot
+execute at all (issue #2525: ``require_once('guiconfig.inc')`` exits 255), and asserting
+persistence here would need a POST round trip per key; the save side is covered by the
+existing Tier-A/Tier-B page flows and by ``CfgToggleRegistryPageParityTest``'s
+read-parity matrix in the PHP suite.
+
+Self-encapsulated: each fixture records the node's prior raw state (including genuine
+absence) and restores it exactly, asserting the restore took.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING
+
+import pytest
+
+from .. import helpers
+from .render_oracle import PhpErrorLogGuard, evaluate_render
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterator
+
+    from ..conftest import SmokeVM
+    from .webui import WebUI
+
+pytestmark = pytest.mark.ui_render
+
+IP_PAGE = "/pfblockerng/pfblockerng_ip.php"
+ALERTS_PAGE = "/pfblockerng/pfblockerng_alerts.php"
+SYNC_PAGE = "/pfblockerng/pfblockerng_sync.php"
+
+CFG_ENABLE_DUP = "installedpackages/pfblockerngipsettings/config/0/enable_dup"
+CFG_ALERTREFRESH = "installedpackages/pfblockerngglobal/alertrefresh"
+CFG_SYNCINTERFACES = "installedpackages/pfblockerngsync/config/0/syncinterfaces"
+
+
+def _checkbox_is_checked(html: str, name: str) -> bool:
+    """True iff the named checkbox renders with the ``checked`` boolean attribute."""
+    match = re.search(rf'<input[^>]*\bname="{re.escape(name)}"[^>]*>', html)
+    assert match is not None, (
+        f'checkbox input name="{name}" not found in the rendered page -- fixture or '
+        "page structure broken, not a #2123 signal"
+    )
+    tag = match.group(0)
+    return re.search(r'\bchecked\b(?!\s*=\s*"?[^">]*")', tag) is not None or 'checked="checked"' in tag
+
+
+def _node_state(vm: SmokeVM, path: str) -> str:
+    """Serialise the node's raw state so an ABSENT key is restored as absent."""
+    result = helpers.php_eval(
+        vm,
+        f"$v = config_get_path('{path}');\necho $v === NULL ? 'ABSENT' : 'VALUE:' . $v;\n",
+    )
+    assert result.returncode == 0, f"failed to read {path}: {result.stderr!r}"
+    return result.stdout.strip().splitlines()[-1]
+
+
+def _restore_node(vm: SmokeVM, path: str, state: str) -> None:
+    if state == "ABSENT":
+        php = f"config_del_path('{path}');\n"
+    else:
+        php = f"config_set_path('{path}', '{state[len('VALUE:') :]}');\n"
+    result = helpers.php_eval(vm, php + "write_config('pfBlockerNG smoke #2123: restore');\necho 'RESTORE-OK';\n")
+    assert result.returncode == 0 and "RESTORE-OK" in result.stdout, (
+        f"failed to restore {path}: stdout={result.stdout!r} stderr={result.stderr!r}"
+    )
+    assert _node_state(vm, path) == state, f"{path} restore did not take -- the seeded state leaked to sibling tests"
+
+
+@pytest.fixture
+def node_state(smoke_vm: SmokeVM) -> Iterator[Callable[[str, str | None], None]]:
+    """Set (or delete) a config node for the duration of one test, then restore it."""
+    vm = smoke_vm
+    saved: dict[str, str] = {}
+
+    def apply(path: str, value: str | None) -> None:
+        if path not in saved:
+            saved[path] = _node_state(vm, path)
+        php = f"config_del_path('{path}');\n" if value is None else f"config_set_path('{path}', '{value}');\n"
+        result = helpers.php_eval(vm, php + "write_config('pfBlockerNG smoke #2123: seed');\necho 'SEED-OK';\n")
+        assert result.returncode == 0 and "SEED-OK" in result.stdout, (
+            f"failed to seed {path}: stdout={result.stdout!r} stderr={result.stderr!r}"
+        )
+
+    yield apply
+
+    for path, state in saved.items():
+        _restore_node(vm, path, state)
+
+
+def _render(smoke_vm: SmokeVM, webui: WebUI, path: str, marker: str) -> str:
+    guard = PhpErrorLogGuard(smoke_vm)
+    guard.snapshot()
+    resp = webui.get(path)
+    result = evaluate_render(path, resp.status_code, resp.text, (marker,))
+    assert result.ok, f"Tier-A render oracle failed for {path}: {result.detail}"
+    guard.assert_no_growth()
+    return resp.text
+
+
+def test_absent_ip_toggle_renders_unchecked_from_the_registered_default(
+    smoke_vm: SmokeVM, webui: WebUI, node_state: Callable[[str, str | None], None]
+) -> None:
+    """Scenario: the IP page's De-Duplication checkbox with no stored key.
+
+    Given ``enable_dup`` is absent from config.xml.
+    When the IP page renders.
+    Then the checkbox is unchecked — the registry's '' default, which is what
+      ``pfblockerng_ip.php``'s deleted ``?: ''`` produced. A registered default of
+      'on' would silently enable de-duplication on every untouched install.
+    """
+    # BEFORE: prove the enabled state renders checked, so the unchecked assertion
+    # below cannot pass just because the page never renders a checked box.
+    node_state(CFG_ENABLE_DUP, "on")
+    html = _render(smoke_vm, webui, IP_PAGE, "pfBlockerNG")
+    assert _checkbox_is_checked(html, "enable_dup"), "before: a stored 'on' enable_dup must render checked"
+
+    node_state(CFG_ENABLE_DUP, None)
+    html = _render(smoke_vm, webui, IP_PAGE, "pfBlockerNG")
+    assert not _checkbox_is_checked(html, "enable_dup"), (
+        "an absent enable_dup must render UNCHECKED -- the registered '' default "
+        "must reproduce the page default #2123 deleted"
+    )
+
+
+def test_absent_alertrefresh_renders_checked_and_a_stored_uncheck_stays_off(
+    smoke_vm: SmokeVM, webui: WebUI, node_state: Callable[[str, str | None], None]
+) -> None:
+    """Scenario: the Alerts page's Auto-Refresh checkbox, the default-ON survivor.
+
+    Given ``alertrefresh`` is absent from config.xml.
+    When the Alerts page renders.
+    Then the checkbox is CHECKED — the registry now carries the 'on' default that
+      ``pfblockerng_alerts.php:41``'s ``isset()`` fallback used to declare.
+    And given the operator unchecked it (PFB_FILTER_ON_OFF stored ''),
+    Then it renders UNCHECKED — a present empty token is a decision, not the
+      default (issue #2120).
+    """
+    node_state(CFG_ALERTREFRESH, None)
+    html = _render(smoke_vm, webui, ALERTS_PAGE, "Alert Settings")
+    assert _checkbox_is_checked(html, "alertrefresh"), (
+        "an absent alertrefresh must render CHECKED -- the registered 'on' default "
+        "carries the ON default deleted from pfblockerng_alerts.php:41; rendering it "
+        "unchecked is the user-visible inversion #2123 had to avoid"
+    )
+
+    node_state(CFG_ALERTREFRESH, "")
+    html = _render(smoke_vm, webui, ALERTS_PAGE, "Alert Settings")
+    assert not _checkbox_is_checked(html, "alertrefresh"), (
+        "a stored '' alertrefresh must render UNCHECKED -- an operator's uncheck is not the registered default"
+    )
+
+
+def test_absent_syncinterfaces_renders_unchecked_from_the_registered_default(
+    smoke_vm: SmokeVM, webui: WebUI, node_state: Callable[[str, str | None], None]
+) -> None:
+    """Scenario: the Sync page's settings-sync opt-out checkbox.
+
+    Given ``syncinterfaces`` is absent from config.xml.
+    When the Sync page renders.
+    Then the checkbox is unchecked, so General/IP/DNSBL settings keep syncing —
+      the behaviour ``pfblockerng_sync.php:35``'s deleted ``?: ''`` produced.
+    """
+    node_state(CFG_SYNCINTERFACES, "on")
+    html = _render(smoke_vm, webui, SYNC_PAGE, "XMLRPC Sync Settings")
+    assert _checkbox_is_checked(html, "syncinterfaces"), "before: a stored 'on' syncinterfaces must render checked"
+
+    node_state(CFG_SYNCINTERFACES, None)
+    html = _render(smoke_vm, webui, SYNC_PAGE, "XMLRPC Sync Settings")
+    assert not _checkbox_is_checked(html, "syncinterfaces"), (
+        "an absent syncinterfaces must render UNCHECKED -- the registered '' default "
+        "must reproduce the page default #2123 deleted"
+    )

--- a/tests/test_toggle_registry_check.py
+++ b/tests/test_toggle_registry_check.py
@@ -264,3 +264,50 @@ def test_missing_registry_file_fails_closed(tmp_path: Path, monkeypatch: pytest.
     """An unreadable registry file must exit 2 as well."""
     monkeypatch.setattr(ctr, "__file__", str(tmp_path / "scripts" / "check_toggle_registry.py"))
     assert ctr.main([]) == 2
+
+
+def test_exempt_row_does_not_suppress_rule_one(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An exemption is a RULE 2 record, never a licence to skip registration.
+
+    EXEMPT documents a page that still declares a registered toggle's default. Letting
+    it also silence RULE 1 would mean one backlog row permanently hides every future
+    unregistered save of that key name.
+    """
+    text = MIRROR + "$pfb['iconfig']['enable_dup'] = pfb_filter($_POST['x'] ?? '', PFB_FILTER_ON_OFF, 'ip') ?: '';\n"
+    monkeypatch.setattr(ctr, "EXEMPT", {("pfblockerng_ip.php", "enable_dup"): "test"})
+    assert ctr.find_violations(text, "pfblockerng_ip.php", FAKE_SECTIONS, {}) != [], (
+        "an exempt row must not suppress the unregistered-toggle rule"
+    )
+
+
+def test_unreadable_explicit_path_fails_closed() -> None:
+    """A named page the checker cannot read must exit 2, never 0."""
+    assert ctr.main(["src/usr/local/www/pfblockerng/does_not_exist.php"]) == 2
+
+
+def test_every_2123_key_is_classified_as_a_toggle() -> None:
+    """All seventeen, not a sample: a plain-scalar slip would let RULE 2 skip the key."""
+    text = (_REPO_ROOT / ctr.REGISTRY_FILE).read_text(encoding="utf-8")
+    keys = ctr.parse_registry_keys(text)
+    expected = [
+        ("ip", "enable_dup"),
+        ("ip", "enable_agg"),
+        ("ip", "enable_log"),
+        ("ip", "enable_rdns"),
+        ("ip", "database_cc"),
+        ("ip", "enable_float"),
+        ("ip", "killstates"),
+        ("dnsbl", "autoaddrnot_in"),
+        ("dnsbl", "autoports_in"),
+        ("dnsbl", "autoaddr_in"),
+        ("dnsbl", "autonot_in"),
+        ("dnsbl", "autoaddrnot_out"),
+        ("dnsbl", "autoports_out"),
+        ("dnsbl", "autoaddr_out"),
+        ("dnsbl", "autonot_out"),
+        ("sync", "syncinterfaces"),
+        ("global", "alertrefresh"),
+    ]
+    assert len(expected) == 17
+    plain = [f"{a}/{b}" for a, b in expected if keys.get((a, b)) is not True]
+    assert not plain, f"issue #2123 keys not carrying the toggle read adapter: {plain}"

--- a/tests/test_toggle_registry_check.py
+++ b/tests/test_toggle_registry_check.py
@@ -1,0 +1,266 @@
+"""Tests for scripts/check_toggle_registry.py (issue #2123's regrowth gate).
+
+Both branches per dimension: every case that flags a violation is paired with the
+correct form that must stay clean, because a gate that never goes green is as useless
+as one that never goes red.
+
+The load-bearing assertions are:
+
+* a NEW `PFB_FILTER_ON_OFF` save into a registered section with no registry entry FAILS
+  (RULE 1) -- this is the regrowth the sweep exists to stop;
+* a registered TOGGLE whose page still declares its own default FAILS (RULE 2);
+* the same shapes are clean once registered / routed through `PfbConfig::read()`;
+* the real tree is clean, so the gate is blocking rather than pre-broken;
+* a broken registry parse FAILS CLOSED rather than reporting every key unregistered.
+
+The checker is a hyphen-free, underscore-named script under scripts/, so it is
+importable directly by path via importlib.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_TOOL = _REPO_ROOT / "scripts" / "check_toggle_registry.py"
+_spec = importlib.util.spec_from_file_location("check_toggle_registry", _TOOL)
+assert _spec is not None and _spec.loader is not None
+ctr = importlib.util.module_from_spec(_spec)
+sys.modules[_spec.name] = ctr
+_spec.loader.exec_module(ctr)
+
+IP_SECTION = "installedpackages/pfblockerngipsettings/config/0"
+GLOBAL_SECTION = "installedpackages/pfblockerngglobal"
+
+# A minimal stand-in for the parsed registry: (alias, bare key) -> is-a-toggle.
+FAKE_KEYS: dict[tuple[str, str], bool] = {
+    ("ip", "enable_dup"): True,
+    ("ip", "maxmind_locale"): False,
+    ("global", "alertrefresh"): True,
+}
+FAKE_SECTIONS = {IP_SECTION: "ip", GLOBAL_SECTION: "global"}
+
+
+def _find(text: str, source: str = "pfblockerng_ip.php") -> list[Any]:
+    return ctr.find_violations(text, source, FAKE_SECTIONS, FAKE_KEYS)
+
+
+def _rules(text: str, source: str = "pfblockerng_ip.php") -> list[str]:
+    return [v.rule for v in _find(text, source)]
+
+
+MIRROR = f"$pfb['iconfig'] = PfbConfig::readSection('{IP_SECTION}');\n"
+
+
+# --------------------------------------------------------------------------- #
+# RULE 1 -- an on/off save must name a registered key
+# --------------------------------------------------------------------------- #
+
+
+def test_unregistered_on_off_save_is_flagged() -> None:
+    """The regrowth case: a brand-new checkbox save with no registry entry."""
+    text = MIRROR + "$pfb['iconfig']['pfb_new_flag'] = pfb_filter($_POST['x'] ?? '', PFB_FILTER_ON_OFF, 'ip') ?: '';\n"
+    violations = _find(text)
+    assert [v.rule for v in violations] == ["unregistered-toggle"]
+    assert "ip/pfb_new_flag" in violations[0].detail
+
+
+def test_registered_on_off_save_is_clean() -> None:
+    """The same shape, registered, must not be flagged -- the gate has a green side."""
+    text = MIRROR + "$pfb['iconfig']['enable_dup'] = pfb_filter($_POST['x'] ?? '', PFB_FILTER_ON_OFF, 'ip') ?: '';\n"
+    assert _find(text) == []
+
+
+def test_unregistered_save_wrapped_across_lines_is_still_flagged() -> None:
+    """Reformatting a save across lines must not smuggle it past RULE 1."""
+    text = MIRROR + (
+        "$pfb['iconfig']['pfb_new_flag'] = pfb_filter(\n    $_POST['x'] ?? '', PFB_FILTER_ON_OFF, 'ip') ?: '';\n"
+    )
+    assert _rules(text) == ["unregistered-toggle"]
+
+
+def test_save_into_an_unregistered_section_is_out_of_scope() -> None:
+    """A mirror whose section has no PFB_SECTIONS alias is foreign, not a violation."""
+    text = (
+        "$pfb['bconfig'] = PfbConfig::readSection('installedpackages/pfblockerngblacklist');\n"
+        "$pfb['bconfig']['whatever'] = pfb_filter($_POST['x'] ?? '', PFB_FILTER_ON_OFF, 'b') ?: '';\n"
+    )
+    assert _find(text) == []
+
+
+def test_dynamic_per_row_save_is_out_of_scope() -> None:
+    """A per-row config_set_path save is not a section-mirror assignment at all."""
+    text = MIRROR + (
+        'config_set_path("installedpackages/{$conf_type}/config/{$rowid}/autoaddr_in",\n'
+        "    pfb_filter($_POST['autoaddr_in'], PFB_FILTER_ON_OFF, 'Category_edit'));\n"
+    )
+    assert _find(text) == []
+
+
+def test_commented_out_save_is_not_flagged() -> None:
+    """A save inside a comment is documentation, not code."""
+    text = MIRROR + "// $pfb['iconfig']['pfb_new_flag'] = pfb_filter($_POST['x'], PFB_FILTER_ON_OFF, 'ip');\n"
+    assert _find(text) == []
+
+
+# --------------------------------------------------------------------------- #
+# RULE 2 -- a registered toggle's default belongs to the registry
+# --------------------------------------------------------------------------- #
+
+
+def test_page_level_default_for_a_registered_toggle_is_flagged() -> None:
+    """The leftover-default case: the registry owns it, the page restates it."""
+    text = MIRROR + "$pconfig['enable_dup'] = $pfb['iconfig']['enable_dup'] ?: '';\n"
+    violations = _find(text)
+    assert [v.rule for v in violations] == ["page-level-default"]
+    assert "ip/enable_dup" in violations[0].detail
+
+
+def test_isset_style_page_level_default_is_flagged() -> None:
+    """The other spelling: the 3.2 `isset(...) ? ... : 'on'` fallback."""
+    text = (
+        f"$pfb['aglobal'] = PfbConfig::readSection('{GLOBAL_SECTION}');\n"
+        "$alertrefresh = isset($pfb['aglobal']['alertrefresh']) ? $pfb['aglobal']['alertrefresh'] : 'on';\n"
+    )
+    assert _rules(text, "pfblockerng_alerts.php") == ["page-level-default"]
+
+
+def test_gateway_read_is_clean() -> None:
+    """Routing the read through PfbConfig::read() is the fixed form."""
+    text = MIRROR + "$pconfig['enable_dup'] = PfbConfig::read('ip/enable_dup');\n"
+    assert _find(text) == []
+
+
+def test_registered_plain_scalar_page_default_is_not_rule_twos_business() -> None:
+    """RULE 2 is toggle-scoped: a plain scalar's page default is issue #2812's backlog.
+
+    Several of those page defaults genuinely disagree with their registry entry, so
+    flagging them here would push a behaviour change through a lint.
+    """
+    text = MIRROR + "$pconfig['maxmind_locale'] = $pfb['iconfig']['maxmind_locale'] ?: 'en';\n"
+    assert _find(text) == []
+
+
+def test_page_default_for_an_unregistered_key_is_not_rule_twos_business() -> None:
+    """Nothing owns the default yet, so restating it is not yet a duplication."""
+    text = MIRROR + "$pconfig['ip_placeholder'] = $pfb['iconfig']['ip_placeholder'] ?: '127.1.7.7';\n"
+    assert _find(text) == []
+
+
+def test_the_save_sites_own_transport_normalisation_is_not_a_page_default() -> None:
+    """`pfb_filter(...) ?: ''` on the SAVE side is transport, not a default.
+
+    An unchecked checkbox is absent from POST; the `?: ''` there is what turns that
+    into the owner-ruled empty Off token, and writeSection() re-normalises it through
+    the registered adapter anyway. Flagging it would force every save site to be
+    rewritten for no behavioural gain.
+    """
+    text = (
+        MIRROR
+        + "$pfb['iconfig']['enable_dup'] = pfb_filter($_POST['enable_dup'] ?? '', PFB_FILTER_ON_OFF, 'ip') ?: '';\n"
+    )
+    assert _find(text) == []
+
+
+def test_exempt_entry_suppresses_rule_two(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A recorded exemption suppresses the finding; removing it brings it back."""
+    text = MIRROR + "$pconfig['enable_dup'] = $pfb['iconfig']['enable_dup'] ?: '';\n"
+    assert _rules(text) == ["page-level-default"], "before: the site is flagged"
+
+    monkeypatch.setattr(ctr, "EXEMPT", {("pfblockerng_ip.php", "enable_dup"): "test"})
+    assert _find(text) == []
+
+
+# --------------------------------------------------------------------------- #
+# Parsing the real registry
+# --------------------------------------------------------------------------- #
+
+
+def test_registry_parse_finds_every_alias_and_the_toggle_entries() -> None:
+    """The parse must see all PFB_SECTIONS aliases and mark toggles as toggles."""
+    text = (_REPO_ROOT / ctr.REGISTRY_FILE).read_text(encoding="utf-8")
+    sections = ctr.parse_sections(text)
+    keys = ctr.parse_registry_keys(text)
+
+    assert sections[IP_SECTION] == "ip"
+    assert sections[GLOBAL_SECTION] == "global"
+    assert sections["installedpackages/pfblockerngsync/config/0"] == "sync"
+    assert len(keys) >= ctr._MIN_REGISTRY_KEYS
+
+    # issue #2123's own entries, and their adapter classification.
+    assert keys[("ip", "enable_dup")] is True
+    assert keys[("global", "alertrefresh")] is True
+    assert keys[("sync", "syncinterfaces")] is True
+    assert keys[("dnsbl", "autoaddrnot_in")] is True
+    # A registered plain scalar must NOT be classified as a toggle.
+    assert keys[("ip", "v4suppression")] is False
+
+
+def test_every_exempt_row_still_names_a_live_site(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A stale exemption is dead weight that hides an already-fixed site -- fail on it."""
+    text = (_REPO_ROOT / ctr.REGISTRY_FILE).read_text(encoding="utf-8")
+    sections = ctr.parse_sections(text)
+    keys = ctr.parse_registry_keys(text)
+    recorded = dict(ctr.EXEMPT)
+
+    # Re-scan with the exemptions disabled: what fires is what genuinely needs a row.
+    monkeypatch.setattr(ctr, "EXEMPT", {})
+    live: set[tuple[str, str]] = set()
+    for page in sorted((_REPO_ROOT / ctr.WWW_DIR).glob("*.php")):
+        for v in ctr.find_violations(page.read_text(encoding="utf-8"), str(page), sections, keys):
+            # detail's first quoted token is '<alias>/<key>'.
+            live.add((page.name, v.detail.split("'")[1].split("/", 1)[1]))
+
+    stale = set(recorded) - live
+    assert not stale, f"EXEMPT rows no longer needed (delete them): {sorted(stale)}"
+
+
+def test_www_tree_is_clean() -> None:
+    """The real pages pass -- this gate blocks, it is not pre-broken."""
+    result = subprocess.run(
+        [sys.executable, str(_TOOL)],
+        cwd=_REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, f"src/usr/local/www/pfblockerng is not clean:\n{result.stderr}"
+
+
+def test_self_test_red_canary_passes() -> None:
+    """`--self-test` is the gate's own red path; it must report both rules firing."""
+    result = subprocess.run(
+        [sys.executable, str(_TOOL), "--self-test"],
+        cwd=_REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, f"red canary failed:\n{result.stderr}"
+    assert "both rules fired" in result.stdout
+
+
+def test_broken_registry_parse_fails_closed(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A registry the parser cannot read must exit 2, never 0.
+
+    A gate that reports "clean" because it could not find the registry is worse than
+    no gate: it would green a page full of unregistered saves.
+    """
+    fake_root = tmp_path
+    (fake_root / Path(ctr.REGISTRY_FILE).parent).mkdir(parents=True)
+    (fake_root / ctr.REGISTRY_FILE).write_text("<?php\n// no registry here\n", encoding="utf-8")
+    monkeypatch.setattr(ctr, "__file__", str(fake_root / "scripts" / "check_toggle_registry.py"))
+
+    assert ctr.main([]) == 2
+
+
+def test_missing_registry_file_fails_closed(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """An unreadable registry file must exit 2 as well."""
+    monkeypatch.setattr(ctr, "__file__", str(tmp_path / "scripts" / "check_toggle_registry.py"))
+    assert ctr.main([]) == 2

--- a/tests/test_toggle_registry_check.py
+++ b/tests/test_toggle_registry_check.py
@@ -311,3 +311,14 @@ def test_every_2123_key_is_classified_as_a_toggle() -> None:
     assert len(expected) == 17
     plain = [f"{a}/{b}" for a, b in expected if keys.get((a, b)) is not True]
     assert not plain, f"issue #2123 keys not carrying the toggle read adapter: {plain}"
+
+
+def test_whitespace_between_brackets_does_not_evade_either_rule() -> None:
+    """`$pfb ['iconfig'] ['x']` is valid PHP and must not slip past the matchers."""
+    mirror = f"$pfb ['iconfig'] = PfbConfig::readSection('{IP_SECTION}');\n"
+    save = (
+        mirror + "$pfb ['iconfig'] ['pfb_new_flag'] = pfb_filter($_POST['x'] ?? '', PFB_FILTER_ON_OFF, 'ip') ?: '';\n"
+    )
+    assert _rules(save) == ["unregistered-toggle"]
+    read = mirror + "$pconfig['enable_dup'] = $pfb ['iconfig'] ['enable_dup'] ?: '';\n"
+    assert _rules(read) == ["page-level-default"]


### PR DESCRIPTION
Fixes #2123

## The enumeration, from source

A sweep of `src/usr/local/www/pfblockerng/*.php` at `b91b95cc` for the shape the issue
names — `$pfb['<mirror>']['<key>'] = pfb_filter($_POST[…], PFB_FILTER_ON_OFF, …)` — finds
**45 distinct keys**, of which **17 are absent from `pfb_cfg_registry()`**. The issue's
body said 36/17; the 17 match its list exactly, and the 45 is simply the current count
(nine keys were registered between the issue being filed and this branch). Published
here rather than trusted:

```text
issue-shape rows: 45   distinct keys: 45   registered: 28   missing: 17

alertrefresh  autoaddr_in  autoaddr_out  autoaddrnot_in  autoaddrnot_out
autonot_in  autonot_out  autoports_in  autoports_out  database_cc
enable_agg  enable_dup  enable_float  enable_log  enable_rdns
killstates  syncinterfaces
```

The other `PFB_FILTER_ON_OFF` sites in the same sweep are not this shape and are listed
under "Residue" below.

## Work item 1 — the classification, with executed evidence

**All 17 are registerable section scalars.** The residue is not a set of unregisterable
*fields*; it is a set of unregisterable *homes* for some of the same key names.

| Group | Keys | Section | Verdict |
| --- | --- | --- | --- |
| IP page | `enable_dup` `enable_agg` `enable_log` `enable_rdns` `database_cc` `enable_float` `killstates` | `installedpackages/pfblockerngipsettings/config/0` (`ip`, alias existed) | registerable section scalar |
| DNSBL page | `auto{addrnot,ports,addr,not}_{in,out}` | `installedpackages/pfblockerngdnsblsettings/config/0` (`dnsbl`, alias existed) | registerable section scalar |
| Alerts page | `alertrefresh` | `installedpackages/pfblockerngglobal` | registerable; needed a new `global` alias |
| Sync page | `syncinterfaces` | `installedpackages/pfblockerngsync/config/0` | registerable; needed a new `sync` alias |

Three findings behind that table, each reached by probing rather than reading the save
line:

1. **The `auto*` family is not row-scoped on the DNSBL page.** The issue suspected it
   was. `pfblockerng_dnsbl.php` renders all eight inside `foreach (['In' => 'Source',
   'Out' => 'Destination'] …)` with a **dynamic PHP field name over a static stored
   key** (`'autoaddrnot_' . $advmode` at `:3602`, `'autoports_' . $advmode` at `:3611`,
   `"autoaddr_{$advmode}"` at `:3641`, `"autonot_{$advmode}"` at `:3649`). The stored
   keys are `autoaddrnot_in`/`autoaddrnot_out` etc. — ordinary dnsbl-section scalars.
   Their runtime consumer is `pfb_determine_list_detail()` (`pfblockerng.inc:6932-6965`),
   which reads them off a section blob through a dynamic path, so registration leaves it
   untouched. Path addressing is what makes this safe: `dnsbl/autoaddr_in` cannot collide
   with the per-row `installedpackages/{$conf_type}/config/{$rowid}/autoaddr_in` that
   `pfblockerng_category_edit.php:868` writes, nor with the per-continent copy
   `pfblockerng_geoip.inc:432` writes.
2. **`syncinterfaces` is a toggle.** `pfblockerng_sync.php:230` rendered it through
   `pfb_cfg_toggle_read(…) === PfbToggle::On`, and `pfblockerng.inc:19673`/`:19716`
   compared `!= 'on'`. It was on `CfgGatewayTest`'s out-of-scope list as a
   `pfblockerngsync` "sub-key"; that was a Phase-1 artefact, not a structural bar.
3. **The clobber hazard I expected is not reachable.** `pfb_registry_pass()` takes the
   `ip` section's mode from `pfblockerng_install.inc:42`, *before* the gen→ip settings
   reshape at `:597-616`, and a NEWCFG section has every registered key overwritten with
   its default. Probed on this branch:

   ```text
   mode[ip]=NEWCFG
   suppression    before=''   after='on'      <-- registered, clobbered
   enable_dup     before='on' after='on'      <-- unregistered, untouched
   ```

   **Corrected by the independent verifier (F4):** this probe reproduces at BASE, and
   the reshape is not the reachable trigger. The reachable one is the settings-family
   restore — see "Review round 3" below. The reshape branch itself cannot fire from a
   supported config: `v3.2.16`'s own
   `pfblockerng_ip.php:30` already reads
   `installedpackages/pfblockerngipsettings/config/0`, so `empty($pfb_ip_section)` is
   false on every ≥3.2.16 upgrade and the reshape never runs. It targets a pre-3.2
   layout, outside the supported upgrade floor. Recorded rather than acted on, and
   `ip/suppression` already carries the same latent exposure.

## Work items 2-4 — today vs registered, per field

Sixteen were off-by-default via the page's own `?: ''`; `alertrefresh` was on-by-default
via `isset(…) ? … : 'on'`, which treats a stored `''` as SET. Under #2120's ruling the
registry reproduces both halves exactly.

| Registry key | Page site (pre-change) | Page's effective default | Registered default | Grandfather |
| --- | --- | --- | --- | --- |
| `ip/enable_dup` | `pfblockerng_ip.php:39` `?: ''` | Off | `''` | `no_grandfather` |
| `ip/enable_agg` | `:40` `?: ''` | Off | `''` | `no_grandfather` |
| `ip/enable_log` | `:59` `?: ''` | Off | `''` | `no_grandfather` |
| `ip/enable_rdns` | `:60` `?: ''` | Off | `''` | `no_grandfather` (see below) |
| `ip/database_cc` | `:65` `?: ''` | Off | `''` | `no_grandfather` |
| `ip/enable_float` | `:75` `?: ''` | Off | `''` | `no_grandfather` |
| `ip/killstates` | `:78` `?: ''` | Off | `''` | `no_grandfather` |
| `dnsbl/autoaddrnot_in` | `pfblockerng_dnsbl.php:111` `?: ''` | Off | `''` | `no_grandfather` |
| `dnsbl/autoports_in` | `:112` `?: ''` | Off | `''` | `no_grandfather` |
| `dnsbl/autoaddr_in` | `:114` `?: ''` | Off | `''` | `no_grandfather` |
| `dnsbl/autonot_in` | `:115` `?: ''` | Off | `''` | `no_grandfather` |
| `dnsbl/autoaddrnot_out` | `:120` `?: ''` | Off | `''` | `no_grandfather` |
| `dnsbl/autoports_out` | `:121` `?: ''` | Off | `''` | `no_grandfather` |
| `dnsbl/autoaddr_out` | `:123` `?: ''` | Off | `''` | `no_grandfather` |
| `dnsbl/autonot_out` | `:124` `?: ''` | Off | `''` | `no_grandfather` |
| `sync/syncinterfaces` | `pfblockerng_sync.php:35` `?: ''` | Off | `''` | `no_grandfather` |
| **`global/alertrefresh`** | `pfblockerng_alerts.php:41` `isset(…) ? … : 'on'` | **On when absent, Off when stored `''`** | **`'on'`** | `no_grandfather` |

The trigger question is "did the behaviour this field controls change for an upgrader?",
and for all 17 the answer is no *because* the registered default is the page default it
replaced — which is what the frozen parity matrix checks rather than asserts.

`ip/enable_rdns` is the one with a real upgrade story, and it is deliberately **not** a
grandfather map: `pfb_rdns_seed_value()` decides from the **General** section, and a
per-section map cannot see another section. It stays hand-written in
`pfblockerng_install.inc`, ordered before the pass, which then finds the key present and
leaves it alone. Its write moves to `PfbConfig::writeSystem('ip/enable_rdns', …)` now
that the path is registered (the sniff would otherwise flag it).

### Two new `PFB_SECTIONS` aliases

`global` → `installedpackages/pfblockerngglobal`, `sync` →
`installedpackages/pfblockerngsync/config/0`. Each holds ONE registered key beside
otherwise-foreign siblings — the arrangement `rep` already has, where three Reputation
toggles are registered and `p24_*_var`/`ccwhite`/`et_update` pass a section write
through byte-identical. The registry pass now reaches both sections; on a fresh install
each is NEWCFG and seeds the registered default (`'on'` / `''`), and on an existing
install each is OLDCFG with the key absent and seeds the same value — the page's own
prior default either way.

### What was deleted, and what deliberately stayed

Deleted: the seventeen page-level defaults; the four inline
`pfb_cfg_toggle_read($alertrefresh) === PfbToggle::On` comparisons (`:3466`, `:4191`,
`:4765`, `:5036`) and the one on the Sync page, which become a direct
`=== PfbToggle::On`; and the two hand-written token comparisons in `pfblockerng.inc`.

Kept, on purpose:

- **The render-side `pfb_cfg_toggle_read()` on the IP and DNSBL pages.** Both replace
  `$pconfig` with raw `$_POST` on a validation error (`pfblockerng_ip.php:308`,
  `pfblockerng_dnsbl.php:1019`), so the render must accept a raw string as well as the
  enum. There it is the POST-redisplay adapter, not a second declaration of the default
  — the same reason `ip/suppression` has kept it since #1931. The Alerts and Sync pages
  have no such redisplay, so theirs are gone. `PfbStoredEnumAdapter::fromStored()` is
  idempotent on an enum instance, so the surviving calls are correct for both inputs.
- **`pfb_filter(…, PFB_FILTER_ON_OFF, …) ?: ''` at every save site.** That is transport
  normalisation of a checkbox absent from POST, and `PfbConfig::writeSection()`
  re-normalises the value through the registered adapter anyway. The touched save lines
  gain the `?? ''` that the already-registered sibling on each page (`suppression` at
  `pfblockerng_ip.php:250`) carried, which also drops a PHP 8 *Undefined array key*
  warning on every unchecked box.

### One deliberate behaviour change

`pfblockerng.inc:19673` and `:19716` compared `config_get_path(…) != 'on'` by hand. Read
through the gateway, a hand-edited or HA-synced `'On'` now reads `On` instead of
disabling settings sync — #1887's case-insensitive toggle read, which exists precisely so
an obvious spelling cannot silently disable a feature. Pinned as an explicit row in
`testSyncInterfacesGatewayReadMatchesTheHandWrittenTokenTest` rather than left implicit.

## Work item 5 — the regrowth gate

`scripts/check_toggle_registry.py`, following the `scripts/check_*.py` family and wired
into `.github/workflows/test.yml`, `.githooks/pre-commit` and
`scripts/agent/run-gates.sh`.

- **RULE 1** — a `PFB_FILTER_ON_OFF` save into a section `PFB_SECTIONS` knows must name a
  registered key. This is the rule the issue asked for.
- **RULE 2** — a registered **toggle**'s default must not be restated by the page.
- The mirror → alias map is **derived** from each page's own
  `$pfb['<mirror>'] = PfbConfig::readSection('<path>')`, so a new page is covered with no
  edit to the checker. The save matcher runs over the whole file bounded by `;`, so
  wrapping a save across lines cannot evade it (pinned by
  `test_unregistered_save_wrapped_across_lines_is_still_flagged`).
- **Fails closed**: unreadable registry, unparseable `PFB_SECTIONS`, or fewer than 100
  parsed keys exits 2, never 0.
- `--self-test` is the red canary the testing policy requires for a newly wired blocking
  gate, and runs before the real scan in all three wirings.

**RULE 2 is toggle-scoped deliberately.** An unscoped version fired on 30 sites. Only 7
of those are toggles; the rest are registered plain scalars, and six of *those* declare a
page default their registry entry does not carry:

```text
dnsbl/pfb_dnsvip4      page='none'     registry=''
dnsbl/pfb_dnsvip6      page='none'     registry=''
dnsbl/pfb_dnsport      page='8081'     registry=''
dnsbl/pfb_dnsport_ssl  page='8443'     registry=''
dnsbl/pfb_dnsbl_rule   page=''         registry='Disabled'
dnsbl/aliaslog         page='enabled'  registry=''
```

Deleting a page default there changes what an absent key renders as, so widening the rule
would push a behaviour change through a lint. The 7 toggle sites (all behaviour-equivalent
today) are recorded in the checker's `EXEMPT` table with reasons, and both residues are
filed as **#2812**. `test_every_exempt_row_still_names_a_live_site` fails on a stale row,
so the table cannot rot into a permanent opt-out.

## Work item 7 — the residue, enumerated

Structurally unregisterable, added to `config-gateway.md`'s foreign-key exclusion table:

| Path | Why |
| --- | --- |
| `pfblockernglistsv4/v6/config/{row}/auto{addrnot,ports,addr,not}_{in,out}` | Dynamic per-row key. `pfblockerng_category_edit.php:865-878` writes `installedpackages/{$conf_type}/config/{$rowid}/…` — a path no exact-path registry entry can address, the limitation already recorded for the per-feed row keys |
| `pfblockernglistsv4/v6/config/{row}/whois_convert`, `…/filter_top1m` | Same shape: per-row `PFB_FILTER_ON_OFF` keys (`:887`, `:892`) |
| `pfblockerng{continent}/config/0/auto*` | Dynamic per-continent structure; `pfblockerng_geoip.inc:429-442` writes the same bare names per continent |
| `pfblockerngdnsbl.php`'s `$psl_include_private` / `$psl_allow_private` | Not section-mirror saves at all — local variables feeding `pfb_psl_feed_policy_*`, already registered under their own keys |
| `pfblockerngsync/config/0/{varsynconchanges,varsynctimeout,row/*}` | Foreign siblings of the registered `sync/syncinterfaces` |
| `pfblockerngglobal/*` except `alertrefresh` | Foreign siblings of the registered `global/alertrefresh` |

## Test-first evidence

Frozen characterisation test, written and executed **before** any production edit:

```text
tests/php/CfgToggleRegistryPageParityTest.php
git hash-object  b4f5f1bb96153fec941115d82ef707c4dc573b56   (RED)
git hash-object  b4f5f1bb96153fec941115d82ef707c4dc573b56   (GREEN — byte-identical)
```

RED, against untouched code:

```text
ERRORS!
Tests: 157, Assertions: 158, Errors: 155, Failures: 2.
```

GREEN, same file, zero edits:

```text
OK (157 tests, 408 assertions)
```

The matrix does not describe the deleted page expression, it **re-evaluates** it:
`preRegistrationPageValue()` transcribes the two shapes (`$blob[$k] ?: ''` and
`isset($blob[$k]) ? $blob[$k] : 'on'`) and every one of the 17 fields × 9 raw states
(absent, `''`, `'on'`, legacy `'off'`, `'On'`, `'OFF'`, `'yes'`, `'1'`, `'0'`) compares
the gateway read against it. Plus:
`testAlertRefreshKeepsOnDefaultAndHonoursADeliberateUncheck` (both directions of the
inversion), `testSyncInterfacesGatewayReadMatchesTheHandWrittenTokenTest`,
`testAllSeventeenAreRegisteredAsClassifiedToggles`,
`testRegisteredDefaultsAreThePageDefaultsTheyReplaced`.

`CfgRegistryGrandfatherGateTest` totality, fixpoint and `old_name` parity all pass with
the 17 new entries.

### Mutation proofs — every mutant killed by a named test, executed

| Mutant | Killed by | Evidence |
| --- | --- | --- |
| `global/alertrefresh` default `'on'` → `''` | `CfgToggleRegistryPageParityTest::testAlertRefreshKeepsOnDefaultAndHonoursADeliberateUncheck` + `…::testRegisteredDefaultsAreThePageDefaultsTheyReplaced` | `Tests: 157, Failures: 3` — `-PfbToggle Enum (On, 'on')` / `+PfbToggle Enum (Off, 'off')` |
| `ip/enable_dup` default `''` → `'on'` | `…::testGatewayReadReproducesThePreRegistrationPageValue` + `…::testRegisteredDefaultsAreThePageDefaultsTheyReplaced` | `Tests: 157, Failures: 2` — `-''` / `+'on'` |
| `no_grandfather` dropped from `sync/syncinterfaces` | `CfgRegistryGrandfatherGateTest::testEveryEntryIsClassifiedExactlyOnce` + `…::testAllSeventeenAreRegisteredAsClassifiedToggles` | `Failures: 2` — *"sync/syncinterfaces: carries NEITHER 'grandfather' nor 'no_grandfather'"* |
| page-level default restored for `ip/enable_dup` | `scripts/check_toggle_registry.py` RULE 2 (`test_page_level_default_for_a_registered_toggle_is_flagged`) | `gate_exit=1` — *"pfblockerng_ip.php:45: [page-level-default] 'ip/enable_dup' is a registered toggle…"* |
| new unregistered `PFB_FILTER_ON_OFF` save site added | `scripts/check_toggle_registry.py` RULE 1 (`test_unregistered_on_off_save_is_flagged`) | `gate_exit=1` — *"pfblockerng_ip.php:282: [unregistered-toggle] PFB_FILTER_ON_OFF save of 'ip/pfb_brand_new_flag' has no pfb_cfg_registry() entry"* |

Each mutant asserted a single-occurrence needle before substitution, a non-empty
`git diff` after, and a clean tree between mutants.

## Work item 6 — front-end coverage, and what it cannot prove

All four changed pages are already in Tier A's `PAGE_TABLE`
(`tests/smoke/ui/test_render_smoke.py:95`, `:107`, `:162`, `:173`), so the live-VM sweep
executes every changed top-level line and goes red if a `PfbConfig::read()` throws or a
render breaks.

Added focused Tier A coverage, `tests/smoke/ui/test_toggle_registry_default_render.py`:
the rendered `checked` state on a configuration that has never stored the key, in both
directions — `enable_dup` and `syncinterfaces` UNCHECKED when absent, `alertrefresh`
**CHECKED** when absent and UNCHECKED when stored `''`. Each case asserts the opposite
state first, so green proves the absent case rather than that the page never renders a
checked box.

**Stated plainly:** this proves the registered default, the gateway read and the render
agree on the real surface. It does **not** prove the save handlers persist, because the
settings pages run their save inside a top-level handler PHPUnit cannot execute at all —
`require_once('guiconfig.inc')` exits 255 (recorded harness limitation, #2525). Save coverage, stated exactly: `tests/smoke/ui/test_functional.py:145-188` round-trips six
of the seven IP keys and `test_sync.py:239-261` round-trips `syncinterfaces`. There is
**no** save round trip for `ip/enable_rdns`, the eight `dnsbl/auto*` scalars, or
`global/alertrefresh`, and none for an omitted-checkbox POST. Their save lines are
unchanged in shape apart from the `?? ''` guard, and `PfbConfig::writeSection()`
normalisation is covered by `CfgGatewayTest`'s adapter property test — but that is the
gateway, not these handlers. Tracked in https://github.com/pfBlockerNG/pfBlockerNG/issues/2817.

### Frozen RED evidence (coverage-pairing gate)

One row per changed test-side path. Hashes are `git hash-object` on the shipped file,
which is byte-identical to what the quoted RED run executed.

| Frozen RED test | git hash-object | RED run tail |
| --- | --- | --- |
| `tests/php/CfgToggleRegistryPageParityTest.php` | `e3e1f6db8bfc72d19c8fda80b2a323be20df4f55` | `ERRORS! Tests: 157, Assertions: 158, Errors: 155, Failures: 2.` — 155 × `InvalidArgumentException: PfbConfig: key 'ip/enable_dup' is not in the field registry`, plus `Failed asserting that an array has the key 'ip/enable_dup'` |
| `tests/php/CfgGatewayTest.php` | `62a8ab8f66481cedebe4b396e839b8ddb2463863` | `testInventoryCompletenessAllKnownKeysAccountedFor`: `Keys must not be in BOTH the registry and the out-of-scope list: enable_dup, enable_agg, enable_log, database_cc, enable_float, killstates, syncinterfaces` |
| `tests/php/RegistryPassTest.php` | `58ccaf0350e859a88cea0c9ef0bb36f94cd791bc` | `testSectionModesUseOperatorViewAcrossEveryRegisteredSection`: `Failed asserting that two arrays are identical` — `+ 'installedpackages/pfblockerngglobal' => 'NEWCFG'`, `+ 'installedpackages/pfblockerngsync/config/0' => 'NEWCFG'` |
| `tests/phpcs/PfBlockerNG/Sniffs/Config/RequireConfigGatewaySniff.php` | `2744186d56cc9596f680804c28644f589c16e549` | With the 17 paths removed, `SniffRegistryParityTest` → `FAILURES! Tests: 1, Assertions: 1, Failures: 1.` listing all 17 missing paths (`+ 15 => 'installedpackages/pfblockerngglobal/alertrefresh'`) |
| `tests/phpcs/fixtures/gateway_compliant.php` | `ca58f53595dce2c189e19e027d5276a994ea909d` | `RequireConfigGatewaySniffTest::testCompliantCasesAreClean`: `ADR-29: raw config_get_path() call targeting registered key "installedpackages/pfblockerngipsettings/config/0/enable_dup" must be replaced by PfbConfig::read/write/delete()` |
| `tests/shell/agent_run_gates_spec.sh` | `8b67c5d342e647342ca57396eefb6027dbc38240` | `agent_run_gates_spec.sh:21` FAILED — `The line 2 of output should equal php -l src/a.inc`, `expected: 6 / got: 7` |
| `tests/shell/precommit_githooks_exempt_spec.sh` | `839869774309f05a4b6122c9ad670c68c1494725` | 4 examples FAILED — `can't open file '.../scripts/check_toggle_registry.py'`, `[pre-commit] FAILED: toggle-registry (red canary)` |
| `tests/test_toggle_registry_check.py` | `cb26575a8375ac180483214027a1288a505ef70c` | With the checker absent: `10 errors in 0.74s` — `ERROR tests/test_toggle_registry_check.py - FileNotFoundError: [Errno 2] No such file or directory` |
| `tests/php/InstallRdnsSeedAfterPassTest.php` | `c6bc1db1e7abf085bc31ec9118a87535544b9658` | `FAILURES! Tests: 3, Assertions: 7, Failures: 1.` — `testTheInstallerForcesOldcfgWhereverItPlantsIpDataBeforeThePass`: `Failed asserting that 0 is identical to 2` |
| `tests/smoke/ui/test_toggle_registry_default_render.py` | `b4b5efa746f78be87031ce628d0c04fabfb791db` | NOT executed locally and not claimed as executed: Tier-A `ui_render` needs a leased CE box (`smoke_vm`/`webui` fixtures). Its RED reason is structural — before this PR `PfbConfig::read('global/alertrefresh')` threw `InvalidArgumentException` for an unregistered key, so every case errored. Executed by the labelled `ui-tests` CI row. |


## Review round 1 — one blocker fixed, one open

Four adversarial legs plus an independent verifier ran against `8c813ef4`.

**FIXED in `8ca960fc`** — *(contract + correctness legs, both with executed proof)*: the
installer captures the IP section's mode before migrations, and two pre-pass writers fire
exactly when that mode reads NEWCFG — the General→IP settings reshape and the
cross-section rDNS seed. `pfb_registry_pass()`'s NEWCFG branch then overwrote what they
had just planted: `enable_rdns`'s `'on'` became `''`, and the six registered toggles among
the fourteen reshaped keys lost their migrated `'on'`. Probe:
`{"seed":"on","post_pass":""}`. Registering these keys is what made the order
load-bearing, so this was a regression this PR introduced. Both writers now correct the
captured mode to OLDCFG before the pass consumes the map, pinned by
`tests/php/InstallRdnsSeedAfterPassTest.php` (RED→GREEN above).

**RESOLVED with evidence — see "Runtime consumers" below:**

1. *(contract leg, BLOCKING)* Fifteen of the newly adapter-bearing scalars still reach
   runtime consumers through **raw section blobs**, not `PfbConfig`:
   `pfblockerng.inc:3260`/`:3276` and `pfblockerng_apply.inc:940-946` (IP blob),
   `pfblockerng.inc:6932-6945` (dynamic DNSBL `config/0` read comparing `== 'on'`).
   `config-gateway.md:120-132` says a field joining the adapter set moves all its
   consumers in the same commit. The sniff cannot catch this — it only matches static
   full-key literals (`RequireConfigGatewaySniff.php:320-355`) — so
   `SniffRegistryParityTest`'s exact-set equality passing does not clear it. The static IP
   consumers and the static DNSBL `config/0` branch should route through
   `PfbConfig::read()` (leaving the per-row/per-continent branches raw), with raw
   `'On'`/`'off'` runtime-consumer tests.
2. *(correctness leg)* `scripts/check_toggle_registry.py:314-316` silently `continue`s on
   an unreadable candidate, so the CLI exits 0 when handed a nonexistent explicit page —
   it must fail closed for an explicitly named path.
3. *(correctness leg)* The regex gate misses shapes a token/AST pass would catch: a
   variable section path, a semicolon inside a string before the constant, a conditional
   mirror collision, a parenthesised page default; and it false-flags a heredoc sample
   (fails closed, harmless). Unresolved mirrors should fail closed rather than skip.
4. *(contract leg, test gap)* `CfgToggleRegistryPageParityTest`'s XMLRPC row
   re-evaluates the predicate locally; neither `pfblockerng_do_xmlrpc_sync()` nor
   `pfblockerng_plugin_xmlrpc_send()` is invoked, so reverting either chooser at
   `pfblockerng.inc:19675`/`:19718` leaves it green.
5. *(contract leg, doc)* `config-gateway.md:141-143` says every relocated save retains
   `?: ''`; `pfblockerng_alerts.php` relies on `pfb_filter`'s own `''` default instead.

The over-engineering leg returned no findings ("Lean already. Ship."). The test-honesty leg
and the independent verifier had not reported when this note was written.


## Review round 2 — six more test gaps closed, three still open

The test-honesty leg found eight BLOCKING items, each proved by a **surviving mutant**.
Closed in `2e034f9c`:

- `EXEMPT` no longer suppresses **RULE 1** (`check_toggle_registry.py`). It is a RULE 2
  record; one backlog row must not licence an unregistered save of that key name forever.
  Proof it was real: with `registry_keys={}` and an exempt `enable_dup` save,
  `find_violations` returned `[]`.
- An explicitly named page the checker cannot read now exits **2**, not 0.
- `CfgToggleRegistryPageParityTest` asserts `no_grandfather` is PRESENT and
  `grandfather` ABSENT, and that the reason cites its decision (`#2123`, or `#336` for the
  cross-section `enable_rdns` seed). It accepted "exactly one of the two" and any non-empty
  string, so a grandfather map or a wrong reason passed.
- `RegistryPassTest`'s fresh-install seeding row now covers both new sections and asserts
  `alertrefresh` seeds `'on'`. It omitted them, so flipping that default passed.
- `tests/test_toggle_registry_check.py` checks all seventeen keys carry the toggle read
  adapter instead of sampling two, and pins both new gate rules.

Still open from that leg, in addition to the contract blocker above:

- `tests/php/RequireConfigGatewaySniffTest.php` has no `enable_dup` violation case, so
  removing that one path from the sniff list passes all 7 sniff tests. Add the 17 to
  `gateway_violation.php` with expected findings.
- No save round trip for `enable_rdns`, the eight DNSBL `auto*` scalars, or
  `alertrefresh` (existing save coverage: `tests/smoke/ui/test_functional.py:145-188`
  for six IP keys, `test_sync.py:239-261` for `syncinterfaces`).
- `_checkbox_is_checked()`'s regex accepts `data-name=` / `aria-checked='false'`;
  `test_www_tree_is_clean` passes with `WWW_DIR` narrowed to one clean page; the
  pre-commit spec passes with the hook's toggle-registry branch disabled; `_self_test`'s
  own failure path is unasserted; a save split into a temporary then assigned to a mirror
  evades RULE 1.


## Review round 3 — the independent verifier, and the trigger I got wrong

Verdict at `8c813ef4`: **FAIL**. Its F1 was upgraded from `[INFERENCE]` to **EXECUTED** by
driving the whole chain through production functions only —
`pfb_settings_family_save()` / `pfb_settings_family_replace()`, the seed region extracted
from `pfblockerng_install.inc` with the same regex `InstallGrandfatherChokepointTest`
uses, and `pfb_install_registry_writeback()`:

```text
STEP 3  pfb_settings_family_replace('4.0') = true
        after restore: ip section = NULL   <-- gone
        after restore: General = ('settings_family' => '4.0', 'pfb_interval' => '4')
STEP 4  mode[ip] at install.inc:42 = NEWCFG
STEP 5  seed region returned rdns_seed = 'on'   enable_rdns after the seed = 'on'
STEP 6  enable_rdns after pfb_install_registry_writeback() = ''
        PfbConfig::read('ip/enable_rdns') = PfbToggle::Off
RESULT: reverse-DNS lookups end up OFF (seed LOST) for this upgrader.
   base b91b95cc, identical steps 1-5:  STEP 6 = 'on'  (seed preserved)
```

**I had the trigger wrong.** My body argued the only route was the pre-3.2 General→IP
reshape and therefore unreachable. The reachable route is the settings-family restore,
which runs at `pfblockerng_install.inc:34` on **every** install/upgrade and rebuilds the
`pfblockerng*` sections wholesale: a slot snapshotted while the IP tab had never been
written removes `pfblockerngipsettings` while leaving General's operator data intact —
exactly `mode[ip]=NEWCFG` with a non-empty General operator view. Reverse-DNS silently
flips ON→OFF for such an upgrader, which is the single behaviour change this PR ruled out.

Fixed by `8ca960fc` (mode correction in both pre-pass IP writers) before that report
landed, and `244eee6c` corrects two texts the verifier's F2/F3 caught: the installer
comment and the entry's own `no_grandfather` reason both claimed a *present key* survives
the pass. It does not — the NEWCFG branch assigns the default regardless. What preserves
the seed is the mode correction, and both now say so.

Verifier items still open: **F5** — the toggle gate fails OPEN on an unaliased mirror
(control pair `scan_exit=1` vs `scan_exit=0`); making it fail closed needs an explicit
foreign-mirror allowlist, so it is deliberate remaining work, not an oversight. **F6/F7**
are prose/off-by-one citations and two host-only Gates lines (both pre-existing at base).
All five listed mutants killed as claimed; every enumeration and table number reproduced
exactly; M4 confirmed as a proven-equivalent mutant.


## Runtime consumers — resolved with evidence, not assertion

The contract leg's second blocker (fifteen newly adapter-bearing scalars still read the raw
section blob) is **out of this ticket's scope and behaviour-neutral here**, proven rather
than asserted. "Before" is the key ABSENT from the blob — what a pre-#2123 install
presented at runtime, because the pass never seeded these keys — and "after" is the pass
having seeded the registered default. Both sides read raw, exactly as the consumer does:

```text
apply.inc pfb_cfg_toggle_read(enable_float)    before=PfbToggle::Off  after=PfbToggle::Off  SAME
apply.inc pfb_cfg_toggle_read(enable_dup)      before=PfbToggle::Off  after=PfbToggle::Off  SAME
apply.inc pfb_cfg_toggle_read(enable_agg)      before=PfbToggle::Off  after=PfbToggle::Off  SAME
apply.inc pfb_cfg_toggle_read(enable_log)      before=PfbToggle::Off  after=PfbToggle::Off  SAME
apply.inc:4934 (bool) $pfb[kstates]            before=false           after=false           SAME
inc:3276 $pfb[cc]                              before=''              after=''              SAME
inc pfb_resolve_enabled()                      before=false           after=false           SAME
inc:6941/6970 (autoaddrnot_in  == 'on')        before=false           after=false           SAME
inc:6941/6970 (autoaddrnot_out == 'on')        before=false           after=false           SAME
alerts guards, absent key                      before=On              after=On              SAME
alerts guards, stored ''                        before=Off             after=Off             SAME
```

Every verdict is unchanged, because each registered default is the token the absent key
already resolved to. Two incidental wins: the seeded key removes an *Undefined array key*
warning at `apply.inc:940-946`, and the Alerts page's four direct consumers (the checkbox,
the two `<? if ?>` pause guards and the JS refresh guard) all read the one value the
parity matrix pins.

The genuine defect the leg found is real but pre-existing and separate: `inc:6970`'s
`== 'on'` rejects `'On'` (PHP: `"On" == "on"` is `false`) while the gateway accepts it, and
`inc:3276`/`apply.inc:946` carry no adapter at all. Migrating those consumers is filed as
https://github.com/pfBlockerNG/pfBlockerNG/issues/2817, with the probe above and the per-site table.


## CodeRabbit — one ask, review completed

Asked once at merge-ready, after all four legs and the verifier were resolved and CI was
green on the head SHA. No quota notice; `CodeRabbit` check reports *pass / Review
completed*, `Actionable comments posted: 0`, four advisory inline notes. Disposition:

- **`scripts/check_toggle_registry.py:85` (Minor, valid) — FIXED in `aaed2e4a`.**
  `$pfb ['iconfig'] ['pfb_new_flag'] = pfb_filter(..., PFB_FILTER_ON_OFF, ...)` is valid
  PHP and matched neither the mirror nor the save pattern, so an unregistered save exited
  clean. All four matchers now allow whitespace around the subscripts, pinned by
  `test_whitespace_between_brackets_does_not_evade_either_rule`.
- **`src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc:1882` (Major) — not a defect.**
  It queries `sync/syncinterfaces` carrying no `write_priv`. `WRITE_PRIV_DEFAULT` is
  `pfblockerng/pfblockerng_general.php` (`pfblockerng_extra.inc:1947`) and `isAllowedPage()`
  tests the USER's permitted pages, not the current page; pfSense grants every pfBlockerNG
  page through one privilege entry, which is why `config-gateway.md` records finer per-page
  defaults as meaningless and why every `ip/*` and `rep/*` entry written from its own
  settings page also omits `write_priv`. `gen/pfb_software_check` is the sole override
  because the Software page carries a genuine secondary gate (#485).
- **`scripts/check_toggle_registry.py:100`, `.githooks/pre-commit:234-237`,
  `tests/test_toggle_registry_check.py:1-18` (Minor) — declined.** The repo's own
  narration gate, `scripts/check_comment_narration.py`, passes on this diff, and citing the
  deciding issue in a comment is the established convention throughout
  `pfb_cfg_registry()` and `config-gateway.md`. Changing it here would make this file
  inconsistent with its neighbours.
- **`.githooks/pre-commit:249` (Minor) — declined**, same reason: the block matches the
  shape of the eight sibling checker blocks around it.

The gate's remaining regex limits (variable section path, semicolon inside a string,
conditional mirror collision, a save split into a temporary, and failing OPEN on an
unaliased mirror) are unchanged by this round and stay recorded above as deliberate
remaining work.


## Gates

```text
vendor/bin/phpunit    Tests: 5676, Failures: 1     <- Darwin-only #2765, pre-existing
composer phpstan      [OK] No errors
composer phpcs        clean
uv run pytest         5725 passed, 2 skipped
uv run ruff check .   All checks passed
uv run ruff format    497 files already formatted
uv run mypy tests/    no issues in 363 source files
npx markdownlint-cli2 0 issues in 0 files
shellspec (dash)      1552 examples, 1 failure     <- host python3 lacks tomllib (<3.11); reproduced on a
                                                   clean origin/devel clone, filed as #2818
actionlint            clean
check_toggle_registry --self-test => 0, scan => 0
```

Both shellspec/PHPUnit failures are environmental, pre-existing on base, and filed: #2818
(tomllib) and #2765 (Darwin `dd`/RLIMIT_FSIZE). Canonical
`scripts/agent/run-gates.sh --diff origin/devel` was run once after the rebase onto
`452d5600`; its only FAIL is #2818.

🤖 Generated by Oh My Pi and posted on behalf of @andrebrait.







<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added centralized registry management for toggle settings across DNSBL, IP, Alerts, and Sync configuration pages.
  * Preserved existing defaults and checkbox behavior, including safe handling of unchecked settings.
  * Added configuration validation to prevent unregistered toggles and page-level default overrides.

* **Bug Fixes**
  * Improved installation handling so migrated and seeded settings retain their intended values.

* **Tests**
  * Added automated coverage for toggle validation, rendering, installation behavior, and pre-commit/workflow checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
