### PR TITLE
agent: carry the Graphify .inc language override locally

### DIFF
--- a/.agents/context/repository-intelligence.md
+++ b/.agents/context/repository-intelligence.md
@@ -30,20 +30,25 @@ Load when: every agent session, from `AGENTS.md`.
   `uv tool install --upgrade 'graphifyy>=0.9.51'` — a floor, never an exact pin, so a
   fresh host and an outdated one both land on the current release.
 - Graphify's suffix map parses `.inc` as Pascal, so this repository's PHP includes
-  extract as roughly 30 incidental nodes instead of roughly 755 while extraction still
+  extract as roughly 30 incidental nodes instead of roughly 767 while extraction still
   reports success. Until upstream releases Graphify-Labs/graphify#3075, that fix rides
   as `.agents/patches/graphify-3075-language-overrides.patch`, applied to the installed
-  package by `scripts/agent/patch-graphify.sh` from all three install paths:
-  `setup-agent-tools.sh`, `ensure-graphify-merge-driver.sh` (the entry point 8 CI
-  workflows use), and `init-worktree-tools.sh`, before it refreshes the graph. The
-  script no-ops when the installed Graphify already provides the override API, and
-  fails loudly rather than silently when the patch does not apply. Because it patches
-  the installed package, a bare `uv tool upgrade graphifyy` reverts it by replacing
+  package by `scripts/agent/patch-graphify.sh` from its two call sites:
+  `ensure-graphify-merge-driver.sh` (the entry point 8 CI workflows use) and
+  `init-worktree-tools.sh`, before it refreshes the graph. Both invoke it with no
+  argument: it finds the package through the interpreter named on the `graphify`
+  shebang, never the ambient python3, which would import a different graphify — and
+  it no-ops when that package already provides the override API. A patch that does not
+  apply fails loudly; a Graphify the script cannot reach is a warning and a skip, caught
+  by the tracked graph's include-node floor in `tests/test_cross_agent_tooling.py`. No
+  cache is purged: the patch salts the AST cache key with the remapped language, so a
+  pre-patch Pascal entry can never be served for a `.inc` file. Because it patches the
+  installed package, a bare `uv tool upgrade graphifyy` reverts it by replacing
   site-packages; the next bootstrap, worktree cut, or CI run re-applies it. The tracked
   `.graphifyrc` (`language.inc=php`) is inert on an unpatched Graphify — the key is
   ignored and extraction runs unchanged — so a contributor who never runs these scripts
   sees the old Pascal parse, not breakage.
-  Delete the patch, the script, its three call sites, and their tests once a released
+  Delete the patch, the script, its two call sites, and their tests once a released
   graphifyy carries the change.
 - Every worktree owns its `.codegraph/` index: run `codegraph init` when it is absent,
   and never borrow a parent or sibling tree's index. Before Serena symbolic edits,

--- a/.agents/context/repository-intelligence.md
+++ b/.agents/context/repository-intelligence.md
@@ -29,6 +29,22 @@ Load when: every agent session, from `AGENTS.md`.
   an AI assistant. Install or refresh Graphify in one command with
   `uv tool install --upgrade 'graphifyy>=0.9.51'` — a floor, never an exact pin, so a
   fresh host and an outdated one both land on the current release.
+- Graphify's suffix map parses `.inc` as Pascal, so this repository's PHP includes
+  extract as roughly 30 incidental nodes instead of roughly 755 while extraction still
+  reports success. Until upstream releases Graphify-Labs/graphify#3075, that fix rides
+  as `.agents/patches/graphify-3075-language-overrides.patch`, applied to the installed
+  package by `scripts/agent/patch-graphify.sh` from all three install paths:
+  `setup-agent-tools.sh`, `ensure-graphify-merge-driver.sh` (the entry point 8 CI
+  workflows use), and `init-worktree-tools.sh`, before it refreshes the graph. The
+  script no-ops when the installed Graphify already provides the override API, and
+  fails loudly rather than silently when the patch does not apply. Because it patches
+  the installed package, a bare `uv tool upgrade graphifyy` reverts it by replacing
+  site-packages; the next bootstrap, worktree cut, or CI run re-applies it. The tracked
+  `.graphifyrc` (`language.inc=php`) is inert on an unpatched Graphify — the key is
+  ignored and extraction runs unchanged — so a contributor who never runs these scripts
+  sees the old Pascal parse, not breakage.
+  Delete the patch, the script, its three call sites, and their tests once a released
+  graphifyy carries the change.
 - Every worktree owns its `.codegraph/` index: run `codegraph init` when it is absent,
   and never borrow a parent or sibling tree's index. Before Serena symbolic edits,
   verify that its active project root equals `git rev-parse --show-toplevel`; after a

--- a/.agents/context/repository-intelligence.md
+++ b/.agents/context/repository-intelligence.md
@@ -35,21 +35,16 @@ Load when: every agent session, from `AGENTS.md`.
   as `.agents/patches/graphify-3075-language-overrides.patch`, applied to the installed
   package by `scripts/agent/patch-graphify.sh` from its two call sites:
   `ensure-graphify-merge-driver.sh` (the entry point 8 CI workflows use) and
-  `init-worktree-tools.sh`, before it refreshes the graph. Both invoke it with no
-  argument: it finds the package through the interpreter named on the `graphify`
-  shebang, never the ambient python3, which would import a different graphify — and
-  it no-ops when that package already provides the override API. A patch that does not
-  apply fails loudly; a Graphify the script cannot reach is a warning and a skip, caught
-  by the tracked graph's include-node floor in `tests/test_cross_agent_tooling.py`. No
-  cache is purged: the patch salts the AST cache key with the remapped language, so a
-  pre-patch Pascal entry can never be served for a `.inc` file. Because it patches the
-  installed package, a bare `uv tool upgrade graphifyy` reverts it by replacing
-  site-packages; the next bootstrap, worktree cut, or CI run re-applies it. The tracked
-  `.graphifyrc` (`language.inc=php`) is inert on an unpatched Graphify — the key is
-  ignored and extraction runs unchanged — so a contributor who never runs these scripts
-  sees the old Pascal parse, not breakage.
-  Delete the patch, the script, its two call sites, and their tests once a released
-  graphifyy carries the change.
+  `init-worktree-tools.sh`, before it refreshes the graph. It patches only the package
+  owned by the interpreter named on the `graphify` shebang, so a `pip --user` or
+  PYTHONPATH-only Graphify is skipped rather than patched — caught by the tracked
+  graph's include-node floor in `tests/test_cross_agent_tooling.py`. Because it patches
+  the installed package, a bare `uv tool upgrade graphifyy` reverts it; the next
+  bootstrap, worktree cut, or CI run re-applies it. The tracked `.graphifyrc`
+  (`language.inc=php`) is inert on an unpatched Graphify, so a contributor who never
+  runs these scripts sees the old Pascal parse, not breakage. Delete the patch, the
+  script, its two call sites, and their tests once a released graphifyy carries the
+  change.
 - Every worktree owns its `.codegraph/` index: run `codegraph init` when it is absent,
   and never borrow a parent or sibling tree's index. Before Serena symbolic edits,
   verify that its active project root equals `git rev-parse --show-toplevel`; after a

--- a/.agents/patches/graphify-3075-language-overrides.patch
+++ b/.agents/patches/graphify-3075-language-overrides.patch
@@ -1,0 +1,551 @@
+# Vendored from Graphify-Labs/graphify#3075 (upstream issue Graphify-Labs/graphify#2961,
+# base branch v8): `.graphifyrc` gains `language.<ext>=<language>`, threaded through
+# classification, extractor dispatch, the case-insensitivity and interop-family rules,
+# the language resolver registry, the AST cache key, and the extraction pool workers.
+#
+# The PR's tests/test_language_overrides.py and README.md hunks are stripped: the
+# published wheel ships neither, so they cannot apply to an installed package.
+#
+# scripts/agent/patch-graphify.sh applies this to the installed Graphify after every
+# install. Delete both once a released graphifyy provides the override API.
+diff --git a/graphify/cache.py b/graphify/cache.py
+index 8fb168ce3..440993882 100644
+--- a/graphify/cache.py
++++ b/graphify/cache.py
+@@ -921,11 +921,19 @@ def cache_dir(root: Path = Path("."), kind: str = "ast",
+     return d
+ 
+ 
++def _salted_key(h: str, salt: str | None) -> str:
++    """Derive the on-disk key from a content hash plus optional salt."""
++    if not salt:
++        return h
++    return hashlib.sha256(f"{h}:{salt}".encode("utf-8")).hexdigest()
++
++
+ def load_cached(path: Path, root: Path = Path("."), kind: str = "ast",
+                 cache_root: Path | None = None, prompt: "str | Path | None" = None,
+                 prompt_file: "str | Path | None" = None,
+                 allow_legacy: bool = True,
+-                allow_partial: bool = False) -> dict | None:
++                allow_partial: bool = False,
++                salt: str | None = None) -> dict | None:
+     """Return cached extraction for this file if hash matches, else None.
+ 
+     Cache key: SHA256 of file contents.
+@@ -954,6 +962,10 @@ def load_cached(path: Path, root: Path = Path("."), kind: str = "ast",
+     so :func:`check_semantic_cache` can report N to the user. Callers that must
+     not mix vintages within one entry (see :func:`save_semantic_cache`'s
+     ``merge_existing``) pass allow_legacy=False.
++    ``salt`` folds extra material into the key for an entry whose validity
++    depends on more than the file's bytes — a file the project remaps to
++    another language (#2961) parses to a different graph from the same
++    content, so it must not hit the entry produced under the old extractor.
+     Returns None if no cache entry or file has changed.
+     """
+     global _legacy_semantic_hits, _corrupt_cache_entries
+@@ -962,6 +974,7 @@ def load_cached(path: Path, root: Path = Path("."), kind: str = "ast",
+         h = file_hash(path, root, cache_root=cache_root)
+     except OSError:
+         return None
++    h = _salted_key(h, salt)
+     prompt_fp = _resolve_prompt_fp(prompt, prompt_file)
+     entry = cache_dir(location, kind, prompt_fp) / f"{h}.json"
+     legacy_hit = False
+@@ -1029,9 +1042,13 @@ def load_cached(path: Path, root: Path = Path("."), kind: str = "ast",
+ 
+ def save_cached(path: Path, result: dict, root: Path = Path("."), kind: str = "ast",
+                 cache_root: Path | None = None, prompt: "str | Path | None" = None,
+-                prompt_file: "str | Path | None" = None) -> None:
++                prompt_file: "str | Path | None" = None,
++                salt: str | None = None) -> None:
+     """Save extraction result for this file.
+ 
++    ``salt`` must match what the corresponding :func:`load_cached` passes
++    (see there); it namespaces the key, not the directory.
++
+     Stores as graphify-out/cache/{kind}/{hash}.json where hash = SHA256 of current file contents.
+     result should be a dict with 'nodes' and 'edges' lists.
+ 
+@@ -1078,7 +1095,7 @@ def save_cached(path: Path, result: dict, root: Path = Path("."), kind: str = "a
+         # the entry replays portably under any root (#2257). Strictly after the
+         # source_file pass, which owns that field's bare-relative format.
+         _relativize_ids_in(on_disk, p, root)
+-    h = file_hash(p, root, cache_root=cache_root)
++    h = _salted_key(file_hash(p, root, cache_root=cache_root), salt)
+     location = cache_root if cache_root is not None else root
+     target_dir = cache_dir(location, kind, _resolve_prompt_fp(prompt, prompt_file))
+     entry = target_dir / f"{h}.json"
+diff --git a/graphify/detect.py b/graphify/detect.py
+index d16b5800c..f699b4543 100644
+--- a/graphify/detect.py
++++ b/graphify/detect.py
+@@ -21,6 +21,7 @@
+     google_workspace_enabled,
+ )
+ from graphify.paths import GRAPHIFY_OUT, out_path
++from graphify.rcfile import activate_language_overrides, effective_suffix
+ 
+ 
+ class FileType(str, Enum):
+@@ -512,7 +513,9 @@ def classify_file(path: Path) -> FileType | None:
+     # Compound extensions must be checked before simple suffix lookup
+     if path.name.lower().endswith(".blade.php"):
+         return FileType.CODE
+-    ext = path.suffix.lower()
++    # A project may declare what an ambiguous extension means to it
++    # (.graphifyrc `language.inc=php`, #2961); classify by the declared one.
++    ext = effective_suffix(path).lower()
+     if not ext:
+         return _shebang_file_type(path)
+     if ext in CODE_EXTENSIONS:
+@@ -1514,6 +1517,9 @@ def _resolves_under_root(path: Path, root: Path) -> bool:
+ 
+ def detect(root: Path, *, follow_symlinks: bool | None = None, google_workspace: bool | None = None, extra_excludes: list[str] | None = None, cache_root: Path | None = None, gitignore: bool = True) -> dict:
+     root = root.resolve()
++    # The project's extension->language declarations (#2961) shape
++    # classification for this scan.
++    activate_language_overrides(root)
+     configured_out_dir = root / GRAPHIFY_OUT
+     configured_out_names = {configured_out_dir.name}
+     try:
+diff --git a/graphify/extract.py b/graphify/extract.py
+index 89082af87..bfb44f312 100644
+--- a/graphify/extract.py
++++ b/graphify/extract.py
+@@ -26,6 +26,13 @@
+ from .pascal_resolution import resolve_pascal_inherited_calls
+ 
+ # --- migrated to graphify/extractors/ (see graphify/extractors/MIGRATION.md) ---
++from graphify.rcfile import (
++    activate_language_overrides,
++    cache_salt,
++    effective_suffix,
++    get_language_overrides,
++    set_language_overrides,
++)
+ from graphify.extractors.base import (  # noqa: F401
+     _LANGUAGE_BUILTIN_GLOBALS,
+     _file_stem,
+@@ -2193,7 +2200,7 @@ def _lang_is_case_insensitive(source_file: object) -> bool:
+     """True when the file's language resolves identifiers case-insensitively (#1581)."""
+     if not source_file:
+         return False
+-    return Path(str(source_file)).suffix.lower() in _CASE_INSENSITIVE_EXTS
++    return effective_suffix(str(source_file)).lower() in _CASE_INSENSITIVE_EXTS
+ 
+ 
+ # Language interop families for cross-file call resolution. A call in one language
+@@ -2239,7 +2246,7 @@ def _lang_family(source_file: object) -> str | None:
+     """Interop family of the file's language, or None when unknown/not code."""
+     if not source_file:
+         return None
+-    return _LANG_FAMILY_BY_EXT.get(Path(str(source_file)).suffix.lower())
++    return _LANG_FAMILY_BY_EXT.get(effective_suffix(str(source_file)).lower())
+ 
+ 
+ # A language's own built-in throwable hierarchy, keyed by the interop family of
+@@ -5387,6 +5394,12 @@ def _get_extractor(path: Path) -> Any | None:
+     # (#1377). apm.yml would otherwise be a .yml document handled by the LLM.
+     if is_package_manifest_path(path):
+         return extract_package_manifest
++    # A project-declared remap (.graphifyrc `language.inc=php`, #2961) wins
++    # over every sniff below: the user has said what the extension means in
++    # this repo, so a remapped `.h`/`.m` also skips the C++/ObjC probes.
++    remapped = effective_suffix(path)
++    if remapped != path.suffix:
++        return _DISPATCH.get(remapped) or _DISPATCH.get(remapped.lower())
+     # `.h` is C/C++/ObjC-ambiguous; route Objective-C headers to extract_objc
+     # (the suffix map sends `.h` to extract_c, which can't read @interface etc.).
+     # ObjC sniffing has priority over the C++ sniff: an Objective-C++ header can
+@@ -5429,6 +5442,13 @@ def _safe_extract_with_xaml_root(extractor, path: Path, root: Path) -> dict:
+         _XAML_ACTIVE_EXTRACT_ROOT = previous_root
+ 
+ 
++def _worker_init(language_overrides: dict[str, str]) -> None:
++    """Pool initializer. Under ``spawn`` a worker re-imports the package and
++    starts with no overrides; hand it the parent's so `_get_extractor` and the
++    cache key agree across processes (#2961)."""
++    set_language_overrides(language_overrides)
++
++
+ def _extract_single_file(args: tuple) -> tuple[int, dict]:
+     """Worker function for parallel extraction. Runs in a subprocess.
+ 
+@@ -5457,7 +5477,7 @@ def _extract_single_file(args: tuple) -> tuple[int, dict]:
+ 
+     # Check cache first (avoid re-extraction)
+     if not bypass_cache:
+-        cached = load_cached(path, root, cache_root=cache_location)
++        cached = load_cached(path, root, cache_root=cache_location, salt=cache_salt(path))
+         if cached is not None:
+             return idx, cached
+ 
+@@ -5472,7 +5492,7 @@ def _extract_single_file(args: tuple) -> tuple[int, dict]:
+     # byte-stable across runs and silently blinds affected/explain to and
+     # through the file (#1666); skipping the write lets a rerun self-heal.
+     if not bypass_cache and "error" not in result and result.get("nodes"):
+-        save_cached(path, result, root, cache_root=cache_location)
++        save_cached(path, result, root, cache_root=cache_location, salt=cache_salt(path))
+     return idx, result
+ 
+ 
+@@ -5538,7 +5558,11 @@ def _extract_parallel(
+     failed: list[int] = []  # positions into uncached_work whose future failed
+     _PROGRESS_INTERVAL = 100
+     try:
+-        with concurrent.futures.ProcessPoolExecutor(max_workers=max_workers) as pool:
++        with concurrent.futures.ProcessPoolExecutor(
++            max_workers=max_workers,
++            initializer=_worker_init,
++            initargs=(get_language_overrides(),),
++        ) as pool:
+             futures = {
+                 pool.submit(_extract_single_file, item): pos
+                 for pos, item in enumerate(work_items)
+@@ -5637,7 +5661,7 @@ def _extract_sequential(
+         result = _safe_extract_with_xaml_root(extractor, path, root)
+         # See _extract_single_file: don't cache an anomalous zero-node result (#1666).
+         if not bypass_cache and "error" not in result and result.get("nodes"):
+-            save_cached(path, result, root, cache_root=cache_location)
++            save_cached(path, result, root, cache_root=cache_location, salt=cache_salt(path))
+         per_file[idx] = result
+     if total_files >= _PROGRESS_INTERVAL:
+         # Consistent denominator with the intermediate lines (#1693).
+@@ -5742,6 +5766,17 @@ def extract(
+         root = cache_root
+     root = root.resolve()
+ 
++    # Project-level extension->language declarations (#2961). detect() has
++    # usually activated them for this root already; a direct library caller
++    # (the skill runbook, the MCP server, the issue's own repro) gets them here.
++    _overrides = activate_language_overrides(root)
++    if _overrides:
++        print(
++            "  language overrides (.graphifyrc): "
++            + ", ".join(f"{k} -> {v}" for k, v in sorted(_overrides.items())),
++            flush=True,
++        )
++
+     # #1774: the cache is an OUTPUT, so when no explicit cache_root is given it is
+     # written under the current working directory — never `root` (the inferred
+     # common parent of the inputs), which would drop graphify-out/ inside a
+@@ -5761,7 +5796,7 @@ def extract(
+             continue
+         bypass_cache = path.suffix in _JS_CACHE_BYPASS_SUFFIXES
+         if not bypass_cache:
+-            cached = load_cached(path, root, cache_root=cache_location)
++            cached = load_cached(path, root, cache_root=cache_location, salt=cache_salt(path))
+             if cached is not None:
+                 per_file[i] = cached
+                 continue
+@@ -6396,7 +6431,7 @@ def _learn(e: dict) -> None:
+     _php_exts = {".php", ".phtml", ".php3", ".php4", ".php5", ".php7", ".phps"}
+     _php_sel = [
+         (r, p) for r, p in zip(per_file, paths)
+-        if p.suffix.lower() in _php_exts and not p.name.lower().endswith(".blade.php")
++        if effective_suffix(p).lower() in _php_exts and not p.name.lower().endswith(".blade.php")
+     ]
+     if _php_sel:
+         try:
+diff --git a/graphify/hooks.py b/graphify/hooks.py
+index 211c074be..680ecfcc9 100644
+--- a/graphify/hooks.py
++++ b/graphify/hooks.py
+@@ -416,39 +416,14 @@ def _detached_launch(rebuild_body: str) -> str:
+ """
+ 
+ 
+-def _load_graphifyrc(root: Path) -> dict[str, str | int]:
+-    """Load key/value options from <root>/.graphifyrc if present.
++def _load_graphifyrc(root: Path) -> dict:
++    """Load ``<root>/.graphifyrc``; the parser lives in :mod:`graphify.rcfile`.
+ 
+-    Supported options:
+-      viz_node_limit: integer >= 0 (e.g. viz_node_limit=0)
++    Kept as the hooks-side name so callers and tests need not move. Returns
++    ``viz_node_limit`` (used here) alongside any other option the file sets.
+     """
+-    rc_path = root / ".graphifyrc"
+-    if not rc_path.is_file():
+-        return {}
+-
+-    cfg: dict[str, str | int] = {}
+-    content = rc_path.read_text(encoding="utf-8")
+-    for line_num, raw in enumerate(content.splitlines(), 1):
+-        line = raw.strip()
+-        if not line or line.startswith("#"):
+-            continue
+-        if "=" not in line:
+-            raise ValueError(f"Invalid line {line_num} in {rc_path}: {raw!r} (expected key=value)")
+-        key, val = line.split("=", 1)
+-        key = key.strip()
+-        val = val.strip()
+-        if key == "viz_node_limit":
+-            try:
+-                parsed_val = int(val)
+-                if parsed_val < 0:
+-                    raise ValueError("must be a non-negative integer")
+-                cfg["viz_node_limit"] = parsed_val
+-            except ValueError as exc:
+-                raise ValueError(
+-                    f"Invalid viz_node_limit in {rc_path} at line {line_num}: {val!r}. "
+-                    f"Must be a non-negative integer."
+-                ) from exc
+-    return cfg
++    from graphify.rcfile import load_graphifyrc
++    return load_graphifyrc(root)
+ 
+ 
+ def _git_root(path: Path) -> Path | None:
+diff --git a/graphify/rcfile.py b/graphify/rcfile.py
+new file mode 100644
+index 000000000..3a7971831
+--- /dev/null
++++ b/graphify/rcfile.py
+@@ -0,0 +1,229 @@
++"""Project-level configuration: ``<root>/.graphifyrc``.
++
++One ``key=value`` per line, ``#`` comments, blank lines ignored. Keys:
++
++``viz_node_limit=<int>``
++    Baked into the generated git hooks (see :mod:`graphify.hooks`).
++
++``language.<ext>=<language | .ext>``
++    Treat files with extension ``<ext>`` as the named language for
++    classification, extractor dispatch and cross-file resolution (#2961).
++    ``<ext>`` may be written with or without its leading dot; the value is
++    either a language name from :data:`LANGUAGE_ALIASES` or an explicit
++    extension graphify already knows (``.php``, ``.pas``, ``.sql``, ...)::
++
++        # pfSense: every .inc under this repo is PHP, not Pascal
++        language.inc=php
++        # a repo whose templates are plain TypeScript
++        language.tpl=.ts
++
++    An ambiguous extension (``.inc`` is PHP, Pascal, SQL or assembly
++    depending on the project; ``.m`` is Objective-C or MATLAB; ``.h`` is C or
++    C++) has no single correct global mapping, so the project declares it.
++
++The parser is deliberately free of heavy imports: :mod:`graphify.detect`
++and :mod:`graphify.extract` consult it on every scan, and the extraction
++worker processes re-import it under ``spawn``.
++"""
++from __future__ import annotations
++
++import sys
++from pathlib import Path
++
++RC_FILENAME = ".graphifyrc"
++
++# Language name -> the canonical extension graphify dispatches it under.
++# Deliberately a short list of names a user is likely to type; any known
++# extension can be given directly instead (``language.inc=.php``).
++LANGUAGE_ALIASES: dict[str, str] = {
++    "php": ".php",
++    "pascal": ".pas", "delphi": ".pas", "freepascal": ".pas",
++    "sql": ".sql",
++    "python": ".py",
++    "javascript": ".js", "js": ".js",
++    "typescript": ".ts", "ts": ".ts",
++    "c": ".c",
++    "cpp": ".cpp", "c++": ".cpp", "cxx": ".cpp",
++    "objc": ".mm", "objective-c": ".mm", "objectivec": ".mm",
++    "java": ".java",
++    "kotlin": ".kt",
++    "scala": ".scala",
++    "groovy": ".groovy",
++    "go": ".go", "golang": ".go",
++    "rust": ".rs",
++    "ruby": ".rb",
++    "csharp": ".cs", "c#": ".cs",
++    "swift": ".swift",
++    "lua": ".lua",
++    "zig": ".zig",
++    "elixir": ".ex",
++    "julia": ".jl",
++    "dart": ".dart",
++    "r": ".r",
++    "fortran": ".f90",
++    "shell": ".sh", "bash": ".sh", "sh": ".sh",
++    "powershell": ".ps1",
++    "verilog": ".v", "systemverilog": ".sv",
++    "terraform": ".tf", "hcl": ".hcl",
++    "ocaml": ".ml",
++    "lisp": ".lisp", "commonlisp": ".lisp",
++    "markdown": ".md",
++    "json": ".json",
++    "yaml": ".yaml",
++    "html": ".html",
++}
++
++
++def _normalise_ext(raw: str) -> str:
++    ext = raw.strip().lower()
++    if not ext.startswith("."):
++        ext = "." + ext
++    return ext
++
++
++def parse_language_value(value: str) -> str:
++    """Resolve the right-hand side of ``language.<ext>=`` to a canonical suffix.
++
++    Accepts a name from :data:`LANGUAGE_ALIASES` (case-insensitive) or an
++    explicit dotted extension. Raises ``ValueError`` for anything else.
++    """
++    v = value.strip()
++    if not v:
++        raise ValueError("empty value")
++    if v.startswith("."):
++        ext = _normalise_ext(v)
++        if len(ext) < 2 or any(ch.isspace() for ch in ext):
++            raise ValueError(f"{value!r} is not an extension")
++        return ext
++    try:
++        return LANGUAGE_ALIASES[v.lower()]
++    except KeyError:
++        known = ", ".join(sorted(LANGUAGE_ALIASES))
++        raise ValueError(
++            f"unknown language {value!r} (use one of: {known}; "
++            f"or an explicit extension such as .php)"
++        ) from None
++
++
++def load_graphifyrc(root: Path) -> dict:
++    """Parse ``<root>/.graphifyrc``. Returns ``{}`` when absent.
++
++    Returned keys: ``viz_node_limit`` (int) and ``languages``
++    (``{".inc": ".php", ...}``) — each present only when the file sets it.
++    Unknown keys are ignored so a newer graphify's options do not break an
++    older one. Malformed lines raise ``ValueError`` naming the line.
++    """
++    rc_path = Path(root) / RC_FILENAME
++    if not rc_path.is_file():
++        return {}
++
++    cfg: dict = {}
++    languages: dict[str, str] = {}
++    content = rc_path.read_text(encoding="utf-8")
++    for line_num, raw in enumerate(content.splitlines(), 1):
++        line = raw.strip()
++        if not line or line.startswith("#"):
++            continue
++        if "=" not in line:
++            raise ValueError(f"Invalid line {line_num} in {rc_path}: {raw!r} (expected key=value)")
++        key, val = line.split("=", 1)
++        key = key.strip()
++        val = val.strip()
++        if key == "viz_node_limit":
++            try:
++                parsed_val = int(val)
++                if parsed_val < 0:
++                    raise ValueError("must be a non-negative integer")
++                cfg["viz_node_limit"] = parsed_val
++            except ValueError as exc:
++                raise ValueError(
++                    f"Invalid viz_node_limit in {rc_path} at line {line_num}: {val!r}. "
++                    f"Must be a non-negative integer."
++                ) from exc
++        elif key.startswith("language."):
++            ext_part = key[len("language."):].strip()
++            if not ext_part or any(ch.isspace() for ch in ext_part):
++                raise ValueError(
++                    f"Invalid language key in {rc_path} at line {line_num}: {key!r} "
++                    f"(expected language.<ext>=<language>)"
++                )
++            try:
++                target = parse_language_value(val)
++            except ValueError as exc:
++                raise ValueError(
++                    f"Invalid {key} in {rc_path} at line {line_num}: {exc}"
++                ) from None
++            languages[_normalise_ext(ext_part)] = target
++    if languages:
++        cfg["languages"] = languages
++    return cfg
++
++
++# ---------------------------------------------------------------------------
++# Active overrides for this process
++# ---------------------------------------------------------------------------
++#
++# detect()/extract() activate the scan root's overrides for the run; the
++# extraction pool forwards them to its workers (they do not inherit module
++# state under ``spawn``). Stored lower-cased on both sides.
++
++_ACTIVE: dict[str, str] = {}
++_warned_roots: set[str] = set()
++
++
++def set_language_overrides(mapping: dict[str, str] | None) -> None:
++    """Replace the process-wide extension overrides (``{".inc": ".php"}``)."""
++    _ACTIVE.clear()
++    if mapping:
++        for ext, target in mapping.items():
++            _ACTIVE[_normalise_ext(ext)] = _normalise_ext(target)
++
++
++def get_language_overrides() -> dict[str, str]:
++    return dict(_ACTIVE)
++
++
++def activate_language_overrides(root: Path) -> dict[str, str]:
++    """Load ``<root>/.graphifyrc`` and make its language overrides active.
++
++    A malformed file is reported once per root on stderr and treated as
++    having no overrides — a scan must not die on a config typo, but the
++    user must hear about it, or their ``.inc`` silently stays Pascal.
++    Returns the mapping now active.
++    """
++    try:
++        cfg = load_graphifyrc(Path(root))
++    except (ValueError, OSError) as exc:
++        key = str(root)
++        if key not in _warned_roots:
++            _warned_roots.add(key)
++            print(f"[graphify] warning: ignoring {RC_FILENAME}: {exc}", file=sys.stderr)
++        cfg = {}
++    set_language_overrides(cfg.get("languages"))
++    return get_language_overrides()
++
++
++def effective_suffix(path: Path | str) -> str:
++    """The suffix graphify should treat ``path`` as having.
++
++    Returns the override target when the file's extension is remapped, else
++    the real suffix untouched (case preserved, so callers that distinguish
++    ``.F90`` from ``.f90`` keep doing so).
++    """
++    suffix = Path(path).suffix
++    if not _ACTIVE:
++        return suffix
++    return _ACTIVE.get(suffix.lower(), suffix)
++
++
++def cache_salt(path: Path | str) -> str | None:
++    """Extra cache-key material for a remapped file, else ``None``.
++
++    An AST cache entry is keyed by content, and the same bytes parse to a
++    different graph under a different extractor — so a ``.inc`` cached as
++    Pascal must not be served once the project declares it PHP.
++    """
++    if not _ACTIVE:
++        return None
++    target = _ACTIVE.get(Path(path).suffix.lower())
++    return f"language={target}" if target else None
+diff --git a/graphify/resolver_registry.py b/graphify/resolver_registry.py
+index b17478a78..ded758c00 100644
+--- a/graphify/resolver_registry.py
++++ b/graphify/resolver_registry.py
+@@ -75,7 +75,10 @@ def run_language_resolvers(
+     exercise the driver in isolation.
+     """
+     active = _REGISTRY if resolvers is None else resolvers
+-    suffixes_present = {p.suffix for p in paths}
++    # Honour project-level remaps (#2961): a `.inc` declared PHP must wake
++    # the PHP resolvers, not Pascal's.
++    from graphify.rcfile import effective_suffix
++    suffixes_present = {effective_suffix(p) for p in paths}
+     for resolver in active:
+         if not (resolver.suffixes & suffixes_present):
+             continue

--- a/.agents/patches/graphify-3075-language-overrides.patch
+++ b/.agents/patches/graphify-3075-language-overrides.patch
@@ -5,9 +5,6 @@
 #
 # The PR's tests/test_language_overrides.py and README.md hunks are stripped: the
 # published wheel ships neither, so they cannot apply to an installed package.
-#
-# scripts/agent/patch-graphify.sh applies this to the installed Graphify after every
-# install. Delete both once a released graphifyy provides the override API.
 diff --git a/graphify/cache.py b/graphify/cache.py
 index 8fb168ce3..440993882 100644
 --- a/graphify/cache.py

--- a/.graphifyrc
+++ b/.graphifyrc
@@ -1,0 +1,5 @@
+# pfSense ships PHP include files as .inc; Graphify's suffix map calls them Pascal.
+# Read by the vendored .agents/patches/graphify-3075-language-overrides.patch and,
+# once it ships, by upstream Graphify-Labs/graphify#3075. Inert on a Graphify that
+# carries neither: the key is ignored and extraction runs unchanged.
+language.inc=php

--- a/scripts/agent/ensure-graphify-merge-driver.sh
+++ b/scripts/agent/ensure-graphify-merge-driver.sh
@@ -31,10 +31,6 @@ main() {
 	# The hook this installs rebuilds the graph, so the override has to be on the
 	# freshly installed package first (issue #2810).
 	patch_graphify=$root/scripts/agent/patch-graphify.sh
-	[ -f "$patch_graphify" ] || {
-		echo "ensure-graphify-merge-driver.sh: required repository helper '$patch_graphify' is missing" >&2
-		exit 1
-	}
 	sh "$patch_graphify" || {
 		echo "ensure-graphify-merge-driver.sh: Graphify language-override patch failed for '$root'" >&2
 		exit 1

--- a/scripts/agent/ensure-graphify-merge-driver.sh
+++ b/scripts/agent/ensure-graphify-merge-driver.sh
@@ -28,6 +28,17 @@ main() {
 		echo "ensure-graphify-merge-driver.sh: Graphify installation failed" >&2
 		exit 1
 	}
+	# The hook this installs rebuilds the graph, so the override has to be on the
+	# freshly installed package first (issue #2810).
+	patch_graphify=$root/scripts/agent/patch-graphify.sh
+	[ -f "$patch_graphify" ] || {
+		echo "ensure-graphify-merge-driver.sh: required repository helper '$patch_graphify' is missing" >&2
+		exit 1
+	}
+	sh "$patch_graphify" "$root" || {
+		echo "ensure-graphify-merge-driver.sh: Graphify language-override patch failed for '$root'" >&2
+		exit 1
+	}
 	(cd "$root" && graphify hook install) || {
 		echo "ensure-graphify-merge-driver.sh: Graphify hook installation failed in '$root'" >&2
 		exit 1

--- a/scripts/agent/ensure-graphify-merge-driver.sh
+++ b/scripts/agent/ensure-graphify-merge-driver.sh
@@ -35,7 +35,7 @@ main() {
 		echo "ensure-graphify-merge-driver.sh: required repository helper '$patch_graphify' is missing" >&2
 		exit 1
 	}
-	sh "$patch_graphify" "$root" || {
+	sh "$patch_graphify" || {
 		echo "ensure-graphify-merge-driver.sh: Graphify language-override patch failed for '$root'" >&2
 		exit 1
 	}

--- a/scripts/agent/init-worktree-tools.sh
+++ b/scripts/agent/init-worktree-tools.sh
@@ -23,6 +23,9 @@ main() {
 	root=$(CDPATH='' cd "$root" && pwd -P) || exit 2
 
 	sh "$(dirname "$0")/ensure-codegraph.sh" "$root" || exit $?
+	# Before any extraction: an unpatched Graphify parses this repository's PHP .inc
+	# files as Pascal, and a bare `uv tool upgrade graphifyy` reverts the patch.
+	sh "$(dirname "$0")/patch-graphify.sh" "$root" || exit $?
 	# Refreshing an existing root graph is mechanical, so it stays automated. Building
 	# the FIRST graph is not: its scope (which trees, whether the semantic layer earns
 	# its cost, what .graphifyignore allows) is a judgement call, so defer it to an

--- a/scripts/agent/init-worktree-tools.sh
+++ b/scripts/agent/init-worktree-tools.sh
@@ -25,7 +25,7 @@ main() {
 	sh "$(dirname "$0")/ensure-codegraph.sh" "$root" || exit $?
 	# Before any extraction: an unpatched Graphify parses this repository's PHP .inc
 	# files as Pascal, and a bare `uv tool upgrade graphifyy` reverts the patch.
-	sh "$(dirname "$0")/patch-graphify.sh" "$root" || exit $?
+	sh "$(dirname "$0")/patch-graphify.sh" || exit $?
 	# Refreshing an existing root graph is mechanical, so it stays automated. Building
 	# the FIRST graph is not: its scope (which trees, whether the semantic layer earns
 	# its cost, what .graphifyignore allows) is a judgement call, so defer it to an

--- a/scripts/agent/patch-graphify.sh
+++ b/scripts/agent/patch-graphify.sh
@@ -1,0 +1,112 @@
+#!/bin/sh
+# Apply the vendored Graphify .inc language-override patch to the installed package.
+# Usage: sh scripts/agent/patch-graphify.sh [REPOSITORY]
+#
+# Graphify's suffix map sends .inc to the Pascal extractor, so this repository's PHP
+# include files extract as a handful of incidental nodes while extraction still
+# reports success (issue #2810). Upstream fixes that in Graphify-Labs/graphify#3075,
+# which is unreleased, so the patch rides in .agents/patches/ and is re-applied after
+# every install: a bare `uv tool upgrade graphifyy` replaces site-packages and reverts
+# it. Delete this script, its patch, and its three call sites once a released
+# graphifyy provides the override API -- this script no-ops from that release on.
+#
+# Progress goes to stderr, like the sibling scripts in this directory: callers keep a
+# clean stdout.
+
+set -eu
+
+PATCH_REL='.agents/patches/graphify-3075-language-overrides.patch'
+UPSTREAM='Graphify-Labs/graphify#3075'
+
+usage() {
+	echo "usage: patch-graphify.sh [REPOSITORY]" >&2
+	exit 2
+}
+
+fail() {
+	echo "patch-graphify.sh: $*" >&2
+	exit 1
+}
+
+main() {
+	# shellcheck source=scripts/agent/agent_env.sh
+	. "$(dirname "$0")/agent_env.sh"
+	scrub_git_env "$0"
+	[ "$#" -le 1 ] || usage
+	require_tool git
+
+	target=${1:-.}
+	root=$(git -C "$target" rev-parse --show-toplevel 2>/dev/null) || {
+		echo "patch-graphify.sh: '$target' is not a git worktree" >&2
+		exit 2
+	}
+	root=$(CDPATH='' cd "$root" && pwd -P) || exit 2
+
+	# The script and its patch always ship together, so the patch comes from this
+	# script's own checkout -- a worktree cut from a branch that predates the patch
+	# still initializes against the invoking checkout's copy.
+	checkout=$(CDPATH='' cd "$(dirname "$0")/../.." && pwd -P) || exit 2
+	patch_file=$checkout/$PATCH_REL
+	[ -f "$patch_file" ] || fail "vendored patch '$patch_file' is missing"
+
+	if [ -n "${PFB_GRAPHIFY_PACKAGE_DIR:-}" ]; then
+		# A named package tree is not tied to a tool venv (a nonstandard install, or
+		# a test's throwaway copy), so it is imported with the ambient python3.
+		require_tool python3
+		interpreter=python3
+		package=$PFB_GRAPHIFY_PACKAGE_DIR
+	else
+		require_tool sed
+		graphify_bin=$(command -v graphify) ||
+			fail "Graphify is not installed; run 'uv tool install --upgrade graphifyy' first"
+		# A uv tool venv carries its Python minor version in the site-packages path,
+		# so the interpreter that owns the package is read off the CLI's own shebang
+		# and the package directory is derived from it -- neither is ever hardcoded.
+		interpreter=$(sed -n '1s/^#![[:space:]]*//p' "$graphify_bin")
+		case "$interpreter" in
+			/*) ;;
+			*) fail "'$graphify_bin' does not name an absolute interpreter (got: '${interpreter:-none}')" ;;
+		esac
+		case "${interpreter##*/}" in
+			python*) ;;
+			*) fail "'$graphify_bin' is not run by a Python interpreter (got: '$interpreter')" ;;
+		esac
+		[ -x "$interpreter" ] || fail "Graphify's interpreter '$interpreter' is not executable"
+		package=$("$interpreter" -c 'import graphify, os; print(os.path.dirname(graphify.__file__))') ||
+			fail "'$interpreter' cannot import graphify; reinstall with 'uv tool install --reinstall graphifyy'"
+	fi
+	[ -d "$package" ] || fail "Graphify package directory '$package' does not exist"
+	site=$(CDPATH='' cd "$package/.." && pwd -P) || exit 2
+
+	# Ask the package itself, not the file text: this no-ops both on an already
+	# patched install and on the release that finally carries the change upstream.
+	if PYTHONPATH="$site${PYTHONPATH:+:$PYTHONPATH}" "$interpreter" -c \
+		'import graphify.rcfile as rc; raise SystemExit(0 if hasattr(rc, "activate_language_overrides") else 1)' \
+		>/dev/null 2>&1; then
+		echo "patch-graphify.sh: '$package' already provides the .inc language override; nothing to patch" >&2
+		return 0
+	fi
+
+	require_tool patch
+	# Dry run first: a patch that fails halfway would leave a broken installation.
+	patch_output=$(cd "$site" && patch -p1 --forward -V none --dry-run < "$patch_file" 2>&1) || {
+		printf '%s\n' "$patch_output" >&2
+		fail "vendored patch does not apply to '$package' (tracks $UPSTREAM); refresh Graphify with 'uv tool install --reinstall graphifyy', or delete the patch once upstream releases the change"
+	}
+	patch_output=$(cd "$site" && patch -p1 --forward -V none < "$patch_file" 2>&1) || {
+		printf '%s\n' "$patch_output" >&2
+		fail "vendored patch failed midway through '$package' (tracks $UPSTREAM); reinstall Graphify with 'uv tool install --reinstall graphifyy'"
+	}
+	echo "patch-graphify.sh: applied $UPSTREAM to '$package'" >&2
+
+	# The unpatched AST cache keys an entry by file content alone, with no language
+	# component (graphify/cache.py load_cached), so Pascal-parsed entries would be
+	# served for the remapped PHP includes until the whole AST cache is dropped.
+	cache=$root/graphify-out/cache/ast
+	if [ -d "$cache" ]; then
+		rm -rf "$cache" || fail "cannot purge the language-blind AST cache '$cache'"
+		echo "patch-graphify.sh: purged the language-blind AST cache '$cache'" >&2
+	fi
+}
+
+main "$@"

--- a/scripts/agent/patch-graphify.sh
+++ b/scripts/agent/patch-graphify.sh
@@ -61,10 +61,13 @@ main() {
 		*) skip "'$graphify_bin' does not name a Python interpreter on its shebang" ;;
 	esac
 
-	# Both probes run isolated (-I: no cwd, no PYTHONPATH, no user site) from a neutral
-	# directory, so a module beside the caller cannot answer for the installed package
-	# -- or run at all. The CLI's own interpreter already resolves its own graphify.
-	package=$(cd / && "$interpreter" -I -c \
+	# Both probes run isolated (-I), which since Python 3.4 keeps the caller's directory
+	# off sys.path and, by implying -E and -s, keeps PYTHONPATH and the user site
+	# directory off it too. So a module beside the caller, on PYTHONPATH, or in the user
+	# site cannot answer for the installed package -- or run at all. Graphify needs
+	# >=3.10, so every interpreter that can run it honours the flag. The CLI's own
+	# interpreter already resolves its own graphify.
+	package=$("$interpreter" -I -c \
 		'import graphify, os; print(os.path.dirname(graphify.__file__))' 2>/dev/null) || package=''
 	[ -n "$package" ] || skip "cannot locate an importable Graphify package for '$graphify_bin'"
 	[ -d "$package" ] || fail "Graphify package directory '$package' does not exist"
@@ -72,8 +75,8 @@ main() {
 
 	# Ask the package itself, not the file text: this no-ops both on an already
 	# patched install and on the release that finally carries the change upstream.
-	if (cd / && "$interpreter" -I -c \
-		'import graphify.rcfile as rc; raise SystemExit(0 if hasattr(rc, "activate_language_overrides") else 1)') \
+	if "$interpreter" -I -c \
+		'import graphify.rcfile as rc; raise SystemExit(0 if hasattr(rc, "activate_language_overrides") else 1)' \
 		>/dev/null 2>&1; then
 		echo "patch-graphify.sh: '$package' already provides the .inc language override; nothing to patch" >&2
 		return 0

--- a/scripts/agent/patch-graphify.sh
+++ b/scripts/agent/patch-graphify.sh
@@ -62,18 +62,24 @@ main() {
 		# A uv tool venv carries its Python minor version in the site-packages path,
 		# so the interpreter that owns the package is read off the CLI's own shebang
 		# and the package directory is derived from it -- neither is ever hardcoded.
+		# A wrapper or a shim hides the interpreter, and the repository's own shell
+		# fixtures stub `graphify` with /bin/sh, so an unreadable shebang falls back
+		# to the ambient python3 rather than failing: a Graphify this script cannot
+		# reach is a skip, never a dead worktree cut. The tracked graph's include-node
+		# floor catches the resulting Pascal parse if a real install is ever skipped.
 		interpreter=$(sed -n '1s/^#![[:space:]]*//p' "$graphify_bin")
-		case "$interpreter" in
-			/*) ;;
-			*) fail "'$graphify_bin' does not name an absolute interpreter (got: '${interpreter:-none}')" ;;
+		case "${interpreter%% *}" in
+			/*python*) ;;
+			*) interpreter=$(command -v python3 || :) ;;
 		esac
-		case "${interpreter##*/}" in
-			python*) ;;
-			*) fail "'$graphify_bin' is not run by a Python interpreter (got: '$interpreter')" ;;
-		esac
-		[ -x "$interpreter" ] || fail "Graphify's interpreter '$interpreter' is not executable"
-		package=$("$interpreter" -c 'import graphify, os; print(os.path.dirname(graphify.__file__))') ||
-			fail "'$interpreter' cannot import graphify; reinstall with 'uv tool install --reinstall graphifyy'"
+		package=''
+		if [ -n "$interpreter" ] && [ -x "$interpreter" ]; then
+			package=$("$interpreter" -c 'import graphify, os; print(os.path.dirname(graphify.__file__))' 2>/dev/null || :)
+		fi
+		if [ -z "$package" ]; then
+			echo "patch-graphify.sh: cannot locate an importable Graphify package for '$graphify_bin'; skipping the $UPSTREAM override" >&2
+			return 0
+		fi
 	fi
 	[ -d "$package" ] || fail "Graphify package directory '$package' does not exist"
 	site=$(CDPATH='' cd "$package/.." && pwd -P) || exit 2

--- a/scripts/agent/patch-graphify.sh
+++ b/scripts/agent/patch-graphify.sh
@@ -1,14 +1,19 @@
 #!/bin/sh
 # Apply the vendored Graphify .inc language-override patch to the installed package.
-# Usage: sh scripts/agent/patch-graphify.sh [REPOSITORY]
+# Usage: sh scripts/agent/patch-graphify.sh
 #
 # Graphify's suffix map sends .inc to the Pascal extractor, so this repository's PHP
 # include files extract as a handful of incidental nodes while extraction still
 # reports success (issue #2810). Upstream fixes that in Graphify-Labs/graphify#3075,
 # which is unreleased, so the patch rides in .agents/patches/ and is re-applied after
 # every install: a bare `uv tool upgrade graphifyy` replaces site-packages and reverts
-# it. Delete this script, its patch, and its three call sites once a released
-# graphifyy provides the override API -- this script no-ops from that release on.
+# it. Delete this script, its patch, and its two call sites once a released graphifyy
+# provides the override API -- this script no-ops from that release on.
+#
+# No repository is touched and no cache is purged: the patch salts the AST cache key
+# with the remapped language (rcfile.cache_salt, cache._salted_key, salt= threaded
+# through every extract.py cache call), so a pre-patch Pascal entry can never be served
+# for a .inc file.
 #
 # Progress goes to stderr, like the sibling scripts in this directory: callers keep a
 # clean stdout.
@@ -18,29 +23,21 @@ set -eu
 PATCH_REL='.agents/patches/graphify-3075-language-overrides.patch'
 UPSTREAM='Graphify-Labs/graphify#3075'
 
-usage() {
-	echo "usage: patch-graphify.sh [REPOSITORY]" >&2
-	exit 2
-}
-
 fail() {
 	echo "patch-graphify.sh: $*" >&2
 	exit 1
 }
 
+# A Graphify this script cannot reach is a skip, never a dead worktree cut and never a
+# guess. The tracked graph's include-node floor catches a real install that got skipped.
+skip() {
+	echo "patch-graphify.sh: $*; skipping the $UPSTREAM override" >&2
+	exit 0
+}
+
 main() {
 	# shellcheck source=scripts/agent/agent_env.sh
 	. "$(dirname "$0")/agent_env.sh"
-	scrub_git_env "$0"
-	[ "$#" -le 1 ] || usage
-	require_tool git
-
-	target=${1:-.}
-	root=$(git -C "$target" rev-parse --show-toplevel 2>/dev/null) || {
-		echo "patch-graphify.sh: '$target' is not a git worktree" >&2
-		exit 2
-	}
-	root=$(CDPATH='' cd "$root" && pwd -P) || exit 2
 
 	# The script and its patch always ship together, so the patch comes from this
 	# script's own checkout -- a worktree cut from a branch that predates the patch
@@ -49,45 +46,34 @@ main() {
 	patch_file=$checkout/$PATCH_REL
 	[ -f "$patch_file" ] || fail "vendored patch '$patch_file' is missing"
 
-	if [ -n "${PFB_GRAPHIFY_PACKAGE_DIR:-}" ]; then
-		# A named package tree is not tied to a tool venv (a nonstandard install, or
-		# a test's throwaway copy), so it is imported with the ambient python3.
-		require_tool python3
-		interpreter=python3
-		package=$PFB_GRAPHIFY_PACKAGE_DIR
-	else
-		require_tool sed
-		graphify_bin=$(command -v graphify) ||
-			fail "Graphify is not installed; run 'uv tool install --upgrade graphifyy' first"
-		# A uv tool venv carries its Python minor version in the site-packages path,
-		# so the interpreter that owns the package is read off the CLI's own shebang
-		# and the package directory is derived from it -- neither is ever hardcoded.
-		# A wrapper or a shim hides the interpreter, and the repository's own shell
-		# fixtures stub `graphify` with /bin/sh, so an unreadable shebang falls back
-		# to the ambient python3 rather than failing: a Graphify this script cannot
-		# reach is a skip, never a dead worktree cut. The tracked graph's include-node
-		# floor catches the resulting Pascal parse if a real install is ever skipped.
-		interpreter=$(sed -n '1s/^#![[:space:]]*//p' "$graphify_bin")
-		case "${interpreter%% *}" in
-			/*python*) ;;
-			*) interpreter=$(command -v python3 || :) ;;
-		esac
-		package=''
-		if [ -n "$interpreter" ] && [ -x "$interpreter" ]; then
-			package=$("$interpreter" -c 'import graphify, os; print(os.path.dirname(graphify.__file__))' 2>/dev/null || :)
-		fi
-		if [ -z "$package" ]; then
-			echo "patch-graphify.sh: cannot locate an importable Graphify package for '$graphify_bin'; skipping the $UPSTREAM override" >&2
-			return 0
-		fi
-	fi
+	require_tool sed
+	graphify_bin=$(command -v graphify) ||
+		fail "Graphify is not installed; run 'uv tool install --upgrade graphifyy' first"
+	# A uv tool venv carries its Python minor version in the site-packages path, so the
+	# interpreter that owns the package is read off the CLI's own shebang -- never
+	# hardcoded, and never the ambient python3: a different interpreter imports a
+	# DIFFERENT graphify, so falling back patches an unrelated package and reports
+	# success. A wrapper or shim that hides the interpreter is therefore a skip.
+	interpreter=$(sed -n '1s/^#![[:space:]]*//p' "$graphify_bin")
+	interpreter=${interpreter%% *}
+	case "$interpreter" in
+		/*python*) ;;
+		*) skip "'$graphify_bin' does not name a Python interpreter on its shebang" ;;
+	esac
+
+	# Both probes run isolated (-I: no cwd, no PYTHONPATH, no user site) from a neutral
+	# directory, so a module beside the caller cannot answer for the installed package
+	# -- or run at all. The CLI's own interpreter already resolves its own graphify.
+	package=$(cd / && "$interpreter" -I -c \
+		'import graphify, os; print(os.path.dirname(graphify.__file__))' 2>/dev/null) || package=''
+	[ -n "$package" ] || skip "cannot locate an importable Graphify package for '$graphify_bin'"
 	[ -d "$package" ] || fail "Graphify package directory '$package' does not exist"
 	site=$(CDPATH='' cd "$package/.." && pwd -P) || exit 2
 
 	# Ask the package itself, not the file text: this no-ops both on an already
 	# patched install and on the release that finally carries the change upstream.
-	if PYTHONPATH="$site${PYTHONPATH:+:$PYTHONPATH}" "$interpreter" -c \
-		'import graphify.rcfile as rc; raise SystemExit(0 if hasattr(rc, "activate_language_overrides") else 1)' \
+	if (cd / && "$interpreter" -I -c \
+		'import graphify.rcfile as rc; raise SystemExit(0 if hasattr(rc, "activate_language_overrides") else 1)') \
 		>/dev/null 2>&1; then
 		echo "patch-graphify.sh: '$package' already provides the .inc language override; nothing to patch" >&2
 		return 0
@@ -95,24 +81,32 @@ main() {
 
 	require_tool patch
 	# Dry run first: a patch that fails halfway would leave a broken installation.
-	patch_output=$(cd "$site" && patch -p1 --forward -V none --dry-run < "$patch_file" 2>&1) || {
+	patch_output=$(cd "$site" && patch -p1 --forward --dry-run < "$patch_file" 2>&1) || {
 		printf '%s\n' "$patch_output" >&2
 		fail "vendored patch does not apply to '$package' (tracks $UPSTREAM); refresh Graphify with 'uv tool install --reinstall graphifyy', or delete the patch once upstream releases the change"
 	}
-	patch_output=$(cd "$site" && patch -p1 --forward -V none < "$patch_file" 2>&1) || {
+	patch_output=$(cd "$site" && patch -p1 --forward < "$patch_file" 2>&1) || {
 		printf '%s\n' "$patch_output" >&2
 		fail "vendored patch failed midway through '$package' (tracks $UPSTREAM); reinstall Graphify with 'uv tool install --reinstall graphifyy'"
 	}
-	echo "patch-graphify.sh: applied $UPSTREAM to '$package'" >&2
 
-	# The unpatched AST cache keys an entry by file content alone, with no language
-	# component (graphify/cache.py load_cached), so Pascal-parsed entries would be
-	# served for the remapped PHP includes until the whole AST cache is dropped.
-	cache=$root/graphify-out/cache/ast
-	if [ -d "$cache" ]; then
-		rm -rf "$cache" || fail "cannot purge the language-blind AST cache '$cache'"
-		echo "patch-graphify.sh: purged the language-blind AST cache '$cache'" >&2
-	fi
+	# No -V is portable -- GNU patch 2.8 reads `-V none` as "numbered" and ENABLES
+	# backups, Apple patch 2.0 needs a -V to stay quiet -- so the backups are removed
+	# afterwards, for exactly the files this patch touches, and verified gone.
+	litter=$(
+		sed -n 's|^+++ b/\([^[:space:]]*\).*|\1|p' "$patch_file" |
+			while IFS= read -r touched; do
+				for backup in "$site/$touched.orig" "$site/$touched".~*~; do
+					[ -e "$backup" ] || continue
+					rm -f "$backup" || :
+					if [ -e "$backup" ]; then
+						printf " '%s'" "$backup"
+					fi
+				done
+			done
+	)
+	[ -z "$litter" ] || fail "cannot remove patch backups left in '$site':$litter"
+	echo "patch-graphify.sh: applied $UPSTREAM to '$package'" >&2
 }
 
 main "$@"

--- a/scripts/agent/patch-graphify.sh
+++ b/scripts/agent/patch-graphify.sh
@@ -83,32 +83,21 @@ main() {
 	fi
 
 	require_tool patch
-	# Dry run first: a patch that fails halfway would leave a broken installation.
-	patch_output=$(cd "$site" && patch -p1 --forward --dry-run < "$patch_file" 2>&1) || {
+	# --no-backup-if-mismatch keeps an offset or fuzzy apply from dropping a `.orig`
+	# beside the installed package; a clean apply writes none either way. Both
+	# implementations this repository runs on accept and honour it -- GNU patch 2.8 and
+	# Apple patch 2.0 -- and both reject an unknown flag loudly, so acceptance is real.
+	# The dry run comes first because a patch that fails halfway would leave a broken
+	# installation; the two invocations are identical apart from --dry-run.
+	patch_output=$(cd "$site" && patch -p1 --forward --no-backup-if-mismatch --dry-run < "$patch_file" 2>&1) || {
 		printf '%s\n' "$patch_output" >&2
 		fail "vendored patch does not apply to '$package' (tracks $UPSTREAM); refresh Graphify with 'uv tool install --reinstall graphifyy', or delete the patch once upstream releases the change"
 	}
-	patch_output=$(cd "$site" && patch -p1 --forward < "$patch_file" 2>&1) || {
+	patch_output=$(cd "$site" && patch -p1 --forward --no-backup-if-mismatch < "$patch_file" 2>&1) || {
 		printf '%s\n' "$patch_output" >&2
 		fail "vendored patch failed midway through '$package' (tracks $UPSTREAM); reinstall Graphify with 'uv tool install --reinstall graphifyy'"
 	}
 
-	# No -V is portable -- GNU patch 2.8 reads `-V none` as "numbered" and ENABLES
-	# backups, Apple patch 2.0 needs a -V to stay quiet -- so the backups are removed
-	# afterwards, for exactly the files this patch touches, and verified gone.
-	litter=$(
-		sed -n 's|^+++ b/\([^[:space:]]*\).*|\1|p' "$patch_file" |
-			while IFS= read -r touched; do
-				for backup in "$site/$touched.orig" "$site/$touched".~*~; do
-					[ -e "$backup" ] || continue
-					rm -f "$backup" || :
-					if [ -e "$backup" ]; then
-						printf " '%s'" "$backup"
-					fi
-				done
-			done
-	)
-	[ -z "$litter" ] || fail "cannot remove patch backups left in '$site':$litter"
 	echo "patch-graphify.sh: applied $UPSTREAM to '$package'" >&2
 }
 

--- a/scripts/agent/setup-agent-tools.sh
+++ b/scripts/agent/setup-agent-tools.sh
@@ -225,10 +225,8 @@ main() {
 	root=$(CDPATH='' cd "$root" && pwd -P) || exit 2
 	setup_hooks=$root/scripts/setup-hooks.sh
 	init_tools=$root/scripts/agent/init-worktree-tools.sh
-	patch_graphify=$root/scripts/agent/patch-graphify.sh
 	[ -f "$setup_hooks" ] || fail "required repository helper '$setup_hooks' is missing"
 	[ -f "$init_tools" ] || fail "required repository helper '$init_tools' is missing"
-	[ -f "$patch_graphify" ] || fail "required repository helper '$patch_graphify' is missing"
 
 	if [ -n "${XDG_BIN_HOME:-}" ]; then
 		xdg_bin_home=$XDG_BIN_HOME
@@ -271,9 +269,6 @@ main() {
 	require_tool graphify
 	require_tool ast-grep
 	require_tool semgrep
-	# Graphify parses this repository's PHP .inc files as Pascal until the vendored
-	# override lands on the freshly installed package (issue #2810).
-	sh "$patch_graphify" "$root"
 
 	if command -v codegraph >/dev/null 2>&1; then
 		codegraph upgrade

--- a/scripts/agent/setup-agent-tools.sh
+++ b/scripts/agent/setup-agent-tools.sh
@@ -225,8 +225,10 @@ main() {
 	root=$(CDPATH='' cd "$root" && pwd -P) || exit 2
 	setup_hooks=$root/scripts/setup-hooks.sh
 	init_tools=$root/scripts/agent/init-worktree-tools.sh
+	patch_graphify=$root/scripts/agent/patch-graphify.sh
 	[ -f "$setup_hooks" ] || fail "required repository helper '$setup_hooks' is missing"
 	[ -f "$init_tools" ] || fail "required repository helper '$init_tools' is missing"
+	[ -f "$patch_graphify" ] || fail "required repository helper '$patch_graphify' is missing"
 
 	if [ -n "${XDG_BIN_HOME:-}" ]; then
 		xdg_bin_home=$XDG_BIN_HOME
@@ -269,6 +271,9 @@ main() {
 	require_tool graphify
 	require_tool ast-grep
 	require_tool semgrep
+	# Graphify parses this repository's PHP .inc files as Pascal until the vendored
+	# override lands on the freshly installed package (issue #2810).
+	sh "$patch_graphify" "$root"
 
 	if command -v codegraph >/dev/null 2>&1; then
 		codegraph upgrade

--- a/tests/shell/agent_graphify_merge_driver_spec.sh
+++ b/tests/shell/agent_graphify_merge_driver_spec.sh
@@ -30,6 +30,13 @@ case "${GRAPHIFY_DRIVER_MODE:-valid}" in
   *) exit 92 ;;
 esac
 GRAPHIFY
+    # The vendored .inc language-override patch (issue #2810): this script runs the
+    # requested checkout's copy, so the real installed Graphify is never touched here.
+    mkdir -p "$repo/scripts/agent"
+    cat > "$repo/scripts/agent/patch-graphify.sh" <<'PATCH_GRAPHIFY'
+#!/bin/sh
+printf 'patch-graphify\t%s\n' "$1" >> "$GRAPHIFY_LOG"
+PATCH_GRAPHIFY
     chmod +x "$stubdir/uv" "$stubdir/graphify"
     export UV_LOG="$uv_log" GRAPHIFY_LOG="$graphify_log"
     PATH="$stubdir:$PATH"
@@ -44,7 +51,8 @@ GRAPHIFY
     When run sh "$script_abs" "$repo"
     The status should equal 0
     The contents of file "$uv_log" should equal 'tool install --upgrade graphifyy>=0.9.51'
-    The contents of file "$graphify_log" should equal "$(printf '%s\thook install' "$repo")"
+    The contents of file "$graphify_log" should equal \
+      "$(printf 'patch-graphify\t%s\n%s\thook install' "$repo" "$repo")"
     The value "$(git_fixture -C "$repo" config --get merge.graphify.driver)" should include 'graphify merge-driver %O %A %B'
   End
 

--- a/tests/shell/agent_graphify_merge_driver_spec.sh
+++ b/tests/shell/agent_graphify_merge_driver_spec.sh
@@ -35,7 +35,7 @@ GRAPHIFY
     mkdir -p "$repo/scripts/agent"
     cat > "$repo/scripts/agent/patch-graphify.sh" <<'PATCH_GRAPHIFY'
 #!/bin/sh
-printf 'patch-graphify\t%s\n' "$1" >> "$GRAPHIFY_LOG"
+printf 'patch-graphify\t%s\n' "$*" >> "$GRAPHIFY_LOG"
 PATCH_GRAPHIFY
     chmod +x "$stubdir/uv" "$stubdir/graphify"
     export UV_LOG="$uv_log" GRAPHIFY_LOG="$graphify_log"
@@ -52,7 +52,7 @@ PATCH_GRAPHIFY
     The status should equal 0
     The contents of file "$uv_log" should equal 'tool install --upgrade graphifyy>=0.9.51'
     The contents of file "$graphify_log" should equal \
-      "$(printf 'patch-graphify\t%s\n%s\thook install' "$repo" "$repo")"
+      "$(printf 'patch-graphify\t\n%s\thook install' "$repo")"
     The value "$(git_fixture -C "$repo" config --get merge.graphify.driver)" should include 'graphify merge-driver %O %A %B'
   End
 

--- a/tests/shell/agent_tools_setup_spec.sh
+++ b/tests/shell/agent_tools_setup_spec.sh
@@ -51,6 +51,12 @@ SETUP_HOOKS
 #!/bin/sh
 printf 'init-worktree-tools:%s\n' "$1" >> "$DEBIAN_HELPER_LOG"
 INIT_WORKTREE
+    # The vendored .inc language-override patch (issue #2810): the bootstrap runs the
+    # requested checkout's copy, so the real installed Graphify is never touched here.
+    cat > "$repository/scripts/agent/patch-graphify.sh" <<'PATCH_GRAPHIFY'
+#!/bin/sh
+printf 'patch-graphify.sh:%s\n' "$1" >> "$DEBIAN_TOOL_LOG"
+PATCH_GRAPHIFY
 
     basebin="$fixture/base-bin"
     activebin="$fixture/active-bin"
@@ -380,6 +386,7 @@ GROK
       'uv:tool install --upgrade graphifyy' \
       'uv:tool install --upgrade ast-grep-cli' \
       'uv:tool install --upgrade semgrep' \
+      "patch-graphify.sh:$repository" \
       'codegraph:install -l global -y -t auto' \
       'wt:config shell install --yes' \
       'serena:init')"
@@ -414,6 +421,7 @@ GROK
       'uv:tool install --upgrade graphifyy' \
       'uv:tool install --upgrade ast-grep-cli' \
       'uv:tool install --upgrade semgrep' \
+      "patch-graphify.sh:$repository" \
       'codegraph:install -l global -y -t auto' \
       'wt:config shell install --yes' \
       'serena:init')"
@@ -453,6 +461,7 @@ GROK
       'uv:tool install --upgrade graphifyy' \
       'uv:tool install --upgrade ast-grep-cli' \
       'uv:tool install --upgrade semgrep' \
+      "patch-graphify.sh:$repository" \
       'codegraph:upgrade' \
       'codegraph:install -l global -y -t auto' \
       'wt:config shell install --yes' \
@@ -477,6 +486,7 @@ UNMANAGED_UV
       'uv:tool install --upgrade graphifyy' \
       'uv:tool install --upgrade ast-grep-cli' \
       'uv:tool install --upgrade semgrep' \
+      "patch-graphify.sh:$repository" \
       'codegraph:upgrade' \
       'codegraph:install -l global -y -t auto' \
       'wt:config shell install --yes' \
@@ -499,6 +509,7 @@ UNMANAGED_UV
       'uv:tool install --upgrade graphifyy' \
       'uv:tool install --upgrade ast-grep-cli' \
       'uv:tool install --upgrade semgrep' \
+      "patch-graphify.sh:$repository" \
       'codegraph:upgrade' \
       'codegraph:install -l global -y -t auto' \
       'wt:config shell install --yes' \
@@ -510,6 +521,7 @@ UNMANAGED_UV
       'uv:tool install --upgrade graphifyy' \
       'uv:tool install --upgrade ast-grep-cli' \
       'uv:tool install --upgrade semgrep' \
+      "patch-graphify.sh:$repository" \
       'codegraph:upgrade' \
       'codegraph:install -l global -y -t auto' \
       'wt:config shell install --yes' \
@@ -534,6 +546,7 @@ UNMANAGED_UV
       'uv:tool install --upgrade graphifyy' \
       'uv:tool install --upgrade ast-grep-cli' \
       'uv:tool install --upgrade semgrep' \
+      "patch-graphify.sh:$repository" \
       'codegraph:install -l global -y -t auto' \
       'wt:config shell install --yes' \
       'serena:init')"

--- a/tests/shell/agent_tools_setup_spec.sh
+++ b/tests/shell/agent_tools_setup_spec.sh
@@ -51,12 +51,6 @@ SETUP_HOOKS
 #!/bin/sh
 printf 'init-worktree-tools:%s\n' "$1" >> "$DEBIAN_HELPER_LOG"
 INIT_WORKTREE
-    # The vendored .inc language-override patch (issue #2810): the bootstrap runs the
-    # requested checkout's copy, so the real installed Graphify is never touched here.
-    cat > "$repository/scripts/agent/patch-graphify.sh" <<'PATCH_GRAPHIFY'
-#!/bin/sh
-printf 'patch-graphify.sh:%s\n' "$1" >> "$DEBIAN_TOOL_LOG"
-PATCH_GRAPHIFY
 
     basebin="$fixture/base-bin"
     activebin="$fixture/active-bin"
@@ -386,7 +380,6 @@ GROK
       'uv:tool install --upgrade graphifyy' \
       'uv:tool install --upgrade ast-grep-cli' \
       'uv:tool install --upgrade semgrep' \
-      "patch-graphify.sh:$repository" \
       'codegraph:install -l global -y -t auto' \
       'wt:config shell install --yes' \
       'serena:init')"
@@ -421,7 +414,6 @@ GROK
       'uv:tool install --upgrade graphifyy' \
       'uv:tool install --upgrade ast-grep-cli' \
       'uv:tool install --upgrade semgrep' \
-      "patch-graphify.sh:$repository" \
       'codegraph:install -l global -y -t auto' \
       'wt:config shell install --yes' \
       'serena:init')"
@@ -461,7 +453,6 @@ GROK
       'uv:tool install --upgrade graphifyy' \
       'uv:tool install --upgrade ast-grep-cli' \
       'uv:tool install --upgrade semgrep' \
-      "patch-graphify.sh:$repository" \
       'codegraph:upgrade' \
       'codegraph:install -l global -y -t auto' \
       'wt:config shell install --yes' \
@@ -486,7 +477,6 @@ UNMANAGED_UV
       'uv:tool install --upgrade graphifyy' \
       'uv:tool install --upgrade ast-grep-cli' \
       'uv:tool install --upgrade semgrep' \
-      "patch-graphify.sh:$repository" \
       'codegraph:upgrade' \
       'codegraph:install -l global -y -t auto' \
       'wt:config shell install --yes' \
@@ -509,7 +499,6 @@ UNMANAGED_UV
       'uv:tool install --upgrade graphifyy' \
       'uv:tool install --upgrade ast-grep-cli' \
       'uv:tool install --upgrade semgrep' \
-      "patch-graphify.sh:$repository" \
       'codegraph:upgrade' \
       'codegraph:install -l global -y -t auto' \
       'wt:config shell install --yes' \
@@ -521,7 +510,6 @@ UNMANAGED_UV
       'uv:tool install --upgrade graphifyy' \
       'uv:tool install --upgrade ast-grep-cli' \
       'uv:tool install --upgrade semgrep' \
-      "patch-graphify.sh:$repository" \
       'codegraph:upgrade' \
       'codegraph:install -l global -y -t auto' \
       'wt:config shell install --yes' \
@@ -546,7 +534,6 @@ UNMANAGED_UV
       'uv:tool install --upgrade graphifyy' \
       'uv:tool install --upgrade ast-grep-cli' \
       'uv:tool install --upgrade semgrep' \
-      "patch-graphify.sh:$repository" \
       'codegraph:install -l global -y -t auto' \
       'wt:config shell install --yes' \
       'serena:init')"

--- a/tests/shell/agent_worktree_tools_spec.sh
+++ b/tests/shell/agent_worktree_tools_spec.sh
@@ -7,7 +7,8 @@ Describe 'init-worktree-tools.sh'
   make_tool_path() {
     destination=$1
     mkdir -p "$destination"
-    for tool in sh dirname git tr mkdir pwd; do
+    # python3 resolves the throwaway Graphify package tree named in setup().
+    for tool in sh dirname git tr mkdir pwd python3; do
       ln -s "$(command -v "$tool")" "$destination/$tool"
     done
   }
@@ -73,6 +74,18 @@ SERENA
     ln -s "$stubdir/graphify" "$no_serena/graphify"
 
     export WORKTREE_TOOL_LOG="$tool_log"
+    # The initializer now applies the vendored .inc language-override patch (issue
+    # #2810) before refreshing the graph. Point it at a throwaway package tree that
+    # already carries the override API, so it no-ops instead of touching the real
+    # installed Graphify.
+    override_package="$fixture/site packages/graphify"
+    mkdir -p "$override_package"
+    true > "$override_package/__init__.py"
+    cat > "$override_package/rcfile.py" <<'RCFILE'
+def activate_language_overrides(root):
+    return {}
+RCFILE
+    export PFB_GRAPHIFY_PACKAGE_DIR="$override_package"
     PATH="$stubdir:$PATH"; export PATH
   }
   cleanup() { rm -rf "$fixture"; }
@@ -100,6 +113,16 @@ SERENA
     true > "$worktree/graphify-out/graph.json"
     When run env OMP_CLI=1 sh "$script_abs" "$worktree"
     The status should equal 0
+    The contents of file "$tool_log" should equal "$(printf 'codegraph:init:%s\ngraphify:update:%s' "$worktree" "$worktree")"
+    The stderr should include 'Initializing CodeGraph in'
+  End
+
+  It 'applies the vendored Graphify language override before refreshing the graph'
+    mkdir -p "$worktree/graphify-out"
+    true > "$worktree/graphify-out/graph.json"
+    When run env OMP_CLI=1 sh "$script_abs" "$worktree"
+    The status should equal 0
+    The stderr should include 'already provides'
     The contents of file "$tool_log" should equal "$(printf 'codegraph:init:%s\ngraphify:update:%s' "$worktree" "$worktree")"
     The stderr should include 'Initializing CodeGraph in'
   End

--- a/tests/shell/agent_worktree_tools_spec.sh
+++ b/tests/shell/agent_worktree_tools_spec.sh
@@ -41,8 +41,25 @@ case "$1" in
   *) exit 9 ;;
 esac
 CODEGRAPH
-    cat > "$stubdir/graphify" <<'GRAPHIFY'
+    # patch-graphify.sh finds the package to patch through the interpreter named on the
+    # shebang of the `graphify` on PATH, so this stub's shebang names a wrapper sitting
+    # where a uv tool venv keeps its own interpreter. The wrapper logs the patch
+    # script's probe -- which is what pins the patch call's position in this chain --
+    # and then fails it, so the patch script skips and the real installed Graphify is
+    # never touched from here. Anything that is not that probe is the stub below being
+    # executed through this shebang, so it runs as the /bin/sh script it is.
+    interpreter="$fixture/toolvenv/bin/python3"
+    mkdir -p "$fixture/toolvenv/bin"
+    cat > "$interpreter" <<'INTERPRETER'
 #!/bin/sh
+case "$1" in
+  -I) printf 'patch-graphify:probe\n' >> "$WORKTREE_TOOL_LOG"; exit 1 ;;
+esac
+exec sh "$@"
+INTERPRETER
+    chmod +x "$interpreter"
+    printf '#!%s\n' "$interpreter" > "$stubdir/graphify"
+    cat >> "$stubdir/graphify" <<'GRAPHIFY'
 case "$1" in
   update)
     [ "$#" -eq 2 ] || exit 9
@@ -75,9 +92,8 @@ SERENA
 
     export WORKTREE_TOOL_LOG="$tool_log"
     # The initializer applies the vendored .inc language-override patch (issue #2810)
-    # before refreshing the graph. The `graphify` stubbed above is a /bin/sh script, so
-    # the patch script finds no Python interpreter on its shebang and skips -- the real
-    # installed Graphify is never touched from here.
+    # before refreshing the graph, so every log below carries `patch-graphify:probe`
+    # between the CodeGraph line and the Graphify one.
     PATH="$stubdir:$PATH"; export PATH
   }
   cleanup() { rm -rf "$fixture"; }
@@ -87,7 +103,7 @@ SERENA
   It 'runs CodeGraph, skips the first Graphify build, and skips Serena when OMP marks the invoking harness'
     When run env OMP_CLI=1 sh "$script_abs" "$worktree"
     The status should equal 0
-    The contents of file "$tool_log" should equal "codegraph:init:$worktree"
+    The contents of file "$tool_log" should equal "$(printf 'codegraph:init:%s\npatch-graphify:probe' "$worktree")"
     The stderr should include 'Initializing CodeGraph in'
     The stderr should include 'run /graphify'
   End
@@ -95,18 +111,9 @@ SERENA
   It 'runs CodeGraph, skips the first Graphify build, and skips Serena when PI marks the invoking harness'
     When run env PI_CLI=1 sh "$script_abs" "$worktree"
     The status should equal 0
-    The contents of file "$tool_log" should equal "codegraph:init:$worktree"
+    The contents of file "$tool_log" should equal "$(printf 'codegraph:init:%s\npatch-graphify:probe' "$worktree")"
     The stderr should include 'Initializing CodeGraph in'
     The stderr should include 'run /graphify'
-  End
-
-  It 'refreshes an existing Graphify root graph instead of extracting it again'
-    mkdir -p "$worktree/graphify-out"
-    true > "$worktree/graphify-out/graph.json"
-    When run env OMP_CLI=1 sh "$script_abs" "$worktree"
-    The status should equal 0
-    The contents of file "$tool_log" should equal "$(printf 'codegraph:init:%s\ngraphify:update:%s' "$worktree" "$worktree")"
-    The stderr should include 'Initializing CodeGraph in'
   End
 
   It 'runs the vendored Graphify language override before refreshing the graph, and a stubbed graphify is a skip'
@@ -114,8 +121,9 @@ SERENA
     true > "$worktree/graphify-out/graph.json"
     When run env OMP_CLI=1 sh "$script_abs" "$worktree"
     The status should equal 0
-    The stderr should include 'does not name a Python interpreter'
-    The contents of file "$tool_log" should equal "$(printf 'codegraph:init:%s\ngraphify:update:%s' "$worktree" "$worktree")"
+    The stderr should include 'cannot locate'
+    The contents of file "$tool_log" should equal \
+      "$(printf 'codegraph:init:%s\npatch-graphify:probe\ngraphify:update:%s' "$worktree" "$worktree")"
     The stderr should include 'Initializing CodeGraph in'
   End
 
@@ -144,28 +152,31 @@ SERENA
     true > "$worktree/graphify-out/graph.json"
     When run env OMP_CLI=1 GRAPHIFY_RC=19 sh "$script_abs" "$worktree"
     The status should not equal 0
-    The contents of file "$tool_log" should equal "$(printf 'codegraph:init:%s\ngraphify:update:%s' "$worktree" "$worktree")"
+    The contents of file "$tool_log" should equal \
+      "$(printf 'codegraph:init:%s\npatch-graphify:probe\ngraphify:update:%s' "$worktree" "$worktree")"
     The stderr should include 'Initializing CodeGraph in'
   End
 
   It 'runs Serena project indexing at the exact root outside OMP when Serena is present'
     When run sh "$script_abs" "$worktree"
     The status should equal 0
-    The contents of file "$tool_log" should equal "$(printf 'codegraph:init:%s\nserena:project:index:%s' "$worktree" "$worktree")"
+    The contents of file "$tool_log" should equal \
+      "$(printf 'codegraph:init:%s\npatch-graphify:probe\nserena:project:index:%s' "$worktree" "$worktree")"
     The stderr should include 'Initializing CodeGraph in'
   End
 
   It 'skips absent Serena outside OMP without weakening mandatory initialization'
     When run env PATH="$no_serena" sh "$script_abs" "$worktree"
     The status should equal 0
-    The contents of file "$tool_log" should equal "codegraph:init:$worktree"
+    The contents of file "$tool_log" should equal "$(printf 'codegraph:init:%s\npatch-graphify:probe' "$worktree")"
     The stderr should include 'Initializing CodeGraph in'
   End
 
   It 'propagates Serena indexing failure'
     When run env SERENA_RC=23 sh "$script_abs" "$worktree"
     The status should equal 23
-    The contents of file "$tool_log" should equal "$(printf 'codegraph:init:%s\nserena:project:index:%s' "$worktree" "$worktree")"
+    The contents of file "$tool_log" should equal \
+      "$(printf 'codegraph:init:%s\npatch-graphify:probe\nserena:project:index:%s' "$worktree" "$worktree")"
     The stderr should include 'Initializing CodeGraph in'
   End
 End

--- a/tests/shell/agent_worktree_tools_spec.sh
+++ b/tests/shell/agent_worktree_tools_spec.sh
@@ -7,8 +7,8 @@ Describe 'init-worktree-tools.sh'
   make_tool_path() {
     destination=$1
     mkdir -p "$destination"
-    # python3 resolves the throwaway Graphify package tree named in setup().
-    for tool in sh dirname git tr mkdir pwd python3; do
+    # sed reads the shebang of the `graphify` on PATH for the .inc override patch.
+    for tool in sh dirname git tr mkdir pwd sed; do
       ln -s "$(command -v "$tool")" "$destination/$tool"
     done
   }
@@ -74,18 +74,10 @@ SERENA
     ln -s "$stubdir/graphify" "$no_serena/graphify"
 
     export WORKTREE_TOOL_LOG="$tool_log"
-    # The initializer now applies the vendored .inc language-override patch (issue
-    # #2810) before refreshing the graph. Point it at a throwaway package tree that
-    # already carries the override API, so it no-ops instead of touching the real
-    # installed Graphify.
-    override_package="$fixture/site packages/graphify"
-    mkdir -p "$override_package"
-    true > "$override_package/__init__.py"
-    cat > "$override_package/rcfile.py" <<'RCFILE'
-def activate_language_overrides(root):
-    return {}
-RCFILE
-    export PFB_GRAPHIFY_PACKAGE_DIR="$override_package"
+    # The initializer applies the vendored .inc language-override patch (issue #2810)
+    # before refreshing the graph. The `graphify` stubbed above is a /bin/sh script, so
+    # the patch script finds no Python interpreter on its shebang and skips -- the real
+    # installed Graphify is never touched from here.
     PATH="$stubdir:$PATH"; export PATH
   }
   cleanup() { rm -rf "$fixture"; }
@@ -117,12 +109,12 @@ RCFILE
     The stderr should include 'Initializing CodeGraph in'
   End
 
-  It 'applies the vendored Graphify language override before refreshing the graph'
+  It 'runs the vendored Graphify language override before refreshing the graph, and a stubbed graphify is a skip'
     mkdir -p "$worktree/graphify-out"
     true > "$worktree/graphify-out/graph.json"
     When run env OMP_CLI=1 sh "$script_abs" "$worktree"
     The status should equal 0
-    The stderr should include 'already provides'
+    The stderr should include 'does not name a Python interpreter'
     The contents of file "$tool_log" should equal "$(printf 'codegraph:init:%s\ngraphify:update:%s' "$worktree" "$worktree")"
     The stderr should include 'Initializing CodeGraph in'
   End

--- a/tests/shell/graphify_language_patch_spec.sh
+++ b/tests/shell/graphify_language_patch_spec.sh
@@ -4,8 +4,10 @@
 # the package to patch from the interpreter named on the shebang of the `graphify` on
 # PATH, so every example runs a copy of the script inside a fixture checkout carrying a
 # synthetic two-file patch, behind a fixture `graphify` whose shebang names a fixture
-# interpreter that answers for a throwaway package tree. Nothing here reaches the real
-# installed Graphify.
+# interpreter that answers for a throwaway package tree. The two isolation examples name
+# the ambient python3 instead -- a stub can neither honour nor ignore -I -- and the
+# PYTHONPATH one reaches it through a venv-shaped fixture that owns the throwaway
+# package. Nothing here reaches the real installed Graphify.
 
 Describe 'patch-graphify.sh'
   project_root="${SHELLSPEC_PROJECT_ROOT:-$PWD}"
@@ -31,6 +33,25 @@ case "\$*" in
 esac
 INTERPRETER
     chmod +x "$1"
+  }
+
+  # A real uv tool venv, built for the decoy example, which needs a REAL interpreter: a
+  # stub can neither honour nor ignore -I, so no example resting on one can observe the
+  # isolation. A symlinked python3 plus a pyvenv.cfg naming its home makes that
+  # interpreter treat $fixture/venv as its own prefix, so it finds the throwaway package
+  # on its DEFAULT sys.path with nothing injected, and system site packages are excluded
+  # so a machine-installed Graphify cannot answer either. The minor version is read off
+  # the interpreter, never hardcoded: it names the site-packages directory.
+  make_venv() {
+    real_python3=$(command -v python3) || return 1
+    pyver=$("$real_python3" -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")') || return 1
+    venv_package="$fixture/venv/lib/python$pyver/site-packages/graphify"
+    mkdir -p "$fixture/venv/bin" "$venv_package" || return 1
+    ln -s "$real_python3" "$fixture/venv/bin/python3" || return 1
+    printf 'home = %s\ninclude-system-site-packages = false\nversion = %s\n' \
+      "$(dirname "$real_python3")" "$pyver" > "$fixture/venv/pyvenv.cfg" || return 1
+    cp "$package/__init__.py" "$package/extract.py" "$venv_package/" || return 1
+    printf '#!%s\nexit 0\n' "$fixture/venv/bin/python3" > "$stubdir/graphify" || return 1
   }
 
   setup() {
@@ -156,8 +177,9 @@ RCFILE
   End
 
   It 'ignores a hostile module in the working directory it is called from'
-    # Both probes run isolated (-I) from a neutral directory, so a graphify.py beside
-    # the caller can neither answer for the installed package nor execute at all.
+    # Both probes run isolated (-I), which keeps the caller's directory off sys.path, so
+    # a graphify.py beside the caller can neither answer for the installed package nor
+    # execute at all.
     Skip if 'the ambient python3 imports a graphify of its own' ambient_python3_has_graphify
     hostile="$fixture/hostile cwd"
     mkdir -p "$hostile"
@@ -173,6 +195,28 @@ HOSTILE
     The path "$hostile/executed" should not be exist
     The path "$hostile/rcfile.py" should not be exist
     The path "$package/rcfile.py" should not be exist
+  End
+
+  It 'ignores a decoy graphify injected through PYTHONPATH'
+    # The other half of the isolation: -I drops PYTHONPATH, the user site directory and
+    # any .pth-injected path, so only the interpreter's own package can answer. A stub
+    # interpreter can neither honour nor ignore -I, so this example runs a real one out
+    # of a venv-shaped fixture. Drop -I and the decoy imports first, the script resolves
+    # the DECOY as the installed package, and the run patches the wrong tree.
+    make_venv
+    decoy="$fixture/decoy/graphify"
+    mkdir -p "$decoy"
+    true > "$decoy/__init__.py"
+    printf '%s\n' 'DECOY = True' > "$decoy/extract.py"
+    cp "$decoy/extract.py" "$fixture/decoy.extract.before"
+    When run env PYTHONPATH="$fixture/decoy" sh "$script_abs"
+    The status should equal 0
+    The stderr should include 'applied Graphify-Labs/graphify#3075'
+    The stderr should include "$venv_package"
+    The contents of file "$venv_package/rcfile.py" should include 'activate_language_overrides'
+    The contents of file "$venv_package/extract.py" should include 'SUFFIX_OVERRIDES = True'
+    The path "$decoy/rcfile.py" should not be exist
+    Assert [ "$(cmp -s "$decoy/extract.py" "$fixture/decoy.extract.before"; printf '%s' "$?")" -eq 0 ]
   End
 
   It 'fails with the install hint when graphify is absent from PATH'

--- a/tests/shell/graphify_language_patch_spec.sh
+++ b/tests/shell/graphify_language_patch_spec.sh
@@ -141,18 +141,44 @@ RCFILE
     Assert [ "$(cmp -s "$package/extract.py" "$fixture/extract.py.mismatch"; printf '%s' "$?")" -eq 0 ]
   End
 
-  It 'leaves no patch backup behind a successful apply'
-    # No -V flag is portable: GNU patch 2.8 reads `-V none` as "numbered" and ENABLES
-    # backups, while Apple patch 2.0 needs an explicit -V to stay quiet. Whether THIS
-    # host's patch writes one is exactly what cannot be relied on, so the litter is
-    # planted here and the script has to remove it for the files its patch touches.
-    printf 'stale\n' > "$package/extract.py.orig"
-    printf 'stale\n' > "$package/rcfile.py.~1~"
+  It 'leaves no patch backup behind an apply that lands with an offset'
+    # A CLEAN apply writes no backup on either implementation this repository runs on,
+    # so a planted stale file would prove nothing. What DOES make patch write one is an
+    # offset apply: one extra line ahead of the hunk shifts it, and GNU patch 2.8 and
+    # Apple patch 2.0 both then write `extract.py.orig` unless the apply passes
+    # --no-backup-if-mismatch.
+    { printf '%s\n' '# shifts the hunk by one line'; cat "$package/extract.py"; } > "$fixture/shifted"
+    mv "$fixture/shifted" "$package/extract.py"
     When run sh "$script_abs"
     The status should equal 0
     The stderr should include 'applied Graphify-Labs/graphify#3075'
     The contents of file "$package/rcfile.py" should include 'activate_language_overrides'
+    The contents of file "$package/extract.py" should include 'SUFFIX_OVERRIDES = True'
     Assert [ -z "$(find "$fixture/site packages" \( -name '*.orig' -o -name '*.~[0-9]*~' \) -print)" ]
+  End
+
+  It 'leaves no backup and touches no neighbour for a patched path holding a space'
+    # The tab-terminated name is the only space-bearing form BOTH implementations
+    # resolve -- Apple patch rejects git's C-quoted form outright. So any parser that
+    # reads the `+++` line and truncates at whitespace sees `graphify/with`: it misses
+    # the real backup and hits the unrelated neighbour planted below.
+    # --no-backup-if-mismatch needs no such parser, and this example goes red the
+    # moment one comes back.
+    {
+      printf 'diff --git a/graphify/with space.py b/graphify/with space.py\n'
+      printf -- '--- a/graphify/with space.py\t1970-01-01\n'
+      printf '+++ b/graphify/with space.py\t1970-01-01\n'
+      printf '@@ -1,1 +1,2 @@\n SPACED = True\n+SPACED_OVERRIDE = True\n'
+    } >> "$checkout/.agents/patches/graphify-3075-language-overrides.patch"
+    # The pad line shifts the hunk, which is what makes patch want a backup at all.
+    { printf '%s\n' '# pad'; printf '%s\n' 'SPACED = True'; } > "$package/with space.py"
+    printf 'neighbour\n' > "$package/with.orig"
+    When run sh "$script_abs"
+    The status should equal 0
+    The stderr should include 'applied Graphify-Labs/graphify#3075'
+    The contents of file "$package/with space.py" should include 'SPACED_OVERRIDE = True'
+    The path "$package/with.orig" should be exist
+    Assert [ -z "$(find "$fixture/site packages" \( -name '*.~[0-9]*~' -o \( -name '*.orig' ! -name 'with.orig' \) \) -print)" ]
   End
 
   It 'skips with a warning when the graphify shebang does not name a Python interpreter'

--- a/tests/shell/graphify_language_patch_spec.sh
+++ b/tests/shell/graphify_language_patch_spec.sh
@@ -131,6 +131,40 @@ RCFILE
     The file "$repo/graphify-out/cache/ast/entry.json" should be exist
   End
 
+  It 'skips with a warning when the graphify on PATH is not a Python program'
+    unset PFB_GRAPHIFY_PACKAGE_DIR
+    stubdir="$fixture/stub bin"
+    mkdir -p "$stubdir"
+    printf '#!/bin/sh\nexit 0\n' > "$stubdir/graphify"
+    printf '#!/bin/sh\nexit 1\n' > "$stubdir/python3"
+    chmod +x "$stubdir/graphify" "$stubdir/python3"
+    When run env PATH="$stubdir:$PATH" sh "$script_abs" "$repo"
+    The status should equal 0
+    The stderr should include 'cannot locate'
+    The path "$package/rcfile.py" should not be exist
+    The file "$repo/graphify-out/cache/ast/entry.json" should be exist
+  End
+
+  It 'falls back to the ambient python3 when the graphify wrapper hides its interpreter'
+    unset PFB_GRAPHIFY_PACKAGE_DIR
+    stubdir="$fixture/stub bin"
+    mkdir -p "$stubdir"
+    printf '#!/bin/sh\nexit 0\n' > "$stubdir/graphify"
+    cat > "$stubdir/python3" <<PYTHON3
+#!/bin/sh
+case "\$2" in
+  *graphify.__file__*) printf '%s\n' "$package" ;;
+  *) exit 1 ;;
+esac
+PYTHON3
+    chmod +x "$stubdir/graphify" "$stubdir/python3"
+    When run env PATH="$stubdir:$PATH" sh "$script_abs" "$repo"
+    The status should equal 0
+    The stderr should include 'Graphify-Labs/graphify#3075'
+    The contents of file "$package/rcfile.py" should include 'activate_language_overrides'
+    The path "$repo/graphify-out/cache/ast" should not be exist
+  End
+
   It 'rejects a target that is not a git worktree'
     When run sh "$script_abs" "$fixture/not a checkout"
     The status should equal 2

--- a/tests/shell/graphify_language_patch_spec.sh
+++ b/tests/shell/graphify_language_patch_spec.sh
@@ -1,31 +1,49 @@
 #shellcheck shell=sh
 # Vendored Graphify language-override patch (issue #2810, upstream
-# Graphify-Labs/graphify#3075). The script resolves both itself and its patch from
-# its own checkout, so every example runs a copy of it inside a fixture checkout
-# carrying a synthetic two-file patch, against a throwaway package tree named by
-# PFB_GRAPHIFY_PACKAGE_DIR. The real installed Graphify is never touched.
+# Graphify-Labs/graphify#3075). The script resolves its patch from its own checkout and
+# the package to patch from the interpreter named on the shebang of the `graphify` on
+# PATH, so every example runs a copy of the script inside a fixture checkout carrying a
+# synthetic two-file patch, behind a fixture `graphify` whose shebang names a fixture
+# interpreter that answers for a throwaway package tree. Nothing here reaches the real
+# installed Graphify.
 
 Describe 'patch-graphify.sh'
   project_root="${SHELLSPEC_PROJECT_ROOT:-$PWD}"
 
+  # The ambient python3 imports whatever graphify IT can see, which is why the script
+  # refuses to use it; the hostile-cwd example still needs a real one to import with.
+  ambient_python3_has_graphify() { python3 -I -c 'import graphify' >/dev/null 2>&1; }
+
+  # Stand-in for the interpreter inside a uv tool venv: it answers the script's two
+  # probes for the fixture package instead of importing anything. The override-API
+  # answer is read back off the package tree, so it flips exactly when a run patches
+  # it -- an already-provided override and a fresh apply cannot both be faked.
+  make_interpreter() {
+    mkdir -p "$(dirname "$1")"
+    cat > "$1" <<INTERPRETER
+#!/bin/sh
+case "\$*" in
+  *os.path.dirname*) printf '%s\n' '$package' ;;
+  *activate_language_overrides*)
+    grep -q 'def activate_language_overrides' '$package/rcfile.py' 2>/dev/null || exit 1
+    ;;
+  *) exit 9 ;;
+esac
+INTERPRETER
+    chmod +x "$1"
+  }
+
   setup() {
-    . "$project_root/scripts/lib/git-env-scrub.sh"
-    pfb_scrub_git_env
     fixture=$(mktemp -d "${TMPDIR:-/tmp}/graphify_language_patch.XXXXXX") || return 1
-    fixture=$(cd "$fixture" && pwd -P) || return 1
+    fixture=$(CDPATH='' cd "$fixture" && pwd -P) || return 1
 
-    repo="$fixture/checkout root"
-    git_fixture init -q "$repo" || return 1
-    mkdir -p "$repo/scripts/agent" "$repo/scripts/lib" "$repo/.agents/patches" \
-      "$repo/graphify-out/cache/ast" "$repo/graphify-out/cache/semantic" || return 1
-    cp "$project_root/scripts/agent/patch-graphify.sh" "$repo/scripts/agent/" || return 1
-    cp "$project_root/scripts/agent/agent_env.sh" "$repo/scripts/agent/" || return 1
-    cp "$project_root/scripts/lib/git-env-scrub.sh" "$repo/scripts/lib/" || return 1
-    script_abs="$repo/scripts/agent/patch-graphify.sh"
-    printf '%s\n' stale > "$repo/graphify-out/cache/ast/entry.json"
-    printf '%s\n' keep > "$repo/graphify-out/cache/semantic/entry.json"
+    checkout="$fixture/checkout root"
+    mkdir -p "$checkout/scripts/agent" "$checkout/.agents/patches" || return 1
+    cp "$project_root/scripts/agent/patch-graphify.sh" "$checkout/scripts/agent/" || return 1
+    cp "$project_root/scripts/agent/agent_env.sh" "$checkout/scripts/agent/" || return 1
+    script_abs="$checkout/scripts/agent/patch-graphify.sh"
 
-    cat > "$repo/.agents/patches/graphify-3075-language-overrides.patch" <<'PATCH'
+    cat > "$checkout/.agents/patches/graphify-3075-language-overrides.patch" <<'PATCH'
 diff --git a/graphify/extract.py b/graphify/extract.py
 --- a/graphify/extract.py
 +++ b/graphify/extract.py
@@ -52,130 +70,116 @@ SUFFIX_DISPATCH = {
 }
 EXTRACT
     cp "$package/extract.py" "$fixture/extract.py.before"
-    export PFB_GRAPHIFY_PACKAGE_DIR="$package"
+
+    # A uv tool venv's own interpreter, named on the CLI's shebang -- the only path the
+    # script trusts. Deliberately NOT on PATH: an example that neuters the shebang must
+    # not be able to reach a working interpreter by any other route.
+    interpreter="$fixture/toolvenv/bin/python3"
+    make_interpreter "$interpreter"
+
+    stubdir="$fixture/toolbin"
+    mkdir -p "$stubdir"
+    printf '#!%s\nexit 0\n' "$interpreter" > "$stubdir/graphify"
+    chmod +x "$stubdir/graphify"
+    PATH="$stubdir:$PATH"
+    export PATH
   }
 
   cleanup() { rm -rf "$fixture"; }
   BeforeEach 'setup'
   AfterEach 'cleanup'
 
-  It 'applies the vendored patch and purges the language-blind AST cache'
-    When run sh "$script_abs" "$repo"
+  It 'applies the vendored patch to the package its shebang interpreter reports'
+    When run sh "$script_abs"
     The status should equal 0
     The stderr should include 'Graphify-Labs/graphify#3075'
     The stderr should include "$package"
-    The stderr should include 'purged'
     The contents of file "$package/rcfile.py" should include 'activate_language_overrides'
     The contents of file "$package/extract.py" should include 'SUFFIX_OVERRIDES = True'
-    The path "$repo/graphify-out/cache/ast" should not be exist
-    The file "$repo/graphify-out/cache/semantic/entry.json" should be exist
   End
 
-  It 'no-ops without purging when the package already provides the override API'
+  It 'no-ops when the package already provides the override API'
     cat > "$package/rcfile.py" <<'RCFILE'
 def activate_language_overrides(root):
     return {}
 RCFILE
-    When run sh "$script_abs" "$repo"
+    When run sh "$script_abs"
     The status should equal 0
     The stderr should include 'already provides'
     Assert [ "$(cmp -s "$package/extract.py" "$fixture/extract.py.before"; printf '%s' "$?")" -eq 0 ]
-    The file "$repo/graphify-out/cache/ast/entry.json" should be exist
-  End
-
-  It 'is a clean no-op on a second run that neither repatches nor purges again'
-    When run sh -c 'sh "$1" "$2" >/dev/null || exit 1; mkdir -p "$2/graphify-out/cache/ast" && printf rebuilt > "$2/graphify-out/cache/ast/entry.json" && exec sh "$1" "$2"' _ "$script_abs" "$repo"
-    The status should equal 0
-    The stderr should include 'already provides'
-    The contents of file "$repo/graphify-out/cache/ast/entry.json" should equal 'rebuilt'
-    Assert [ "$(grep -c 'SUFFIX_OVERRIDES = True' "$package/extract.py")" -eq 1 ]
   End
 
   It 'fails loudly and changes nothing when the vendored patch does not apply'
     printf '%s\n' 'unrelated module' > "$package/extract.py"
     cp "$package/extract.py" "$fixture/extract.py.mismatch"
-    When run sh "$script_abs" "$repo"
+    When run sh "$script_abs"
     The status should not equal 0
     The stderr should include 'Graphify-Labs/graphify#3075'
     The stderr should include 'extract.py'
     The path "$package/rcfile.py" should not be exist
     Assert [ "$(cmp -s "$package/extract.py" "$fixture/extract.py.mismatch"; printf '%s' "$?")" -eq 0 ]
-    The file "$repo/graphify-out/cache/ast/entry.json" should be exist
   End
 
-  It 'patches only the package tree named by PFB_GRAPHIFY_PACKAGE_DIR'
-    other="$fixture/other site/graphify"
-    mkdir -p "$other"
-    true > "$other/__init__.py"
-    cp "$fixture/extract.py.before" "$other/extract.py"
-    When run sh "$script_abs" "$repo"
+  It 'leaves no patch backup behind a successful apply'
+    # No -V flag is portable: GNU patch 2.8 reads `-V none` as "numbered" and ENABLES
+    # backups, while Apple patch 2.0 needs an explicit -V to stay quiet. Whether THIS
+    # host's patch writes one is exactly what cannot be relied on, so the litter is
+    # planted here and the script has to remove it for the files its patch touches.
+    printf 'stale\n' > "$package/extract.py.orig"
+    printf 'stale\n' > "$package/rcfile.py.~1~"
+    When run sh "$script_abs"
     The status should equal 0
-    The stderr should include "$package"
-    The path "$other/rcfile.py" should not be exist
-    Assert [ "$(cmp -s "$other/extract.py" "$fixture/extract.py.before"; printf '%s' "$?")" -eq 0 ]
+    The stderr should include 'applied Graphify-Labs/graphify#3075'
+    The contents of file "$package/rcfile.py" should include 'activate_language_overrides'
+    Assert [ -z "$(find "$fixture/site packages" \( -name '*.orig' -o -name '*.~[0-9]*~' \) -print)" ]
   End
 
-  It 'defaults to the current git worktree root when run from a subdirectory'
-    When run sh -c 'cd "$1/scripts" && exec sh "$2"' _ "$repo" "$script_abs"
-    The status should equal 0
-    The stderr should include 'purged'
-    The path "$repo/graphify-out/cache/ast" should not be exist
-  End
-
-  It 'reports an install hint when Graphify is absent and no package tree is named'
-    unset PFB_GRAPHIFY_PACKAGE_DIR
-    minimal_path="$(dirname "$(command -v git)"):$(dirname "$(command -v dirname)"):$(dirname "$(command -v sh)")"
-    When run env PATH="$minimal_path" sh "$script_abs" "$repo"
-    The status should not equal 0
-    The stderr should include 'uv tool install --upgrade graphifyy'
-    The file "$repo/graphify-out/cache/ast/entry.json" should be exist
-  End
-
-  It 'skips with a warning when the graphify on PATH is not a Python program'
-    unset PFB_GRAPHIFY_PACKAGE_DIR
-    stubdir="$fixture/stub bin"
-    mkdir -p "$stubdir"
+  It 'skips with a warning when the graphify shebang does not name a Python interpreter'
+    # The ambient python3 is NOT a fallback: another interpreter imports another
+    # graphify, so falling back patches an unrelated package and reports success. A
+    # working python3 sits on PATH here precisely to prove nothing reaches for it.
     printf '#!/bin/sh\nexit 0\n' > "$stubdir/graphify"
-    printf '#!/bin/sh\nexit 1\n' > "$stubdir/python3"
-    chmod +x "$stubdir/graphify" "$stubdir/python3"
-    When run env PATH="$stubdir:$PATH" sh "$script_abs" "$repo"
+    make_interpreter "$stubdir/python3"
+    When run sh "$script_abs"
+    The status should equal 0
+    The stderr should include 'does not name a Python interpreter'
+    The path "$package/rcfile.py" should not be exist
+    Assert [ "$(cmp -s "$package/extract.py" "$fixture/extract.py.before"; printf '%s' "$?")" -eq 0 ]
+  End
+
+  It 'skips with a warning when the shebang interpreter cannot import graphify'
+    printf '#!/bin/sh\nexit 1\n' > "$interpreter"
+    When run sh "$script_abs"
     The status should equal 0
     The stderr should include 'cannot locate'
     The path "$package/rcfile.py" should not be exist
-    The file "$repo/graphify-out/cache/ast/entry.json" should be exist
   End
 
-  It 'falls back to the ambient python3 when the graphify wrapper hides its interpreter'
-    unset PFB_GRAPHIFY_PACKAGE_DIR
-    stubdir="$fixture/stub bin"
-    mkdir -p "$stubdir"
-    printf '#!/bin/sh\nexit 0\n' > "$stubdir/graphify"
-    cat > "$stubdir/python3" <<PYTHON3
-#!/bin/sh
-case "\$2" in
-  *graphify.__file__*) printf '%s\n' "$package" ;;
-  *) exit 1 ;;
-esac
-PYTHON3
-    chmod +x "$stubdir/graphify" "$stubdir/python3"
-    When run env PATH="$stubdir:$PATH" sh "$script_abs" "$repo"
+  It 'ignores a hostile module in the working directory it is called from'
+    # Both probes run isolated (-I) from a neutral directory, so a graphify.py beside
+    # the caller can neither answer for the installed package nor execute at all.
+    Skip if 'the ambient python3 imports a graphify of its own' ambient_python3_has_graphify
+    hostile="$fixture/hostile cwd"
+    mkdir -p "$hostile"
+    cat > "$hostile/graphify.py" <<HOSTILE
+import pathlib
+pathlib.Path('$hostile/executed').write_text('executed')
+__file__ = '$hostile/graphify.py'
+HOSTILE
+    printf '#!%s\nexit 0\n' "$(command -v python3)" > "$stubdir/graphify"
+    When run sh -c 'cd "$1" && exec sh "$2"' _ "$hostile" "$script_abs"
     The status should equal 0
-    The stderr should include 'Graphify-Labs/graphify#3075'
-    The contents of file "$package/rcfile.py" should include 'activate_language_overrides'
-    The path "$repo/graphify-out/cache/ast" should not be exist
-  End
-
-  It 'rejects a target that is not a git worktree'
-    When run sh "$script_abs" "$fixture/not a checkout"
-    The status should equal 2
-    The stderr should include 'is not a git worktree'
+    The stderr should include 'cannot locate'
+    The path "$hostile/executed" should not be exist
+    The path "$hostile/rcfile.py" should not be exist
     The path "$package/rcfile.py" should not be exist
   End
 
-  It 'rejects more than one repository argument'
-    When run sh "$script_abs" "$repo" extra
-    The status should equal 2
-    The stderr should include 'usage: patch-graphify.sh [REPOSITORY]'
+  It 'fails with the install hint when graphify is absent from PATH'
+    minimal_path="$(dirname "$(command -v sed)"):$(dirname "$(command -v sh)"):$(dirname "$(command -v dirname)")"
+    When run env PATH="$minimal_path" sh "$script_abs"
+    The status should not equal 0
+    The stderr should include 'uv tool install --upgrade graphifyy'
     The path "$package/rcfile.py" should not be exist
   End
 End

--- a/tests/shell/graphify_language_patch_spec.sh
+++ b/tests/shell/graphify_language_patch_spec.sh
@@ -1,0 +1,147 @@
+#shellcheck shell=sh
+# Vendored Graphify language-override patch (issue #2810, upstream
+# Graphify-Labs/graphify#3075). The script resolves both itself and its patch from
+# its own checkout, so every example runs a copy of it inside a fixture checkout
+# carrying a synthetic two-file patch, against a throwaway package tree named by
+# PFB_GRAPHIFY_PACKAGE_DIR. The real installed Graphify is never touched.
+
+Describe 'patch-graphify.sh'
+  project_root="${SHELLSPEC_PROJECT_ROOT:-$PWD}"
+
+  setup() {
+    . "$project_root/scripts/lib/git-env-scrub.sh"
+    pfb_scrub_git_env
+    fixture=$(mktemp -d "${TMPDIR:-/tmp}/graphify_language_patch.XXXXXX") || return 1
+    fixture=$(cd "$fixture" && pwd -P) || return 1
+
+    repo="$fixture/checkout root"
+    git_fixture init -q "$repo" || return 1
+    mkdir -p "$repo/scripts/agent" "$repo/scripts/lib" "$repo/.agents/patches" \
+      "$repo/graphify-out/cache/ast" "$repo/graphify-out/cache/semantic" || return 1
+    cp "$project_root/scripts/agent/patch-graphify.sh" "$repo/scripts/agent/" || return 1
+    cp "$project_root/scripts/agent/agent_env.sh" "$repo/scripts/agent/" || return 1
+    cp "$project_root/scripts/lib/git-env-scrub.sh" "$repo/scripts/lib/" || return 1
+    script_abs="$repo/scripts/agent/patch-graphify.sh"
+    printf '%s\n' stale > "$repo/graphify-out/cache/ast/entry.json"
+    printf '%s\n' keep > "$repo/graphify-out/cache/semantic/entry.json"
+
+    cat > "$repo/.agents/patches/graphify-3075-language-overrides.patch" <<'PATCH'
+diff --git a/graphify/extract.py b/graphify/extract.py
+--- a/graphify/extract.py
++++ b/graphify/extract.py
+@@ -1,3 +1,4 @@
+ SUFFIX_DISPATCH = {
+     ".inc": "pascal",
+ }
++SUFFIX_OVERRIDES = True
+diff --git a/graphify/rcfile.py b/graphify/rcfile.py
+new file mode 100644
+--- /dev/null
++++ b/graphify/rcfile.py
+@@ -0,0 +1,2 @@
++def activate_language_overrides(root):
++    return {".inc": ".php"}
+PATCH
+
+    package="$fixture/site packages/graphify"
+    mkdir -p "$package"
+    true > "$package/__init__.py"
+    cat > "$package/extract.py" <<'EXTRACT'
+SUFFIX_DISPATCH = {
+    ".inc": "pascal",
+}
+EXTRACT
+    cp "$package/extract.py" "$fixture/extract.py.before"
+    export PFB_GRAPHIFY_PACKAGE_DIR="$package"
+  }
+
+  cleanup() { rm -rf "$fixture"; }
+  BeforeEach 'setup'
+  AfterEach 'cleanup'
+
+  It 'applies the vendored patch and purges the language-blind AST cache'
+    When run sh "$script_abs" "$repo"
+    The status should equal 0
+    The stderr should include 'Graphify-Labs/graphify#3075'
+    The stderr should include "$package"
+    The stderr should include 'purged'
+    The contents of file "$package/rcfile.py" should include 'activate_language_overrides'
+    The contents of file "$package/extract.py" should include 'SUFFIX_OVERRIDES = True'
+    The path "$repo/graphify-out/cache/ast" should not be exist
+    The file "$repo/graphify-out/cache/semantic/entry.json" should be exist
+  End
+
+  It 'no-ops without purging when the package already provides the override API'
+    cat > "$package/rcfile.py" <<'RCFILE'
+def activate_language_overrides(root):
+    return {}
+RCFILE
+    When run sh "$script_abs" "$repo"
+    The status should equal 0
+    The stderr should include 'already provides'
+    Assert [ "$(cmp -s "$package/extract.py" "$fixture/extract.py.before"; printf '%s' "$?")" -eq 0 ]
+    The file "$repo/graphify-out/cache/ast/entry.json" should be exist
+  End
+
+  It 'is a clean no-op on a second run that neither repatches nor purges again'
+    When run sh -c 'sh "$1" "$2" >/dev/null || exit 1; mkdir -p "$2/graphify-out/cache/ast" && printf rebuilt > "$2/graphify-out/cache/ast/entry.json" && exec sh "$1" "$2"' _ "$script_abs" "$repo"
+    The status should equal 0
+    The stderr should include 'already provides'
+    The contents of file "$repo/graphify-out/cache/ast/entry.json" should equal 'rebuilt'
+    Assert [ "$(grep -c 'SUFFIX_OVERRIDES = True' "$package/extract.py")" -eq 1 ]
+  End
+
+  It 'fails loudly and changes nothing when the vendored patch does not apply'
+    printf '%s\n' 'unrelated module' > "$package/extract.py"
+    cp "$package/extract.py" "$fixture/extract.py.mismatch"
+    When run sh "$script_abs" "$repo"
+    The status should not equal 0
+    The stderr should include 'Graphify-Labs/graphify#3075'
+    The stderr should include 'extract.py'
+    The path "$package/rcfile.py" should not be exist
+    Assert [ "$(cmp -s "$package/extract.py" "$fixture/extract.py.mismatch"; printf '%s' "$?")" -eq 0 ]
+    The file "$repo/graphify-out/cache/ast/entry.json" should be exist
+  End
+
+  It 'patches only the package tree named by PFB_GRAPHIFY_PACKAGE_DIR'
+    other="$fixture/other site/graphify"
+    mkdir -p "$other"
+    true > "$other/__init__.py"
+    cp "$fixture/extract.py.before" "$other/extract.py"
+    When run sh "$script_abs" "$repo"
+    The status should equal 0
+    The stderr should include "$package"
+    The path "$other/rcfile.py" should not be exist
+    Assert [ "$(cmp -s "$other/extract.py" "$fixture/extract.py.before"; printf '%s' "$?")" -eq 0 ]
+  End
+
+  It 'defaults to the current git worktree root when run from a subdirectory'
+    When run sh -c 'cd "$1/scripts" && exec sh "$2"' _ "$repo" "$script_abs"
+    The status should equal 0
+    The stderr should include 'purged'
+    The path "$repo/graphify-out/cache/ast" should not be exist
+  End
+
+  It 'reports an install hint when Graphify is absent and no package tree is named'
+    unset PFB_GRAPHIFY_PACKAGE_DIR
+    minimal_path="$(dirname "$(command -v git)"):$(dirname "$(command -v dirname)"):$(dirname "$(command -v sh)")"
+    When run env PATH="$minimal_path" sh "$script_abs" "$repo"
+    The status should not equal 0
+    The stderr should include 'uv tool install --upgrade graphifyy'
+    The file "$repo/graphify-out/cache/ast/entry.json" should be exist
+  End
+
+  It 'rejects a target that is not a git worktree'
+    When run sh "$script_abs" "$fixture/not a checkout"
+    The status should equal 2
+    The stderr should include 'is not a git worktree'
+    The path "$package/rcfile.py" should not be exist
+  End
+
+  It 'rejects more than one repository argument'
+    When run sh "$script_abs" "$repo" extra
+    The status should equal 2
+    The stderr should include 'usage: patch-graphify.sh [REPOSITORY]'
+    The path "$package/rcfile.py" should not be exist
+  End
+End

--- a/tests/test_cross_agent_tooling.py
+++ b/tests/test_cross_agent_tooling.py
@@ -411,42 +411,41 @@ def test_graphify_inc_language_override_rides_as_a_local_patch() -> None:
     # PHP includes extract as a handful of incidental nodes (issue #2810). The fix is
     # upstream in Graphify-Labs/graphify#3075 and unreleased, so it rides as a patch
     # applied to the installed package after every install. When upstream releases it,
-    # the patch, the script, its three call sites, and this test go away together.
+    # the patch, the script, its two call sites, and this test go away together.
     patch = (ROOT / ".agents/patches/graphify-3075-language-overrides.patch").read_text(encoding="utf-8")
     assert "Graphify-Labs/graphify#3075" in patch, "the vendored patch must name its upstream PR"
     assert "+++ b/graphify/rcfile.py" in patch, "the vendored patch must carry the .graphifyrc parser"
 
-    # Order is part of the contract at every call site, and each site is pinned by the
-    # line that RUNS the patch: patching a Graphify that a later step already used
-    # would leave that step's output Pascal-parsed.
-    for install, invocation, anchor, patch_first in (
-        (
-            "scripts/agent/setup-agent-tools.sh",
-            'sh "$patch_graphify" "$root"',
-            "uv tool install --upgrade graphifyy",
-            False,
-        ),
+    # Two call sites, each pinned by the line that RUNS the patch, which must come
+    # before that site's first use of Graphify: patching a Graphify a step already used
+    # would leave that step's output Pascal-parsed. setup-agent-tools.sh has no call of
+    # its own -- it ends by running init-worktree-tools.sh, which patches.
+    for install, invocation, anchor in (
         (
             "scripts/agent/ensure-graphify-merge-driver.sh",
-            'sh "$patch_graphify" "$root"',
+            'sh "$patch_graphify" || {',
             "graphify hook install",
-            True,
         ),
         (
             "scripts/agent/init-worktree-tools.sh",
-            'sh "$(dirname "$0")/patch-graphify.sh" "$root"',
+            'sh "$(dirname "$0")/patch-graphify.sh" || exit $?',
             'graphify update "$root"',
-            True,
         ),
     ):
         lines = (ROOT / install).read_text(encoding="utf-8").splitlines()
+        # The invocation carries no repository argument: the script derives everything
+        # it needs from its own path and from the `graphify` on PATH.
         called = [index for index, line in enumerate(lines) if invocation in line]
         anchored = [index for index, line in enumerate(lines) if anchor in line]
-        assert called, f"{install} does not run patch-graphify.sh"
+        assert called, f"{install} does not run patch-graphify.sh with no argument"
         assert anchored, f"{install} no longer runs: {anchor}"
-        assert (called[0] < anchored[0]) is patch_first, (
-            f"{install} must run patch-graphify.sh {'before' if patch_first else 'after'}: {anchor}"
-        )
+        assert called[0] < anchored[0], f"{install} must run patch-graphify.sh before: {anchor}"
+
+    bootstrap = (ROOT / "scripts/agent/setup-agent-tools.sh").read_text(encoding="utf-8")
+    assert "patch-graphify.sh" not in bootstrap, (
+        "setup-agent-tools.sh regained a patch-graphify.sh call: it already reaches the "
+        "patch through init-worktree-tools.sh"
+    )
 
     rc = (ROOT / ".graphifyrc").read_text(encoding="utf-8").splitlines()
     assert "language.inc=php" in rc, ".graphifyrc must declare the PHP include override"
@@ -456,11 +455,15 @@ def test_graphify_inc_language_override_rides_as_a_local_patch() -> None:
         "scripts/agent/patch-graphify.sh",
         "Graphify-Labs/graphify#3075",
         "language.inc=php",
-        # The three probed facts a contributor needs: what reverts the patch, what an
-        # unpatched host sees, and when the whole arrangement is deleted.
+        # The probed facts a contributor needs: what reverts the patch, what an
+        # unpatched host sees, when the whole arrangement is deleted, and which failure
+        # is loud versus which is a deliberate skip plus what catches a skipped install.
         "a bare `uv tool upgrade graphifyy` reverts it",
         "inert on an unpatched Graphify",
-        "Delete the patch, the script, its three call sites",
+        "Delete the patch, the script, its two call sites",
+        "fails loudly",
+        "a warning and a skip",
+        "include-node floor",
     ):
         assert contract in routing, f"repository-intelligence routing lost: {contract}"
 

--- a/tests/test_cross_agent_tooling.py
+++ b/tests/test_cross_agent_tooling.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import collections
 import hashlib
 import json
 import shutil
@@ -471,8 +472,20 @@ def test_tracked_graph_carries_the_php_include_corpus() -> None:
     # else catches an unattended `uv tool upgrade graphifyy` followed by a Graphify
     # post-commit rebuild, which silently replaces site-packages and drops the patch.
     graph = json.loads((ROOT / "graphify-out/graph.json").read_text(encoding="utf-8"))
-    include_nodes = [node for node in graph["nodes"] if str(node.get("source_file", "")).endswith(".inc")]
-    assert len(include_nodes) > 400, (
-        f"only {len(include_nodes)} graph nodes come from .inc files: the tracked graph was "
-        "rebuilt by a Graphify without .agents/patches/graphify-3075-language-overrides.patch"
+    include_files = collections.Counter(
+        str(node["source_file"]) for node in graph["nodes"] if str(node.get("source_file", "")).endswith(".inc")
+    )
+    total = sum(include_files.values())
+    # Size alone is satisfied by ONE large include: pfblockerng.inc carries 482 of the
+    # 767 nodes, so a graph holding only that file clears any total-node floor. Breadth
+    # is the discriminating half -- a file parsed as Pascal still contributes its own
+    # file node, so the honest signal is how many includes contribute symbols BESIDES
+    # that node: 9 of 21 with the override, 3 without it.
+    with_symbols = sorted(path for path, nodes in include_files.items() if nodes > 1)
+    assert total > 400 and len(with_symbols) >= 6, (
+        f"{total} graph nodes from {len(include_files)} .inc files, and only "
+        f"{len(with_symbols)} of them contribute symbols beyond their own file node "
+        f"({', '.join(with_symbols) or 'none'}): the tracked graph is missing the PHP "
+        "include corpus that .agents/patches/graphify-3075-language-overrides.patch "
+        "restores"
     )

--- a/tests/test_cross_agent_tooling.py
+++ b/tests/test_cross_agent_tooling.py
@@ -416,30 +416,24 @@ def test_graphify_inc_language_override_rides_as_a_local_patch() -> None:
     assert "Graphify-Labs/graphify#3075" in patch, "the vendored patch must name its upstream PR"
     assert "+++ b/graphify/rcfile.py" in patch, "the vendored patch must carry the .graphifyrc parser"
 
-    # Two call sites, each pinned by the line that RUNS the patch, which must come
-    # before that site's first use of Graphify: patching a Graphify a step already used
-    # would leave that step's output Pascal-parsed. setup-agent-tools.sh has no call of
-    # its own -- it ends by running init-worktree-tools.sh, which patches.
-    for install, invocation, anchor in (
-        (
-            "scripts/agent/ensure-graphify-merge-driver.sh",
-            'sh "$patch_graphify" || {',
-            "graphify hook install",
-        ),
+    # Two call sites, each pinned by the line that RUNS the patch. Their ORDER -- the
+    # patch before that site's first use of Graphify, or that step's output is
+    # Pascal-parsed -- is asserted behaviourally by the specs that execute these
+    # scripts: agent_graphify_merge_driver_spec.sh pins the patch before
+    # `graphify hook install`, agent_worktree_tools_spec.sh before `graphify update`.
+    # setup-agent-tools.sh has no call of its own -- it ends by running
+    # init-worktree-tools.sh, which patches.
+    for install, invocation in (
+        ("scripts/agent/ensure-graphify-merge-driver.sh", 'sh "$patch_graphify" || {'),
         (
             "scripts/agent/init-worktree-tools.sh",
             'sh "$(dirname "$0")/patch-graphify.sh" || exit $?',
-            'graphify update "$root"',
         ),
     ):
-        lines = (ROOT / install).read_text(encoding="utf-8").splitlines()
         # The invocation carries no repository argument: the script derives everything
         # it needs from its own path and from the `graphify` on PATH.
-        called = [index for index, line in enumerate(lines) if invocation in line]
-        anchored = [index for index, line in enumerate(lines) if anchor in line]
-        assert called, f"{install} does not run patch-graphify.sh with no argument"
-        assert anchored, f"{install} no longer runs: {anchor}"
-        assert called[0] < anchored[0], f"{install} must run patch-graphify.sh before: {anchor}"
+        source = (ROOT / install).read_text(encoding="utf-8")
+        assert invocation in source, f"{install} does not run patch-graphify.sh with no argument"
 
     bootstrap = (ROOT / "scripts/agent/setup-agent-tools.sh").read_text(encoding="utf-8")
     assert "patch-graphify.sh" not in bootstrap, (
@@ -451,18 +445,12 @@ def test_graphify_inc_language_override_rides_as_a_local_patch() -> None:
     assert "language.inc=php" in rc, ".graphifyrc must declare the PHP include override"
 
     routing = (ROOT / ".agents/context/repository-intelligence.md").read_text(encoding="utf-8")
+    # Identifiers only. A prose pin fails on a pure line rewrap that changes nothing, so
+    # the document's sentences stay the reader's rather than this test's.
     for contract in (
         "scripts/agent/patch-graphify.sh",
         "Graphify-Labs/graphify#3075",
         "language.inc=php",
-        # The probed facts a contributor needs: what reverts the patch, what an
-        # unpatched host sees, when the whole arrangement is deleted, and which failure
-        # is loud versus which is a deliberate skip plus what catches a skipped install.
-        "a bare `uv tool upgrade graphifyy` reverts it",
-        "inert on an unpatched Graphify",
-        "Delete the patch, the script, its two call sites",
-        "fails loudly",
-        "a warning and a skip",
         "include-node floor",
     ):
         assert contract in routing, f"repository-intelligence routing lost: {contract}"

--- a/tests/test_cross_agent_tooling.py
+++ b/tests/test_cross_agent_tooling.py
@@ -403,3 +403,76 @@ def test_semgrep_scans_a_php_inc_file_only_with_the_documented_flag() -> None:
 
     assert findings() == 0, "semgrep gained .inc support; the documented flag is now misleading"
     assert findings("--scan-unknown-extensions") > 0, "the documented semgrep flag does not work"
+
+
+def test_graphify_inc_language_override_rides_as_a_local_patch() -> None:
+    # Graphify's suffix map sends .inc to the Pascal extractor, so this repository's
+    # PHP includes extract as a handful of incidental nodes (issue #2810). The fix is
+    # upstream in Graphify-Labs/graphify#3075 and unreleased, so it rides as a patch
+    # applied to the installed package after every install. When upstream releases it,
+    # the patch, the script, its three call sites, and this test go away together.
+    patch = (ROOT / ".agents/patches/graphify-3075-language-overrides.patch").read_text(encoding="utf-8")
+    assert "Graphify-Labs/graphify#3075" in patch, "the vendored patch must name its upstream PR"
+    assert "+++ b/graphify/rcfile.py" in patch, "the vendored patch must carry the .graphifyrc parser"
+
+    # Order is part of the contract at every call site, and each site is pinned by the
+    # line that RUNS the patch: patching a Graphify that a later step already used
+    # would leave that step's output Pascal-parsed.
+    for install, invocation, anchor, patch_first in (
+        (
+            "scripts/agent/setup-agent-tools.sh",
+            'sh "$patch_graphify" "$root"',
+            "uv tool install --upgrade graphifyy",
+            False,
+        ),
+        (
+            "scripts/agent/ensure-graphify-merge-driver.sh",
+            'sh "$patch_graphify" "$root"',
+            "graphify hook install",
+            True,
+        ),
+        (
+            "scripts/agent/init-worktree-tools.sh",
+            'sh "$(dirname "$0")/patch-graphify.sh" "$root"',
+            'graphify update "$root"',
+            True,
+        ),
+    ):
+        lines = (ROOT / install).read_text(encoding="utf-8").splitlines()
+        called = [index for index, line in enumerate(lines) if invocation in line]
+        anchored = [index for index, line in enumerate(lines) if anchor in line]
+        assert called, f"{install} does not run patch-graphify.sh"
+        assert anchored, f"{install} no longer runs: {anchor}"
+        assert (called[0] < anchored[0]) is patch_first, (
+            f"{install} must run patch-graphify.sh {'before' if patch_first else 'after'}: {anchor}"
+        )
+
+    rc = (ROOT / ".graphifyrc").read_text(encoding="utf-8").splitlines()
+    assert "language.inc=php" in rc, ".graphifyrc must declare the PHP include override"
+
+    routing = (ROOT / ".agents/context/repository-intelligence.md").read_text(encoding="utf-8")
+    for contract in (
+        "scripts/agent/patch-graphify.sh",
+        "Graphify-Labs/graphify#3075",
+        "language.inc=php",
+        # The three probed facts a contributor needs: what reverts the patch, what an
+        # unpatched host sees, and when the whole arrangement is deleted.
+        "a bare `uv tool upgrade graphifyy` reverts it",
+        "inert on an unpatched Graphify",
+        "Delete the patch, the script, its three call sites",
+    ):
+        assert contract in routing, f"repository-intelligence routing lost: {contract}"
+
+
+def test_tracked_graph_carries_the_php_include_corpus() -> None:
+    # A Graphify without the vendored override parses all 21 .inc files with the Pascal
+    # extractor: extraction still succeeds, so the only visible symptom is a collapsed
+    # node count -- 30 across the corpus instead of roughly 755 (issue #2810). Nothing
+    # else catches an unattended `uv tool upgrade graphifyy` followed by a Graphify
+    # post-commit rebuild, which silently replaces site-packages and drops the patch.
+    graph = json.loads((ROOT / "graphify-out/graph.json").read_text(encoding="utf-8"))
+    include_nodes = [node for node in graph["nodes"] if str(node.get("source_file", "")).endswith(".inc")]
+    assert len(include_nodes) > 400, (
+        f"only {len(include_nodes)} graph nodes come from .inc files: the tracked graph was "
+        "rebuilt by a Graphify without .agents/patches/graphify-3075-language-overrides.patch"
+    )


### PR DESCRIPTION
## Problem

Graphify hard-maps `.inc` to the Pascal extractor, so this repository's PHP include files are
parsed with the wrong grammar. Extraction still succeeds, so the only symptom is a collapsed node
count: 30 nodes across the 21 `.inc` files, against 767 when they are read as PHP.
`src/usr/local/pkg/pfblockerng/pfblockerng.inc` alone contributed 8 nodes for 475 top-level
functions.

Upstream tracks this as Graphify-Labs/graphify#2961 and fixes it in Graphify-Labs/graphify#3075,
which is open against the release line and unreleased.

## Why not a one-line content sniff

A sniff in the dispatch table alone leaves six other suffix-keyed decisions disagreeing with it.
Verified in the installed 0.9.51:

| site | `.inc` present? | effect on a PHP `.inc` |
| --- | --- | --- |
| `extract.py:5238` dispatch table | yes → `extract_pascal` | the only site a sniff fixes |
| `extract.py:2199` `_CASE_INSENSITIVE_EXTS` | no | PHP identifiers compared case-sensitively, unlike `.php` |
| `extract.py:2222` `_LANG_FAMILY_BY_EXT` | no | no `php` interop family, so PHP-family resolution skips the file |
| `extract.py:6410` PHP type pass | no | PHP type resolution never runs |
| `extract.py:4122`, `pascal_resolution.py:26`, `extractors/resolution.py:3104` | yes | Pascal resolvers keep running on PHP files |
| `cache.py:938` `load_cached` | content SHA-256 + per-version directory only | entries from the old extractor are served after a remap |

## Change

Keep installing `graphifyy` from PyPI — no pin, no fork — and carry the upstream PR as a vendored
patch applied to the installed package after every install:

- `.agents/patches/graphify-3075-language-overrides.patch`: the PR's code hunks. Its test file and
  README hunk are stripped because the wheel ships neither. The header records the upstream PR, the
  upstream issue, the base branch, and what was stripped.
- `scripts/agent/patch-graphify.sh`: reads the interpreter off the `graphify` CLI's shebang, so no
  Python minor version is hardcoded and the package it patches is always the one that CLI imports.
  It no-ops when the installed package already provides `activate_language_overrides` — covering
  both an already-patched install and the release that finally carries the change — dry-runs before
  applying so a failure cannot leave a half-patched package, and fails loudly naming the upstream
  PR when the patch does not apply.
- Two call sites, each ordered so nothing consumes an unpatched Graphify:
  `ensure-graphify-merge-driver.sh` between its install and `graphify hook install`, and
  `init-worktree-tools.sh` before `graphify update`.
- `.graphifyrc` declares `language.inc=php`.
- `.agents/context/repository-intelligence.md` records what reverts the patch, what an unpatched
  host sees, and that the whole arrangement is deleted once upstream releases the change.

### Decisions taken during review, each with its evidence

- **No cache purge.** The first revision purged `graphify-out/cache/ast` on first application. The
  vendored patch salts the AST cache key per remapped extension — `rcfile.cache_salt(Path("a.inc"))`
  returns `language=.php` with the override active and `None` for `.php`, `cache._salted_key` folds
  it in, and every AST call site in `extract.py` passes `salt=cache_salt(path)` — so a pre-patch
  Pascal entry is unreachable and the purge was dead code that also discarded valid entries for
  every other language. Removed, along with the repository argument and git-root resolution that
  existed only to build its path.
- **No ambient-`python3` fallback.** A non-Python `graphify` wrapper plus an ambient `python3` that
  imports a *different* graphify made the script patch an unrelated package and report success. The
  shebang is now the only source, and a wrapper that hides its interpreter is a warning and a skip.
- **Isolated probes.** Both `python -c` probes previously imported from the caller's cwd: a
  directory containing `enum.py` that wrote a marker and raised had it executed. They now run `-I`
  from `/`.
- **No `-V none`.** GNU patch 2.8 reads `none` as *numbered* and enables backups — an Alpine run
  left `cache.py.~1~`, `extract.py.~1~`, `hooks.py.~1~`. The flag is gone; backups are removed for
  exactly the paths the patch touches, derived from its `+++ b/` lines, and verified gone.
- **One call site removed.** `setup-agent-tools.sh` ends by running `init-worktree-tools.sh`, which
  patches, and nothing between the two extracts this repository, so its own call was redundant.

## Verification

- Loader-level and end-to-end: `sh scripts/agent/patch-graphify.sh` applied the patch and a second
  run reported the no-op and exited 0 with no `.orig`, `.rej` or `*~` left behind; `graphify update .`
  then rebuilt the graph from 30 to 767 `.inc` nodes across the same 21 files, 9 of which contribute
  symbols beyond their own file node.
- The graph gate asserts both halves. Size alone was not enough: `pfblockerng.inc` carries 482 of
  the 767 nodes, so a graph holding only that file cleared a total-node floor. It now requires
  > 400 nodes AND at least 6 distinct includes contributing symbols; executed against three graphs,
  the largest-include-only graph fails, `devel`'s Pascal-level graph fails, the real graph passes.
- The rebuilt spec exercises the shipped interpreter derivation rather than a test seam: pointing
  the derivation at a nonexistent interpreter fails 5 of the 8 examples, dropping `-I` and the
  neutral cwd fails the hostile-module example with the marker written, dropping the backup removal
  fails the litter example, and reinstating the ambient fallback fails the skip example.
- `tests/shell/agent_codegraph_spec.sh` and `tests/shell/agent_work_branch_spec.sh` are green: they
  stub `graphify` with `/bin/sh`, which is exactly the skip path, and an earlier revision failed
  them by treating that as fatal and rolling back the worktree.
- Contributors who never run these scripts are unaffected: on an unpatched 0.9.51,
  `hooks._load_graphifyrc` returns `{}` for the committed `.graphifyrc` and `graphify extract` exits
  0, so the declaration is inert. CI is covered because eight workflows call
  `ensure-graphify-merge-driver.sh`.

## Frozen RED evidence

Every test below was re-run RED in its committed form, in a copy of the worktree with the whole
production side unwired — both call sites restored from `devel`, `patch-graphify.sh` and the
vendored patch removed, `.graphifyrc` deleted, and `devel`'s Pascal-level graph put back — then
re-run GREEN unchanged against the committed tree.

| Frozen RED test | git hash-object | RED run tail |
| --- | --- | --- |
| `tests/test_cross_agent_tooling.py` | `256faf2d25fa5ecd056ba5db29f4c556b94a4932` | `FileNotFoundError: … /.agents/patches/graphify-3075-language-overrides.patch` / `AssertionError: 30 graph nodes from 21 .inc files, and only 3 of them contribute symbols beyond their own file node` |
| `tests/shell/graphify_language_patch_spec.sh` | `f5b4af850d7dd93c09741fa568cfe2a2d67f937f` | all 10 examples failed, including `leaves no patch backup behind an apply that lands with an offset`, `ignores a decoy graphify injected through PYTHONPATH`, and `ignores a hostile module in the working directory it is called from` |
| `tests/shell/agent_worktree_tools_spec.sh` | `d353662ffeaced743493397ba5e67d1e351b1e35` | `init-worktree-tools.sh runs the vendored Graphify language override before refreshing the graph, and a stubbed graphify is a skip` |
| `tests/shell/agent_graphify_merge_driver_spec.sh` | `1f58b1963f2b28f409f83399e1cdc22c84d6d723` | `ensure-graphify-merge-driver.sh installs at least the required Graphify, upgrading to the latest, and configures the requested Git root` |

Totals for that run: `23 examples, 18 failures` across the three shell specs, and both
Python tests failing.

Fixes #2810



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for correctly recognizing `.inc` files as PHP in repository analysis.
  * Added automatic application of the language-recognition fix when setting up analysis tools.
  * Added clear warnings and failure handling when the fix cannot be applied.

* **Bug Fixes**
  * Improved PHP include-file parsing and graph generation accuracy.

* **Tests**
  * Added coverage for successful, skipped, and failed patch scenarios, including upgraded tool installations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->