### PR TITLE
download: stream the XLSX shared-strings part past the run tmpdir

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -15021,6 +15021,22 @@ function pfb_download(PfbDownloadRequest $request): PfbDownloadResult {
 			// Check if ZIP archive contains xlsx files
 			$xlsxtest = exec("/usr/bin/tar -tf {$file_dwn_esc}");
 			if (strpos($xlsxtest, '.xlsx') !== FALSE) {
+				// issue #2684: the helper unpacks the workbook into its OWN per-run temp
+				// directory (`mktemp -d "${TMPDIR:-/tmp}/pfb.XXXXXXXX"`), which the
+				// precheck above cannot see -- it belongs to a child process, not to
+				// this function -- and which is a RAM disk on a default use_mfs_tmpvar
+				// install. Same requirement as every other extraction and no fixed
+				// floor: room for the archive itself. sys_get_temp_dir() reads the same
+				// ${TMPDIR:-/tmp} the helper's mktemp does, so the two cannot drift.
+				// Scoped to this branch on purpose: the gzip, bzip2 and tar paths write
+				// nowhere near /tmp, and refusing them over a filesystem they never
+				// touch would repeat issue #2658's 64 MiB-floor mistake.
+				$xlsx_short = pfb_extract_space_shortfall(array(sys_get_temp_dir()), (int) @filesize($file_download));
+				if ($xlsx_short !== NULL) {
+					pfb_validate_log($header, 'size', 'staging_space_low', $xlsx_short);
+					unlink_if_exists($file_download);
+					return PfbDownloadResult::failure();
+				}
 				// issue #2666: the helper's exit status decides the ingest, which is what
 				// lets issue #2658's ceiling ride along. No unlink up front -- the
 				// '.orig' already in service must survive a refused refresh.

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -4298,6 +4298,19 @@ function pfb_extract_space_shortfall(array $dirs, int $need, ?callable $free = N
 	return NULL;
 }
 
+/**
+ * issue #2684: the temp root the shell helpers unpack into, resolved the way the
+ * CHILD resolves it -- `${TMPDIR:-/tmp}`, against the environment exec() hands it.
+ * Deliberately NOT sys_get_temp_dir(): PHP's `sys_temp_dir` INI setting outranks
+ * TMPDIR, so on an install that sets it a free-space precheck would measure one
+ * filesystem while `pfb_make_tmpdir()`'s `mktemp -d` wrote to another. Deliberately
+ * not `?:` either -- that discards the legitimate value "0", which the shell keeps.
+ */
+function pfb_extract_temp_root(): string {
+	$tmp = (string) getenv('TMPDIR');
+	return $tmp !== '' ? $tmp : '/tmp';
+}
+
 function pfb_download_initial_retval(): int {
 	return 1;
 }
@@ -15026,15 +15039,13 @@ function pfb_download(PfbDownloadRequest $request): PfbDownloadResult {
 				// precheck above cannot see -- it belongs to a child process, not to
 				// this function -- and which is a RAM disk on a default use_mfs_tmpvar
 				// install. Same requirement as every other extraction and no fixed
-				// floor: room for the archive itself. The path is derived the way the
-				// CHILD derives it, off the environment exec() hands it, and NOT with
-				// sys_get_temp_dir(): PHP's `sys_temp_dir` INI setting outranks TMPDIR,
-				// so on an install that sets it this would measure one filesystem while
-				// the helper wrote to another.
+				// floor: room for the archive itself. pfb_extract_temp_root() resolves
+				// that directory the way the child does; the reasons it is neither
+				// sys_get_temp_dir() nor a `?:` shorthand live at the helper.
 				// Scoped to this branch on purpose: the gzip, bzip2 and tar paths write
 				// nowhere near /tmp, and refusing them over a filesystem they never
 				// touch would repeat issue #2658's 64 MiB-floor mistake.
-				$xlsx_short = pfb_extract_space_shortfall(array(getenv('TMPDIR') ?: '/tmp'), (int) @filesize($file_download));
+				$xlsx_short = pfb_extract_space_shortfall(array(pfb_extract_temp_root()), (int) @filesize($file_download));
 				if ($xlsx_short !== NULL) {
 					pfb_validate_log($header, 'size', 'staging_space_low', $xlsx_short);
 					unlink_if_exists($file_download);

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -15026,12 +15026,15 @@ function pfb_download(PfbDownloadRequest $request): PfbDownloadResult {
 				// precheck above cannot see -- it belongs to a child process, not to
 				// this function -- and which is a RAM disk on a default use_mfs_tmpvar
 				// install. Same requirement as every other extraction and no fixed
-				// floor: room for the archive itself. sys_get_temp_dir() reads the same
-				// ${TMPDIR:-/tmp} the helper's mktemp does, so the two cannot drift.
+				// floor: room for the archive itself. The path is derived the way the
+				// CHILD derives it, off the environment exec() hands it, and NOT with
+				// sys_get_temp_dir(): PHP's `sys_temp_dir` INI setting outranks TMPDIR,
+				// so on an install that sets it this would measure one filesystem while
+				// the helper wrote to another.
 				// Scoped to this branch on purpose: the gzip, bzip2 and tar paths write
 				// nowhere near /tmp, and refusing them over a filesystem they never
 				// touch would repeat issue #2658's 64 MiB-floor mistake.
-				$xlsx_short = pfb_extract_space_shortfall(array(sys_get_temp_dir()), (int) @filesize($file_download));
+				$xlsx_short = pfb_extract_space_shortfall(array(getenv('TMPDIR') ?: '/tmp'), (int) @filesize($file_download));
 				if ($xlsx_short !== NULL) {
 					pfb_validate_log($header, 'size', 'staging_space_low', $xlsx_short);
 					unlink_if_exists($file_download);

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.sh
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.sh
@@ -2045,9 +2045,11 @@ processet() {
 # contract -- it refuses the refresh instead of publishing an empty feed.
 #
 # issue #2684: the shared-strings part is streamed, not written to a file. It is
-# XML, so it expands by two orders of magnitude past the workbook carrying it
-# (measured 49,160 bytes on disk -> 10,083,388 decompressed), and ${tmpdir} is a
-# RAM disk on a default use_mfs_tmpvar install.
+# XML, so it expands by two orders of magnitude past the workbook carrying it --
+# 4,181,827 bytes from a 20,897-byte workbook on the fixture in
+# tests/shell/pfblockerng_processxlsx_stream_spec.sh, and 10,083,388 from 49,160
+# on a real ZIP-in-ZIP workbook -- while ${tmpdir} is a RAM disk on a default
+# use_mfs_tmpvar install.
 processxlsx() {
 	if [ ! -x "${pathtar}" ]; then
 		log='Application [ TAR ] Not found, cannot proceed.'

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.sh
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.sh
@@ -2061,7 +2061,11 @@ processxlsx() {
 		return 1
 	fi
 
-	xlsxtarrc="${tmpxlsx}sharedStrings.rc"
+	# A SIBLING of the extraction target, never a file inside it: the container is
+	# untrusted, and a member landing on this path would hand a remote feed the
+	# status the publish gate below reads. ${tmpxlsx} is "${tmpdir}/xlsx/", so this
+	# is "${tmpdir}/xlsx.rc" -- still inside the run's own 0700 mktemp directory.
+	xlsxtarrc="${tmpxlsx%/}.rc"
 	xlsxstage="${pfborig}${alias}.orig.tmp"
 
 	# Only ONE status may be lost to the pipe, and neither of the two that decide
@@ -2070,9 +2074,8 @@ processxlsx() {
 	# does not support aborts the whole script rather than failing one command).
 	# So `grep` is the pipeline's LAST stage, which keeps its no-match exit 1
 	# (issue #2682) as the pipeline's own status, and tar's status is stashed to a
-	# file. That stash is readable the moment the pipeline returns because the
-	# subshell writing it holds the pipe's only write end: `grep` cannot see EOF,
-	# so the shell cannot reap it, until the write is done.
+	# file. Nothing can pre-seed that stash: it is not a path any container member
+	# can reach, and ${tmpdir} is a fresh 0700 mktemp directory every run.
 	# `set --` names ONE workbook: the glob splats into tar's argument list, where
 	# every match after the first is a member selector, not a second archive.
 	"${pathtar}" -xf "${pfborig}${alias}.raw" -C "${tmpxlsx}" &&
@@ -2080,12 +2083,16 @@ processxlsx() {
 		{ "${pathtar}" -xOf "$1" "xl/sharedStrings.xml" || echo "$?" > "${xlsxtarrc}"; } |
 			grep -aoEw "(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)" > "${xlsxstage}"
 	xlsxrc=$?
-	# tar's own status outranks the pipeline's, and is read BEFORE the publish: a
-	# partial read still emits an address for `grep` to match, so publishing would
-	# be issue #2666's defect again -- a truncated feed reported as a success. It
-	# outranks a FAILING pipeline too, so a ceiling kill still reaches the caller
-	# as the 153 pfb_extract_cap_note() reads even when nothing matched.
-	if [ -s "${xlsxtarrc}" ]; then
+	# tar's stashed status is read only when `grep` ran to completion -- exit 0 or
+	# its no-match 1 -- and BEFORE the publish: a partial read still emits an
+	# address for `grep` to match, so publishing would be issue #2666's defect
+	# again, a truncated feed reported as a success. Above 1 the pipeline's own
+	# status stands, because tar cannot be the cause: its only output is the pipe,
+	# and RLIMIT_FSIZE does not bound a pipe write, so issue #2658's ceiling can
+	# only kill the stage that writes a FILE. tar merely dies of EPIPE behind it,
+	# and reading that over the 153 would cost pfb_extract_cap_note() the one
+	# value it keys on to tell the operator "too large".
+	if [ "${xlsxrc}" -le 1 ] && [ -s "${xlsxtarrc}" ]; then
 		xlsxrc="$(cat "${xlsxtarrc}")"
 	fi
 	# `chmod` before the rename because published feeds have unprivileged readers
@@ -2097,7 +2104,7 @@ processxlsx() {
 			mv -f "${xlsxstage}" "${pfborig}${alias}.orig"
 		xlsxrc=$?
 	fi
-	rm -rf "${tmpxlsx}"*
+	rm -rf "${tmpxlsx}"* "${xlsxtarrc}"
 
 	if [ "${xlsxrc}" -ne 0 ]; then
 		# -rf, not -f: crash-leftover DIRECTORY debris here would otherwise survive

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.sh
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.sh
@@ -2043,6 +2043,11 @@ processet() {
 #
 # issue #2682: an extraction that parses but yields no address is part of that
 # contract -- it refuses the refresh instead of publishing an empty feed.
+#
+# issue #2684: the shared-strings part is streamed, not written to a file. It is
+# XML, so it expands by two orders of magnitude past the workbook carrying it
+# (measured 51,114 bytes on disk -> 10,486,635 decompressed), and ${tmpdir} is a
+# RAM disk on a default use_mfs_tmpvar install.
 processxlsx() {
 	if [ ! -x "${pathtar}" ]; then
 		log='Application [ TAR ] Not found, cannot proceed.'
@@ -2056,24 +2061,45 @@ processxlsx() {
 		return 1
 	fi
 
-	xlsxshared="${tmpxlsx}sharedStrings.xml"
+	xlsxtarrc="${tmpxlsx}sharedStrings.rc"
 	xlsxstage="${pfborig}${alias}.orig.tmp"
 
-	# Nothing here is piped: POSIX sh has no pipefail, so a pipeline reports only
-	# its last command's status -- `grep`'s no-match exit 1 (issue #2682) and a
-	# ceiling kill would both be lost. (POSIX permits sort -o's file among its inputs.)
+	# Only ONE status may be lost to the pipe, and neither of the two that decide
+	# the feed is expendable: POSIX sh has no `pipefail` (and `set -o pipefail` is
+	# not an option here -- `set` is a special builtin, so an option a base system
+	# does not support aborts the whole script rather than failing one command).
+	# So `grep` is the pipeline's LAST stage, which keeps its no-match exit 1
+	# (issue #2682) as the pipeline's own status, and tar's status is stashed to a
+	# file and re-read below. The stash is readable the moment the pipeline
+	# returns: the write happens inside the subshell holding the pipe's only write
+	# end, so `grep` cannot see EOF -- and the shell cannot reap it -- until that
+	# write has completed.
 	# `set --` names ONE workbook: the glob splats into tar's argument list, where
 	# every match after the first is a member selector, not a second archive.
-	# `chmod` before the rename because published feeds have unprivileged readers
-	# and a rename would hand the file the run's umask (as pfb_stage_publish()).
 	"${pathtar}" -xf "${pfborig}${alias}.raw" -C "${tmpxlsx}" &&
 		set -- "${tmpxlsx}"*.[xX][lL][sS][xX] &&
-		"${pathtar}" -xOf "$1" "xl/sharedStrings.xml" > "${xlsxshared}" &&
-		grep -aoEw "(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)" "${xlsxshared}" > "${xlsxstage}" &&
-		LC_ALL=C sort -u -o "${xlsxstage}" "${xlsxstage}" &&
-		chmod 644 "${xlsxstage}" &&
-		mv -f "${xlsxstage}" "${pfborig}${alias}.orig"
+		{ "${pathtar}" -xOf "$1" "xl/sharedStrings.xml" || echo "$?" > "${xlsxtarrc}"; } |
+			grep -aoEw "(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)" > "${xlsxstage}"
 	xlsxrc=$?
+	# tar's own status outranks the pipeline's, and is read BEFORE the publish: a
+	# workbook that read only partway still emits its leading megabytes, so `grep`
+	# matches and exits 0, and publishing that would be issue #2666's defect over
+	# again -- a truncated feed reported as a successful ingest. It outranks a
+	# failing pipeline too, so a child killed at the extraction ceiling reaches
+	# the caller as the 153 pfb_extract_cap_note() reads even when the bytes it
+	# managed to emit held no address for `grep` to match.
+	if [ -s "${xlsxtarrc}" ]; then
+		xlsxrc="$(cat "${xlsxtarrc}")"
+	fi
+	# `chmod` before the rename because published feeds have unprivileged readers
+	# and a rename would hand the file the run's umask (as pfb_stage_publish()).
+	# (POSIX permits sort -o's file among its inputs.)
+	if [ "${xlsxrc}" -eq 0 ]; then
+		LC_ALL=C sort -u -o "${xlsxstage}" "${xlsxstage}" &&
+			chmod 644 "${xlsxstage}" &&
+			mv -f "${xlsxstage}" "${pfborig}${alias}.orig"
+		xlsxrc=$?
+	fi
 	rm -rf "${tmpxlsx}"*
 
 	if [ "${xlsxrc}" -ne 0 ]; then

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.sh
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.sh
@@ -2046,7 +2046,7 @@ processet() {
 #
 # issue #2684: the shared-strings part is streamed, not written to a file. It is
 # XML, so it expands by two orders of magnitude past the workbook carrying it
-# (measured 51,114 bytes on disk -> 10,486,635 decompressed), and ${tmpdir} is a
+# (measured 49,160 bytes on disk -> 10,083,388 decompressed), and ${tmpdir} is a
 # RAM disk on a default use_mfs_tmpvar install.
 processxlsx() {
 	if [ ! -x "${pathtar}" ]; then
@@ -2070,10 +2070,9 @@ processxlsx() {
 	# does not support aborts the whole script rather than failing one command).
 	# So `grep` is the pipeline's LAST stage, which keeps its no-match exit 1
 	# (issue #2682) as the pipeline's own status, and tar's status is stashed to a
-	# file and re-read below. The stash is readable the moment the pipeline
-	# returns: the write happens inside the subshell holding the pipe's only write
-	# end, so `grep` cannot see EOF -- and the shell cannot reap it -- until that
-	# write has completed.
+	# file. That stash is readable the moment the pipeline returns because the
+	# subshell writing it holds the pipe's only write end: `grep` cannot see EOF,
+	# so the shell cannot reap it, until the write is done.
 	# `set --` names ONE workbook: the glob splats into tar's argument list, where
 	# every match after the first is a member selector, not a second archive.
 	"${pathtar}" -xf "${pfborig}${alias}.raw" -C "${tmpxlsx}" &&
@@ -2082,12 +2081,10 @@ processxlsx() {
 			grep -aoEw "(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)" > "${xlsxstage}"
 	xlsxrc=$?
 	# tar's own status outranks the pipeline's, and is read BEFORE the publish: a
-	# workbook that read only partway still emits its leading megabytes, so `grep`
-	# matches and exits 0, and publishing that would be issue #2666's defect over
-	# again -- a truncated feed reported as a successful ingest. It outranks a
-	# failing pipeline too, so a child killed at the extraction ceiling reaches
-	# the caller as the 153 pfb_extract_cap_note() reads even when the bytes it
-	# managed to emit held no address for `grep` to match.
+	# partial read still emits an address for `grep` to match, so publishing would
+	# be issue #2666's defect again -- a truncated feed reported as a success. It
+	# outranks a FAILING pipeline too, so a ceiling kill still reaches the caller
+	# as the 153 pfb_extract_cap_note() reads even when nothing matched.
 	if [ -s "${xlsxtarrc}" ]; then
 		xlsxrc="$(cat "${xlsxtarrc}")"
 	fi

--- a/tests/php/DownloadSizeCeilingTest.php
+++ b/tests/php/DownloadSizeCeilingTest.php
@@ -433,9 +433,12 @@ final class DownloadSizeCeilingTest extends TestCase
 	 *
 	 * Issue #2684: that filesystem is /tmp -- a RAM disk on a default
 	 * use_mfs_tmpvar install, and the one consumer the precheck above cannot see,
-	 * because it belongs to a child process rather than to this function. Probed
-	 * with sys_get_temp_dir() rather than a literal, which is the same
-	 * ${TMPDIR:-/tmp} the helper's own `mktemp -d` reads.
+	 * because it belongs to a child process rather than to this function. The
+	 * probed path is derived the way the CHILD derives it, `getenv('TMPDIR') ?:
+	 * '/tmp'` against the environment exec() hands it, and deliberately NOT with
+	 * sys_get_temp_dir(): PHP's `sys_temp_dir` INI setting outranks TMPDIR, so on
+	 * an install that sets it the guard would measure one filesystem while the
+	 * helper's `mktemp -d "${TMPDIR:-/tmp}/pfb.XXXXXXXX"` wrote to another.
 	 *
 	 * Scoped to the xlsx branch, NOT folded into the precheck above: the gzip,
 	 * bzip2 and tar paths write nowhere near /tmp, and refusing a 50 MiB gzip feed
@@ -453,7 +456,7 @@ final class DownloadSizeCeilingTest extends TestCase
 		$scope = substr(self::$downloadBody, $xlsx, $zipBranch - $xlsx);
 
 		$check = strpos($scope,
-			'pfb_extract_space_shortfall(array(sys_get_temp_dir()), (int) @filesize($file_download))');
+			"pfb_extract_space_shortfall(array(getenv('TMPDIR') ?: '/tmp'), (int) @filesize(\$file_download))");
 		$this->assertNotFalse($check,
 			'the xlsx branch must probe the temp filesystem the helper unpacks the workbook into');
 		$run = strpos($scope, 'exec(pfb_extract_cmd("{$pfb[\'script\']} xlsx');

--- a/tests/php/DownloadSizeCeilingTest.php
+++ b/tests/php/DownloadSizeCeilingTest.php
@@ -421,4 +421,50 @@ final class DownloadSizeCeilingTest extends TestCase
 		$this->assertStringContainsString(
 			'pfb_extract_space_shortfall($extract_dirs, (int) @filesize($file_download))', self::$downloadBody);
 	}
+
+	/**
+	 * Scenario: the XLSX helper's own temp filesystem is prechecked too
+	 *
+	 * Given  a ZIP container carrying a workbook
+	 * When   the source is read
+	 * Then   the xlsx branch probes the temp directory the shell helper unpacks
+	 *        that workbook into, names the shortfall in the refusal log, and
+	 *        returns before the helper is executed.
+	 *
+	 * Issue #2684: that filesystem is /tmp -- a RAM disk on a default
+	 * use_mfs_tmpvar install, and the one consumer the precheck above cannot see,
+	 * because it belongs to a child process rather than to this function. Probed
+	 * with sys_get_temp_dir() rather than a literal, which is the same
+	 * ${TMPDIR:-/tmp} the helper's own `mktemp -d` reads.
+	 *
+	 * Scoped to the xlsx branch, NOT folded into the precheck above: the gzip,
+	 * bzip2 and tar paths write nowhere near /tmp, and refusing a 50 MiB gzip feed
+	 * because a 40 MiB RAM disk it never touches is short would be the 64 MiB-floor
+	 * mistake of issue #2658 over again.
+	 */
+	public function test_xlsx_branch_prechecks_the_helper_temp_filesystem(): void
+	{
+		$xlsx = strpos(self::$downloadBody, "if (strpos(\$xlsxtest, '.xlsx') !== FALSE) {");
+		$this->assertNotFalse($xlsx, 'the xlsx branch must still be identifiable');
+		$zipBranch = strpos(self::$downloadBody, '} else {', $xlsx);
+		$this->assertNotFalse($zipBranch);
+		// Bounded by the branch, so the sibling precheck further up the function
+		// cannot satisfy a neutered xlsx one.
+		$scope = substr(self::$downloadBody, $xlsx, $zipBranch - $xlsx);
+
+		$check = strpos($scope,
+			'pfb_extract_space_shortfall(array(sys_get_temp_dir()), (int) @filesize($file_download))');
+		$this->assertNotFalse($check,
+			'the xlsx branch must probe the temp filesystem the helper unpacks the workbook into');
+		$run = strpos($scope, 'exec(pfb_extract_cmd("{$pfb[\'script\']} xlsx');
+		$this->assertNotFalse($run);
+		$this->assertLessThan($run, $check,
+			'the precheck must refuse before the helper runs, not after it has written');
+
+		$refusal = substr($scope, $check, $run - $check);
+		$this->assertStringContainsString("pfb_validate_log(\$header, 'size', 'staging_space_low'", $refusal,
+			'the refusal must name its reason, like every other size refusal');
+		$this->assertStringContainsString('return PfbDownloadResult::failure();', $refusal,
+			'the refusal must return, not fall through into the extraction');
+	}
 }

--- a/tests/php/DownloadSizeCeilingTest.php
+++ b/tests/php/DownloadSizeCeilingTest.php
@@ -434,11 +434,12 @@ final class DownloadSizeCeilingTest extends TestCase
 	 * Issue #2684: that filesystem is /tmp -- a RAM disk on a default
 	 * use_mfs_tmpvar install, and the one consumer the precheck above cannot see,
 	 * because it belongs to a child process rather than to this function. The
-	 * probed path is derived the way the CHILD derives it, `getenv('TMPDIR') ?:
-	 * '/tmp'` against the environment exec() hands it, and deliberately NOT with
-	 * sys_get_temp_dir(): PHP's `sys_temp_dir` INI setting outranks TMPDIR, so on
-	 * an install that sets it the guard would measure one filesystem while the
-	 * helper's `mktemp -d "${TMPDIR:-/tmp}/pfb.XXXXXXXX"` wrote to another.
+	 * probed path is derived the way the CHILD derives it, off the environment
+	 * exec() hands it, and deliberately NOT with sys_get_temp_dir(): PHP's
+	 * `sys_temp_dir` INI setting outranks TMPDIR, so on an install that sets it the
+	 * guard would measure one filesystem while the helper's
+	 * `mktemp -d "${TMPDIR:-/tmp}/pfb.XXXXXXXX"` wrote to another. That resolution
+	 * lives in pfb_extract_temp_root(), which the test below exercises directly.
 	 *
 	 * Scoped to the xlsx branch, NOT folded into the precheck above: the gzip,
 	 * bzip2 and tar paths write nowhere near /tmp, and refusing a 50 MiB gzip feed
@@ -456,7 +457,7 @@ final class DownloadSizeCeilingTest extends TestCase
 		$scope = substr(self::$downloadBody, $xlsx, $zipBranch - $xlsx);
 
 		$check = strpos($scope,
-			"pfb_extract_space_shortfall(array(getenv('TMPDIR') ?: '/tmp'), (int) @filesize(\$file_download))");
+			'pfb_extract_space_shortfall(array(pfb_extract_temp_root()), (int) @filesize($file_download))');
 		$this->assertNotFalse($check,
 			'the xlsx branch must probe the temp filesystem the helper unpacks the workbook into');
 		$run = strpos($scope, 'exec(pfb_extract_cmd("{$pfb[\'script\']} xlsx');
@@ -469,5 +470,44 @@ final class DownloadSizeCeilingTest extends TestCase
 			'the refusal must name its reason, like every other size refusal');
 		$this->assertStringContainsString('return PfbDownloadResult::failure();', $refusal,
 			'the refusal must return, not fall through into the extraction');
+	}
+
+	/**
+	 * Scenario: the probed temp root resolves exactly as the helper's shell does
+	 *
+	 * Given  TMPDIR unset, empty, set to "0", and set to a real path
+	 * When   pfb_extract_temp_root() and the shell's own ${TMPDIR:-/tmp} both
+	 *        resolve the temp root
+	 * Then   they name the same directory in every case.
+	 *
+	 * Issue #2684: the guard only means anything if it measures the filesystem the
+	 * child actually writes to, so the shell is the oracle here rather than a
+	 * restatement of the PHP. PHP's `?:` shorthand agrees for three of these four
+	 * and diverges on the fourth -- "0" is a non-empty string the shell keeps and
+	 * PHP's truthiness discards -- and the last assertion pins that the rejected
+	 * shorthand really is wrong here rather than a hypothetical.
+	 */
+	public function test_extract_temp_root_matches_the_shell_fallback(): void
+	{
+		$restore = getenv('TMPDIR');
+		try {
+			foreach (['unset' => NULL, 'empty' => '', 'zero' => '0', 'path' => '/var/tmp'] as $label => $value) {
+				$prelude = $value === NULL
+					? 'unset TMPDIR;'
+					: 'TMPDIR=' . escapeshellarg($value) . '; export TMPDIR;';
+				$shell = exec('/bin/sh -c ' . escapeshellarg($prelude . ' printf %s "${TMPDIR:-/tmp}"'));
+
+				$value === NULL ? putenv('TMPDIR') : putenv("TMPDIR={$value}");
+				$this->assertSame($shell, pfb_extract_temp_root(),
+					"TMPDIR {$label}: the precheck must resolve the temp root the helper writes to");
+
+				if ($label === 'zero') {
+					$this->assertNotSame($shell, (string) (getenv('TMPDIR') ?: '/tmp'),
+						'the rejected `?:` shorthand must be demonstrably wrong here');
+				}
+			}
+		} finally {
+			$restore === FALSE ? putenv('TMPDIR') : putenv("TMPDIR={$restore}");
+		}
 	}
 }

--- a/tests/php/fixtures/function_inventory.json
+++ b/tests/php/fixtures/function_inventory.json
@@ -4240,6 +4240,11 @@
             }
         ]
     },
+    "pfb_extract_temp_root": {
+        "returnsRef": false,
+        "returnType": "string",
+        "params": []
+    },
     "pfb_extras_credentials": {
         "returnsRef": false,
         "returnType": "array",

--- a/tests/shell/pfblockerng_adr26_locale_spec.sh
+++ b/tests/shell/pfblockerng_adr26_locale_spec.sh
@@ -77,8 +77,10 @@ Describe 'ADR-26 — pfblockerng.sh locale/portability source invariants (Phases
   # issue #2666 staged this sink: the addresses are sorted onto "${xlsxstage}" and
   # only moved onto "${pfborig}${alias}.orig" once every extraction step reported
   # success. Same sink, same collation requirement, one filename earlier.
-  # issue #2682 took it off the pipe as well -- `grep` stages its matches and this
-  # `sort` rewrites that file in place -- so grep's no-match status is readable.
+  # issue #2682 made `grep` the writer of that staged file, so its no-match exit 1
+  # is readable, and this `sort` rewrites the file in place afterwards.
+  # issue #2684 put the extraction back on a pipe -- `grep` is its last stage, so
+  # that status still arrives -- and this `sort` still runs after it, unpiped.
   It 'prefixes the extracted-IP .orig sink with LC_ALL=C'
     When call has 'LC_ALL=C sort -u -o "${xlsxstage}" "${xlsxstage}"'
     The status should be success

--- a/tests/shell/pfblockerng_processxlsx_stream_spec.sh
+++ b/tests/shell/pfblockerng_processxlsx_stream_spec.sh
@@ -125,6 +125,17 @@ PROBE
 		}' > "${work}/inner/xl/sharedStrings.xml"
 	}
 
+	# The same pool with both addresses removed: a workbook that parses and carries
+	# the same expansion, but no IPv4 literal for `grep` to match (issue #2682).
+	build_addressless_part() {
+		awk 'BEGIN {
+			for (n = 0; n < 128; n++) { line = line "<si><t>row-" (n % 16) "-category-not-an-address</t></si>" }
+			printf "<sst>"
+			for (r = 0; r < 720; r++) { printf "%s", line }
+			print "</sst>"
+		}' > "${work}/inner/xl/sharedStrings.xml"
+	}
+
 	# The workbook is compressed, like the real thing; the outer container is not,
 	# because a real producer does not re-deflate an already-deflated ZIP -- so the
 	# ".raw" pfb_download() hands over is about the size of the workbook it carries.
@@ -203,12 +214,7 @@ PROBE
 		# stashed tar status in a way that overwrote a clean tar's 0 onto this would
 		# publish zero bytes over the last-good feed again.
 		plant_addressless_raw() {
-			awk 'BEGIN {
-				for (n = 0; n < 128; n++) { line = line "<si><t>row-" (n % 16) "-category-not-an-address</t></si>" }
-				printf "<sst>"
-				for (r = 0; r < 720; r++) { printf "%s", line }
-				print "</sst>"
-			}' > "${work}/inner/xl/sharedStrings.xml"
+			build_addressless_part
 			( cd "${work}/inner" && tar -czf "${work}/build/${alias}.xlsx" xl )
 			( cd "${work}/build" && tar -cf "${orig}${alias}.raw" "${alias}.xlsx" )
 		}
@@ -236,12 +242,7 @@ PROBE
 		# container has been unpacked, before anything can read it.
 		plant_planted_stash_raw() {
 			printf '0\n' > "${work}/build/sharedStrings.rc"
-			awk 'BEGIN {
-				for (n = 0; n < 128; n++) { line = line "<si><t>row-" (n % 16) "-category-not-an-address</t></si>" }
-				printf "<sst>"
-				for (r = 0; r < 720; r++) { printf "%s", line }
-				print "</sst>"
-			}' > "${work}/inner/xl/sharedStrings.xml"
+			build_addressless_part
 			( cd "${work}/inner" && tar -czf "${work}/build/${alias}.xlsx" xl )
 			( cd "${work}/build" && tar -cf "${orig}${alias}.raw" sharedStrings.rc "${alias}.xlsx" )
 		}

--- a/tests/shell/pfblockerng_processxlsx_stream_spec.sh
+++ b/tests/shell/pfblockerng_processxlsx_stream_spec.sh
@@ -1,0 +1,214 @@
+#shellcheck shell=sh
+# issue #2684: processxlsx() wrote the workbook's decompressed "xl/sharedStrings.xml"
+# to a file under the per-run temp directory before scanning it. That part is XML and
+# expands by two orders of magnitude past the workbook that carries it -- measured on
+# the production-shape ZIP-in-ZIP fixture below at 10,486,635 bytes from 51,114 on
+# disk -- and ${tmpdir} lives under /tmp, a RAM disk on a default use_mfs_tmpvar
+# install. A workbook well inside every existing ceiling could therefore fill the
+# temp filesystem, or be killed at issue #2658's inherited RLIMIT_FSIZE, where it
+# previously streamed through a pipe and never touched the disk.
+#
+# It was written to a file because POSIX sh has no `pipefail`: piped, a pipeline
+# reports only its last command's status, and issue #2666's exit contract needs
+# tar's. `set -o pipefail` is not available either -- `set` is a special builtin, so
+# an option a base system does not support aborts the whole script rather than
+# failing one command. So tar's status is stashed out of band instead, and these
+# examples pin BOTH halves of that: the part no longer lands in ${tmpdir}, and every
+# status the pipe could have swallowed still refuses the feed.
+#
+# Fixture shape: the ".raw" container holds one "*.xlsx" member which is itself a
+# COMPRESSED archive holding "xl/sharedStrings.xml" -- the two layers processxlsx()
+# opens, with the expansion that is the whole point of the ticket. Real feeds ship
+# ZIP containers; these are tars because the function only ever calls ${pathtar}
+# with -xf/-xOf, and GNU tar (the CI runner's /usr/bin/tar) cannot read a ZIP at
+# all, which would silently reduce this file to a macOS-only test. Both flavours
+# auto-detect the inner compression on read with no explicit -z (probed: bsdtar
+# 3.5.3 rc=0, GNU tar 1.35 rc=0).
+
+Describe 'processxlsx() streams the shared-strings part (issue #2684)'
+	setup() {
+		work="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/xlsxstream.XXXXXX")"
+		orig="${work}/orig/"
+		alias='XlsxFeed'
+		errorlog="${work}/error.log"
+		runner="${work}/run.sh"
+		probe="${work}/probe.sh"
+		scratch="${work}/scratch"
+		# The whole part must fit far outside this, and the workbook plus the
+		# published feed far inside it: 64 KiB sits between the two by two orders
+		# of magnitude, so neither verdict rides on a narrow margin.
+		bound=65536
+		mkdir -p "${orig}" "${scratch}" "${work}/build" "${work}/inner/xl" "${work}/shim"
+		expected="$(printf '%s\n' '192.0.2.10' '198.51.100.20')"
+		prior="$(printf '%s\n' '203.0.113.7' 'PRIOR-MARKER')"
+
+		# processxlsx() reads its inputs from the top-level init's globals, which
+		# never resolve off-appliance. Source the script as a library, point those
+		# globals at the fixture, and call the function -- from a real child
+		# process, so an example may impose an RLIMIT_FSIZE without the shellspec
+		# harness itself then writing under it.
+		cat > "${runner}" <<RUNNER
+#!/bin/sh
+PFB_SOURCED=1
+. "${PFB_PKGDIR}/pfblockerng.sh"
+pathtar="$(command -v tar)"
+pfborig="${orig}"
+alias="${alias}"
+tmpxlsx="${scratch}/"
+errorlog="${errorlog}"
+now='2026-01-01 00:00:00'
+ip_placeholder2='127\.1\.7\.7'
+processxlsx
+RUNNER
+		chmod +x "${runner}"
+
+		# Sampling point for the footprint: the moment the `sort` sink runs. By then
+		# the whole part has been consumed either way -- written to ${tmpdir} or
+		# streamed through the pipe -- so both shapes are measured at the same
+		# instant, and the sample is the peak because nothing in ${tmpdir} is removed
+		# before it. A PATH shim takes the sample and then execs the real sort, so
+		# the rest of the contract still runs underneath the measurement.
+		cat > "${work}/shim/sort" <<SHIM
+#!/bin/sh
+find "${scratch}" -type f -exec cat {} + | wc -c | tr -d ' ' > "${work}/sink_bytes"
+exec "$(command -v sort)" "\$@"
+SHIM
+		chmod +x "${work}/shim/sort"
+
+		# Reports the measurement on BOTH verdicts, so a failure prints the bytes
+		# that produced it instead of a bare boolean, and exits with the run's own
+		# status so the ingest is still under test.
+		cat > "${probe}" <<PROBE
+#!/bin/sh
+PATH="${work}/shim:\${PATH}" sh "${runner}" >/dev/null 2>&1
+rc=\$?
+observed="\$(cat "${work}/sink_bytes" 2>/dev/null || echo NA)"
+part="\$(wc -c < "${work}/inner/xl/sharedStrings.xml" | tr -d ' ')"
+workbook="\$(wc -c < "${work}/build/${alias}.xlsx" | tr -d ' ')"
+verdict=materialised
+if [ "\${observed}" != NA ] && [ "\${observed}" -lt ${bound} ]; then
+	verdict=streamed
+fi
+echo "verdict=\${verdict} tmpdir_bytes_at_sink=\${observed} bound=${bound} part_bytes=\${part} workbook_bytes=\${workbook}"
+exit "\${rc}"
+PROBE
+		chmod +x "${probe}"
+	}
+	cleanup() { rm -rf "$work"; }
+	Before 'setup'
+	After 'cleanup'
+
+	# A shared-strings table is a DEDUPLICATED string pool with a small vocabulary --
+	# category names, country codes, comment boilerplate -- referenced over and over
+	# by the sheet, which is why it deflates by two orders of magnitude. Cycling a
+	# bounded pool of distinct rows reproduces that shape; one endlessly repeated
+	# token would compress past anything real, a random one past nothing at all.
+	build_part() {
+		awk 'BEGIN {
+			for (n = 0; n < 128; n++) { line = line "<si><t>row-" (n % 16) "-category-not-an-address</t></si>" }
+			printf "<sst><si><t>192.0.2.10</t></si>"
+			for (r = 0; r < 720; r++) { printf "%s", line }
+			print "<si><t>198.51.100.20</t></si></sst>"
+		}' > "${work}/inner/xl/sharedStrings.xml"
+	}
+
+	# The workbook is compressed, like the real thing; the outer container is not,
+	# because a real producer does not re-deflate an already-deflated ZIP -- so the
+	# ".raw" pfb_download() hands over is about the size of the workbook it carries.
+	# The payload repeats one address and lists them out of order, so every example
+	# asserting "${expected}" also pins the staging sort and its de-duplication.
+	plant_streaming_raw() {
+		build_part
+		( cd "${work}/inner" && tar -czf "${work}/build/${alias}.xlsx" xl )
+		( cd "${work}/build" && tar -cf "${orig}${alias}.raw" "${alias}.xlsx" )
+	}
+
+	# A live publication left by a previous, successful run.
+	plant_prior_publication() {
+		printf '%s\n' "${prior}" > "${orig}${alias}.orig"
+	}
+
+	Context 'on a healthy production-shape workbook'
+		Before 'plant_streaming_raw'
+
+		It 'keeps the run temp directory to the workbook, not the part it expands to'
+			When run sh "${probe}"
+			The output should include 'verdict=streamed'
+			The status should be success
+			The contents of file "${orig}${alias}.orig" should equal "${expected}"
+			The path "${orig}${alias}.orig.tmp" should not be exist
+		End
+
+		It 'ingests a workbook whose part expands past the extraction write ceiling'
+			# The availability regression the ticket names. pfb_extract_cmd() wraps
+			# this call site in `ulimit -f`, and RLIMIT_FSIZE is inherited by every
+			# descendant, so materialising the part made a workbook well inside every
+			# ceiling refusable on size alone. 64 KiB is above the workbook and the
+			# published feed and two orders of magnitude below the part, so this
+			# passes only if the part is never written to a file at all.
+			When run sh -c "ulimit -f 128 || exit 1; sh '${runner}' >/dev/null 2>&1"
+			The status should be success
+			The contents of file "${orig}${alias}.orig" should equal "${expected}"
+		End
+	End
+
+	Context 'on a workbook whose compressed part stops mid-stream'
+		# The one shape where tar's own status is the ONLY evidence the read failed:
+		# tar emits the leading megabytes -- an address among them -- and then dies,
+		# so `grep` matches, exits 0, and a pipeline reports only that. Probed on the
+		# fixture: bsdtar 3.5.3 exits 1 and GNU tar 1.35 exits 2, both after emitting
+		# ~2 MiB carrying one address. Publishing that is issue #2666's defect
+		# exactly -- a truncated feed reported as a successful ingest -- so the
+		# streamed shape has to carry tar's status past the pipe to keep refusing it.
+		plant_partial_workbook() {
+			build_part
+			( cd "${work}/inner" && tar -czf "${work}/build/${alias}.xlsx" xl )
+			whole="$(wc -c < "${work}/build/${alias}.xlsx" | tr -d ' ')"
+			dd if="${work}/build/${alias}.xlsx" of="${work}/cut" bs=512 \
+				count="$((whole / 1024))" 2>/dev/null
+			mv -f "${work}/cut" "${work}/build/${alias}.xlsx"
+			( cd "${work}/build" && tar -cf "${orig}${alias}.raw" "${alias}.xlsx" )
+		}
+		Before 'plant_prior_publication'
+		Before 'plant_partial_workbook'
+
+		It 'refuses the feed and keeps the live publication byte-unchanged'
+			When run sh "${runner}"
+			The status should be failure
+			The contents of file "${orig}${alias}.orig" should equal "${prior}"
+			The path "${orig}${alias}.orig.tmp" should not be exist
+			The output should include 'XLSX processing failed'
+			The contents of file "${errorlog}" should include 'keeping existing'
+			The stderr should be present
+		End
+	End
+
+	Context 'on a production-shape workbook carrying no IPv4 literal'
+		# issue #2682's refusal, on the compressed fixture and through the pipe:
+		# `grep` is the pipeline's LAST stage, so its no-match exit 1 is the
+		# pipeline's own status and still reaches the caller verbatim. Reading the
+		# stashed tar status in a way that overwrote a clean tar's 0 onto this would
+		# publish zero bytes over the last-good feed again.
+		plant_addressless_raw() {
+			awk 'BEGIN {
+				for (n = 0; n < 128; n++) { line = line "<si><t>row-" (n % 16) "-category-not-an-address</t></si>" }
+				printf "<sst>"
+				for (r = 0; r < 720; r++) { printf "%s", line }
+				print "</sst>"
+			}' > "${work}/inner/xl/sharedStrings.xml"
+			( cd "${work}/inner" && tar -czf "${work}/build/${alias}.xlsx" xl )
+			( cd "${work}/build" && tar -cf "${orig}${alias}.raw" "${alias}.xlsx" )
+		}
+		Before 'plant_prior_publication'
+		Before 'plant_addressless_raw'
+
+		It 'refuses the refresh and keeps the live publication byte-unchanged'
+			When run sh "${runner}"
+			The status should be failure
+			The contents of file "${orig}${alias}.orig" should equal "${prior}"
+			The path "${orig}${alias}.orig.tmp" should not be exist
+			The output should include 'XLSX processing failed'
+			The contents of file "${errorlog}" should include " [ ${alias} ] XLSX processing failed, exit 1; keeping existing [ 2026-01-01 00:00:00 ]"
+		End
+	End
+End

--- a/tests/shell/pfblockerng_processxlsx_stream_spec.sh
+++ b/tests/shell/pfblockerng_processxlsx_stream_spec.sh
@@ -238,8 +238,8 @@ PROBE
 		# it is issue #2682's defect back under the container's control -- `grep`
 		# reports no match, a planted `0` overrides it, and zero bytes publish over
 		# the live feed as a success. So the stash is derived as a SIBLING of the
-		# extraction target rather than a file inside it, and is cleared once the
-		# container has been unpacked, before anything can read it.
+		# extraction target rather than a file inside it -- that derivation is the
+		# whole defence; there is no clearing step between the unpack and the read.
 		plant_planted_stash_raw() {
 			printf '0\n' > "${work}/build/sharedStrings.rc"
 			build_addressless_part

--- a/tests/shell/pfblockerng_processxlsx_stream_spec.sh
+++ b/tests/shell/pfblockerng_processxlsx_stream_spec.sh
@@ -1,12 +1,13 @@
 #shellcheck shell=sh
 # issue #2684: processxlsx() wrote the workbook's decompressed "xl/sharedStrings.xml"
 # to a file under the per-run temp directory before scanning it. That part is XML and
-# expands by two orders of magnitude past the workbook that carries it -- measured on
-# the production-shape ZIP-in-ZIP fixture below at 10,486,635 bytes from 51,114 on
-# disk -- and ${tmpdir} lives under /tmp, a RAM disk on a default use_mfs_tmpvar
-# install. A workbook well inside every existing ceiling could therefore fill the
-# temp filesystem, or be killed at issue #2658's inherited RLIMIT_FSIZE, where it
-# previously streamed through a pipe and never touched the disk.
+# expands by two orders of magnitude past the workbook that carries it -- this file's
+# own fixture reaches roughly 4.2 MB from a ~21 KB workbook, and a real ZIP-in-ZIP
+# workbook was measured at 10,083,388 bytes from 49,160 on disk -- while ${tmpdir}
+# lives under /tmp, a RAM disk on a default use_mfs_tmpvar install. A workbook well
+# inside every existing ceiling could therefore fill the temp filesystem, or be
+# killed at issue #2658's inherited RLIMIT_FSIZE, where it previously streamed
+# through a pipe and never touched the disk.
 #
 # It was written to a file because POSIX sh has no `pipefail`: piped, a pipeline
 # reports only its last command's status, and issue #2666's exit contract needs
@@ -75,21 +76,33 @@ exec "$(command -v sort)" "\$@"
 SHIM
 		chmod +x "${work}/shim/sort"
 
-		# Reports the measurement on BOTH verdicts, so a failure prints the bytes
+		# Reports the measurement on EVERY verdict, so a failure prints the bytes
 		# that produced it instead of a bare boolean, and exits with the run's own
-		# status so the ingest is still under test.
+		# status so the ingest is still under test. A sample below the workbook's
+		# own size is reported as `unmeasured`, never as a win: the workbook IS in
+		# ${tmpdir} at the sink in the shape this pins, so a shim that silently
+		# stopped measuring -- an absent file, a broken `find`, an empty `wc` --
+		# would otherwise read as the smallest possible footprint and pass.
 		cat > "${probe}" <<PROBE
 #!/bin/sh
 PATH="${work}/shim:\${PATH}" sh "${runner}" >/dev/null 2>&1
 rc=\$?
-observed="\$(cat "${work}/sink_bytes" 2>/dev/null || echo NA)"
+observed="\$(cat "${work}/sink_bytes" 2>/dev/null)"
 part="\$(wc -c < "${work}/inner/xl/sharedStrings.xml" | tr -d ' ')"
 workbook="\$(wc -c < "${work}/build/${alias}.xlsx" | tr -d ' ')"
-verdict=materialised
-if [ "\${observed}" != NA ] && [ "\${observed}" -lt ${bound} ]; then
-	verdict=streamed
-fi
-echo "verdict=\${verdict} tmpdir_bytes_at_sink=\${observed} bound=${bound} part_bytes=\${part} workbook_bytes=\${workbook}"
+case "\${observed}" in
+	'' | *[!0-9]*) verdict=unmeasured ;;
+	*)
+		if [ "\${observed}" -lt "\${workbook}" ]; then
+			verdict=unmeasured
+		elif [ "\${observed}" -lt ${bound} ]; then
+			verdict=streamed
+		else
+			verdict=materialised
+		fi
+		;;
+esac
+echo "verdict=\${verdict} tmpdir_bytes_at_sink=\${observed:-none} bound=${bound} part_bytes=\${part} workbook_bytes=\${workbook}"
 exit "\${rc}"
 PROBE
 		chmod +x "${probe}"

--- a/tests/shell/pfblockerng_processxlsx_stream_spec.sh
+++ b/tests/shell/pfblockerng_processxlsx_stream_spec.sh
@@ -224,4 +224,94 @@ PROBE
 			The contents of file "${errorlog}" should include " [ ${alias} ] XLSX processing failed, exit 1; keeping existing [ 2026-01-01 00:00:00 ]"
 		End
 	End
+
+	Context 'on a container that carries a status stash of its own'
+		# The stash is the one new file this shape writes, and the container is
+		# UNTRUSTED: a member landing on that path would hand a remote feed the
+		# status the publish gate reads. Paired with a workbook carrying no address
+		# it is issue #2682's defect back under the container's control -- `grep`
+		# reports no match, a planted `0` overrides it, and zero bytes publish over
+		# the live feed as a success. So the stash is derived as a SIBLING of the
+		# extraction target rather than a file inside it, and is cleared once the
+		# container has been unpacked, before anything can read it.
+		plant_planted_stash_raw() {
+			printf '0\n' > "${work}/build/sharedStrings.rc"
+			awk 'BEGIN {
+				for (n = 0; n < 128; n++) { line = line "<si><t>row-" (n % 16) "-category-not-an-address</t></si>" }
+				printf "<sst>"
+				for (r = 0; r < 720; r++) { printf "%s", line }
+				print "</sst>"
+			}' > "${work}/inner/xl/sharedStrings.xml"
+			( cd "${work}/inner" && tar -czf "${work}/build/${alias}.xlsx" xl )
+			( cd "${work}/build" && tar -cf "${orig}${alias}.raw" sharedStrings.rc "${alias}.xlsx" )
+		}
+		Before 'plant_prior_publication'
+		Before 'plant_planted_stash_raw'
+
+		It 'refuses the addressless workbook anyway and keeps the live publication'
+			When run sh "${runner}"
+			The status should be failure
+			The contents of file "${orig}${alias}.orig" should equal "${prior}"
+			The path "${orig}${alias}.orig.tmp" should not be exist
+			The output should include 'XLSX processing failed'
+		End
+	End
+
+	Context 'on a container whose member name climbs out of the extraction target'
+		# The sibling path the stash now uses is exactly one "../" away, so the
+		# escape is worth pinning rather than assuming. Both flavours refuse the
+		# member outright and extract nothing (probed: bsdtar 3.5.3 "Path contains
+		# '..'" exit 1, GNU tar 1.35 "Member name contains '..'" exit 2), so the
+		# feed is refused on the first tar and the stash is never reachable.
+		plant_traversal_raw() {
+			printf '0\n' > "${work}/build/climb"
+			python3 - "${orig}${alias}.raw" "${work}/build/climb" <<'PY'
+import io, sys, tarfile
+data = open(sys.argv[2], 'rb').read()
+with tarfile.open(sys.argv[1], 'w') as tf:
+    info = tarfile.TarInfo('../scratch.rc')
+    info.size = len(data)
+    tf.addfile(info, io.BytesIO(data))
+PY
+		}
+		Before 'plant_prior_publication'
+		Before 'plant_traversal_raw'
+
+		It 'refuses the feed and plants nothing beside the extraction target'
+			When run sh "${runner}"
+			The status should be failure
+			The contents of file "${orig}${alias}.orig" should equal "${prior}"
+			The path "${work}/scratch.rc" should not be exist
+			The output should include 'XLSX processing failed'
+			The stderr should be present
+		End
+	End
+
+	Context 'when the extraction ceiling kills the stage that writes'
+		# Streamed, tar's only output is the pipe, and RLIMIT_FSIZE does not bound
+		# a pipe write (probed: 64 KiB through a pipe under `ulimit -f 1` exits 0
+		# where the same bytes to a file exit 1). So issue #2658's ceiling can only
+		# bite the stage that writes a FILE -- `grep`, here -- and when it does,
+		# tar dies of EPIPE behind it. Its status must NOT be read over the 153:
+		# pfb_extract_cap_note() keys on exactly that value to tell the operator
+		# "too large" instead of printing a bare exit code, and tar's EPIPE status
+		# (1 under bsdtar, 141 under GNU tar) carries no such meaning.
+		plant_killed_grep() {
+			printf '#!/bin/sh\nhead -c 32\nexit 153\n' > "${work}/shim/grep"
+			chmod +x "${work}/shim/grep"
+		}
+		Before 'plant_streaming_raw'
+		Before 'plant_prior_publication'
+		Before 'plant_killed_grep'
+
+		It 'returns the kill status verbatim and keeps the live publication'
+			When run sh -c "PATH='${work}/shim:${PATH}' sh '${runner}'"
+			The status should equal 153
+			The contents of file "${orig}${alias}.orig" should equal "${prior}"
+			The path "${orig}${alias}.orig.tmp" should not be exist
+			The output should include 'XLSX processing failed'
+			The stderr should be present
+			The contents of file "${errorlog}" should include 'exit 153'
+		End
+	End
 End


### PR DESCRIPTION
Fixes #2684.

`processxlsx()` wrote the workbook's decompressed `xl/sharedStrings.xml` to a file under the per-run temp directory before scanning it. That part is XML, so it expands by two orders of magnitude past the workbook that carries it, and `${tmpdir}` lives under `/tmp` — a RAM disk on a default `use_mfs_tmpvar` install. A workbook well inside every existing ceiling could therefore fill the temp filesystem, or be killed at issue #2658's inherited `RLIMIT_FSIZE`, where before PR #2680 it streamed through a pipe and never touched the disk.

Two changes, the two the ticket said compose:

1. **The part streams again, and `tar`'s status is stashed out of band.** `grep` is the pipeline's last stage, so its no-match exit 1 (issue #2682) is the pipeline's own status; `tar`'s status is written to a file inside the subshell that holds the pipe's only write end, and re-read *before* the publish.
2. **The free-space precheck learns about that temp filesystem.** The xlsx branch probes it with `pfb_extract_space_shortfall()` under the same requirement every other extraction carries — the archive's own size, no fixed floor — and refuses with the named `staging_space_low` reason before the helper runs.

## Measured footprint, before and after

Two fixtures, deliberately: the real thing, measured out of tree, and a portable analogue that ships as the regression test.

**The real thing.** A ZIP container (`STORED`) holding one `*.xlsx` member which is itself a real ZIP (`DEFLATED`) holding `xl/sharedStrings.xml` — the two layers `processxlsx()` opens. Every ZIP entry carries a fixed timestamp and fixed attributes, so the container is byte-identical on every build (`sha256 3436370a4d5f2ccc059038d25d02af3920da260ee6418d04ed1257b3065e15b6`, 49,276 bytes) and the numbers below are reproducible rather than approximate. The driver's full source and its raw output are in a comment on this PR.

Sampling point is the moment the `sort` sink runs — by then the whole part has been consumed either way, so both shapes are measured at the same instant, and it is the peak because nothing in `${tmpdir}` is removed before it.

| | `${tmpdir}` bytes at the sink | contents |
| --- | --- | --- |
| `452d5600` (base) | **10,132,548** | `Feed.xlsx` 49,160 + `sharedStrings.xml` 10,083,388 |
| head (this PR) | **49,160** | `Feed.xlsx` only |

The workbook on disk is 49,160 bytes and the part it expands to is 10,083,388 — **205×**, the same order as the 410× the ticket recorded. 10,083,388 bytes, 99.51% of the footprint, no longer reach the disk, and the feed publishes the same two addresses either way. Host: Darwin/arm64, `/usr/bin/tar` is bsdtar 3.5.3.

**The shipped test.** `tests/shell/pfblockerng_processxlsx_stream_spec.sh` uses a tar container holding a gzip-compressed inner `*.xlsx`, not real ZIPs: GNU tar — the CI runner's `/usr/bin/tar` — cannot read a ZIP at all, so a ZIP fixture would silently reduce the whole file to a macOS-only test. Both flavours auto-detect the inner compression on read with no explicit `-z` (probed: bsdtar 3.5.3 rc=0, GNU tar 1.35 rc=0), which is what makes one fixture carry the expansion on both. Its own numbers are smaller and, because gzip stores a timestamp, vary by a byte between builds: ~4,181,827 decompressed from a ~20,895-byte workbook, so `${tmpdir}` at the sink reads ~4,202,72x on base and ~20,89x at head against a 64 KiB bound. It proves the same property; it does not reproduce the real-ZIP table above, and does not claim to.

## Two hypotheses and the discriminating probe

The ticket says round 1 of PR #2680's review skipped this on the assumption that the workbook on disk was the larger artifact. Both readings were live:

- **H1** — the footprint is the *decompressed* part, because the inner workbook is compressed and `tar -xOf` expands it on the way to the file.
- **H2** — the footprint is the workbook itself, written whole into `${tmpdir}` by the *first* `tar`, and the round-1 rationale was right.

The driver measures the two files in `${tmpdir}` separately, at base:

```
part_decompressed_bytes=10083388
workbook_on_disk_bytes=49160
tmpdir_contents_at_sink:
  49160     .../scratch/Feed.xlsx
  10083388  .../scratch/sharedStrings.xml
```

**H1 confirmed** (the part is 99.51% of the footprint). **H2 refuted** (the workbook is 0.49%). The first `tar`'s write is real but is the archive's own size, which is exactly what the free-space precheck now bounds.

## Why option 1 + option 3, and why not `pipefail`

**Option 2 (`set -o pipefail`) is rejected.** `pfblockerng.sh` is `#!/bin/sh`, graded under strict POSIX (`shellspec --shell dash`), and `set` is a **special builtin**: an option a given base system does not support aborts the whole script rather than failing one command. The ticket's own note that `pfblockerng.inc` ships `pipefail` in the adjacent ZIP branch does not transfer — that string is built by PHP for an `sh -c` that runs on the appliance only, where FreeBSD's `sh` is known to accept it. This file has no such guarantee.

**Option 1 works because only one status can be lost to the pipe, and it need not be either of the two that decide the feed.** `grep` is the last stage, so its no-match exit 1 arrives as the pipeline's status unchanged. `tar`'s goes to a file, and the ordering is not a race: the write happens inside the `{ …; }` subshell that holds the pipe's only write end, so `grep` cannot see EOF — and the shell cannot reap it — until that write has completed. Probed with a one-second delay between the failure and the stash write, which is precisely what a shell racing here would lose:

```
== /bin/sh                       == dash
   pipeline_rc=0                    pipeline_rc=0
   stash_readable=yes value=42      stash_readable=yes value=42
```

The stash is read **before** the publish, and it outranks a failing pipeline as well as a clean one — so a child killed at the extraction ceiling still reaches the caller as the 153 `pfb_extract_cap_note()` keys on, even when the truncated bytes it emitted held no address for `grep` to match.

**Option 3 is scoped to the xlsx branch, not folded into the precheck above it.** The gzip, bzip2 and tar paths write nowhere near `/tmp`; refusing a 50 MiB gzip feed because a RAM disk it never touches is short would repeat the 64 MiB-floor mistake issue #2658 had to reverse.

The probed path is derived the way the *child* derives it — `getenv('TMPDIR') ?: '/tmp'`, against the same environment `exec()` hands it — and deliberately not with `sys_get_temp_dir()`. Review caught that: PHP's `sys_temp_dir` INI setting outranks `TMPDIR`, so on an install that sets it the guard would have measured one filesystem while the helper's `mktemp -d "${TMPDIR:-/tmp}/pfb.XXXXXXXX"` wrote to another.

```console
$ env TMPDIR=/tmp/shell-temp php -d sys_temp_dir=/tmp/php-temp \
    -r 'printf("php=%s env=%s\n", sys_get_temp_dir(), getenv("TMPDIR"));'
php=/tmp/php-temp env=/tmp/shell-temp
```

`?:` falls back on an empty value as well as an unset one, matching `${TMPDIR:-/tmp}` exactly, so the two agree by construction rather than by coincidence.

## Test-first evidence

Frozen at the RED run:

| file | `git hash-object` |
| --- | --- |
| `tests/shell/pfblockerng_processxlsx_stream_spec.sh` | `eb70db898be6bbb7234b3faff6274c43de49fbaa` |
| `tests/php/DownloadSizeCeilingTest.php` | `63a1f1236e086db146b12bc7faa14bf0515ea0cc` |

Byte-identical at the GREEN run; the hashes above are re-read after the production edit and unchanged, and `cmp` against the copies taken at freeze time reports no difference.

Review re-froze the files four times, and **each re-freeze was itself proven red against the *then-current* production code** before the production side moved — not merely against base. Shell spec: `8d9dc8ff…` → `d84af79d…` (the `unmeasured` guard) → `04571d80…` (the planted-stash, traversal and ceiling-kill examples) → `bac50f21…` (the two fixtures share one address-free payload builder) → `eb70db89…` (a comment the review found false). PHP test: `38095ff8…` → `bd273d10…` (the `getenv` pin) → `63a1f123…` (the behavioural temp-root parity test). The hashes in the table are the final ones; every intermediate red run is quoted in the commit that carries it.

**RED**, frozen tests against untouched base production code:

```
$ shellspec --shell dash tests/shell/pfblockerng_processxlsx_stream_spec.sh
     1.1) The output should include verdict=streamed
            expected "verdict=materialised tmpdir_bytes_at_sink=4202723 bound=65536
                      part_bytes=4181827 workbook_bytes=20896" to include "verdict=streamed"
     2.1) The status should be success
            expected: success (zero)
                 got: failure (non-zero) [status: 1]
     3.1) The stderr should be present            # the ceiling example, red on base for
                                                 # its own reason: base never reaches tar
7 examples, 3 failures

$ vendor/bin/phpunit --filter test_xlsx_branch_prechecks_the_helper_temp_filesystem
the xlsx branch must probe the temp filesystem the helper unpacks the workbook into
Failed asserting that false is not false.
Tests: 1, Assertions: 3, Failures: 1.
```

The remaining shell examples pass on base by design: they pin behaviour the streamed shape must **preserve**, not behaviour it introduces.

**GREEN**, same files, zero edits:

```
$ shellspec --shell dash tests/shell/pfblockerng_processxlsx_stream_spec.sh \
    tests/shell/pfblockerng_processxlsx_exit_spec.sh \
    tests/shell/pfblockerng_adr26_locale_spec.sh tests/shell/pfblockerng_tempfile_spec.sh
43 examples, 0 failures, 1 skip

$ vendor/bin/phpunit --filter 'test_xlsx_branch…|test_free_space_precheck…|testXlsx'
OK (4 tests, 24 assertions)
```

Seven new ShellSpec examples, proven executed by the run's own count, not by counting the file — the #2749 lesson. The one skip is the pre-existing GNU-only `pfb_list_orig_by_mtime` case in the ADR-26 spec.

## Two defects review found in the streaming shape itself

Both were introduced by the first commit on this branch and are fixed by the last one; both are pinned by examples that fail against the commit before the fix.

**The status stash sat inside the untrusted extraction directory.** It was `${tmpxlsx}sharedStrings.rc` — a path a container member can land on. A feed shipping a member of that name pre-seeded the status the publish gate reads: `tar -xOf` then succeeds, so `|| echo "$?"` never overwrites it. Paired with a workbook carrying no IPv4 literal it is issue #2682's defect back under the container's control — `grep` reports no match, the planted `0` overrides it, and zero bytes publish over the live `.orig` as a success, which an `inode/x-empty` probe then carries through the inner-content gate and the content-hash sidecar. The example at `:252` reproduces it: the live publication came back `""` at `status: 0` with `Final count [ 0 ]`. The stash is now a **sibling** of the extraction target, `${tmpxlsx%/}.rc` — inside the run's own 0700 `mktemp -d` directory, on no path a member can reach. Both tar flavours refuse a `../` member outright (bsdtar 3.5.3 exit 1 `Path contains '..'`, GNU tar 1.35 exit 2 `Member name contains '..'`), which `:281` pins.

**The stash outranked the pipeline unconditionally, costing the ceiling its name.** Streamed, `tar -xOf` writes only to the pipe, and `RLIMIT_FSIZE` does not bound a pipe write:

```console
$ dash -c 'ulimit -f 1 || exit 1; dd if=/dev/zero bs=1024 count=64 2>/dev/null | wc -c'
65536                                            # rc=0 — through a pipe
$ dash -c 'ulimit -f 1 || exit 1; dd if=/dev/zero of=f bs=1024 count=64'
                                                 # rc=1 — the same bytes to a file
```

So issue #2658's ceiling can only kill the stage that writes a **file**, which in this shape is `grep`; `tar` merely dies of EPIPE behind it. Reading that status over the kill gave the caller 1 under bsdtar and 141 under GNU tar where base returned 153 — and `pfb_extract_cap_note()` keys on exactly 153 to tell the operator "output exceeded the extraction size ceiling" instead of printing a bare exit code. The stash is now read only when `grep` ran to completion, `[ "${xlsxrc}" -le 1 ]`, so the kill status reaches the caller verbatim. That gate also repairs the design's own justification: the stash is readable when the pipeline returns because the subshell holding the pipe's only write end finishes the write before `grep` can see EOF — and `grep` completing is now exactly the condition under which the stash is read.

## Mutation kills

Every mutant applied by a driver that asserts the needle occurs **exactly once**, asserts `git diff` is non-empty afterwards, and reverts to a verified-clean tree between mutants.

| # | mutant | named test | exit | decisive failure |
| --- | --- | --- | --- | --- |
| M1 | drop the status stash (piped status regresses to `grep`'s) | `pfblockerng_processxlsx_stream_spec.sh:199` | 101 | `.orig` `expected "203.0.113.7\nPRIOR-MARKER"` / `got: "192.0.2.10"` at `status: 0`, `Final count [ 1 ]` |
| M2 | read the stash before the pipeline completes | `pfblockerng_processxlsx_stream_spec.sh:199` | 101 | same example: the truncated feed publishes over the live one |
| M3 | drop the `${tmpdir}` probe from the shortfall precheck | `DownloadSizeCeilingTest::test_xlsx_branch_prechecks_the_helper_temp_filesystem` | 1 | `the xlsx branch must probe the temp filesystem the helper unpacks the workbook into` |
| M4 | refuse without a named reason | same test | 1 | `the refusal must name its reason, like every other size refusal` |
| M5 | make the footprint measurement silently no-op (`false \| wc -c`) | `pfblockerng_processxlsx_stream_spec.sh:158` | 101 | `verdict=unmeasured tmpdir_bytes_at_sink=0` |
| M6 | probe PHP's `sys_temp_dir` instead of the child's own `TMPDIR` | `DownloadSizeCeilingTest::test_xlsx_branch_prechecks_the_helper_temp_filesystem` | 1 | `the xlsx branch must probe the temp filesystem the helper unpacks the workbook into` |
| M7 | put the status stash back inside the extraction directory | `pfblockerng_processxlsx_stream_spec.sh:252` | 101 | live `.orig` `got: ""` at `status: 0`, `Final count [ 0 ]` |
| M8 | let the stashed status outrank a ceiling kill on the writing stage | `pfblockerng_processxlsx_stream_spec.sh:308` | 101 | `expected … to include "exit 153"` against `exit 1` |

M1's kill is issue #2666's defect verbatim — a truncated feed reported as a successful ingest — which is why the frozen file carries a *partially readable* workbook and not just an unreadable one. An unreadable workbook is already caught by `grep`'s no-match status; only a partial read, which emits an address before dying, makes `tar`'s own status the sole evidence. Probed on the fixture: bsdtar 3.5.3 exits 1 and GNU tar 1.35 exits 2, both after emitting ~2 MiB carrying one address.

M5 through M8 exist because review found the holes they now cover; the two production defects behind M7 and M8 are described below.

## What is unregressed, and how

- **The #2666 exit contract.** A corrupt container, a truncated container, a non-archive inner member, an unstageable publication, a `SIGXFSZ`-killed sink returning exactly 153, and the `ulimit -f 1` ceiling case all still refuse with the live `.orig` byte-unchanged — `pfblockerng_processxlsx_exit_spec.sh`, unmodified, green.
- **The #2682 refusal.** An addressless workbook is still refused at exit 1 with the previous `.orig` byte-identical, now pinned on the production-shape compressed fixture as well as the plain one.
- **A healthy workbook still publishes** the same two addresses in the same `LC_ALL=C sort -u` order, still `chmod 644` before the rename, still no `.orig.tmp` left behind.
- **The ADR-26 collation gate.** `pfblockerng_adr26_locale_spec.sh` pins the production string `LC_ALL=C sort -u -o "${xlsxstage}" "${xlsxstage}"` with `grep -qF`; that line is untouched. Its comment *was* stale — it claimed the extraction is off the pipe — so the comment is corrected in the same PR. Grepping the whole test tree for the text being replaced is the #2682 lesson; the only other pin found was this one, and `xlsxshared` now has zero hits tree-wide.

## Scope

Diff is 5 files. Not touched, by the ticket's own non-goals: the ET path, GeoIP staging, `tar` type work (#2638), `pfb_extract_cmd()`'s 2 GiB ceiling value, and the staged-publish design. No smoke case is added: there is no XLSX case in the ADR-04 tier today, and the claim under test is a byte count on a filesystem, which the hermetic measurement above pins deterministically where a live run could not.

🤖 Generated by Oh My Pi and posted on behalf of @andrebrait.
