### PR TITLE
agent: adopt the graphify query-outcome feedback loop

### DIFF
--- a/.agents/context/repository-intelligence.md
+++ b/.agents/context/repository-intelligence.md
@@ -65,12 +65,12 @@ Load when: every agent session, from `AGENTS.md`.
   skip Graphify; skip it only when the task is about stale or incorrect graph output. Run
   `graphify update .` after modifying code (AST only, no API cost).
 - Close the loop on every query: record it with `graphify save-result --question … --answer …
-  --outcome useful|dead_end|corrected`. The boundary is where the answer came from, not
-  whether the output looked plausible: `useful` when the returned subgraph answered the
-  question or narrowed it enough to act on, `dead_end` when another surface answered it,
-  `corrected` when the graph answered and was wrong. A dead end MUST carry `--correction`
-  naming the surface that actually answered it, and a correction MUST name the right
-  answer — an unexplained dead end is what makes the next session re-derive it. Records
+  --outcome useful|dead_end|corrected`. The boundary is where the answer came from:
+  `useful` when the returned subgraph answered or narrowed the question,
+  `dead_end` when another surface answered it,
+  `corrected` when the graph answered and was wrong.
+  A dead end MUST carry `--correction` naming the surface that actually answered it —
+  an unexplained dead end is what makes the next session re-derive it. Records
   land in `graphify-out/memory/` and are committed with the work. `graphify reflect`
   aggregates them deterministically into `graphify-out/reflections/LESSONS.md`; that file
   is derivable, so it stays untracked — rebuild it, and read it for orientation before

--- a/.agents/context/repository-intelligence.md
+++ b/.agents/context/repository-intelligence.md
@@ -34,12 +34,14 @@ Load when: every agent session, from `AGENTS.md`.
   verify that its active project root equals `git rev-parse --show-toplevel`; after a
   mid-session worktree switch Serena is forbidden until a fresh top-level session starts
   there. Claude Agent Teams teammates use built-ins.
-- `graphify-out/graph.json` is tracked; everything else under `graphify-out/` is ignored
-  and regenerated locally from it. Refresh the graph with `graphify update <root>` and
-  commit it alongside the change that moved it. Every clone needs the union merge driver
-  that `.gitattributes` assigns to the graph — `scripts/agent/ensure-graphify-merge-driver.sh`
-  installs Graphify, runs `graphify hook install`, and verifies the registration. Without
-  it a merge leaves conflict markers in the graph instead of union-merging it.
+- `graphify-out/graph.json` is tracked, and records under `graphify-out/memory/` are tracked
+  with the work that produced them; everything else under `graphify-out/` is ignored and
+  regenerated locally.
+  Refresh the graph with `graphify update <root>` and commit it alongside the change that
+  moved it. Every clone needs the union merge driver that `.gitattributes` assigns to the
+  graph — `scripts/agent/ensure-graphify-merge-driver.sh` installs Graphify, runs
+  `graphify hook install`, and verifies the registration. Without it a merge leaves
+  conflict markers in the graph instead of union-merging it.
 - For indexed code discovery, understanding, cross-file architecture, call paths,
   flows, structural exploration, and impact analysis, use CodeGraph through
   `codegraph_explore` or `codegraph explore`. Every client uses the same standard
@@ -51,12 +53,25 @@ Load when: every agent session, from `AGENTS.md`.
   harness/test, and `stubs/` is shim/support; communities describe topology only.
   The root graph excludes `src/**/vendor/**`, documents/media, and `legacy/`.
 - Prefer `graphify query "<question>"`, `graphify path "<A>" "<B>"`, and
-  `graphify explain "<concept>"` over raw grep and file reads for codebase questions:
-  they return a scoped subgraph. Read `graphify-out/GRAPH_REPORT.md` only for broad
-  architecture review, and `graphify-out/wiki/index.md`, when present, for navigation.
-  A dirty `graphify-out/` after a hook or incremental update is expected and is not a
-  reason to skip Graphify; skip it only when the task is about stale or incorrect graph
-  output. Run `graphify update .` after modifying code (AST only, no API cost).
+  `graphify explain "<concept>"` for questions about CODE STRUCTURE — call paths, flows,
+  cross-file relationships, blast radius. They return a scoped subgraph. Go to grep first
+  for the three classes the graph does not model, because it indexes code structure and
+  nothing else: configuration surfaces and tool wiring (which extensions a linter claims,
+  where a tool is installed, what a hook runs), reference counts and other text-frequency
+  questions, and a third-party tool's own feature set, which lives in its `--help`. Every
+  query in this repository's first `graphify reflect` run was one of those three and every
+  one was a dead end. Read `graphify-out/GRAPH_REPORT.md` only for broad architecture
+  review, and `graphify-out/wiki/index.md`, when present, for navigation. A dirty
+  `graphify-out/` after a hook or incremental update is expected and is not a reason to
+  skip Graphify; skip it only when the task is about stale or incorrect graph output. Run
+  `graphify update .` after modifying code (AST only, no API cost).
+- Close the loop on every query: record it with `graphify save-result --question … --answer …
+  --outcome useful|dead_end|corrected`. A dead end MUST carry `--correction` naming what
+  actually answered the question — an unexplained dead end is what makes the next session
+  re-derive it. Records land in `graphify-out/memory/` and are committed with the work.
+  `graphify reflect` aggregates them deterministically into
+  `graphify-out/reflections/LESSONS.md`; that file is derivable, so it stays untracked —
+  rebuild it, and read it for orientation before querying.
 - Use `rg`, globbing, and file reads for literals, configuration, non-code files,
   and details CodeGraph did not cover. Use the client's LSP surface—Serena where
   available—for exact symbols, definitions, references, implementations,

--- a/.agents/context/repository-intelligence.md
+++ b/.agents/context/repository-intelligence.md
@@ -58,20 +58,23 @@ Load when: every agent session, from `AGENTS.md`.
   for the three classes the graph does not model, because it indexes code structure and
   nothing else: configuration surfaces and tool wiring (which extensions a linter claims,
   where a tool is installed, what a hook runs), reference counts and other text-frequency
-  questions, and a third-party tool's own feature set, which lives in its `--help`. Every
-  query in this repository's first `graphify reflect` run was one of those three and every
-  one was a dead end. Read `graphify-out/GRAPH_REPORT.md` only for broad architecture
+  questions, and a third-party tool's own feature set, which lives in its `--help`.
+  Read `graphify-out/GRAPH_REPORT.md` only for broad architecture
   review, and `graphify-out/wiki/index.md`, when present, for navigation. A dirty
   `graphify-out/` after a hook or incremental update is expected and is not a reason to
   skip Graphify; skip it only when the task is about stale or incorrect graph output. Run
   `graphify update .` after modifying code (AST only, no API cost).
 - Close the loop on every query: record it with `graphify save-result --question … --answer …
-  --outcome useful|dead_end|corrected`. A dead end MUST carry `--correction` naming what
-  actually answered the question — an unexplained dead end is what makes the next session
-  re-derive it. Records land in `graphify-out/memory/` and are committed with the work.
-  `graphify reflect` aggregates them deterministically into
-  `graphify-out/reflections/LESSONS.md`; that file is derivable, so it stays untracked —
-  rebuild it, and read it for orientation before querying.
+  --outcome useful|dead_end|corrected`. The boundary is where the answer came from, not
+  whether the output looked plausible: `useful` when the returned subgraph answered the
+  question or narrowed it enough to act on, `dead_end` when another surface answered it,
+  `corrected` when the graph answered and was wrong. A dead end MUST carry `--correction`
+  naming the surface that actually answered it, and a correction MUST name the right
+  answer — an unexplained dead end is what makes the next session re-derive it. Records
+  land in `graphify-out/memory/` and are committed with the work. `graphify reflect`
+  aggregates them deterministically into `graphify-out/reflections/LESSONS.md`; that file
+  is derivable, so it stays untracked — rebuild it, and read it for orientation before
+  querying.
 - Use `rg`, globbing, and file reads for literals, configuration, non-code files,
   and details CodeGraph did not cover. Use the client's LSP surface—Serena where
   available—for exact symbols, definitions, references, implementations,

--- a/.gitattributes
+++ b/.gitattributes
@@ -10,7 +10,6 @@ docs/** linguist-documentation
 # diffs and drops it from the language stats, while merge=graphify keeps resolving
 # parallel updates through the union driver.
 graphify-out/graph.json merge=graphify linguist-generated=true
-# Query-outcome records are prose one file per query, and unlike the graph they are
-# written to be READ in review — linguist-documentation keeps them out of the language
-# stats while leaving their diffs visible, the same trade as legacy/ and docs/ above.
+# Records are prose reviewed in diffs, so they stay out of the language stats without
+# linguist-generated, which would suppress the diffs they exist to be read in.
 graphify-out/memory/** linguist-documentation

--- a/.gitattributes
+++ b/.gitattributes
@@ -10,3 +10,7 @@ docs/** linguist-documentation
 # diffs and drops it from the language stats, while merge=graphify keeps resolving
 # parallel updates through the union driver.
 graphify-out/graph.json merge=graphify linguist-generated=true
+# Query-outcome records are prose one file per query, and unlike the graph they are
+# written to be READ in review — linguist-documentation keeps them out of the language
+# stats while leaving their diffs visible, the same trade as legacy/ and docs/ above.
+graphify-out/memory/** linguist-documentation

--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,11 @@ test-results/
 *.graphify-bak
 graphify-out/*
 !graphify-out/graph.json
+# Query-outcome records accumulate across tickets, so they outlive the worktree that
+# wrote them. The re-include names the DIRECTORY: `graphify-out/*` matches `memory`
+# itself, and git never descends into an excluded directory, so a `/**` contents glob
+# would leave every record ignored. The reflect aggregate stays local — it is derivable.
+!graphify-out/memory/
 
 # Per-machine Claude Code / Grok overrides — never committed
 .claude/settings.local.json

--- a/.gitignore
+++ b/.gitignore
@@ -67,10 +67,8 @@ test-results/
 *.graphify-bak
 graphify-out/*
 !graphify-out/graph.json
-# Query-outcome records accumulate across tickets, so they outlive the worktree that
-# wrote them. The re-include names the DIRECTORY: `graphify-out/*` matches `memory`
-# itself, and git never descends into an excluded directory, so a `/**` contents glob
-# would leave every record ignored. The reflect aggregate stays local — it is derivable.
+# Records accumulate across tickets, so they outlive the worktree that wrote them. The
+# re-include names the DIRECTORY on purpose — contract pinned by test_cross_agent_tooling.
 !graphify-out/memory/
 
 # Per-machine Claude Code / Grok overrides — never committed

--- a/graphify-out/memory/query_20260828_074508_ast_grep_semgrep_static_analysis_invocation_in_ci.md
+++ b/graphify-out/memory/query_20260828_074508_ast_grep_semgrep_static_analysis_invocation_in_ci.md
@@ -1,0 +1,19 @@
+---
+type: "query"
+date: "2026-08-28T07:45:08.605157+00:00"
+question: "ast-grep semgrep static analysis invocation in CI scripts hooks gates"
+contributor: "graphify"
+outcome: "dead_end"
+correction: "ast-grep and semgrep are installed by scripts/agent/setup-agent-tools.sh:265-271 and asserted in tests/shell/agent_tools_setup_spec.sh; they are agent-host tools, not CI gates. Found by grep on .github, scripts, .githooks."
+---
+
+# Q: ast-grep semgrep static analysis invocation in CI scripts hooks gates
+
+## Answer
+
+Returned unrelated test nodes (test_local_hook_scope, AliasCntGrepCountGuardTest, HooksSanitizeIngestionTest).
+
+## Outcome
+
+- Signal: dead_end
+- Correction: ast-grep and semgrep are installed by scripts/agent/setup-agent-tools.sh:265-271 and asserted in tests/shell/agent_tools_setup_spec.sh; they are agent-host tools, not CI gates. Found by grep on .github, scripts, .githooks.

--- a/graphify-out/memory/query_20260828_074508_packaging__release_archive__deploy_overlay__file_l.md
+++ b/graphify-out/memory/query_20260828_074508_packaging__release_archive__deploy_overlay__file_l.md
@@ -1,0 +1,19 @@
+---
+type: "query"
+date: "2026-08-28T07:45:08.505226+00:00"
+question: "packaging, release archive, deploy overlay, file lists referencing .inc paths"
+contributor: "graphify"
+outcome: "dead_end"
+correction: "The question was about reference COUNTS across file types, which is a text-frequency question the graph does not model. git grep -Io on the owned basenames answered it: 37 files inside src/, 2279 hits outside."
+---
+
+# Q: packaging, release archive, deploy overlay, file lists referencing .inc paths
+
+## Answer
+
+Returned smoke-test and archive-test nodes (ArchiveProbeTest, test_reproducible_source_archive, SmokeVM helpers); truncated at 63 of 518 nodes by the token budget.
+
+## Outcome
+
+- Signal: dead_end
+- Correction: The question was about reference COUNTS across file types, which is a text-frequency question the graph does not model. git grep -Io on the owned basenames answered it: 37 files inside src/, 2279 hits outside.

--- a/graphify-out/memory/query_20260828_074508_php_include_require_of__inc_files__pfblockerng_inc.md
+++ b/graphify-out/memory/query_20260828_074508_php_include_require_of__inc_files__pfblockerng_inc.md
@@ -1,0 +1,19 @@
+---
+type: "query"
+date: "2026-08-28T07:45:08.400332+00:00"
+question: "PHP include require of .inc files, pfblockerng.inc loading convention"
+contributor: "graphify"
+outcome: "dead_end"
+correction: "The answer was in configuration and require_once lines, not code structure: phpcs.xml.dist extensions=\"php,inc\", phpstan.neon fileExtensions [php, inc], .editorconfig [*.{php,inc}], and the require_once('...inc') statements at the head of each www/ page. Reached by reading those files and by git grep, not by the graph."
+---
+
+# Q: PHP include require of .inc files, pfblockerng.inc loading convention
+
+## Answer
+
+Returned PHPCS sniff and test nodes (RequirePfbFilterSniff, WidgetIncludeConventionTest, pfblockerng.sh functions); none carried the include convention.
+
+## Outcome
+
+- Signal: dead_end
+- Correction: The answer was in configuration and require_once lines, not code structure: phpcs.xml.dist extensions="php,inc", phpstan.neon fileExtensions [php, inc], .editorconfig [*.{php,inc}], and the require_once('...inc') statements at the head of each www/ page. Reached by reading those files and by git grep, not by the graph.

--- a/graphify-out/memory/query_20260828_074517_graphify_memory_feedback_loop__save_result__reflec.md
+++ b/graphify-out/memory/query_20260828_074517_graphify_memory_feedback_loop__save_result__reflec.md
@@ -1,0 +1,19 @@
+---
+type: "query"
+date: "2026-08-28T07:45:17.123317+00:00"
+question: "graphify memory feedback loop, save-result, reflect, lessons doc"
+contributor: "graphify"
+outcome: "dead_end"
+correction: "graphify's own feature surface is documented in graphify --help, not in this repository's graph. Substring collision on 'reflect' and 'memory' inside test identifiers dominated the result."
+---
+
+# Q: graphify memory feedback loop, save-result, reflect, lessons doc
+
+## Answer
+
+Returned unrelated nodes matching the words memory, reflect and result inside test names (LogAgeCutoffStreamTest, test_hooks_ip_changed_reflects_pass).
+
+## Outcome
+
+- Signal: dead_end
+- Correction: graphify's own feature surface is documented in graphify --help, not in this repository's graph. Substring collision on 'reflect' and 'memory' inside test identifiers dominated the result.

--- a/graphify-out/memory/query_20260828_074517_inc_extension_tooling__linguist__phpcs_phpstan_ext.md
+++ b/graphify-out/memory/query_20260828_074517_inc_extension_tooling__linguist__phpcs_phpstan_ext.md
@@ -1,0 +1,19 @@
+---
+type: "query"
+date: "2026-08-28T07:45:17.012016+00:00"
+question: "inc extension tooling, linguist, phpcs phpstan extensions, file naming convention"
+contributor: "graphify"
+outcome: "dead_end"
+correction: "Tool-configuration questions are answered by the config files themselves (.gitattributes, .editorconfig, phpcs.xml.dist, phpstan.neon), which the code graph does not index as configuration semantics."
+---
+
+# Q: inc extension tooling, linguist, phpcs phpstan extensions, file naming convention
+
+## Answer
+
+Returned test-file nodes (test_workflow_files_scan_both_yaml_extensions, WidgetIncludeConventionTest, test_context_budget); no configuration surface.
+
+## Outcome
+
+- Signal: dead_end
+- Correction: Tool-configuration questions are answered by the config files themselves (.gitattributes, .editorconfig, phpcs.xml.dist, phpstan.neon), which the code graph does not index as configuration semantics.

--- a/tests/test_cross_agent_tooling.py
+++ b/tests/test_cross_agent_tooling.py
@@ -251,12 +251,19 @@ def test_repository_intelligence_initializes_each_worktree_directly() -> None:
     # updates, so both attributes must ride on the row.
     graphify_attribute = "graphify-out/graph.json merge=graphify linguist-generated=true"
     assert attrs.count(graphify_attribute) == 1, f"expected exact .gitattributes row: {graphify_attribute}"
-    # The root graph is tracked so a fresh checkout starts with the map; everything
-    # else under graphify-out/ is regenerated from it and stays ignored. Asserting the
-    # exact set fails both ways: a dropped graph and a tracked generated artifact.
-    assert subprocess.run(
+    # The root graph is tracked so a fresh checkout starts with the map, and the
+    # query-outcome records are tracked so lessons outlive the worktree that wrote them
+    # (issue #2823). Records are named per query and accumulate, so the durable contract
+    # is the SET of allowed prefixes: it still fails both ways, on a dropped graph and on
+    # a newly tracked generated artifact.
+    tracked = subprocess.run(
         ["git", "ls-files", "graphify-out"], cwd=ROOT, check=True, text=True, capture_output=True
-    ).stdout.split() == ["graphify-out/graph.json"]
+    ).stdout.split()
+    assert "graphify-out/graph.json" in tracked, "the root graph must stay tracked"
+    strays = [
+        path for path in tracked if path != "graphify-out/graph.json" and not path.startswith("graphify-out/memory/")
+    ]
+    assert strays == [], f"generated Graphify output must stay ignored: {strays}"
     root_ignore = (ROOT / ".gitignore").read_text(encoding="utf-8").splitlines()
     # The pair, in order: ignore the directory's contents, then re-include only the
     # tracked graph. Either line alone gets the tracking wrong, and so does a later

--- a/tests/test_cross_agent_tooling.py
+++ b/tests/test_cross_agent_tooling.py
@@ -208,7 +208,19 @@ def test_repository_intelligence_initializes_each_worktree_directly() -> None:
         "harness/test",
         "stubs/` is shim/support",
         "graph.json` is tracked",
-        "everything else under `graphify-out/` is ignored",
+        "records under `graphify-out/memory/` are tracked",
+        # The query-outcome feedback loop (issue #2823). A dead end with no correction
+        # is what makes the next session re-derive it.
+        "graphify save-result",
+        "graphify reflect",
+        "dead_end",
+        "--correction",
+        "reflections/LESSONS.md",
+        # Graphify-first holds for code structure ONLY. Every query in this
+        # repository's first reflect run was a question the code graph cannot answer.
+        "grep first",
+        "reference counts",
+        "tool wiring",
         # Every agent tool installs the same way: one command that installs on a
         # fresh host and upgrades an outdated one, a floor at most, never a pin --
         # including the install added when a setup script hits a missing dependency.
@@ -270,6 +282,31 @@ def test_codegraph_generated_state_is_ignored_by_its_own_tracked_contract() -> N
     assert "!.gitignore" in local_ignore
     root_ignore = (ROOT / ".gitignore").read_text(encoding="utf-8").splitlines()
     assert ".codegraph/" not in root_ignore, "root ignore would hide CodeGraph's own tracked contract"
+
+
+def test_graphify_memory_records_are_tracked_by_a_directory_reinclude() -> None:
+    # issue #2823: `!graphify-out/memory/**` does NOT work. `graphify-out/*` matches the
+    # memory directory itself, git never descends into it, and every record stays
+    # ignored while the ignore file reads as though they are tracked.
+    lines = (ROOT / ".gitignore").read_text(encoding="utf-8").splitlines()
+    assert lines.count("graphify-out/*") == 1, "one ignore rule, or the ordering below is ambiguous"
+    assert lines.count("!graphify-out/memory/") == 1, "re-include the directory, exactly once"
+    assert "!graphify-out/memory/**" not in lines, "a contents glob leaves every record ignored"
+    # gitignore takes the LAST matching rule, so the re-include must follow the ignore.
+    assert lines.index("graphify-out/*") < lines.index("!graphify-out/memory/")
+
+    def ignored(path: str) -> bool:
+        return (
+            subprocess.run(["git", "check-ignore", "-q", path], cwd=ROOT, capture_output=True, check=False).returncode
+            == 0
+        )
+
+    assert not ignored("graphify-out/memory/query_20260101_000000_probe.md"), "records must be trackable"
+    assert ignored("graphify-out/GRAPH_REPORT.md"), "the re-include must not un-ignore the rest"
+    assert ignored("graphify-out/reflections/LESSONS.md"), "the aggregate is derivable, so it stays local"
+
+    attributes = (ROOT / ".gitattributes").read_text(encoding="utf-8").splitlines()
+    assert "graphify-out/memory/** linguist-documentation" in attributes, "records are prose, not code"
 
 
 def test_omp_language_servers_route_php_include_files() -> None:

--- a/tests/test_cross_agent_tooling.py
+++ b/tests/test_cross_agent_tooling.py
@@ -209,15 +209,16 @@ def test_repository_intelligence_initializes_each_worktree_directly() -> None:
         "stubs/` is shim/support",
         "graph.json` is tracked",
         "records under `graphify-out/memory/` are tracked",
-        # The query-outcome feedback loop (issue #2823). A dead end with no correction
-        # is what makes the next session re-derive it.
+        # The query-outcome feedback loop (issue #2823).
         "graphify save-result",
         "graphify reflect",
-        "dead_end",
-        "--correction",
+        "--outcome useful|dead_end|corrected",
+        "`useful` when the returned subgraph answered the",
+        "`dead_end` when another surface answered it",
+        "`corrected` when the graph answered and was wrong",
+        "A dead end MUST carry `--correction`",
         "reflections/LESSONS.md",
-        # Graphify-first holds for code structure ONLY. Every query in this
-        # repository's first reflect run was a question the code graph cannot answer.
+        # Graphify-first holds for code structure ONLY.
         "grep first",
         "reference counts",
         "tool wiring",
@@ -251,11 +252,9 @@ def test_repository_intelligence_initializes_each_worktree_directly() -> None:
     # updates, so both attributes must ride on the row.
     graphify_attribute = "graphify-out/graph.json merge=graphify linguist-generated=true"
     assert attrs.count(graphify_attribute) == 1, f"expected exact .gitattributes row: {graphify_attribute}"
-    # The root graph is tracked so a fresh checkout starts with the map, and the
-    # query-outcome records are tracked so lessons outlive the worktree that wrote them
-    # (issue #2823). Records are named per query and accumulate, so the durable contract
-    # is the SET of allowed prefixes: it still fails both ways, on a dropped graph and on
-    # a newly tracked generated artifact.
+    # The root graph plus the query-outcome records are tracked (issue #2823). Records are
+    # named per query and accumulate, so the durable contract is the SET of allowed
+    # prefixes: it fails on a dropped graph and on a newly tracked generated artifact.
     tracked = subprocess.run(
         ["git", "ls-files", "graphify-out"], cwd=ROOT, check=True, text=True, capture_output=True
     ).stdout.split()
@@ -292,21 +291,23 @@ def test_codegraph_generated_state_is_ignored_by_its_own_tracked_contract() -> N
 
 
 def test_graphify_memory_records_are_tracked_by_a_directory_reinclude() -> None:
-    # issue #2823: `!graphify-out/memory/**` does NOT work. `graphify-out/*` matches the
-    # memory directory itself, git never descends into it, and every record stays
+    # issue #2823: `!graphify-out/memory/**` silently fails. `graphify-out/*` matches the
+    # memory directory itself and git never descends into it, so every record stays
     # ignored while the ignore file reads as though they are tracked.
     lines = (ROOT / ".gitignore").read_text(encoding="utf-8").splitlines()
-    assert lines.count("graphify-out/*") == 1, "one ignore rule, or the ordering below is ambiguous"
     assert lines.count("!graphify-out/memory/") == 1, "re-include the directory, exactly once"
     assert "!graphify-out/memory/**" not in lines, "a contents glob leaves every record ignored"
     # gitignore takes the LAST matching rule, so the re-include must follow the ignore.
     assert lines.index("graphify-out/*") < lines.index("!graphify-out/memory/")
 
     def ignored(path: str) -> bool:
-        return (
-            subprocess.run(["git", "check-ignore", "-q", path], cwd=ROOT, capture_output=True, check=False).returncode
-            == 0
+        # Only 0 and 1 are verdicts. Anything else is git failing to answer -- a symlinked
+        # memory/ exits 128, which read as "not ignored" and passed the probe below.
+        probe = subprocess.run(
+            ["git", "check-ignore", "-q", path], cwd=ROOT, capture_output=True, text=True, check=False
         )
+        assert probe.returncode in (0, 1), f"git could not classify {path}: {probe.stderr.strip()}"
+        return probe.returncode == 0
 
     assert not ignored("graphify-out/memory/query_20260101_000000_probe.md"), "records must be trackable"
     assert ignored("graphify-out/GRAPH_REPORT.md"), "the re-include must not un-ignore the rest"

--- a/tests/test_cross_agent_tooling.py
+++ b/tests/test_cross_agent_tooling.py
@@ -213,7 +213,7 @@ def test_repository_intelligence_initializes_each_worktree_directly() -> None:
         "graphify save-result",
         "graphify reflect",
         "--outcome useful|dead_end|corrected",
-        "`useful` when the returned subgraph answered the",
+        "`useful` when the returned subgraph answered",
         "`dead_end` when another surface answered it",
         "`corrected` when the graph answered and was wrong",
         "A dead end MUST carry `--correction`",
@@ -301,8 +301,7 @@ def test_graphify_memory_records_are_tracked_by_a_directory_reinclude() -> None:
     assert lines.index("graphify-out/*") < lines.index("!graphify-out/memory/")
 
     def ignored(path: str) -> bool:
-        # Only 0 and 1 are verdicts. Anything else is git failing to answer -- a symlinked
-        # memory/ exits 128, which read as "not ignored" and passed the probe below.
+        # Only 0 and 1 are verdicts; a symlinked memory/ exits 128.
         probe = subprocess.run(
             ["git", "check-ignore", "-q", path], cwd=ROOT, capture_output=True, text=True, check=False
         )


### PR DESCRIPTION
## Summary

`graphify save-result` writes one Markdown record per query carrying an outcome of `useful`,
`dead_end` or `corrected` plus an optional `--correction`; `graphify reflect` aggregates those
records into a deterministic lessons document. Neither appeared anywhere in `.agents/`, `scripts/`,
`.github/` or `.gitignore`, and `graphify-out/memory/` did not exist — so every query outcome this
repository produced was discarded, while `.agents/context/repository-intelligence.md` was already
routing every session to graphify first.

Owner decisions taken before implementation: track the raw memory records, and narrow the mandate
with named exceptions.

## Change

- **`.gitignore`** — re-include the records. The re-include names the **directory**, not its
  contents.
- **`.gitattributes`** — `graphify-out/memory/** linguist-documentation`, the same trade already
  made for `legacy/**` and `docs/**`: out of the language stats, diffs still reviewable. Not
  `linguist-generated`, which would suppress the diffs these records exist to be read in.
- **`.agents/context/repository-intelligence.md`** — route the loop (outcome vocabulary, the
  mandatory `--correction` on a dead end, records committed with the work, `LESSONS.md` derivable
  and read for orientation), and narrow graphify-first to code-structure questions.
- **Five memory records** ship as the loop's first content.

## The trap this could have shipped with

`!graphify-out/memory/**` looks correct and does nothing. `graphify-out/*` matches the `memory`
directory itself, git never descends into an excluded directory, and every record stays ignored
while the ignore file reads as though they are tracked. Measured in this repository on the record
path `graphify-out/memory/query_20260101_000000_probe.md`:

| `.gitignore` form | `git check-ignore` |
| --- | --- |
| `!graphify-out/memory/**` | ignored |
| `!graphify-out/memory/` | not ignored |

The test asserts the behaviour, not just the text, so the trap form fails it even though the text
reads plausibly. Ordering is asserted too: gitignore takes the LAST matching rule, which is the
exact defect class found in #2790.

## Why the mandate narrowed

The first `graphify reflect` run over this repository:

```text
Reflected 5 memories (0 useful, 5 dead ends, 0 corrected) -> graphify-out/reflections/LESSONS.md
```

Five for five, and not randomly distributed — every one was a question the code graph structurally
does not model:

| Query | What actually answered it |
| --- | --- |
| `.inc` include/require loading convention | `phpcs.xml.dist`, `phpstan.neon`, `.editorconfig`, the `require_once` heads |
| Packaging references to `.inc` paths | `git grep -Io` counts: 37 files in `src/`, 2279 hits outside |
| ast-grep / semgrep invocation in CI | `scripts/agent/setup-agent-tools.sh:265-271` — agent-host tools, not CI gates |
| `.inc` tooling, Linguist, PHPCS/PHPStan extensions | the configuration files themselves |
| graphify's own memory/reflect surface | `graphify --help` |

Two also hit substring collisions on test identifiers (`reflect` inside
`test_hooks_ip_changed_reflects_pass`, `memory` inside
`testStreamingTrimStaysMemoryBoundedOnLargeMostlyExpiredFile`). Three classes now go to grep first —
configuration and tool wiring, reference counts and text frequency, and a third-party tool's own
feature set — while graphify-first still holds for call paths, flows, cross-file relationships and
blast radius. Recording the cost was step one; removing it is the point.

## Test-first proof

Frozen test `md5 3850d336d37d305d9cb2b750005ad4e9`, identical across both runs:

- RED, configuration withheld: `2 failed, 15 passed`.
- GREEN: `17 passed`.

Both legs were re-run after `ruff format` touched the file, so the frozen hash covers the formatted
version. Mutations, each executed:

| Mutation | Result |
| --- | --- |
| `!graphify-out/memory/` → `!graphify-out/memory/**` | fails |
| re-include moved above `graphify-out/*` | fails on the ordering assertion |
| `graphify-out/memory/** linguist-documentation` removed | fails |

The routing contract additions ride the existing
`test_repository_initializes_each_worktree_directly` tuple rather than a new document read. One
pre-existing pinned substring, ``graph.json` is tracked``, was broken by the reworded bullet and by
a line wrap; the document was reflowed to satisfy the frozen test rather than the assertion relaxed.

## Gates

`scripts/agent/run-gates.sh`: all six PASS.

## Not done, deliberately

A separate report in the same session proposed adding `.claudeignore` to stop prompt-cache
invalidation from graphify writes. It is not in this PR and no file was created: `.claudeignore` is
not a Claude Code feature — it is an open feature request
([anthropics/claude-code#29455](https://github.com/anthropics/claude-code/issues/29455),
[#30810](https://github.com/anthropics/claude-code/issues/30810)) — and the community
implementations filter automatic context loading rather than cache validity. The owner elected to
drop it rather than adopt an inert file or a third-party hook.

Fixes #2823


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Classified accumulated Graphify memory records as documentation for repository statistics while keeping diffs visible.
  * Updated repository guidance to document query outcomes, corrections, reflections, and recommended reference-count searches.

* **Chores**
  * Preserved Graphify memory records in version control while continuing to ignore other generated output.
  * Added validation to ensure the intended tracking and classification rules remain effective.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->