### PR TITLE
extras: name the lost dispatcher lock so a deferred dc/dcc run is diagnosable

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -5464,6 +5464,14 @@ function pfb_extras_process_begin(): bool
 	$dispatch_owner = !isset($GLOBALS['pfb_schedule_dispatch_lock'])
 		|| !is_resource($GLOBALS['pfb_schedule_dispatch_lock']);
 	if (!pfb_schedule_dispatch_begin()) {
+		// issue #2592: the Extras verbs exit 1 on a FALSE from here with no other
+		// output, so every guard must name itself or the failure is undiagnosable
+		// (issue #2496). Observability only -- the rc is deliberately unchanged.
+		pfb_logger("\n Extras process deferred: dispatcher lock unavailable.\n", 1);
+		// issue #2592: feed-pass parity (pfb_feed_pass_begin() raises LOG_NOTICE) --
+		// a live wedged lock holder must be visible outside /var/log/pfblockerng.
+		logger(LOG_NOTICE, localize_text('Feed pass [ extras ] deferred - the scheduler dispatcher lock is unavailable.'),
+			LOG_PREFIX_PKG_PFBLOCKERNG);
 		return FALSE;
 	}
 	if (!pfb_feed_pass_begin('extras')) {

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -5464,12 +5464,8 @@ function pfb_extras_process_begin(): bool
 	$dispatch_owner = !isset($GLOBALS['pfb_schedule_dispatch_lock'])
 		|| !is_resource($GLOBALS['pfb_schedule_dispatch_lock']);
 	if (!pfb_schedule_dispatch_begin()) {
-		// issue #2592: the Extras verbs exit 1 on a FALSE from here with no other
-		// output, so every guard must name itself or the failure is undiagnosable
-		// (issue #2496). Observability only -- the rc is deliberately unchanged.
+		// issue #2592: name the guard (#2496) + feed-pass syslog parity (#2505); rc deliberately unchanged.
 		pfb_logger("\n Extras process deferred: dispatcher lock unavailable.\n", 1);
-		// issue #2592: feed-pass parity (pfb_feed_pass_begin() raises LOG_NOTICE) --
-		// a live wedged lock holder must be visible outside /var/log/pfblockerng.
 		logger(LOG_NOTICE, localize_text('Feed pass [ extras ] deferred - the scheduler dispatcher lock is unavailable.'),
 			LOG_PREFIX_PKG_PFBLOCKERNG);
 		return FALSE;

--- a/tests/php/ExtrasDispatcherDeferralLoggingTest.php
+++ b/tests/php/ExtrasDispatcherDeferralLoggingTest.php
@@ -16,27 +16,28 @@ use PHPUnit\Framework\TestCase;
  * live wedged lock holder was undiagnosable. Same class as issue #2496 ("every guard
  * must name itself or the failure is undiagnosable") on a third dispatcher-lock site.
  *
- * The deferral must be visible in BOTH places the sibling guards use, and the
- * exit-code semantics must not move (a deferred Extras run got no work, so the verb
- * keeps reporting it):
+ * The deferral must be visible in BOTH sinks the sibling guards use, and the
+ * exit-code semantics must not move (a deferred Extras run got no work, so the verbs
+ * keep reporting it):
  *
- *   pfblockerng.inc  pfb_feed_pass_begin()  pfb_logger(logtype 1) + logger(LOG_NOTICE)
- *   pfblockerng_apply.inc:722-726 (#2505)   pfb_logger(logtype 1) + logger(LOG_NOTICE)
- *   pfblockerng_cron.inc:266-270  (#2505)   pfb_logger(logtype 1) + logger(LOG_NOTICE)
+ *   pfblockerng.inc:18608-18610   pfb_feed_pass_begin()  pfb_logger(1) + logger(LOG_NOTICE)
+ *   pfblockerng_apply.inc:722-726 (issue #2505)          pfb_logger(1) + logger(LOG_NOTICE)
+ *   pfblockerng_cron.inc:266-270  (issue #2505)          pfb_logger(1) + logger(LOG_NOTICE)
  *
- * Rows 1-2 are RED before the fix (the branch is silent). Rows 3-5 are the
- * before-state guards that keep the fix honest and pass on both sides: row 3 pins the
- * unchanged rc=1 wiring shared by `dc` and `dcc`, rows 4-5 pin that nothing new is
- * logged when the dispatcher lock was actually acquired.
+ * Rows 1-2 and 6 are RED before the fix. Rows 3-5 are before-state guards that pass
+ * on both sides: row 3 pins the unchanged rc=1 wiring of `dc` AND `dcc`, rows 4-5 pin
+ * that nothing new is logged when the dispatcher lock was actually acquired.
  *
- * flock(2) belongs to the open file description, not the process, so the raw fd held
- * here conflicts with the guard's own fopen() inside this one process -- the same
- * mechanism FeedPassLockTest relies on for its contention rows.
+ * Contention is provoked the way FeedPassLockTest's rows do it -- see its docblock for
+ * the flock(2) open-file-description semantics that make it work within one process.
  */
 final class ExtrasDispatcherDeferralLoggingTest extends TestCase
 {
 	/** The verb dispatcher whose rc=1 wiring row 3 pins (not loadable off-appliance). */
 	private const PHP = __DIR__ . '/../../src/usr/local/www/pfblockerng/pfblockerng.php';
+
+	/** The syslog wording the sibling guards use, with this guard's label. */
+	private const NOTICE = 'Feed pass [ extras ] deferred - the scheduler dispatcher lock is unavailable.';
 
 	private string $dir = '';
 	private bool $hadPfb = FALSE;
@@ -110,6 +111,15 @@ final class ExtrasDispatcherDeferralLoggingTest extends TestCase
 		return implode("\n", array_column($GLOBALS['pfb_test_logger_calls'] ?? [], 'message'));
 	}
 
+	/** The captured syslog calls that blame the dispatcher lock. */
+	private function dispatcherDeferralNotices(): array
+	{
+		return array_values(array_filter(
+			$GLOBALS['pfb_test_logger_calls'] ?? [],
+			static fn (array $call): bool => str_contains($call['message'], 'dispatcher lock')
+		));
+	}
+
 	/** ANOTHER process wedges the scheduler dispatcher lock. */
 	private function holdDispatcherLock(): void
 	{
@@ -129,7 +139,7 @@ final class ExtrasDispatcherDeferralLoggingTest extends TestCase
 	}
 
 	// -----------------------------------------------------------------------
-	// RED rows: a lost dispatcher lock must name itself in both places.
+	// RED rows: a lost dispatcher lock must name itself in both sinks.
 	// -----------------------------------------------------------------------
 
 	/**
@@ -146,18 +156,19 @@ final class ExtrasDispatcherDeferralLoggingTest extends TestCase
 		$this->assertFalse(pfb_extras_process_begin(),
 			'before-state: a wedged dispatcher lock must keep reporting the deferral');
 		$this->assertStringContainsString('Extras process deferred: dispatcher lock unavailable', $this->mainLog(),
-			'the deferred Extras run must name WHICH guard stood it down (issue #2592) -- '
-			. 'pfblockerng.log held: ' . var_export($this->mainLog(), TRUE));
+			'the deferred Extras run must name WHICH guard stood it down (issue #2592)');
 	}
 
 	/**
 	 * Scenario: the same deferral must escape /var/log/pfblockerng.
 	 *   Given another process holds the scheduler dispatcher lock
 	 *   When  pfb_extras_process_begin() runs
-	 *   Then  a LOG_NOTICE syslog line names the Extras feed pass and the dispatcher lock
+	 *   Then  exactly one syslog notice carries the sibling guards' wording,
+	 *         at LOG_NOTICE, under the pfBlockerNG prefix
 	 *
-	 * Priority is asserted, not just the text: feed-pass parity is specifically
-	 * LOG_NOTICE (pfb_feed_pass_begin()), so a LOG_INFO downgrade must fail here.
+	 * All three attributes are asserted, not just the text: feed-pass parity is
+	 * specifically LOG_NOTICE (pfb_feed_pass_begin()), and without the prefix the
+	 * line is not attributable to this package in syslog.
 	 */
 	public function testDispatcherDeferralRaisesLogNoticeSyslogLine(): void
 	{
@@ -165,20 +176,40 @@ final class ExtrasDispatcherDeferralLoggingTest extends TestCase
 
 		pfb_extras_process_begin();
 
-		$this->assertStringContainsString('Feed pass [ extras ] deferred', $this->syslogMessages(),
-			'a wedged dispatcher-lock holder must be visible on syslog, not only in pfblockerng.log '
-			. '(issue #2592) -- captured: ' . var_export($GLOBALS['pfb_test_logger_calls'], TRUE));
-		$this->assertStringContainsString('dispatcher lock', $this->syslogMessages(),
-			'the syslog notice must name the dispatcher lock as the cause');
-		$priorities = [];
-		foreach ($GLOBALS['pfb_test_logger_calls'] ?? [] as $call) {
-			if (str_contains($call['message'], 'dispatcher lock')) {
-				$priorities[] = $call['priority'];
-			}
-		}
-		$this->assertContains(LOG_NOTICE, $priorities,
-			'the dispatcher-lock deferral notice must be LOG_NOTICE (feed-pass parity) -- got priorities: '
-			. var_export($priorities, TRUE));
+		$notices = $this->dispatcherDeferralNotices();
+		$this->assertCount(1, $notices,
+			'a wedged dispatcher-lock holder must raise exactly one syslog notice (issue #2592) -- captured: '
+			. var_export($GLOBALS['pfb_test_logger_calls'], TRUE));
+		$this->assertSame(self::NOTICE, $notices[0]['message'],
+			"the notice must keep the sibling guards' wording (pfblockerng_apply.inc:725)");
+		$this->assertSame(LOG_NOTICE, $notices[0]['priority'],
+			'the deferral notice must be LOG_NOTICE (feed-pass parity)');
+		$this->assertSame(LOG_PREFIX_PKG_PFBLOCKERNG, $notices[0]['prefix'],
+			'the notice must be attributable to pfBlockerNG in syslog');
+	}
+
+	/**
+	 * Scenario: the deferral line must not graft onto a half-written log line.
+	 *   Given the main log ends mid-line (a previous writer's partial write)
+	 *   When  the dispatcher-lock deferral logs
+	 *   Then  the new line starts on a fresh line carrying its own ISO timestamp
+	 *
+	 * pfb_logger() inserts the stamp AFTER any leading newlines and only when the
+	 * target is at BOL (pfb_logger_format_for_target()), so dropping the message's
+	 * leading "\n" would append unstamped text to whatever was written last.
+	 */
+	public function testDeferralLineStartsOnItsOwnStampedLogLine(): void
+	{
+		file_put_contents($GLOBALS['pfb']['log'], 'unterminated line from the lock holder');
+		$this->holdDispatcherLock();
+
+		pfb_extras_process_begin();
+
+		$this->assertMatchesRegularExpression(
+			'/^unterminated line from the lock holder\n'
+			. '\d{4}-\d\d-\d\d \d\d:\d\d:\d\d  Extras process deferred: dispatcher lock unavailable\.\n$/',
+			$this->mainLog(),
+			'the deferral must begin its own stamped line, not extend the previous partial write');
 	}
 
 	// -----------------------------------------------------------------------
@@ -189,13 +220,15 @@ final class ExtrasDispatcherDeferralLoggingTest extends TestCase
 	 * Scenario: logging the deferral must not change what the verbs report.
 	 *   Given another process holds the scheduler dispatcher lock
 	 *   Then  pfb_extras_process_begin() returns FALSE
-	 *   And   the shared `dc`/`dcc` label still turns that FALSE into exit(1)
+	 *   And   `dc` and `dcc` are each still behind a guard that turns that into exit(1)
 	 *
 	 * The verb wiring is asserted against the dispatcher's source because
-	 * pfblockerng.php is not loadable off-appliance (absolute /usr/local requires
-	 * plus pfb_global()'s real /var writes), the same reason
-	 * GeoipSwapConsumerGuardTest reads it as text. Both verbs share ONE guard
-	 * statement, so this pins the rc for `dc` and `dcc` together.
+	 * pfblockerng.php is not loadable off-appliance (absolute /usr/local requires plus
+	 * pfb_global()'s real /var writes), the same reason GeoipSwapConsumerGuardTest
+	 * reads it as text. The match is anchored on the guard statement and captures the
+	 * contiguous `case` labels feeding it, so it is order-insensitive and tolerates an
+	 * equivalent reformat, while still failing if either verb is moved to a label with
+	 * no guard or if the guard stops exiting 1.
 	 */
 	public function testDcAndDccVerbsKeepExitingOneOnDispatcherDeferral(): void
 	{
@@ -205,19 +238,35 @@ final class ExtrasDispatcherDeferralLoggingTest extends TestCase
 
 		$source = file_get_contents(self::PHP);
 		$this->assertIsString($source, 'test setup: could not read the verb dispatcher');
-		$start = strpos($source, "case 'dc':");
-		$this->assertIsInt($start, "the `dc` verb label is gone from pfblockerng.php");
-		$end = strpos($source, "case 'bu':", $start);
-		$this->assertIsInt($end, "the `bu` verb label that bounds the dc/dcc case is gone");
-		$region = substr($source, $start, $end - $start);
 
-		$this->assertStringContainsString("case 'dcc':", $region,
-			'`dcc` must keep sharing the `dc` label, so one guard covers both verbs');
-		$this->assertMatchesRegularExpression(
-			'/if \(!\$scheduled && !pfb_extras_process_begin\(\)\) \{\s*exit\(1\);\s*\}/',
-			$region,
-			'issue #2592 changes observability only: a deferred dc/dcc run got no work, '
-			. 'so the verbs must keep exiting 1');
+		$arms = [];
+		$found = preg_match_all(
+			'/((?:[ \t]*case[ \t]*\'[a-z0-9_]+\'[ \t]*:[^\n]*\n)+)'
+			. '\s*\$scheduled\s*=\s*\(\$argv\[2\]\s*\?\?\s*\'\'\)\s*===\s*\'scheduled\';'
+			. '\s*if\s*\(\s*!\s*\$scheduled\s*&&\s*!\s*pfb_extras_process_begin\(\)\s*\)'
+			. '\s*\{\s*exit\(1\);\s*\}/',
+			$source,
+			$arms
+		);
+		$this->assertNotFalse($found, 'the verb-arm matcher failed to compile');
+		$this->assertGreaterThan(0, $found,
+			'no Extras verb arm guards on pfb_extras_process_begin() with exit(1) any more');
+
+		// Sharing one arm (today) and owning separate guarded arms are both fine; a
+		// label reachable without the guard is not -- that is the regression this pins.
+		foreach (['dc', 'dcc'] as $verb) {
+			$guarded = FALSE;
+			foreach ($arms[1] as $labels) {
+				if (preg_match('/case[ \t]*\'' . $verb . '\'[ \t]*:/', $labels) === 1) {
+					$guarded = TRUE;
+					break;
+				}
+			}
+			$this->assertTrue($guarded,
+				"issue #2592 changes observability only: `{$verb}` must stay behind a guard that "
+				. 'exits 1 on a dispatcher deferral -- guarded label blocks found: '
+				. var_export($arms[1], TRUE));
+		}
 	}
 
 	/**
@@ -233,11 +282,9 @@ final class ExtrasDispatcherDeferralLoggingTest extends TestCase
 			'before-state: an uncontended Extras run must get both locks');
 
 		$this->assertStringNotContainsString('deferred', $this->mainLog(),
-			'a granted Extras run must not log a deferral -- pfblockerng.log held: '
-			. var_export($this->mainLog(), TRUE));
+			'a granted Extras run must not log a deferral');
 		$this->assertSame([], $GLOBALS['pfb_test_logger_calls'],
-			'a granted Extras run must raise no syslog line -- captured: '
-			. var_export($GLOBALS['pfb_test_logger_calls'], TRUE));
+			'a granted Extras run must raise no syslog line');
 	}
 
 	/**
@@ -257,10 +304,8 @@ final class ExtrasDispatcherDeferralLoggingTest extends TestCase
 		$this->assertStringContainsString('Feed pass [ extras ] skipped', $this->mainLog(),
 			'before-state: the run must actually have taken the feed-pass deferral path');
 		$this->assertStringNotContainsString('dispatcher lock unavailable', $this->mainLog(),
-			'the dispatcher lock WAS acquired on this path -- pfblockerng.log held: '
-			. var_export($this->mainLog(), TRUE));
+			'the dispatcher lock WAS acquired on this path');
 		$this->assertStringNotContainsString('dispatcher lock', $this->syslogMessages(),
-			'the dispatcher lock WAS acquired on this path -- captured: '
-			. var_export($GLOBALS['pfb_test_logger_calls'], TRUE));
+			'the dispatcher lock WAS acquired on this path');
 	}
 }

--- a/tests/php/ExtrasDispatcherDeferralLoggingTest.php
+++ b/tests/php/ExtrasDispatcherDeferralLoggingTest.php
@@ -219,10 +219,11 @@ final class ExtrasDispatcherDeferralLoggingTest extends TestCase
 	 * The verb wiring is asserted against the dispatcher's source because
 	 * pfblockerng.php is not loadable off-appliance (absolute /usr/local requires plus
 	 * pfb_global()'s real /var writes), the same reason GeoipSwapConsumerGuardTest
-	 * reads it as text. Each verb is matched from ITS OWN label through to the guard,
-	 * so label order and an equivalent reformat are tolerated while a verb that can
-	 * reach the switch body without the guard -- or a guard that stops exiting 1 --
-	 * fails.
+	 * reads it as text. Comments are removed through token_get_all() first, so a
+	 * commented-out copy of the arm cannot stand in for live wiring, and each verb is
+	 * then matched from ITS OWN label through to the guard: label order, interleaved
+	 * labels and any equivalent reformat are tolerated, while a verb that can reach the
+	 * switch body without the guard -- or a guard that stops exiting 1 -- fails.
 	 */
 	public function testDcAndDccVerbsKeepExitingOneOnDispatcherDeferral(): void
 	{
@@ -233,19 +234,33 @@ final class ExtrasDispatcherDeferralLoggingTest extends TestCase
 		$source = file_get_contents(self::PHP);
 		$this->assertIsString($source, 'test setup: could not read the verb dispatcher');
 
-		// Nothing executable may ride behind a label's colon: `case 'dcc': break;`
+		// Comments are not wiring: strip them before matching, keeping line structure so
+		// a trailing comment still ends its label's line. Without this a commented-out
+		// copy of the guarded arm satisfies the match while the live labels break out.
+		$code = '';
+		foreach (token_get_all($source) as $token) {
+			if (!is_array($token)) {
+				$code .= $token;
+				continue;
+			}
+			$code .= in_array($token[0], [T_COMMENT, T_DOC_COMMENT], TRUE)
+				? str_repeat("\n", substr_count($token[1], "\n"))
+				: $token[1];
+		}
+
+		// A label's colon may be followed only by the end of its line: `case 'dcc': break;`
 		// leaves that verb unguarded while still looking like a shared label.
-		$label = '[ \t]*(?:case[ \t]*\'[a-z0-9_]+\'|default)[ \t]*:[ \t]*(?:\/\/[^\n]*)?\n';
-		// Further labels, comment-only lines and blank lines may sit between the two.
-		$filler = '(?:' . $label . '|[ \t]*(?:\/\/[^\n]*)?\n)*';
+		$label = '(?:case\s*[\'"][a-z0-9_]+[\'"]|default)\s*:[ \t]*\n';
+		// Further labels and blank lines may sit between a verb and the guard it shares.
+		$filler = '(?:[ \t]*' . $label . '|[ \t]*\n)*';
 		$guard = '[ \t]*\$scheduled[ \t]*=[ \t]*\(\$argv\[2\][ \t]*\?\?[ \t]*\'\'\)[ \t]*===[ \t]*\'scheduled\';'
 			. '\s*if\s*\(\s*!\s*\$scheduled\s*&&\s*!\s*pfb_extras_process_begin\(\)\s*\)'
 			. '\s*\{\s*exit\(1\);\s*\}';
 
 		foreach (['dc', 'dcc'] as $verb) {
 			$this->assertSame(1, preg_match(
-				'/[ \t]*case[ \t]*\'' . $verb . '\'[ \t]*:[ \t]*(?:\/\/[^\n]*)?\n' . $filler . $guard . '/',
-				$source
+				'/case\s*[\'"]' . $verb . '[\'"]\s*:[ \t]*\n' . $filler . $guard . '/',
+				$code
 			), "issue #2592 changes observability only: `{$verb}` must stay behind a guard that exits 1 "
 				. 'on a dispatcher deferral');
 		}

--- a/tests/php/ExtrasDispatcherDeferralLoggingTest.php
+++ b/tests/php/ExtrasDispatcherDeferralLoggingTest.php
@@ -111,15 +111,6 @@ final class ExtrasDispatcherDeferralLoggingTest extends TestCase
 		return implode("\n", array_column($GLOBALS['pfb_test_logger_calls'] ?? [], 'message'));
 	}
 
-	/** The captured syslog calls that blame the dispatcher lock. */
-	private function dispatcherDeferralNotices(): array
-	{
-		return array_values(array_filter(
-			$GLOBALS['pfb_test_logger_calls'] ?? [],
-			static fn (array $call): bool => str_contains($call['message'], 'dispatcher lock')
-		));
-	}
-
 	/** ANOTHER process wedges the scheduler dispatcher lock. */
 	private function holdDispatcherLock(): void
 	{
@@ -176,7 +167,10 @@ final class ExtrasDispatcherDeferralLoggingTest extends TestCase
 
 		pfb_extras_process_begin();
 
-		$notices = $this->dispatcherDeferralNotices();
+		$notices = array_values(array_filter(
+			$GLOBALS['pfb_test_logger_calls'],
+			static fn (array $call): bool => str_contains($call['message'], 'dispatcher lock')
+		));
 		$this->assertCount(1, $notices,
 			'a wedged dispatcher-lock holder must raise exactly one syslog notice (issue #2592) -- captured: '
 			. var_export($GLOBALS['pfb_test_logger_calls'], TRUE));
@@ -225,10 +219,10 @@ final class ExtrasDispatcherDeferralLoggingTest extends TestCase
 	 * The verb wiring is asserted against the dispatcher's source because
 	 * pfblockerng.php is not loadable off-appliance (absolute /usr/local requires plus
 	 * pfb_global()'s real /var writes), the same reason GeoipSwapConsumerGuardTest
-	 * reads it as text. The match is anchored on the guard statement and captures the
-	 * contiguous `case` labels feeding it, so it is order-insensitive and tolerates an
-	 * equivalent reformat, while still failing if either verb is moved to a label with
-	 * no guard or if the guard stops exiting 1.
+	 * reads it as text. Each verb is matched from ITS OWN label through to the guard,
+	 * so label order and an equivalent reformat are tolerated while a verb that can
+	 * reach the switch body without the guard -- or a guard that stops exiting 1 --
+	 * fails.
 	 */
 	public function testDcAndDccVerbsKeepExitingOneOnDispatcherDeferral(): void
 	{
@@ -239,33 +233,21 @@ final class ExtrasDispatcherDeferralLoggingTest extends TestCase
 		$source = file_get_contents(self::PHP);
 		$this->assertIsString($source, 'test setup: could not read the verb dispatcher');
 
-		$arms = [];
-		$found = preg_match_all(
-			'/((?:[ \t]*case[ \t]*\'[a-z0-9_]+\'[ \t]*:[^\n]*\n)+)'
-			. '\s*\$scheduled\s*=\s*\(\$argv\[2\]\s*\?\?\s*\'\'\)\s*===\s*\'scheduled\';'
+		// Nothing executable may ride behind a label's colon: `case 'dcc': break;`
+		// leaves that verb unguarded while still looking like a shared label.
+		$label = '[ \t]*(?:case[ \t]*\'[a-z0-9_]+\'|default)[ \t]*:[ \t]*(?:\/\/[^\n]*)?\n';
+		// Further labels, comment-only lines and blank lines may sit between the two.
+		$filler = '(?:' . $label . '|[ \t]*(?:\/\/[^\n]*)?\n)*';
+		$guard = '[ \t]*\$scheduled[ \t]*=[ \t]*\(\$argv\[2\][ \t]*\?\?[ \t]*\'\'\)[ \t]*===[ \t]*\'scheduled\';'
 			. '\s*if\s*\(\s*!\s*\$scheduled\s*&&\s*!\s*pfb_extras_process_begin\(\)\s*\)'
-			. '\s*\{\s*exit\(1\);\s*\}/',
-			$source,
-			$arms
-		);
-		$this->assertNotFalse($found, 'the verb-arm matcher failed to compile');
-		$this->assertGreaterThan(0, $found,
-			'no Extras verb arm guards on pfb_extras_process_begin() with exit(1) any more');
+			. '\s*\{\s*exit\(1\);\s*\}';
 
-		// Sharing one arm (today) and owning separate guarded arms are both fine; a
-		// label reachable without the guard is not -- that is the regression this pins.
 		foreach (['dc', 'dcc'] as $verb) {
-			$guarded = FALSE;
-			foreach ($arms[1] as $labels) {
-				if (preg_match('/case[ \t]*\'' . $verb . '\'[ \t]*:/', $labels) === 1) {
-					$guarded = TRUE;
-					break;
-				}
-			}
-			$this->assertTrue($guarded,
-				"issue #2592 changes observability only: `{$verb}` must stay behind a guard that "
-				. 'exits 1 on a dispatcher deferral -- guarded label blocks found: '
-				. var_export($arms[1], TRUE));
+			$this->assertSame(1, preg_match(
+				'/[ \t]*case[ \t]*\'' . $verb . '\'[ \t]*:[ \t]*(?:\/\/[^\n]*)?\n' . $filler . $guard . '/',
+				$source
+			), "issue #2592 changes observability only: `{$verb}` must stay behind a guard that exits 1 "
+				. 'on a dispatcher deferral');
 		}
 	}
 

--- a/tests/php/ExtrasDispatcherDeferralLoggingTest.php
+++ b/tests/php/ExtrasDispatcherDeferralLoggingTest.php
@@ -213,15 +213,11 @@ final class ExtrasDispatcherDeferralLoggingTest extends TestCase
 	 *   Then  pfb_extras_process_begin() returns FALSE, which is what the Extras verbs
 	 *         turn into exit(1)
 	 *
-	 * This pins the half that is executable. The other half -- that `dc` and `dcc` are
-	 * still WIRED as `if (!$scheduled && !pfb_extras_process_begin()) { exit(1); }` --
-	 * is guaranteed by pfblockerng.php being outside this change's diff, which
-	 * `git diff` proves directly; re-deriving an unmodified file's own text from a
-	 * static oracle proved unsound five times over (a label with executable text behind
-	 * its colon, an arm parked in a comment, in a heredoc, in a nowdoc, in inline HTML,
-	 * in another switch entirely). Nothing pinned this exit code before this change
-	 * either. An exit-code test that can really load pfblockerng.php needs the
-	 * appliance tier, tracked separately.
+	 * Only the executable half is pinned here. That `dc`/`dcc` stay WIRED as
+	 * `if (!$scheduled && !pfb_extras_process_begin()) { exit(1); }` is guaranteed by
+	 * pfblockerng.php being outside this change's diff, not by re-deriving an
+	 * unmodified file's text -- and nothing pinned that exit code before this change
+	 * either. Asserting it for real needs the appliance tier: issue #2832.
 	 */
 	public function testDcAndDccVerbsKeepExitingOneOnDispatcherDeferral(): void
 	{

--- a/tests/php/ExtrasDispatcherDeferralLoggingTest.php
+++ b/tests/php/ExtrasDispatcherDeferralLoggingTest.php
@@ -219,11 +219,12 @@ final class ExtrasDispatcherDeferralLoggingTest extends TestCase
 	 * The verb wiring is asserted against the dispatcher's source because
 	 * pfblockerng.php is not loadable off-appliance (absolute /usr/local requires plus
 	 * pfb_global()'s real /var writes), the same reason GeoipSwapConsumerGuardTest
-	 * reads it as text. Comments are removed through token_get_all() first, so a
-	 * commented-out copy of the arm cannot stand in for live wiring, and each verb is
-	 * then matched from ITS OWN label through to the guard: label order, interleaved
-	 * labels and any equivalent reformat are tolerated, while a verb that can reach the
-	 * switch body without the guard -- or a guard that stops exiting 1 -- fails.
+	 * reads it as text. The oracle is PHP's own token stream, not the raw bytes: only
+	 * executable tokens survive, so a copy of the arm parked in a comment, heredoc,
+	 * nowdoc or inline-HTML block cannot stand in for live wiring. One space per token
+	 * also makes formatting irrelevant, so every equivalent reformat matches while a
+	 * verb that can reach the switch body without the guard -- or a guard that stops
+	 * exiting 1 -- fails.
 	 */
 	public function testDcAndDccVerbsKeepExitingOneOnDispatcherDeferral(): void
 	{
@@ -234,32 +235,33 @@ final class ExtrasDispatcherDeferralLoggingTest extends TestCase
 		$source = file_get_contents(self::PHP);
 		$this->assertIsString($source, 'test setup: could not read the verb dispatcher');
 
-		// Comments are not wiring: strip them before matching, keeping line structure so
-		// a trailing comment still ends its label's line. Without this a commented-out
-		// copy of the guarded arm satisfies the match while the live labels break out.
-		$code = '';
+		// Only executable tokens are wiring. Dropping whitespace and comments and
+		// blanking the payload of the literal kinds that can carry newlines leaves a
+		// stream no decoy copy of the arm can join, whatever it is parked inside.
+		$tokens = [];
 		foreach (token_get_all($source) as $token) {
 			if (!is_array($token)) {
-				$code .= $token;
+				$tokens[] = $token;
 				continue;
 			}
-			$code .= in_array($token[0], [T_COMMENT, T_DOC_COMMENT], TRUE)
-				? str_repeat("\n", substr_count($token[1], "\n"))
+			if (in_array($token[0], [T_WHITESPACE, T_COMMENT, T_DOC_COMMENT], TRUE)) {
+				continue;
+			}
+			$tokens[] = in_array($token[0], [T_ENCAPSED_AND_WHITESPACE, T_INLINE_HTML], TRUE)
+				? '<literal>'
 				: $token[1];
 		}
+		$code = implode(' ', $tokens);
+		$this->assertStringContainsString('pfb_extras_process_begin', $code,
+			'test setup: the verb dispatcher did not tokenise into anything recognisable');
 
-		// A label's colon may be followed only by the end of its line: `case 'dcc': break;`
-		// leaves that verb unguarded while still looking like a shared label.
-		$label = '(?:case\s*[\'"][a-z0-9_]+[\'"]|default)\s*:[ \t]*\n';
-		// Further labels and blank lines may sit between a verb and the guard it shares.
-		$filler = '(?:[ \t]*' . $label . '|[ \t]*\n)*';
-		$guard = '[ \t]*\$scheduled[ \t]*=[ \t]*\(\$argv\[2\][ \t]*\?\?[ \t]*\'\'\)[ \t]*===[ \t]*\'scheduled\';'
-			. '\s*if\s*\(\s*!\s*\$scheduled\s*&&\s*!\s*pfb_extras_process_begin\(\)\s*\)'
-			. '\s*\{\s*exit\(1\);\s*\}';
+		$label = '(?:case [\'"][a-z0-9_]+[\'"]|default) : ';
+		$guard = preg_quote('$scheduled = ( $argv [ 2 ] ?? \'\' ) === \'scheduled\' ; '
+			. 'if ( ! $scheduled && ! pfb_extras_process_begin ( ) ) { exit ( 1 ) ; }', '/');
 
 		foreach (['dc', 'dcc'] as $verb) {
 			$this->assertSame(1, preg_match(
-				'/case\s*[\'"]' . $verb . '[\'"]\s*:[ \t]*\n' . $filler . $guard . '/',
+				'/case [\'"]' . $verb . '[\'"] : (?:' . $label . ')*' . $guard . '/',
 				$code
 			), "issue #2592 changes observability only: `{$verb}` must stay behind a guard that exits 1 "
 				. 'on a dispatcher deferral');

--- a/tests/php/ExtrasDispatcherDeferralLoggingTest.php
+++ b/tests/php/ExtrasDispatcherDeferralLoggingTest.php
@@ -251,19 +251,46 @@ final class ExtrasDispatcherDeferralLoggingTest extends TestCase
 				? '<literal>'
 				: $token[1];
 		}
-		$code = implode(' ', $tokens);
+
+		// Scope the oracle to the verb dispatcher's OWN switch: a guarded arm anywhere
+		// else in the file -- a second switch, an uncalled function -- is not this
+		// wiring. Depth is counted over tokens, so braces inside a literal cannot skew
+		// it, and a literal's text can never equal the one-character brace token.
+		$head = ['switch', '(', '$argv', '[', '1', ']', ')', '{'];
+		$open = NULL;
+		for ($i = 0, $last = count($tokens) - count($head); $i <= $last; $i++) {
+			if (array_slice($tokens, $i, count($head)) === $head) {
+				$open = $i + count($head);
+				break;
+			}
+		}
+		$this->assertNotNull($open, 'test setup: the verb dispatcher switch was not found');
+
+		$body = [];
+		$depth = 1;
+		for ($i = $open, $count = count($tokens); $i < $count && $depth > 0; $i++) {
+			$depth += (int) ($tokens[$i] === '{') - (int) ($tokens[$i] === '}');
+			if ($depth > 0) {
+				$body[] = $tokens[$i];
+			}
+		}
+		$this->assertSame(0, $depth, 'test setup: the verb dispatcher switch never closed');
+		$code = implode(' ', $body);
 		$this->assertStringContainsString('pfb_extras_process_begin', $code,
-			'test setup: the verb dispatcher did not tokenise into anything recognisable');
+			'test setup: the verb switch did not tokenise into anything recognisable');
 
 		$label = '(?:case [\'"][a-z0-9_]+[\'"]|default) : ';
 		$guard = preg_quote('$scheduled = ( $argv [ 2 ] ?? \'\' ) === \'scheduled\' ; '
-			. 'if ( ! $scheduled && ! pfb_extras_process_begin ( ) ) { exit ( 1 ) ; }', '/');
+			. 'if ( ! $scheduled && ! pfb_extras_process_begin ( ) ) { ', '/')
+			. '(?:exit|die)' . preg_quote(' ( 1 ) ; }', '/');
 
 		foreach (['dc', 'dcc'] as $verb) {
-			$this->assertSame(1, preg_match(
-				'/case [\'"]' . $verb . '[\'"] : (?:' . $label . ')*' . $guard . '/',
-				$code
-			), "issue #2592 changes observability only: `{$verb}` must stay behind a guard that exits 1 "
+			$at = 'case [\'"]' . $verb . '[\'"] : ';
+			$this->assertSame(1, preg_match_all('/' . $at . '/', $code),
+				"`{$verb}` must appear exactly once as a label in the verb switch, or the guarded "
+				. 'arm the next assertion finds need not be the one that runs');
+			$this->assertSame(1, preg_match('/' . $at . '(?:' . $label . ')*' . $guard . '/', $code),
+				"issue #2592 changes observability only: `{$verb}` must stay behind a guard that exits 1 "
 				. 'on a dispatcher deferral');
 		}
 	}

--- a/tests/php/ExtrasDispatcherDeferralLoggingTest.php
+++ b/tests/php/ExtrasDispatcherDeferralLoggingTest.php
@@ -1,0 +1,266 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Issue #2592: pfb_extras_process_begin()'s dispatcher-lock guard must name itself.
+ *
+ * The Extras verbs are wired as `if (!$scheduled && !pfb_extras_process_begin())
+ * { exit(1); }` (pfblockerng.php, the shared `case 'dc': case 'dcc':` label), so a
+ * FALSE from that guard surfaces as rc=1 with empty stdout AND stderr. Before this
+ * change the lost-dispatcher-lock branch returned FALSE writing nothing anywhere --
+ * a probe against the untouched guard produced rc=1 with a 0-byte delta on
+ * $pfb['log'], $pfb['errlog'] AND $pfb['extraslog'] and zero logger() calls -- so a
+ * live wedged lock holder was undiagnosable. Same class as issue #2496 ("every guard
+ * must name itself or the failure is undiagnosable") on a third dispatcher-lock site.
+ *
+ * The deferral must be visible in BOTH places the sibling guards use, and the
+ * exit-code semantics must not move (a deferred Extras run got no work, so the verb
+ * keeps reporting it):
+ *
+ *   pfblockerng.inc  pfb_feed_pass_begin()  pfb_logger(logtype 1) + logger(LOG_NOTICE)
+ *   pfblockerng_apply.inc:722-726 (#2505)   pfb_logger(logtype 1) + logger(LOG_NOTICE)
+ *   pfblockerng_cron.inc:266-270  (#2505)   pfb_logger(logtype 1) + logger(LOG_NOTICE)
+ *
+ * Rows 1-2 are RED before the fix (the branch is silent). Rows 3-5 are the
+ * before-state guards that keep the fix honest and pass on both sides: row 3 pins the
+ * unchanged rc=1 wiring shared by `dc` and `dcc`, rows 4-5 pin that nothing new is
+ * logged when the dispatcher lock was actually acquired.
+ *
+ * flock(2) belongs to the open file description, not the process, so the raw fd held
+ * here conflicts with the guard's own fopen() inside this one process -- the same
+ * mechanism FeedPassLockTest relies on for its contention rows.
+ */
+final class ExtrasDispatcherDeferralLoggingTest extends TestCase
+{
+	/** The verb dispatcher whose rc=1 wiring row 3 pins (not loadable off-appliance). */
+	private const PHP = __DIR__ . '/../../src/usr/local/www/pfblockerng/pfblockerng.php';
+
+	private string $dir = '';
+	private bool $hadPfb = FALSE;
+	private array $originalPfb = [];
+
+	/** Raw fds simulating ANOTHER process holding a lock -- closed in tearDown. */
+	private array $rawFps = [];
+
+	protected function setUp(): void
+	{
+		$this->hadPfb      = array_key_exists('pfb', $GLOBALS);
+		$this->originalPfb = $GLOBALS['pfb'] ?? [];
+
+		$this->dir = sys_get_temp_dir() . '/pfb_extras_defer_' . uniqid('', TRUE);
+		mkdir($this->dir, 0755, TRUE);
+
+		$GLOBALS['pfb'] = array_merge($GLOBALS['pfb'] ?? [], [
+			'dbdir'              => $this->dir,
+			'schedule_state_dir' => $this->dir,
+			'log'                => "{$this->dir}/pfblockerng.log",
+			'errlog'             => "{$this->dir}/error.log",
+			'extraslog'          => "{$this->dir}/extras.log",
+		]);
+
+		// No inherited locks: a leaked handle makes pfb_schedule_dispatch_begin()
+		// short-circuit on its reentrancy check, so the guard under test is never
+		// reached and a deferral row would pass vacuously.
+		unset($GLOBALS['pfb_schedule_dispatch_lock'], $GLOBALS['pfb_feed_pass_lock']);
+
+		// Fresh syslog capture (pfsense_doubles.php logger() double).
+		$GLOBALS['pfb_test_logger_calls'] = [];
+	}
+
+	protected function tearDown(): void
+	{
+		foreach ($this->rawFps as $fp) {
+			if (is_resource($fp)) {
+				@flock($fp, LOCK_UN);
+				@fclose($fp);
+			}
+		}
+		$this->rawFps = [];
+
+		// Never leave this process holding a lock across tests (self-encapsulation).
+		pfb_feed_pass_release();
+		pfb_schedule_dispatch_release();
+		unset($GLOBALS['pfb_schedule_dispatch_lock'], $GLOBALS['pfb_feed_pass_lock']);
+		unset($GLOBALS['pfb_test_logger_calls']);
+
+		foreach (glob("{$this->dir}/*") ?: [] as $path) {
+			is_dir($path) ? @rmdir($path) : @unlink($path);
+		}
+		@rmdir($this->dir);
+
+		if ($this->hadPfb) {
+			$GLOBALS['pfb'] = $this->originalPfb;
+		} else {
+			unset($GLOBALS['pfb']);
+		}
+	}
+
+	private function mainLog(): string
+	{
+		$log = $GLOBALS['pfb']['log'];
+		return is_file($log) ? (string) file_get_contents($log) : '';
+	}
+
+	/** The syslog messages captured by the logger() double, one per line. */
+	private function syslogMessages(): string
+	{
+		return implode("\n", array_column($GLOBALS['pfb_test_logger_calls'] ?? [], 'message'));
+	}
+
+	/** ANOTHER process wedges the scheduler dispatcher lock. */
+	private function holdDispatcherLock(): void
+	{
+		$fp = fopen("{$this->dir}/pfb_schedule_dispatch.lock", 'c');
+		$this->assertIsResource($fp, 'test setup: could not open the dispatcher lock');
+		$this->rawFps[] = $fp;
+		$this->assertTrue(flock($fp, LOCK_EX), 'test setup: could not hold the dispatcher lock');
+	}
+
+	/** ANOTHER process wedges the feed-pass lock. */
+	private function holdFeedPassLock(): void
+	{
+		$fp = fopen("{$this->dir}/pfb_feed_pass.lock", 'c');
+		$this->assertIsResource($fp, 'test setup: could not open the feed-pass lock');
+		$this->rawFps[] = $fp;
+		$this->assertTrue(flock($fp, LOCK_EX), 'test setup: could not hold the feed-pass lock');
+	}
+
+	// -----------------------------------------------------------------------
+	// RED rows: a lost dispatcher lock must name itself in both places.
+	// -----------------------------------------------------------------------
+
+	/**
+	 * Scenario: an Extras run (`pfblockerng.php dc` / `dcc`) loses the dispatcher race.
+	 *   Given another process holds the scheduler dispatcher lock
+	 *   When  pfb_extras_process_begin() runs
+	 *   Then  it still reports the deferral (FALSE -> the verb's exit 1)
+	 *   And   /var/log/pfblockerng/pfblockerng.log names THIS guard, not just "deferred"
+	 */
+	public function testDispatcherDeferralNamesTheGuardInTheMainLog(): void
+	{
+		$this->holdDispatcherLock();
+
+		$this->assertFalse(pfb_extras_process_begin(),
+			'before-state: a wedged dispatcher lock must keep reporting the deferral');
+		$this->assertStringContainsString('Extras process deferred: dispatcher lock unavailable', $this->mainLog(),
+			'the deferred Extras run must name WHICH guard stood it down (issue #2592) -- '
+			. 'pfblockerng.log held: ' . var_export($this->mainLog(), TRUE));
+	}
+
+	/**
+	 * Scenario: the same deferral must escape /var/log/pfblockerng.
+	 *   Given another process holds the scheduler dispatcher lock
+	 *   When  pfb_extras_process_begin() runs
+	 *   Then  a LOG_NOTICE syslog line names the Extras feed pass and the dispatcher lock
+	 *
+	 * Priority is asserted, not just the text: feed-pass parity is specifically
+	 * LOG_NOTICE (pfb_feed_pass_begin()), so a LOG_INFO downgrade must fail here.
+	 */
+	public function testDispatcherDeferralRaisesLogNoticeSyslogLine(): void
+	{
+		$this->holdDispatcherLock();
+
+		pfb_extras_process_begin();
+
+		$this->assertStringContainsString('Feed pass [ extras ] deferred', $this->syslogMessages(),
+			'a wedged dispatcher-lock holder must be visible on syslog, not only in pfblockerng.log '
+			. '(issue #2592) -- captured: ' . var_export($GLOBALS['pfb_test_logger_calls'], TRUE));
+		$this->assertStringContainsString('dispatcher lock', $this->syslogMessages(),
+			'the syslog notice must name the dispatcher lock as the cause');
+		$priorities = [];
+		foreach ($GLOBALS['pfb_test_logger_calls'] ?? [] as $call) {
+			if (str_contains($call['message'], 'dispatcher lock')) {
+				$priorities[] = $call['priority'];
+			}
+		}
+		$this->assertContains(LOG_NOTICE, $priorities,
+			'the dispatcher-lock deferral notice must be LOG_NOTICE (feed-pass parity) -- got priorities: '
+			. var_export($priorities, TRUE));
+	}
+
+	// -----------------------------------------------------------------------
+	// Guard rows (green before AND after the fix).
+	// -----------------------------------------------------------------------
+
+	/**
+	 * Scenario: logging the deferral must not change what the verbs report.
+	 *   Given another process holds the scheduler dispatcher lock
+	 *   Then  pfb_extras_process_begin() returns FALSE
+	 *   And   the shared `dc`/`dcc` label still turns that FALSE into exit(1)
+	 *
+	 * The verb wiring is asserted against the dispatcher's source because
+	 * pfblockerng.php is not loadable off-appliance (absolute /usr/local requires
+	 * plus pfb_global()'s real /var writes), the same reason
+	 * GeoipSwapConsumerGuardTest reads it as text. Both verbs share ONE guard
+	 * statement, so this pins the rc for `dc` and `dcc` together.
+	 */
+	public function testDcAndDccVerbsKeepExitingOneOnDispatcherDeferral(): void
+	{
+		$this->holdDispatcherLock();
+		$this->assertFalse(pfb_extras_process_begin(),
+			'the Extras guard must keep returning FALSE -- that FALSE IS the verbs rc=1');
+
+		$source = file_get_contents(self::PHP);
+		$this->assertIsString($source, 'test setup: could not read the verb dispatcher');
+		$start = strpos($source, "case 'dc':");
+		$this->assertIsInt($start, "the `dc` verb label is gone from pfblockerng.php");
+		$end = strpos($source, "case 'bu':", $start);
+		$this->assertIsInt($end, "the `bu` verb label that bounds the dc/dcc case is gone");
+		$region = substr($source, $start, $end - $start);
+
+		$this->assertStringContainsString("case 'dcc':", $region,
+			'`dcc` must keep sharing the `dc` label, so one guard covers both verbs');
+		$this->assertMatchesRegularExpression(
+			'/if \(!\$scheduled && !pfb_extras_process_begin\(\)\) \{\s*exit\(1\);\s*\}/',
+			$region,
+			'issue #2592 changes observability only: a deferred dc/dcc run got no work, '
+			. 'so the verbs must keep exiting 1');
+	}
+
+	/**
+	 * Scenario: the granted path stays quiet -- the new lines are deferral-only.
+	 *   Given nothing holds either lock
+	 *   When  pfb_extras_process_begin() runs
+	 *   Then  it returns TRUE
+	 *   And   nothing new reaches pfblockerng.log or syslog
+	 */
+	public function testGrantedExtrasProcessLogsNothingNew(): void
+	{
+		$this->assertTrue(pfb_extras_process_begin(),
+			'before-state: an uncontended Extras run must get both locks');
+
+		$this->assertStringNotContainsString('deferred', $this->mainLog(),
+			'a granted Extras run must not log a deferral -- pfblockerng.log held: '
+			. var_export($this->mainLog(), TRUE));
+		$this->assertSame([], $GLOBALS['pfb_test_logger_calls'],
+			'a granted Extras run must raise no syslog line -- captured: '
+			. var_export($GLOBALS['pfb_test_logger_calls'], TRUE));
+	}
+
+	/**
+	 * Scenario: the OTHER failure branch must not borrow the dispatcher's message.
+	 *   Given nothing holds the dispatcher lock but another process holds the feed-pass lock
+	 *   When  pfb_extras_process_begin() runs
+	 *   Then  it reports the deferral
+	 *   And   pfb_feed_pass_begin()'s own skip line is what names it
+	 *   And   nothing claims the dispatcher lock was unavailable (it was acquired)
+	 */
+	public function testFeedPassDeferralDoesNotClaimTheDispatcherLockWasUnavailable(): void
+	{
+		$this->holdFeedPassLock();
+
+		$this->assertFalse(pfb_extras_process_begin(),
+			'before-state: a wedged feed-pass lock must keep reporting the deferral');
+		$this->assertStringContainsString('Feed pass [ extras ] skipped', $this->mainLog(),
+			'before-state: the run must actually have taken the feed-pass deferral path');
+		$this->assertStringNotContainsString('dispatcher lock unavailable', $this->mainLog(),
+			'the dispatcher lock WAS acquired on this path -- pfblockerng.log held: '
+			. var_export($this->mainLog(), TRUE));
+		$this->assertStringNotContainsString('dispatcher lock', $this->syslogMessages(),
+			'the dispatcher lock WAS acquired on this path -- captured: '
+			. var_export($GLOBALS['pfb_test_logger_calls'], TRUE));
+	}
+}

--- a/tests/php/ExtrasDispatcherDeferralLoggingTest.php
+++ b/tests/php/ExtrasDispatcherDeferralLoggingTest.php
@@ -25,17 +25,14 @@ use PHPUnit\Framework\TestCase;
  *   pfblockerng_cron.inc:266-270  (issue #2505)          pfb_logger(1) + logger(LOG_NOTICE)
  *
  * Rows 1-2 and 6 are RED before the fix. Rows 3-5 are before-state guards that pass
- * on both sides: row 3 pins the unchanged rc=1 wiring of `dc` AND `dcc`, rows 4-5 pin
- * that nothing new is logged when the dispatcher lock was actually acquired.
+ * on both sides: row 3 pins the FALSE that drives the verbs' rc=1, rows 4-5 pin that
+ * nothing new is logged when the dispatcher lock was actually acquired.
  *
  * Contention is provoked the way FeedPassLockTest's rows do it -- see its docblock for
  * the flock(2) open-file-description semantics that make it work within one process.
  */
 final class ExtrasDispatcherDeferralLoggingTest extends TestCase
 {
-	/** The verb dispatcher whose rc=1 wiring row 3 pins (not loadable off-appliance). */
-	private const PHP = __DIR__ . '/../../src/usr/local/www/pfblockerng/pfblockerng.php';
-
 	/** The syslog wording the sibling guards use, with this guard's label. */
 	private const NOTICE = 'Feed pass [ extras ] deferred - the scheduler dispatcher lock is unavailable.';
 
@@ -213,86 +210,24 @@ final class ExtrasDispatcherDeferralLoggingTest extends TestCase
 	/**
 	 * Scenario: logging the deferral must not change what the verbs report.
 	 *   Given another process holds the scheduler dispatcher lock
-	 *   Then  pfb_extras_process_begin() returns FALSE
-	 *   And   `dc` and `dcc` are each still behind a guard that turns that into exit(1)
+	 *   Then  pfb_extras_process_begin() returns FALSE, which is what the Extras verbs
+	 *         turn into exit(1)
 	 *
-	 * The verb wiring is asserted against the dispatcher's source because
-	 * pfblockerng.php is not loadable off-appliance (absolute /usr/local requires plus
-	 * pfb_global()'s real /var writes), the same reason GeoipSwapConsumerGuardTest
-	 * reads it as text. The oracle is PHP's own token stream, not the raw bytes: only
-	 * executable tokens survive, so a copy of the arm parked in a comment, heredoc,
-	 * nowdoc or inline-HTML block cannot stand in for live wiring. One space per token
-	 * also makes formatting irrelevant, so every equivalent reformat matches while a
-	 * verb that can reach the switch body without the guard -- or a guard that stops
-	 * exiting 1 -- fails.
+	 * This pins the half that is executable. The other half -- that `dc` and `dcc` are
+	 * still WIRED as `if (!$scheduled && !pfb_extras_process_begin()) { exit(1); }` --
+	 * is guaranteed by pfblockerng.php being outside this change's diff, which
+	 * `git diff` proves directly; re-deriving an unmodified file's own text from a
+	 * static oracle proved unsound five times over (a label with executable text behind
+	 * its colon, an arm parked in a comment, in a heredoc, in a nowdoc, in inline HTML,
+	 * in another switch entirely). Nothing pinned this exit code before this change
+	 * either. An exit-code test that can really load pfblockerng.php needs the
+	 * appliance tier, tracked separately.
 	 */
 	public function testDcAndDccVerbsKeepExitingOneOnDispatcherDeferral(): void
 	{
 		$this->holdDispatcherLock();
 		$this->assertFalse(pfb_extras_process_begin(),
 			'the Extras guard must keep returning FALSE -- that FALSE IS the verbs rc=1');
-
-		$source = file_get_contents(self::PHP);
-		$this->assertIsString($source, 'test setup: could not read the verb dispatcher');
-
-		// Only executable tokens are wiring. Dropping whitespace and comments and
-		// blanking the payload of the literal kinds that can carry newlines leaves a
-		// stream no decoy copy of the arm can join, whatever it is parked inside.
-		$tokens = [];
-		foreach (token_get_all($source) as $token) {
-			if (!is_array($token)) {
-				$tokens[] = $token;
-				continue;
-			}
-			if (in_array($token[0], [T_WHITESPACE, T_COMMENT, T_DOC_COMMENT], TRUE)) {
-				continue;
-			}
-			$tokens[] = in_array($token[0], [T_ENCAPSED_AND_WHITESPACE, T_INLINE_HTML], TRUE)
-				? '<literal>'
-				: $token[1];
-		}
-
-		// Scope the oracle to the verb dispatcher's OWN switch: a guarded arm anywhere
-		// else in the file -- a second switch, an uncalled function -- is not this
-		// wiring. Depth is counted over tokens, so braces inside a literal cannot skew
-		// it, and a literal's text can never equal the one-character brace token.
-		$head = ['switch', '(', '$argv', '[', '1', ']', ')', '{'];
-		$open = NULL;
-		for ($i = 0, $last = count($tokens) - count($head); $i <= $last; $i++) {
-			if (array_slice($tokens, $i, count($head)) === $head) {
-				$open = $i + count($head);
-				break;
-			}
-		}
-		$this->assertNotNull($open, 'test setup: the verb dispatcher switch was not found');
-
-		$body = [];
-		$depth = 1;
-		for ($i = $open, $count = count($tokens); $i < $count && $depth > 0; $i++) {
-			$depth += (int) ($tokens[$i] === '{') - (int) ($tokens[$i] === '}');
-			if ($depth > 0) {
-				$body[] = $tokens[$i];
-			}
-		}
-		$this->assertSame(0, $depth, 'test setup: the verb dispatcher switch never closed');
-		$code = implode(' ', $body);
-		$this->assertStringContainsString('pfb_extras_process_begin', $code,
-			'test setup: the verb switch did not tokenise into anything recognisable');
-
-		$label = '(?:case [\'"][a-z0-9_]+[\'"]|default) : ';
-		$guard = preg_quote('$scheduled = ( $argv [ 2 ] ?? \'\' ) === \'scheduled\' ; '
-			. 'if ( ! $scheduled && ! pfb_extras_process_begin ( ) ) { ', '/')
-			. '(?:exit|die)' . preg_quote(' ( 1 ) ; }', '/');
-
-		foreach (['dc', 'dcc'] as $verb) {
-			$at = 'case [\'"]' . $verb . '[\'"] : ';
-			$this->assertSame(1, preg_match_all('/' . $at . '/', $code),
-				"`{$verb}` must appear exactly once as a label in the verb switch, or the guarded "
-				. 'arm the next assertion finds need not be the one that runs');
-			$this->assertSame(1, preg_match('/' . $at . '(?:' . $label . ')*' . $guard . '/', $code),
-				"issue #2592 changes observability only: `{$verb}` must stay behind a guard that exits 1 "
-				. 'on a dispatcher deferral');
-		}
 	}
 
 	/**


### PR DESCRIPTION
Fixes #2592. Follow-up to PR #2589 (issue #2505), contract-conformance leg finding OD1.

## Problem

`pfb_extras_process_begin()` (`pfblockerng_extra.inc`) returned FALSE when it lost the
scheduler dispatcher lock **writing nothing anywhere**. The Extras verbs are wired as
`if (!$scheduled && !pfb_extras_process_begin()) { exit(1); }` (`pfblockerng.php`, the
shared `case 'dc': case 'dcc':` label), so a wedged lock holder surfaced as rc=1 with
empty stdout AND stderr — the same undiagnosable-silent-guard class as issue #2496
("every guard must name itself or the failure is undiagnosable"), on a third
dispatcher-lock site.

## The sibling shape this copies

`pfb_feed_pass_begin()` — `pfblockerng.inc:18608-18610`:

```php
pfb_logger("\nFeed pass [ {$label} ] skipped -- another pfBlockerNG feed pass is running.\n", 1);
logger(LOG_NOTICE, localize_text('Feed pass [ %s ] skipped - another pfBlockerNG feed pass is running.', $label),
	LOG_PREFIX_PKG_PFBLOCKERNG);
```

The two #2505 sites — `pfblockerng_apply.inc:722-726`:

```php
pfb_logger("\n sync aborted: dispatcher lock unavailable; pending changes retained.\n", 1);
logger(LOG_NOTICE, localize_text('Feed pass [ sync ] deferred - the scheduler dispatcher lock is unavailable.'),
	LOG_PREFIX_PKG_PFBLOCKERNG);
```

and `pfblockerng_cron.inc:266-270`, the same pair with `%s` = `forcecheck`/`cron`.

What landed is byte-parallel to those — `pfb_logger()` at **logtype 1** (the main log, which
is the sink #2592 named as empty; the Extras log is logtype 3/4) and the same
`logger(LOG_NOTICE, localize_text(...), LOG_PREFIX_PKG_PFBLOCKERNG)` call, using the
`extras` label the very next statement already passes to `pfb_feed_pass_begin('extras')`:

```php
	if (!pfb_schedule_dispatch_begin()) {
		// issue #2592: name the guard (#2496) + feed-pass syslog parity (#2505); rc deliberately unchanged.
		pfb_logger("\n Extras process deferred: dispatcher lock unavailable.\n", 1);
		logger(LOG_NOTICE, localize_text('Feed pass [ extras ] deferred - the scheduler dispatcher lock is unavailable.'),
			LOG_PREFIX_PKG_PFBLOCKERNG);
		return FALSE;
	}
```

No new message format was invented. The silent branch it replaced was simply
`if (!pfb_schedule_dispatch_begin()) { return FALSE; }`.

## Discriminating probe (executed)

Two hypotheses for the invisibility: **H1** silent by omission, or **H2** it logs but to a
sink the operator is not reading. Probe: wedge the dispatcher lock from another open file
description, point `$pfb['log']`, `$pfb['errlog']` and `$pfb['extraslog']` at temp files,
run the verb's exact guard shape, report every delta. Against untouched code:

```text
verb=dc  pfb_extras_process_begin()=false        verb=dcc  pfb_extras_process_begin()=false
  $pfb['log'] delta: 0 bytes ''                    $pfb['log'] delta: 0 bytes ''
  $pfb['errlog'] delta: 0 bytes ''                 $pfb['errlog'] delta: 0 bytes ''
  $pfb['extraslog'] delta: 0 bytes ''              $pfb['extraslog'] delta: 0 bytes ''
  syslog logger() calls: 0                         syslog logger() calls: 0
rc=1                                             rc=1
```

H1 confirmed, H2 refuted — the Extras log and error log are equally empty. After the fix,
same rc, now diagnosable:

```text
verb=dcc  pfb_extras_process_begin()=false
  $pfb['log'] delta: 76 bytes '
2026-08-28 08:03:02  Extras process deferred: dispatcher lock unavailable.
'
  syslog logger() calls: 1 array (
  0 => array ('priority' => 5, 'message' => 'Feed pass [ extras ] deferred - the scheduler dispatcher lock is unavailable.', 'prefix' => 'pfBlockerNG'),
)
rc=1
```

(`priority => 5` is `LOG_NOTICE`.)

## Changes

- `src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc` — the lost-dispatcher-lock branch
  of `pfb_extras_process_begin()` gains the two sibling-shaped log lines. Still returns
  FALSE, so **every** verb keeps its exit code.
- `tests/php/ExtrasDispatcherDeferralLoggingTest.php` — new; 6 rows.

`pfblockerng.php` needed no change: the guard lives in the shared callee, so the one fix
covers `dc`/`dcc` and the seven other Extras verb call sites (nine further verbs — `bu`,
`al`, `asn`, `asn_shell`, `bl`, `bls`, `uc`, `gc`, `ugc`). `pfblockerng.inc` is untouched.

## How the exit-code half is guaranteed

Owner-directed after five review rounds — quoting the authorisation verbatim:
**"Option B: drop the oracle, file appliance follow-up"** and **"Authorize one final round"**
(the latter authorising the extra review fix round past `workflow.md`'s 3-round cap).

The test row pins the executable half: `pfb_extras_process_begin()` must still return FALSE
under a genuinely held dispatcher lock, which is what the verbs turn into `exit(1)`. The
**wiring** is guaranteed by `pfblockerng.php` being outside this diff, which `git diff`
proves directly:

```text
$ git diff --name-status 5be3763d..HEAD
M	src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
A	tests/php/ExtrasDispatcherDeferralLoggingTest.php

$ git diff --quiet 5be3763d..HEAD -- src/usr/local/www/pfblockerng/pfblockerng.php && echo UNTOUCHED
UNTOUCHED
```

Earlier heads instead re-derived that unmodified file's own text with a static oracle. That
proved unsound five rounds running, each time on `php -l`-valid source where the oracle said
"guarded" while PHP's execution showed both verbs skipping the guard: executable text behind
a label's colon, then the guarded arm parked in a block comment, a doc comment, a heredoc, a
nowdoc, an inline-HTML gap, a quoted string, and finally a second switch inside an uncalled
function. Nothing pinned this exit code before this change either. An exit-code test that
can really load `pfblockerng.php` needs the appliance tier and is filed as **#2832**.

## Red→green proof

`tests/php/ExtrasDispatcherDeferralLoggingTest.php`, frozen at
`9913f73fe9da4a7b16ac4341d9d577331a6a110b` — hash re-verified identical at RED and at GREEN.

RED, with **only** the production file reverted to base `5be3763d` and the test byte-frozen:

```text
1) ExtrasDispatcherDeferralLoggingTest::testDispatcherDeferralNamesTheGuardInTheMainLog
Failed asserting that '' [ASCII](length: 0) contains "Extras process deferred: dispatcher lock unavailable" [ASCII](length: 52).
2) ExtrasDispatcherDeferralLoggingTest::testDispatcherDeferralRaisesLogNoticeSyslogLine
Failed asserting that actual size 0 matches expected size 1.
3) ExtrasDispatcherDeferralLoggingTest::testDeferralLineStartsOnItsOwnStampedLogLine
Failed asserting that 'unterminated line from the lock holder' matches PCRE pattern "…Extras process deferred: dispatcher lock unavailable\.\n$/".
```

GREEN after restoring: `OK (6 tests, 25 assertions)`. The other three rows are before-state
guards, green on both sides — the FALSE-return row, and the two rows proving nothing new is
logged when the dispatcher lock was actually acquired (granted path, and the feed-pass
branch which must not claim the dispatcher lock was unavailable).

Green together with every sibling deferral/lock suite: `FeedPassLockTest`,
`TriggerFunnelDeferralExitCodeTest`, `SyncGuardLoggingTest`, `CronDeferralExitCodeTest`.

## Mutation proof

Each mutant applied singly by a driver that asserts the needle is single-occurrence before
replacing, asserts a non-empty `git diff` after, `php -l`-checks the mutated file, runs the
suite, reverts, and asserts the tree is clean again. Baseline unmutated: 6/6 green.

| # | Mutant | Rows that failed |
| --- | --- | --- |
| 1 | drop the `pfb_logger()` line | main-log, stamped-line |
| 2 | drop the `logger(LOG_NOTICE)` line | syslog |
| 3 | log without naming the guard, both sinks | main-log, syslog, stamped-line |
| 4 | `LOG_NOTICE` → `LOG_INFO` | syslog |
| 5 | `pfb_logger` logtype 1 → 3 (Extras log) | main-log, stamped-line |
| 6 | drop `LOG_PREFIX_PKG_PFBLOCKERNG` | syslog |
| 7 | drop the message's leading newline | stamped-line |
| 8 | log the deferral on the GRANTED path too | granted, feed-pass |
| 9 | guard returns TRUE instead of FALSE | main-log, verb-rc |
| 10 | drop `localize_text()` | *none — recorded gap, see below* |

**9 killed, 1 recorded gap, 0 problems.** Mutant 10 is documented rather than papered over:
with no gettext catalog loaded `localize_text()` is the identity function, so no honest
off-appliance assertion can discriminate its removal — the only alternative would be a
source-text assertion pinning the wrapper's spelling rather than any behaviour. Both the
test-honesty leg and this author reached that independently.

## Gates

`scripts/agent/run-gates.sh --diff origin/devel`:

```text
GATE PASS: python3 scripts/check_coverage_pairing.py --name-status-z
GATE PASS: uv run --locked python scripts/check_composer_vendor.py
GATE PASS: uv run --locked python scripts/check_toggle_registry.py --self-test && … check_toggle_registry.py
GATE PASS: php -l src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
GATE PASS: php -l tests/php/ExtrasDispatcherDeferralLoggingTest.php
GATE FAIL: vendor/bin/phpunit
GATE PASS: composer phpstan
GATE PASS: composer phpcs -- --standard=phpcs.xml.dist src/
```

The only **deterministic** PHPUnit failure is
`DownloadSizeCeilingTest::test_extract_cmd_ceiling_stops_a_child_that_writes_past_it`
("Darwin dd must surface RLIMIT_FSIZE as its EFBIG exit") — Darwin-only, issue #2765,
reproduced identically at base `5be3763d` in an isolated clone (`Tests: 17, Assertions: 86,
Failures: 1`). Four full-suite runs — two at this branch, two at base — showed every *other*
failure varying run to run **on base as well**, with different rows each time; evidence and a
host-load hypothesis are on issue #2828, which this work widened from two rows to include
`PkgCaHookDelegateTest` and `LintEndpointWiringTest`. CI (Linux, one job) has been green on
every head.

Skip-allowlist gate run standalone (the PHPUnit gate short-circuits before it on the Darwin
red): `check_skip_allowlist.py --suite phpunit` → rc=0. The new suite contains no skip
directive of any kind.

No `www/` surface touched, so no UI tier applies; log/syslog behaviour only, covered by the
PHPUnit rows above.

## Deferred findings

- **#2827** — five suites hand-copy the deferral/lock fixture harness; the win needs all
  five converted at once, and a one-consumer trait would itself be the finding.
- **#2828** — a set of full-suite-only flaky rows, with measured evidence they flap on
  `devel` too.
- **#2832** — appliance-tier exit-code test for the `dc`/`dcc` deferral (see above).

🤖 Generated by Oh My Pi and posted on behalf of @andrebrait.
