### PR TITLE
tests: stop the lint endpoint shim leaking a PID-keyed temp dir

### DIFF
--- a/tests/php/LintEndpointWiringTest.php
+++ b/tests/php/LintEndpointWiringTest.php
@@ -97,11 +97,7 @@ final class LintEndpointWiringTest extends TestCase
 	private function shimResidue(int $pid): array
 	{
 		$prefix = sys_get_temp_dir() . '/pfb_lint_shim_' . $pid;
-		$found  = glob($prefix . '_*') ?: [];
-		if (is_dir($prefix)) {
-			array_unshift($found, $prefix);
-		}
-		return $found;
+		return array_merge(glob($prefix) ?: [], glob($prefix . '_*') ?: []);
 	}
 
 	/** @param array<string,mixed> $post @param array<string,string> $server @param array<string,bool> $allowed @return array{body:array<string,mixed>,pid:int} */
@@ -134,8 +130,8 @@ PHP;
 		$this->assertIsResource($process);
 		$pid = (int) proc_get_status($process)['pid'];
 		if ($plantStaleShim) {
-			// The child blocks on STDIN until the fwrite() below, so the plant
-			// always lands before it creates its own shim.
+			// The child blocks on STDIN until the pipe is closed below, so the
+			// plant always lands before it creates its own shim.
 			$residue = sys_get_temp_dir() . '/pfb_lint_shim_' . $pid;
 			$this->planted[] = $residue;
 			@mkdir($residue, 0777, TRUE);

--- a/tests/php/LintEndpointWiringTest.php
+++ b/tests/php/LintEndpointWiringTest.php
@@ -70,9 +70,12 @@ final class LintEndpointWiringTest extends TestCase
 	 */
 	public function testRealPageRunLeavesNoShimResidue(): void
 	{
+		// A checkout without this fix, sharing the host, can already hold a bare
+		// pfb_lint_shim_<pid>, so only what this run added counts.
+		$before = glob(sys_get_temp_dir() . '/pfb_lint_shim_*') ?: [];
 		$result = $this->request(['lang' => 'regex', 'content' => 'x'], ['REQUEST_METHOD' => 'GET']);
 		$this->assertSame('POST only', $result['body']['error']);
-		$this->assertSame([], $this->shimResidue($result['pid']));
+		$this->assertSame([], array_values(array_diff($this->shimResidue($result['pid']), $before)));
 	}
 
 	/**
@@ -80,7 +83,8 @@ final class LintEndpointWiringTest extends TestCase
 	 * Given a shim directory already sitting at this run's PID-keyed path,
 	 * When the real page is requested,
 	 * Then it still answers clean JSON on a clean stderr, instead of the
-	 * mkdir()/"headers already sent" cascade of issue #2612.
+	 * mkdir()/"headers already sent" cascade of issue #2612, and adds no
+	 * residue of its own beside the directory it inherited.
 	 */
 	public function testRealPageSurvivesAShimLeftOverFromARecycledPid(): void
 	{
@@ -91,6 +95,7 @@ final class LintEndpointWiringTest extends TestCase
 			TRUE
 		);
 		$this->assertSame('POST only', $result['body']['error']);
+		$this->assertSame([], array_values(array_diff($this->shimResidue($result['pid']), $this->planted)));
 	}
 
 	/** @return list<string> Shim directories owned by child PID $pid, with or without a per-invocation suffix. */

--- a/tests/php/LintEndpointWiringTest.php
+++ b/tests/php/LintEndpointWiringTest.php
@@ -9,6 +9,18 @@ final class LintEndpointWiringTest extends TestCase
 	private const ROOT = __DIR__ . '/../..';
 	private const PAGE = self::ROOT . '/src/usr/local/www/pfblockerng/pfblockerng_lint.php';
 
+	/** @var list<string> Stale shim paths planted by request(), swept after each test. */
+	private array $planted = [];
+
+	protected function tearDown(): void
+	{
+		foreach ($this->planted as $path) {
+			@unlink($path . '/guiconfig.inc');
+			@rmdir($path);
+		}
+		$this->planted = [];
+	}
+
 	public function testRealPageRejectsWrongMethodBeforeDispatch(): void
 	{
 		$result = $this->request(['lang' => 'regex', 'content' => 'x'], ['REQUEST_METHOD' => 'GET']);
@@ -49,8 +61,51 @@ final class LintEndpointWiringTest extends TestCase
 		$this->assertSame('content too large', $large['body']['error']);
 	}
 
-	/** @param array<string,mixed> $post @param array<string,string> $server @param array<string,bool> $allowed @return array{body:array<string,mixed>} */
-	private function request(array $post, array $server, array $allowed = []): array
+	/**
+	 * Scenario: the include shim is per-invocation scratch.
+	 * Given a run of the real page,
+	 * When it finishes,
+	 * Then the temp directory holds nothing keyed to that run -- a shim left
+	 * behind is what lets a later run on a recycled PID collide (issue #2612).
+	 */
+	public function testRealPageRunLeavesNoShimResidue(): void
+	{
+		$result = $this->request(['lang' => 'regex', 'content' => 'x'], ['REQUEST_METHOD' => 'GET']);
+		$this->assertSame('POST only', $result['body']['error']);
+		$this->assertSame([], $this->shimResidue($result['pid']));
+	}
+
+	/**
+	 * Scenario: the OS recycles a PID an earlier suite run already used.
+	 * Given a shim directory already sitting at this run's PID-keyed path,
+	 * When the real page is requested,
+	 * Then it still answers clean JSON on a clean stderr, instead of the
+	 * mkdir()/"headers already sent" cascade of issue #2612.
+	 */
+	public function testRealPageSurvivesAShimLeftOverFromARecycledPid(): void
+	{
+		$result = $this->request(
+			['lang' => 'regex', 'content' => 'x'],
+			['REQUEST_METHOD' => 'GET'],
+			[],
+			TRUE
+		);
+		$this->assertSame('POST only', $result['body']['error']);
+	}
+
+	/** @return list<string> Shim directories owned by child PID $pid, with or without a per-invocation suffix. */
+	private function shimResidue(int $pid): array
+	{
+		$prefix = sys_get_temp_dir() . '/pfb_lint_shim_' . $pid;
+		$found  = glob($prefix . '_*') ?: [];
+		if (is_dir($prefix)) {
+			array_unshift($found, $prefix);
+		}
+		return $found;
+	}
+
+	/** @param array<string,mixed> $post @param array<string,string> $server @param array<string,bool> $allowed @return array{body:array<string,mixed>,pid:int} */
+	private function request(array $post, array $server, array $allowed = [], bool $plantStaleShim = FALSE): array
 	{
 		$payload = json_encode(compact('post', 'server', 'allowed'), JSON_THROW_ON_ERROR);
 		$root = var_export(self::ROOT, TRUE);
@@ -60,8 +115,15 @@ final class LintEndpointWiringTest extends TestCase
 \$GLOBALS['pfb_test_allowed_pages'] = \$request['allowed'];
 \$_SERVER = \$request['server'];
 \$_POST = \$request['post'];
-\$shim = sys_get_temp_dir() . '/pfb_lint_shim_' . getmypid();
-mkdir(\$shim, 0777, TRUE);
+\$shim = sys_get_temp_dir() . '/pfb_lint_shim_' . getmypid() . '_' . bin2hex(random_bytes(8));
+if (!mkdir(\$shim, 0700, TRUE)) {
+	fwrite(STDERR, "lint include shim creation failed\\n");
+	exit(1);
+}
+register_shutdown_function(static function () use (\$shim): void {
+	@unlink(\$shim . '/guiconfig.inc');
+	@rmdir(\$shim);
+});
 file_put_contents(\$shim . '/guiconfig.inc', "<?php");
 set_include_path(\$shim . PATH_SEPARATOR . get_include_path());
 require {$root} . '/tests/php/bootstrap.php';
@@ -70,6 +132,15 @@ PHP;
 		$descriptors = [0 => ['pipe', 'r'], 1 => ['pipe', 'w'], 2 => ['pipe', 'w']];
 		$process = proc_open([PHP_BINARY, '-r', $script], $descriptors, $pipes);
 		$this->assertIsResource($process);
+		$pid = (int) proc_get_status($process)['pid'];
+		if ($plantStaleShim) {
+			// The child blocks on STDIN until the fwrite() below, so the plant
+			// always lands before it creates its own shim.
+			$residue = sys_get_temp_dir() . '/pfb_lint_shim_' . $pid;
+			$this->planted[] = $residue;
+			@mkdir($residue, 0777, TRUE);
+			$this->assertDirectoryExists($residue);
+		}
 		fwrite($pipes[0], $payload);
 		fclose($pipes[0]);
 		$stdout = stream_get_contents($pipes[1]);
@@ -81,6 +152,6 @@ PHP;
 		$body = json_decode((string) $stdout, TRUE);
 		$this->assertIsArray($body, (string) $stdout);
 		$this->assertSame(0, $status);
-		return ['body' => $body];
+		return ['body' => $body, 'pid' => $pid];
 	}
 }

--- a/tests/php/LintEndpointWiringTest.php
+++ b/tests/php/LintEndpointWiringTest.php
@@ -75,7 +75,7 @@ final class LintEndpointWiringTest extends TestCase
 		$before = glob(sys_get_temp_dir() . '/pfb_lint_shim_*') ?: [];
 		$result = $this->request(['lang' => 'regex', 'content' => 'x'], ['REQUEST_METHOD' => 'GET']);
 		$this->assertSame('POST only', $result['body']['error']);
-		$this->assertSame([], array_values(array_diff($this->shimResidue($result['pid']), $before)));
+		$this->assertSame([], array_diff($this->shimResidue($result['pid']), $before));
 	}
 
 	/**
@@ -95,7 +95,7 @@ final class LintEndpointWiringTest extends TestCase
 			TRUE
 		);
 		$this->assertSame('POST only', $result['body']['error']);
-		$this->assertSame([], array_values(array_diff($this->shimResidue($result['pid']), $this->planted)));
+		$this->assertSame([], array_diff($this->shimResidue($result['pid']), $this->planted));
 	}
 
 	/** @return list<string> Shim directories owned by child PID $pid, with or without a per-invocation suffix. */


### PR DESCRIPTION
Fixes #2612

## What was wrong

`LintEndpointWiringTest` spawned a `php -r` child that created its `guiconfig.inc` include shim
at `sys_get_temp_dir() . '/pfb_lint_shim_' . getmypid()` and never removed it. Every suite run
left one directory behind. Once the OS recycled a PID a previous run had used, the child's
`mkdir()` warned `File exists`, that warning was emitted before the page under test set its
headers, and the run failed on output it never expected — attributed to whatever branch happened
to be running at the time.

## Probe: which cause?

Two hypotheses, one probe. **H1** — a residual PID-keyed directory makes the child's `mkdir()`
warn, and the warning lands ahead of the page's headers. **H2** — the page's own header path
emits output before headers regardless, so residue is not the producer.

The probe reproduced the committed child script byte-for-byte and ran it twice: once clean, once
with a directory planted at the child's own PID-keyed path. The child blocks on
`stream_get_contents(STDIN)` until the parent writes, so the plant always precedes its `mkdir()`.

Leg (a), control — clean, and **the shim is still left behind**:

```
--- exit status: 0
--- stdout:
{"error":"POST only"}
--- stderr:

--- json_decode is array: true
--- shim left behind at /var/folders/.../T/pfb_lint_shim_51295: true
```

Leg (b), residue planted — the exact cascade the issue quotes:

```
planted: /var/folders/.../T/pfb_lint_shim_51299 exists=true
--- stdout:

Warning: mkdir(): File exists in Command line code on line 6

Warning: http_response_code(): Cannot set response code - headers already sent (output started at Command line code:6) in .../pfblockerng_lint.php on line 49

Warning: Cannot modify header information - headers already sent by (output started at Command line code:6) in .../pfblockerng_lint.php on line 51
{"error":"POST only"}
--- json_decode is array: false
```

H1 confirmed, H2 refuted: the page is clean on its own and only the residue produces the cascade.

For scale, this host had accumulated **932** stale `pfb_lint_shim_*` directories before the work
started, consistent with the 557 the issue reports.

## The fix

Key the shim on a per-invocation random suffix and drop it from a shutdown function, mirroring
`tests/php/WidgetSubmitPostGuardTest.php:71-79`, which already does exactly this:

```php
$shim = sys_get_temp_dir() . '/pfb_lint_shim_' . getmypid() . '_' . bin2hex(random_bytes(8));
if (!mkdir($shim, 0700, TRUE)) {
	fwrite(STDERR, "lint include shim creation failed\n");
	exit(1);
}
register_shutdown_function(static function () use ($shim): void {
	@unlink($shim . '/guiconfig.inc');
	@rmdir($shim);
});
```

The shutdown hook rather than a trailing statement is load-bearing: `pfblockerng_lint.php` ends
in `exit`, so cleanup placed after the `require` would never run.

No production code is touched; the diff is one test file.

## Test-first: RED before, GREEN after, frozen

Two tests pin the two properties. `testRealPageRunLeavesNoShimResidue` asserts a run leaves
nothing under its own child PID. `testRealPageSurvivesAShimLeftOverFromARecycledPid` plants a
shim at the child's PID-keyed path before the child reads its payload and requires clean JSON on
a clean stderr anyway. Scoping the residue assertion to the invocation's own child PID, and diffing it against a
snapshot of `pfb_lint_shim_*` taken before the run — against the deliberately planted directory,
in the recycled-PID test — keeps it immune to any other suite run sharing the host.

Frozen test-file hash at red time: `43566f23c569e4a35202254785bf195709bdf9dd`. That evidence is
anchored at the first commit, `e414d4ee`, not at HEAD: two review-fix commits edited the test
bodies after green, so the reconstruction below reproduces from `e414d4ee` and deliberately does
not from HEAD.

RED — the two new tests, on untouched harness code:

```
...FF                                                               5 / 5 (100%)

1) LintEndpointWiringTest::testRealPageRunLeavesNoShimResidue
Failed asserting that two arrays are identical.
-Array &0 []
+Array &0 [
+    0 => '/var/folders/.../T/pfb_lint_shim_53513',
+]

2) LintEndpointWiringTest::testRealPageSurvivesAShimLeftOverFromARecycledPid
PHP Warning:  mkdir(): File exists in Command line code on line 6
PHP Warning:  http_response_code(): Cannot set response code - headers already sent ...
PHP Warning:  Cannot modify header information - headers already sent by ...

FAILURES!
Tests: 5, Assertions: 34, Failures: 2.
```

GREEN — same tests, zero edits, after the fix:

```
.....                                                               5 / 5 (100%)
OK (5 tests, 37 assertions)
```

At HEAD, after the review fixes, the same class reads `OK (5 tests, 38 assertions)` — one
assertion more, because the recycled-PID test gained a residue assertion of its own.

The fix and the tests live in the same file, because the harness *is* the subject of the defect.
The freeze is therefore proven on the test methods rather than on whole-file bytes: reverting
only the nine child-script lines back to the original two reproduces the red-time hash exactly.

```
reconstructed red hash: 43566f23c569e4a35202254785bf195709bdf9dd
matches red-time freeze hash 43566f23c569e4a35202254785bf195709bdf9dd: True
```

Everything else in the file — both test bodies, the `shimResidue()` helper, the `tearDown()`
sweep and the plant seam — is byte-identical between the red and green runs.

## Mutation proof

Driver asserts each needle occurs exactly once, applies it, asserts `git diff` is non-empty,
runs the class, reverts, and asserts `git diff` is empty again before the next mutant.

At HEAD:

| Mutant | Killed by | Observed |
| --- | --- | --- |
| M1 — remove uniqueness (PID-only shim path) | `testRealPageSurvivesAShimLeftOverFromARecycledPid` | `mkdir(): File exists` + `lint include shim creation failed` on stderr; `Failures: 1` |
| M2 — remove the cleanup entirely | `testRealPageRunLeavesNoShimResidue` **and** `testRealPageSurvivesAShimLeftOverFromARecycledPid` | `Failures: 2` |
| M3 — cleanup off the failure path (after the `require`, not registered) | `testRealPageRunLeavesNoShimResidue` **and** `testRealPageSurvivesAShimLeftOverFromARecycledPid` | `Failures: 2` |

Baseline and post-revert runs both `OK (5 tests, 38 assertions)`.

The most direct answer to "were the tests weakened when they were edited after green" is to run
the tests as they stand at HEAD against the original, unfixed child script. They still catch it,
2/2:

```
...FF                                                               5 / 5 (100%)

1) LintEndpointWiringTest::testRealPageRunLeavesNoShimResidue
2) LintEndpointWiringTest::testRealPageSurvivesAShimLeftOverFromARecycledPid
PHP Warning:  mkdir(): File exists in Command line code on line 6
PHP Warning:  http_response_code(): Cannot set response code - headers already sent ...
PHP Warning:  Cannot modify header information - headers already sent by ...

FAILURES!
Tests: 5, Assertions: 34, Failures: 2.
```

At the freeze commit `e414d4ee`, before the review fixes, M2 and M3 killed only the residue test
(`Failures: 1`, residue `pfb_lint_shim_63047_75dcc4e4db65cb38` and
`pfb_lint_shim_63064_7e733ee148a6e870` respectively). M2 and M3 now killing the survival test too
is what proves that test's added residue assertion is not a tautology.

## Residue counts, executed

Host cleared of `pfb_lint_shim_*` first, by exact directory name.

At the freeze commit `e414d4ee`:

```
BEFORE class run:  pfb_lint_shim_* 0
AFTER  class run:  pfb_lint_shim_* 0        OK (5 tests, 37 assertions)

BEFORE full suite: pfb_lint_shim_* 0        pfb_widget_shim_* 1248   pfb_edit_hooks_shim_* 183
AFTER  full suite: pfb_lint_shim_* 5        pfb_widget_shim_* 1262   pfb_edit_hooks_shim_* 185
```

Re-measured at HEAD, on a host by then carrying 288 `pfb_lint_shim_*` directories left by the
review legs' own mutant runs and by checkouts without this fix — which is a better test of the
property than a clean host is:

```
class run: OK (5 tests, 38 assertions)
BEFORE class run at HEAD: 288
AFTER  class run at HEAD: 288
added by the run: []
```

The five `pfb_lint_shim_*` entries after that full suite are not this branch's. The branch nets
zero by construction: the child removes its own shim from a shutdown function, and the one path
the harness deliberately creates — the planted directory in the recycled-PID test — is swept by
`tearDown()`. The `added by the run: []` measurement above is the direct check of that, on a dirty
host. This host was running concurrent suites from other worktrees at the time, and those five
carry the bare `pfb_lint_shim_<pid>` shape the unfixed code produces.

The `pfb_widget_shim_*` and `pfb_edit_hooks_shim_*` growth is the same defect in three sibling
test files that were outside #2612's scope. Split out as #2834.

The correctness leg's review turned up one more instance outside this diff: `tests/php/bootstrap.php:30-34`
keys the whole PHPUnit sandbox (`db/`, `log/`, `tmp/`) on the PID alone and never removes it, with
the `mkdir` `@`-suppressed so a recycled PID silently inherits a dead run's state instead of
failing loudly. 8944 of those sandboxes on this host, 2202 of them non-empty, 4639 residual files.
Split out as #2836.

## Review fixes

`e414d4ee` is the fix and the two frozen tests. Two commits follow.

`42bd0997` adopts two round-1 nitpicks verbatim. The over-engineering leg's: `shimResidue()`
dropped a temporary, an `is_dir()` branch and an `array_unshift()` for
`return array_merge(glob($prefix) ?: [], glob($prefix . '_*') ?: []);` — `glob()` with no wildcard
matches the exact path when it exists, and `GLOB_BRACE` stays out because musl builds lack it. The
correctness leg's: the plant comment said the child blocks until the `fwrite()`, but that leg
probed the child staying blocked through a full 64 KiB write and released only by the `fclose()`
that delivers EOF, so the comment now says what actually holds.

`86b720e0` goes past what the reviewers asked for. The correctness leg filed a nitpick, explicitly
requesting no change, noting that the residue check's bare-prefix arm can also match a
`pfb_lint_shim_<pid>` left by a checkout without this fix, so on a shared host the test could red
with no defect behind it. Shipping a test that reds on somebody else's leak is the exact failure
this issue is about, so both residue assertions now diff against a baseline — a snapshot taken
before the run in one test, the deliberately planted directory in the other — and speak only about
what the invocation itself created. Nothing a mutant produces falls into that exclusion, which the
kill table above demonstrates.

## Gates

Re-run on this head after both review-fix commits.

```
GATE PASS: python3 scripts/check_coverage_pairing.py --name-status-z
GATE PASS: uv run --locked python scripts/check_composer_vendor.py
GATE PASS: uv run --locked python scripts/check_toggle_registry.py --self-test && uv run --locked python scripts/check_toggle_registry.py
GATE PASS: php -l tests/php/LintEndpointWiringTest.php
GATE PASS: vendor/bin/phpunit
GATE PASS: composer phpstan
GATE PASS: composer phpcs -- --standard=phpcs.xml.dist src/
GATES: PASS
```

🤖 Generated by Oh My Pi and posted on behalf of @andrebrait.
