### PR TITLE
pfblockerng: name the Unbound start and stop-wait boundaries

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -11261,6 +11261,16 @@ function pfb_dnsbl_tld_stats_finalize(array $group_counts): void {
 	dnsbl_save_stats();
 }
 
+// The daemon-start command and the stop-wait budget are named so a harness can
+// override them before this file loads (issue #2613: the unit suite would otherwise
+// start a real resolver on any box carrying Unbound at the shipped path).
+if (!defined('PFB_UNBOUND_START_CMD')) {
+	define('PFB_UNBOUND_START_CMD', '/usr/local/sbin/unbound -c /var/unbound/unbound.conf 2>&1');
+}
+if (!defined('PFB_UNBOUND_STOP_WAIT')) {
+	define('PFB_UNBOUND_STOP_WAIT', 30);
+}
+
 // Function to Start Unbound
 function pfb_stop_start_unbound($type) {
 	global $g, $pfb;
@@ -11271,8 +11281,8 @@ function pfb_stop_start_unbound($type) {
 		sigkillbypid("{$g['varrun_path']}/unbound.pid", 'TERM');
 	}
 
-	// If unbound is still running, wait up to 30 seconds for it to terminate.
-	for ($i=1; $i <= 30; $i++) {
+	// If unbound is still running, wait up to PFB_UNBOUND_STOP_WAIT seconds for it to terminate.
+	for ($i=1; $i <= PFB_UNBOUND_STOP_WAIT; $i++) {
 		if (is_process_running('unbound')) {
 			pfb_logger('.', 1);
 			sleep(1);
@@ -11296,7 +11306,7 @@ function pfb_stop_start_unbound($type) {
 	}
 
 	pfb_logger("\nStarting Unbound Resolver", 1);
-	exec("/usr/local/sbin/unbound -c /var/unbound/unbound.conf 2>&1", $final['result'], $final['retval']);
+	exec(PFB_UNBOUND_START_CMD, $final['result'], $final['retval']);
 	return $final;
 }
 

--- a/tests/php/DnsblLoadedCountTest.php
+++ b/tests/php/DnsblLoadedCountTest.php
@@ -92,9 +92,10 @@ final class DnsblLoadedCountTest extends TestCase
 		$GLOBALS['g']['varrun_path'] = $this->dir;
 		$GLOBALS['config']['unbound'] = ['python' => 'on', 'python_script' => 'pfb_unbound'];
 
-		// Unbound is up throughout. The pass an absent count forces (the RAM gate failing
-		// closed) takes the restart fallback, whose stop-wait the harness caps (issue
-		// #2613) -- so this double does not have to model the daemon dying to stay fast.
+		// Unbound is up throughout, so the pass an absent count forces (the RAM gate
+		// failing closed) reaches the real restart fallback and its post-restart
+		// confirmation branch, and the harness caps the stop-wait (issue #2613) -- this
+		// double neither has to model the daemon dying nor to keep a call counter.
 		$GLOBALS['pfb_test_process_running'] = ['unbound' => TRUE];
 
 		// A live, healthy generation: manifest published, Python's emitted count on disk.

--- a/tests/php/DnsblLoadedCountTest.php
+++ b/tests/php/DnsblLoadedCountTest.php
@@ -92,14 +92,10 @@ final class DnsblLoadedCountTest extends TestCase
 		$GLOBALS['g']['varrun_path'] = $this->dir;
 		$GLOBALS['config']['unbound'] = ['python' => 'on', 'python_script' => 'pfb_unbound'];
 
-		// Unbound answers "running" once, then reports gone. Without the second half, a
-		// pass that takes the restart fallback (which is exactly what an absent count
-		// forces, the RAM gate failing closed) sits in a real 30-second stop-wait loop.
-		$checks = 0;
-		$GLOBALS['pfb_test_process_running'] = ['unbound' => static function () use (&$checks): bool {
-			$checks++;
-			return $checks === 1;
-		}];
+		// Unbound is up throughout. The pass an absent count forces (the RAM gate failing
+		// closed) takes the restart fallback, whose stop-wait the harness caps (issue
+		// #2613) -- so this double does not have to model the daemon dying to stay fast.
+		$GLOBALS['pfb_test_process_running'] = ['unbound' => TRUE];
 
 		// A live, healthy generation: manifest published, Python's emitted count on disk.
 		file_put_contents($GLOBALS['pfb']['unbound_py_count'], "11732\n");

--- a/tests/php/PfbSyncStatusDnsblWritersTest.php
+++ b/tests/php/PfbSyncStatusDnsblWritersTest.php
@@ -371,9 +371,9 @@ final class PfbSyncStatusDnsblWritersTest extends TestCase
 		// "should we log Reloading" check, (3)/(4) pfb_stop_start_unbound()'s own
 		// "wait for it to stop" loop -- once per invocation, TWO invocations happen
 		// here (the first restart, then this file's retval!=0 retry) -- FALSE so each
-		// loop breaks on its very first check instead of spinning up to 30 real
-		// seconds, (5) the post-restart "Confirm that Resolver is running" check, (6)
-		// pfb_dnsbl_converged()'s own read at the tail. Only calls 3 and 4 are FALSE.
+		// loop breaks on its very first check, (5) the post-restart "Confirm that
+		// Resolver is running" check, (6) pfb_dnsbl_converged()'s own read at the tail.
+		// Only calls 3 and 4 are FALSE.
 		$calls = 0;
 		$GLOBALS['pfb_test_process_running']['unbound'] = function () use (&$calls) {
 			$calls++;
@@ -439,8 +439,8 @@ final class PfbSyncStatusDnsblWritersTest extends TestCase
 
 		// TRUE only for the two expected success-path calls -- if a regression falls
 		// through to the restart path instead, is_process_running() resolves FALSE
-		// immediately so pfb_stop_start_unbound()'s 30-iteration wait loop never
-		// real-sleeps; the call-count assertion below still catches the regression.
+		// immediately so pfb_stop_start_unbound()'s wait loop never real-sleeps; the
+		// call-count assertion below still catches the regression.
 		$calls = 0;
 		$GLOBALS['pfb_test_process_running']['unbound'] = function () use (&$calls) {
 			$calls++;

--- a/tests/php/UnboundRestartSeamTest.php
+++ b/tests/php/UnboundRestartSeamTest.php
@@ -1,0 +1,171 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * issue #2613 -- pfb_stop_start_unbound() execs the Unbound daemon and polls for the
+ * outgoing process to exit. Both boundaries are named constants (PFB_UNBOUND_START_CMD,
+ * PFB_UNBOUND_STOP_WAIT) that tests/php/bootstrap.php overrides before the package loads,
+ * so a unit run starts no resolver on a developer box that HAS Unbound installed at the
+ * shipped path, and no individual test has to defuse the appliance's 30-poll stop-wait.
+ *
+ * The shipped appliance values are pinned from source: the harness necessarily replaces
+ * both constants for the whole process, so the only place their real values can be
+ * asserted is the file that ships them.
+ */
+#[CoversFunction('pfb_stop_start_unbound')]
+final class UnboundRestartSeamTest extends TestCase
+{
+	private string $dir;
+	/** @var array<string, array{0: bool, 1: mixed}> key => [existed, value] */
+	private array $savedPfb = [];
+	/** @var array{0: bool, 1: mixed} */
+	private array $savedVarrun = [FALSE, NULL];
+
+	protected function setUp(): void
+	{
+		$this->dir = sys_get_temp_dir() . '/pfb_unbound_seam_' . getmypid() . '_' . uniqid();
+		mkdir($this->dir, 0777, TRUE);
+
+		// Track key EXISTENCE separately from value: 'dnsbl_python_unmount' is legitimately
+		// boolean FALSE, so a FALSE sentinel would unset a sibling suite's value instead of
+		// restoring it.
+		foreach (['log', 'errlog', 'dnsbl_python_unmount'] as $key) {
+			$this->savedPfb[$key] = [
+				array_key_exists($key, $GLOBALS['pfb'] ?? []),
+				$GLOBALS['pfb'][$key] ?? NULL,
+			];
+		}
+		$this->savedVarrun = [
+			array_key_exists('varrun_path', $GLOBALS['g'] ?? []),
+			$GLOBALS['g']['varrun_path'] ?? NULL,
+		];
+
+		// varrun_path holds no unbound.pid, so the TERM half is skipped; the stop-wait
+		// loop and the daemon start are what this file exercises.
+		$GLOBALS['pfb'] = array_replace($GLOBALS['pfb'], [
+			'log'                  => "{$this->dir}/pfblockerng.log",
+			'errlog'               => "{$this->dir}/error.log",
+			'dnsbl_python_unmount' => FALSE,
+		]);
+		$GLOBALS['g']['varrun_path'] = $this->dir;
+	}
+
+	protected function tearDown(): void
+	{
+		foreach ($this->savedPfb as $key => [$existed, $value]) {
+			if ($existed) {
+				$GLOBALS['pfb'][$key] = $value;
+			} else {
+				unset($GLOBALS['pfb'][$key]);
+			}
+		}
+		[$existed, $value] = $this->savedVarrun;
+		if ($existed) {
+			$GLOBALS['g']['varrun_path'] = $value;
+		} else {
+			unset($GLOBALS['g']['varrun_path']);
+		}
+		unset($GLOBALS['pfb_test_process_running']);
+		rmdir_recursive($this->dir);
+	}
+
+	/**
+	 * Invocations the harness daemon-start double has recorded so far. Counted
+	 * relatively, never absolutely: the log accumulates over the whole process, and
+	 * sibling suites that reach the restart fallback append to it too.
+	 *
+	 * @return list<string>
+	 */
+	private function doubleInvocations(): array
+	{
+		$log = (string) ($GLOBALS['pfb_test_unbound_start_log'] ?? '');
+		$this->assertNotSame('', $log,
+			'the harness must publish the path of its daemon-start double log');
+		return file_exists($log) ? (file($log, FILE_IGNORE_NEW_LINES) ?: []) : [];
+	}
+
+	/**
+	 * Scenario: a restart under the unit harness must not reach the real daemon.
+	 *   Given the harness has overridden the daemon-start boundary,
+	 *   When pfb_stop_start_unbound() runs its start step,
+	 *   Then the harness double records the attempt and the shipped binary is never named.
+	 */
+	public function testDaemonStartRunsTheHarnessDoubleNotTheShippedBinary(): void
+	{
+		$before = $this->doubleInvocations();
+		$this->assertTrue(defined('PFB_UNBOUND_START_CMD'),
+			'the daemon-start boundary must be an overridable constant, not a hardcoded exec()');
+		$this->assertStringNotContainsString('/usr/local/sbin/unbound', PFB_UNBOUND_START_CMD,
+			'a unit run must never be pointed at the real Unbound binary');
+		$GLOBALS['pfb_test_process_running']['unbound'] = FALSE;
+
+		$final = pfb_stop_start_unbound(' (DNSBL python)');
+
+		$this->assertCount(count($before) + 1, $this->doubleInvocations(),
+			'the start step must run the harness double exactly once per call');
+		$this->assertSame(127, $final['retval'],
+			'the double must keep reporting command-not-found, the status an absent binary '
+			. "already produces off-appliance, so the caller's retry branch stays exercised");
+		$this->assertNotEmpty($final['result'],
+			'the caller logs the start output on failure, so the double must produce one');
+	}
+
+	/**
+	 * Scenario: the stop-wait must not cost a test the appliance's full budget.
+	 *   Given a process-running double that never reports the daemon gone,
+	 *   When pfb_stop_start_unbound() waits for it to terminate,
+	 *   Then it polls only the harness budget -- 30 one-second polls per call otherwise.
+	 */
+	public function testStopWaitIsBoundedWhenTheDaemonNeverExits(): void
+	{
+		$polls = 0;
+		$GLOBALS['pfb_test_process_running']['unbound'] = static function () use (&$polls): bool {
+			$polls++;
+			return TRUE;
+		};
+
+		pfb_stop_start_unbound('');
+
+		$this->assertLessThanOrEqual(3, $polls,
+			'a test that never reports the daemon gone must not pay the appliance stop-wait');
+		$this->assertSame(PFB_UNBOUND_STOP_WAIT, $polls,
+			'the wait loop must poll exactly its configured budget when the daemon never exits');
+	}
+
+	/**
+	 * The appliance keeps starting the shipped daemon against the shipped config, and
+	 * keeps waiting the full 30 seconds for the old one -- asserted against the source
+	 * because the harness replaces both constants at load time in this process.
+	 */
+	public function testShippedDefaultsStillStartTheApplianceDaemon(): void
+	{
+		$path = dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng.inc';
+		$src = (string) @file_get_contents($path);
+		$this->assertNotSame('', $src, "could not read {$path}");
+
+		// strpos() rather than assertStringContainsString(): the haystack is the whole
+		// 800 KB package file, and a failed containment assertion would dump all of it.
+		$this->assertNotFalse(strpos($src,
+			"define('PFB_UNBOUND_START_CMD', '/usr/local/sbin/unbound -c /var/unbound/unbound.conf 2>&1');"),
+			'the appliance must still start the shipped daemon against the shipped config');
+		$this->assertNotFalse(strpos($src, "define('PFB_UNBOUND_STOP_WAIT', 30);"),
+			'the appliance must still wait up to 30 seconds for the outgoing daemon');
+
+		$start = strpos($src, 'function pfb_stop_start_unbound(');
+		$this->assertNotFalse($start, 'pfb_stop_start_unbound() must still exist');
+		$end = strpos($src, "\n}\n", $start);
+		$this->assertNotFalse($end, 'could not find the end of pfb_stop_start_unbound()');
+		$body = substr($src, $start, $end - $start);
+
+		$this->assertStringContainsString('exec(PFB_UNBOUND_START_CMD,', $body,
+			'the daemon start must run through the constant so a harness can neuter it');
+		$this->assertStringNotContainsString('/usr/local/sbin/unbound', $body,
+			'no branch may reach the daemon binary except through PFB_UNBOUND_START_CMD');
+		$this->assertStringContainsString('$i <= PFB_UNBOUND_STOP_WAIT;', $body,
+			'the stop-wait budget must come from the constant, not a literal');
+	}
+}

--- a/tests/php/UnboundRestartSeamTest.php
+++ b/tests/php/UnboundRestartSeamTest.php
@@ -130,8 +130,8 @@ final class UnboundRestartSeamTest extends TestCase
 
 		pfb_stop_start_unbound('');
 
-		$this->assertLessThanOrEqual(3, $polls,
-			'a test that never reports the daemon gone must not pay the appliance stop-wait');
+		$this->assertLessThan(30, $polls,
+			"a test that never reports the daemon gone must not pay the appliance's 30 one-second polls");
 		$this->assertSame(PFB_UNBOUND_STOP_WAIT, $polls,
 			'the wait loop must poll exactly its configured budget when the daemon never exits');
 	}

--- a/tests/php/bootstrap.php
+++ b/tests/php/bootstrap.php
@@ -46,6 +46,21 @@ $GLOBALS['pfb'] = [];
 $GLOBALS['argv'] = ['pfblockerng.inc'];
 $GLOBALS['argc'] = 1;
 
+// 4b. Keep the resolver start dormant too. pfb_stop_start_unbound() execs the Unbound
+//     daemon and polls up to 30 one-second rounds for the outgoing one (issue #2613), so
+//     point its start command at a shell double that records the attempt and exits 127 --
+//     the command-not-found status an absent binary already produces here -- and cap the
+//     poll budget, so no individual test has to defuse either. Both guarded: a second
+//     load of this bootstrap must stay silent.
+$GLOBALS['pfb_test_unbound_start_log'] = "{$pfb_test_tmp}/unbound_start.log";
+if (!defined('PFB_UNBOUND_START_CMD')) {
+	define('PFB_UNBOUND_START_CMD', 'echo "unit-test double: Unbound start suppressed" | tee -a '
+		. escapeshellarg($GLOBALS['pfb_test_unbound_start_log']) . '; exit 127');
+}
+if (!defined('PFB_UNBOUND_STOP_WAIT')) {
+	define('PFB_UNBOUND_STOP_WAIT', 2);
+}
+
 // 2 + load. Define the production functions by including the real source.
 // pfblockerng.inc is legacy code that emits some load-time E_DEPRECATED/E_WARNING
 // notices (e.g. an optional-before-required parameter, a switch `continue`) that

--- a/tests/php/bootstrap.php
+++ b/tests/php/bootstrap.php
@@ -46,16 +46,14 @@ $GLOBALS['pfb'] = [];
 $GLOBALS['argv'] = ['pfblockerng.inc'];
 $GLOBALS['argc'] = 1;
 
-// 4b. Keep the resolver start dormant too. pfb_stop_start_unbound() execs the Unbound
-//     daemon and polls up to 30 one-second rounds for the outgoing one (issue #2613), so
-//     point its start command at a shell double that records the attempt and exits 127 --
-//     the command-not-found status an absent binary already produces here -- and cap the
-//     poll budget, so no individual test has to defuse either. Both guarded: a second
-//     load of this bootstrap must stay silent.
+// 4b. Keep the resolver start dormant too, the sibling of step 4: no unit test may
+//     start Unbound (issue #2613) or pay its 30-poll stop-wait. The double exits 127
+//     because an absent binary returns exactly that off-appliance, which is what keeps
+//     the caller's retval != 0 retry branch exercised. Guarded: a re-load stays silent.
 $GLOBALS['pfb_test_unbound_start_log'] = "{$pfb_test_tmp}/unbound_start.log";
 if (!defined('PFB_UNBOUND_START_CMD')) {
 	define('PFB_UNBOUND_START_CMD', 'echo "unit-test double: Unbound start suppressed" | tee -a '
-		. escapeshellarg($GLOBALS['pfb_test_unbound_start_log']) . '; exit 127');
+		. escapeshellarg($GLOBALS['pfb_test_unbound_start_log']) . ' 2>&1; exit 127');
 }
 if (!defined('PFB_UNBOUND_STOP_WAIT')) {
 	define('PFB_UNBOUND_STOP_WAIT', 2);


### PR DESCRIPTION
Fixes #2613

## What was wrong

`pfb_stop_start_unbound()` ended in a hardcoded daemon start:

```php
exec("/usr/local/sbin/unbound -c /var/unbound/unbound.conf 2>&1", $final['result'], $final['retval']);
```

No seam, so a unit run could start a real resolver on any host that has Unbound at that path
(Homebrew's prefix on Intel macOS *is* `/usr/local`, and FreeBSD `pkg` installs `unbound` to exactly
`/usr/local/sbin/unbound`). The same function polled `is_process_running('unbound')` 30 times with
`sleep(1)`, so a test whose double kept answering "running" paid 30 real seconds per restart.

## Probe: which hypothesis holds

**H1** — the hazard reaches any host where `/usr/local/sbin/unbound` exists; nothing gates the
`exec()` but the file's existence.
**H2** — it needs a live appliance; something on the path (pid file, chroot mounts,
`/var/unbound/unbound.conf`, python mounts) stops a dev box from reaching it.

**Leg A — is the line reached?** The two tests named in the issue, run on unmodified `devel` with
`exec()` disabled, so a reached call is loud and no resolver can start:

```text
$ php -d disable_functions=exec vendor/bin/phpunit --no-coverage \
    --filter 'testRestartFallbackDoesNotRestoreOrBulkFlushCache|testLoadedCountIsNotCarriedOverFromAPreviousGeneration'
1) DnsblLoadedCountTest::testLoadedCountIsNotCarriedOverFromAPreviousGeneration
Error: Call to undefined function exec()
  src/usr/local/pkg/pfblockerng/pfblockerng.inc:11299   <- the daemon start
  src/usr/local/pkg/pfblockerng/pfblockerng.inc:11587   <- pfb_reload_unbound()
  src/usr/local/pkg/pfblockerng/pfblockerng.inc:11767   <- pfb_update_unbound()
  tests/php/DnsblLoadedCountTest.php:154
2) PfbUpdateUnboundCachePolicyTest::testRestartFallbackDoesNotRestoreOrBulkFlushCache
Error: Call to undefined function exec()
  (same four frames, tests/php/PfbUpdateUnboundCachePolicyTest.php:147)
Tests: 2, Assertions: 4, Errors: 2.
```

Reached from a bare dev box with no appliance state at all: **H2 refuted.**

**Leg B — would it start what lives there?** Isolated clone of `e0ea7dad`, the daemon binary path
(and only that) replaced with a recorder that logs its argv, prints a line and exits 0 like a
successful daemon start — never a resolver, never the real config consumed:

```text
$ vendor/bin/phpunit --no-coverage --filter '<the two tests>'
OK (2 tests, 11 assertions)
$ cat started.log
INVOKED: -c /var/unbound/unbound.conf
INVOKED: -c /var/unbound/unbound.conf

$ vendor/bin/phpunit --no-coverage          # whole suite
Tests: 5729, Assertions: 32874 ... OK, but there were issues!
$ wc -l < started.log
4
```

**H1 confirmed:** one `vendor/bin/phpunit` starts whatever sits at `/usr/local/sbin/unbound`
**4 times**, each against `/var/unbound/unbound.conf`.

**Leg B', the same experiment after the fix** — identical clone and substitution against this
branch (one substitution site, as before), so the difference is the seam and nothing else:

```text
$ vendor/bin/phpunit --no-coverage --filter '<the two tests>'
OK (2 tests, 11 assertions)
=== planted-binary invocations AFTER the fix ===
0 (recorder never ran)
```

## The change

Both boundaries become named constants whose defaults are the shipped values, guarded the way
`PFB_PYTHON_WRAPPER` / `PFB_PKG_TIMEOUT` / `PFB_LIST_SCRIPT_TIMEOUT` already are:

```php
if (!defined('PFB_UNBOUND_START_CMD')) {
	define('PFB_UNBOUND_START_CMD', '/usr/local/sbin/unbound -c /var/unbound/unbound.conf 2>&1');
}
if (!defined('PFB_UNBOUND_STOP_WAIT')) {
	define('PFB_UNBOUND_STOP_WAIT', 30);
}
```

`tests/php/bootstrap.php` defines both before the package loads — the sibling of its existing "keep
the daemon dispatch dormant" step — pointing the start command at a shell double that records the
attempt and `exit 127`, and capping the poll budget at 2. Exiting 127 is deliberate: that is the
status an absent binary already produces off-appliance, so the caller's `retval != 0` retry branch
stays exercised and no sibling test's call sequence moves. Nothing defines either constant on the
appliance, so the binary, the config path and the 30-second wait are byte-identical there.

One more file is touched, comment-only: two comments in `tests/php/PfbSyncStatusDnsblWritersTest.php`
justified their process-running doubles by "up to 30 real seconds" and a "30-iteration wait loop",
which the harness cap makes untrue. The call-sequence rationale their assertions depend on stays.

## Test-first evidence

Frozen at the red run, byte-identical at green. The round-1 review fixes re-froze the test files, so
these are the post-review hashes (the first commit's were `c3edad9a…` and `fbfb1d65…`), and the
whole red→green cycle plus the mutation table were re-executed against them:

| file | `git hash-object` (red == green) |
| ---- | -------------------------------- |
| `tests/php/UnboundRestartSeamTest.php` | `af7dca762fd13edec03eb964d217ffae5bddf5b3` |
| `tests/php/DnsblLoadedCountTest.php` | `9709d64c017b38b75ff89b74e97c176a2dbcc17a` |
| `tests/php/PfbSyncStatusDnsblWritersTest.php` | `843e7467aee71d1c7fcccd1170317cc56fccafa0` |

RED — production and harness at `origin/devel`, the test files at their committed content:

```text
1) UnboundRestartSeamTest::testDaemonStartRunsTheHarnessDoubleNotTheShippedBinary
the harness must publish the path of its daemon-start double log
Failed asserting that two strings are not identical.
2) UnboundRestartSeamTest::testStopWaitIsBoundedWhenTheDaemonNeverExits
a test that never reports the daemon gone must not pay the appliance's 30 one-second polls
Failed asserting that 30 is less than 30.
3) UnboundRestartSeamTest::testShippedDefaultsStillStartTheApplianceDaemon
the appliance must still start the shipped daemon against the shipped config
Failed asserting that false is not false.
FAILURES!
Tests: 3, Assertions: 4, Failures: 3.
Time: 00:30.392
```

The red run costs 30.4 s — that *is* the unbounded stop-wait, and the second failure prints it as
"30 is less than 30".

GREEN — same files, same hashes:

```text
...                                                                 3 / 3 (100%)
OK (3 tests, 17 assertions)
Time: 00:02.283
```

## Mutation kill table

Each mutant applied to a copy of this branch, needle asserted unique, diff asserted non-empty,
reverted and asserted clean between mutants. Re-run after the review fixes; identical outcomes, and
independently reproduced by the test-honesty leg in its own clone:

| mutant | verdict | killed by |
| ------ | ------- | --------- |
| M1 hardcode the path again (`exec("/usr/local/sbin/unbound …")`) | 2 failures | `testDaemonStartRunsTheHarnessDoubleNotTheShippedBinary`, `testShippedDefaultsStillStartTheApplianceDaemon` |
| M2 bypass the seam on one branch (`if ($type === '') { exec("…real…"); return $final; }`) | 1 failure | `testShippedDefaultsStillStartTheApplianceDaemon` |
| M3 remove the wait bound (`$i <= 30`) | 2 failures | `testStopWaitIsBoundedWhenTheDaemonNeverExits`, `testShippedDefaultsStillStartTheApplianceDaemon` |
| M4 seam defaults to the real binary under test (bootstrap defines the shipped values) | 2 failures | `testDaemonStartRunsTheHarnessDoubleNotTheShippedBinary`, `testStopWaitIsBoundedWhenTheDaemonNeverExits` |

M2 is killed only by the source pin, and that is the pin's reason to exist: a behavioural probe
would have to enumerate every `$type` to catch a branch-gated bypass, while the body scan is
exhaustive over the function regardless of `$type`. Delete the pin and M2 survives the whole suite.

## Runtime

| measurement | before | after |
| ----------- | ------ | ----- |
| `DnsblLoadedCountTest` with the plain "Unbound is up" double | **61.15 s** (matches the ~61 s the issue records) | **4.90 s**, 5.60 s on a second run |
| `UnboundRestartSeamTest` | 30.39 s (red, unbounded wait) | 2.28 s |
| `PfbUpdateUnboundCachePolicyTest` + `PfbSyncStatusDnsblWritersTest` + `PfbReloadCachePolicyTest` | 2.657 s, 23 tests / 70 assertions | 2.623 s, 23 tests / 70 assertions |
| whole suite | 3 m 55.9 s, 5729 tests | 4 m 13.8 s, 5732 tests |

Straight talk on the last row: this change does not make today's suite faster. It makes the *honest*
double affordable (the 61 s → 4.9 s row) and removes the 30-second trap for any future test, at the
cost of the ~7 s those two rows add. The three sibling classes that also reach the restart fallback
are unchanged in outcome and in time — same 23 tests, same 70 assertions — which is the point of the
127 exit status.

## The simplified double was not only slow

The test-honesty leg found something worth recording. `DnsblLoadedCountTest`'s old double
(`fn() => $checks === 1`) shared one counter across every `is_process_running()` call site and both
`runUpdate()` passes, so by the second pass it had gone permanently FALSE — which short-circuited
the zero-downtime eligibility check *before* `pfb_unbound_py_swap_fits_ram()`, the RAM gate the
test exists to exercise, was ever called. The assertions still passed, on the wrong branch. With the
plain `TRUE` double the pass reaches the real fallback: the log line `ADR-10: RAM-constrained box`
appears only with this change. So the double simplification fixes a pre-existing test-honesty bug on
`devel`, not just a 56-second bill.

## Gates

```text
GATE PASS: python3 scripts/check_coverage_pairing.py --name-status-z
GATE PASS: uv run --locked python scripts/check_composer_vendor.py
GATE PASS: uv run --locked python scripts/check_toggle_registry.py --self-test && uv run --locked python scripts/check_toggle_registry.py
GATE PASS: php -l src/usr/local/pkg/pfblockerng/pfblockerng.inc
GATE PASS: php -l tests/php/DnsblLoadedCountTest.php
GATE PASS: php -l tests/php/PfbSyncStatusDnsblWritersTest.php
GATE PASS: php -l tests/php/UnboundRestartSeamTest.php
GATE PASS: php -l tests/php/bootstrap.php
GATE PASS: vendor/bin/phpunit
GATE PASS: composer phpstan
GATE PASS: composer phpcs -- --standard=phpcs.xml.dist src/
GATES: PASS
```

## Deliberately not in this PR

- **Three neighbouring boundaries the harness still cannot neuter → #2839.** The biggest is inside
  the very function this PR seals: `pfb_stop_start_unbound()` still `require_once`'s the hardcoded
  `/var/unbound/pfb_unbound_include.inc`, whose top level calls `pfb_python_mount()` four times and
  so runs `exec("/sbin/mount_nullfs …")` / `exec("/sbin/umount …")`. It is dormant only because
  `/var/unbound/` does not exist off-appliance. Also there: `PFB_PKG_BIN` (the file's one unguarded
  constant) and `$pfb['chroot_cmd']` (still defused per test in six files).
- **Stale `pfb_stop_start_unbound` anchors in docs and smoke helpers → #2840**, including
  `tests/smoke/helpers.py:2485`, which hand-mirrors the start command that is now a named constant.
- **`tests/php/bootstrap.php:30` keys the whole per-run sandbox on the PID alone** (silent
  `@mkdir`) → #2836, filed from the #2612 lane. The new double log lives inside that directory but
  is counted **relatively** (before-count vs after-count inside one test), so a stale log left by a
  reused PID cannot affect it — and two live processes cannot share a PID, so there is no concurrent
  case.
- **The 30-round wait itself on the appliance.** Bounding it there is a behaviour change for the
  live box and belongs to its own ticket if anyone wants it.

🤖 Generated by Oh My Pi and posted on behalf of @andrebrait.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when stopping and restarting the DNS service.
  * Added bounded waiting to prevent restart operations from hanging indefinitely.

* **Tests**
  * Expanded coverage for DNS service restart behavior, command execution, and timeout handling.
  * Improved test isolation by preventing real service startup during automated tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->