### PR TITLE
agent: read the CodeRabbit quota window without a colon

### DIFF
--- a/scripts/agent/wait-reviewer.sh
+++ b/scripts/agent/wait-reviewer.sh
@@ -61,8 +61,11 @@ classify() {
 		return 0
 	fi
 	if printf '%s' "$issuec" | grep -Eqi 'run out of usage credits|review limit reached|rate limited by coderabbit|reached your .*review (rate )?limit'; then
-		mins=$(printf '%s' "$issuec" | grep -oEi 'available in:.{0,10}[0-9]+ *(minute|hour)' | grep -oE '[0-9]+' | head -1)
-		if printf '%s' "$issuec" | grep -oEi 'available in:.{0,10}[0-9]+ *hour' | grep -q .; then
+		# issue #2837: the colon is optional ("available in 40 minutes"), and only
+		# non-digits may sit before the count, so a multi-unit window falls back
+		# instead of resuming on its first number.
+		mins=$(printf '%s' "$issuec" | grep -oEi 'available in:?[^0-9]{0,10}[0-9]+ *(minute|hour)' | grep -oE '[0-9]+' | head -1)
+		if printf '%s' "$issuec" | grep -oEi 'available in:?[^0-9]{0,10}[0-9]+ *hour' | grep -q .; then
 			mins=$(( ${mins:-1} * 60 ))
 		fi
 		printf 'QUOTA %s' "${mins:-999}"

--- a/scripts/agent/wait-reviewer.sh
+++ b/scripts/agent/wait-reviewer.sh
@@ -61,12 +61,17 @@ classify() {
 		return 0
 	fi
 	if printf '%s' "$issuec" | grep -Eqi 'run out of usage credits|review limit reached|rate limited by coderabbit|reached your .*review (rate )?limit'; then
-		# issue #2837: the colon is optional ("available in 40 minutes"), and only
-		# non-digits may sit before the count, so a multi-unit window falls back
-		# instead of resuming on its first number.
-		mins=$(printf '%s' "$issuec" | grep -oEi 'available in:?[^0-9]{0,10}[0-9]+ *(minute|hour)' | grep -oE '[0-9]+' | head -1)
-		if printf '%s' "$issuec" | grep -oEi 'available in:?[^0-9]{0,10}[0-9]+ *hour' | grep -q .; then
-			mins=$(( ${mins:-1} * 60 ))
+		# issue #2837: the colon is optional ("available in 40 minutes"), and the
+		# window must name exactly ONE numeric component -- a compound window
+		# ("1 hour 30 minutes") falls back rather than resuming on one of its parts.
+		win=$(printf '%s' "$issuec" | grep -oEi 'available in:?[^.]{0,48}' | head -1)
+		mins=''
+		if [ "$(printf '%s' "$win" | grep -oE '[0-9]+' | wc -l | tr -d ' ')" = '1' ] &&
+		   printf '%s' "$win" | grep -qEi '[0-9]+ *(minute|hour)'; then
+			mins=$(printf '%s' "$win" | grep -oE '[0-9]+' | head -1)
+			if printf '%s' "$win" | grep -qEi '[0-9]+ *hour'; then
+				mins=$(( mins * 60 ))
+			fi
 		fi
 		printf 'QUOTA %s' "${mins:-999}"
 		return 0

--- a/tests/shell/agent_wait_reviewer_spec.sh
+++ b/tests/shell/agent_wait_reviewer_spec.sh
@@ -67,6 +67,18 @@ Describe 'wait-reviewer.sh classify()'
     The output should equal 'QUOTA 999'
   End
 
+  It 'falls back when the window names an hour and a minute component'
+    issuec='Review limit reached. Next included review available in 1 hour 30 minutes.'
+    When call classify
+    The output should equal 'QUOTA 999'
+  End
+
+  It 'falls back when the window names its components in the other order'
+    issuec='Review limit reached. Next included review available in 40 minutes and 2 hours.'
+    When call classify
+    The output should equal 'QUOTA 999'
+  End
+
   It 'reports QUOTA 999 when the resume time is unparsable'
     issuec='You have run out of usage credits.'
     When call classify

--- a/tests/shell/agent_wait_reviewer_spec.sh
+++ b/tests/shell/agent_wait_reviewer_spec.sh
@@ -45,6 +45,28 @@ Describe 'wait-reviewer.sh classify()'
     The output should equal 'QUOTA 120'
   End
 
+  It 'reports QUOTA with the stated minutes when the notice carries no colon'
+    issuec='> ## Review limit reached
+>
+> **Next included review available in 40 minutes.**'
+    When call classify
+    The output should equal 'QUOTA 40'
+  End
+
+  It 'converts a colonless hours-denominated resume time to minutes'
+    issuec='> ## Review limit reached
+>
+> **Next included review available in 2 hours.**'
+    When call classify
+    The output should equal 'QUOTA 120'
+  End
+
+  It 'falls back rather than reading a multi-unit window as its first number'
+    issuec='Review limit reached. Next included review available in 1 day 30 minutes.'
+    When call classify
+    The output should equal 'QUOTA 999'
+  End
+
   It 'reports QUOTA 999 when the resume time is unparsable'
     issuec='You have run out of usage credits.'
     When call classify


### PR DESCRIPTION
Closes #2837.

## Problem

`scripts/agent/wait-reviewer.sh` reported `QUOTA 999` for a CodeRabbit notice whose real window was 40 minutes. 999 is the fallback, not a parsed value, so a caller was told to wait roughly 16.6 hours — long enough for a landing flow to abandon the review and record a miss it did not have.

## Root cause, confirmed from source

Detection on line 63 matched the observed body; only the minutes extraction failed, because it required a colon the current wording does not carry:

```sh
mins=$(printf '%s' "$issuec" | grep -oEi 'available in:.{0,10}[0-9]+ *(minute|hour)' | grep -oE '[0-9]+' | head -1)
```

Discriminating probe: the observed notice body fed through the unfixed script yields `QUOTA 999`, while the same body with `available in:` yields `QUOTA 46` — so the wording, not the delivery path, is the variable.

## Change

The colon is optional, and only non-digits may sit between `available in` and the count, so a multi-unit window falls back deliberately instead of resuming on its first number:

```sh
mins=$(printf '%s' "$issuec" | grep -oEi 'available in:?[^0-9]{0,10}[0-9]+ *(minute|hour)' | grep -oE '[0-9]+' | head -1)
```

## Red before green

Frozen `tests/shell/agent_wait_reviewer_spec.sh`, `git hash-object` = `a27f0a46e924ee7589c7cf6e07c547d151d62331`, identical at both moments.

- RED, production unchanged: `88 examples, 2 failures` — the colonless minutes row got `QUOTA 999` where `QUOTA 40` was expected, and the colonless hours row got `QUOTA 999` where `QUOTA 120` was expected.
- GREEN, same test bytes: `88 examples, 0 failures`.

Three rows added, all executed in the run count above: the observed colonless wording (`QUOTA 40`), its hours form (`QUOTA 120`), and a multi-unit window that must fall back (`QUOTA 999`) rather than resume on `1`. The pre-existing colon rows stay as regression guards.

## Frozen RED evidence

| Frozen RED test | git hash-object | RED run tail |
| --- | --- | --- |
| `tests/shell/agent_wait_reviewer_spec.sh` | 2da728b44082a2a44d4bce4fbab4631cfd58e52f | `90 examples, 2 failures` — `:70` expected `QUOTA 999`, got `QUOTA 60`; `:76` expected `QUOTA 999`, got `QUOTA 40` (round 1 at hash `a27f0a46e924ee7589c7cf6e07c547d151d62331`: `88 examples, 2 failures`, `:48` expected `QUOTA 40` got `QUOTA 999`, `:56` expected `QUOTA 120` got `QUOTA 999`) |

## Mutation kills

| Mutant | Result |
| --- | --- |
| restore the colon requirement (both extraction lines) | `88 examples, 2 failures` — colonless minutes row and colonless hours row |
| `[^0-9]{0,10}` back to `.{0,10}` | `88 examples, 1 failure` — the multi-unit row, which would otherwise resume after 1 minute |

Each mutant asserted a single-occurrence needle before replacement, a non-empty `git diff` after, and a clean tree on restore; the restored tree re-ran `88 examples, 0 failures`.


## CodeRabbit round

CodeRabbit posted one actionable finding, and it was right: the colon-optional matcher still stopped at the first supported unit, so `available in 1 hour 30 minutes` returned `QUOTA 60` and `available in 40 minutes and 2 hours` returned `QUOTA 40`. Both resume earlier than the notice allows, which spends the next ask on a still-limited reviewer.

Fixed test-first at the same frozen file: two rows added, executed RED (`90 examples, 2 failures`, the exact `QUOTA 60` and `QUOTA 40` above), then the matcher now reads the window up to its sentence end and accepts it only when it names exactly one numeric component, GREEN `90 examples, 0 failures` at the identical hash.

Second mutation battery on the final shape, each mutant single-occurrence, `sh -n` clean, tree restored between runs:

| Mutant | Result |
| --- | --- |
| require the colon again | `90 examples, 2 failures` — the two colonless rows |
| drop the single-component gate | `90 examples, 3 failures` — all three compound-window rows |
| drop the hour conversion | `90 examples, 2 failures` — both hours rows |
| drop the `999` fallback | `90 examples, 5 failures` — every fallback row |

Restored tree re-ran `90 examples, 0 failures`.

## Gates

`scripts/agent/run-gates.sh --diff origin/devel` → `GATES: PASS` (coverage pairing, `sh -n` on both files, ShellCheck, ShellSpec under dash).

🤖 Generated by Oh My Pi and posted on behalf of @andrebrait.