### PR TITLE
pfblockerng: mark failed feed post-scripts in the sync-status ledger (#2059)

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
@@ -538,24 +538,20 @@ function pfb_ip_parse_line(string $raw_line, array $config): array {
 }
 
 /**
- * pfb_list_script_failure_record -- issue #1958: a per-feed pre-script that
- * exits non-zero must not let the alias pass close as full success. Opens a
- * distinct ADR-61 stage='script' ledger entry -- separate from stage='download',
- * since the download itself genuinely succeeded and only the transform failed
- * -- and (re)writes the '.update' retry marker. The marker matters because a
- * row that entered the update branch via a '.fail' marker alone had that
- * marker unlinked by the successful download; without this write the next
- * ordinary pass takes the verbatim-reuse fast path and never retries the
- * transform. The marker write is best-effort (@-suppressed): ledger
- * visibility must never depend on it succeeding. ADR-61 symmetric ownership:
- * the paired close is pfb_list_script_failure_close() at the alias-pass end.
+ * pfb_list_script_failure_record -- issue #1958/#2059: a per-feed pre- or
+ * post-script that exits non-zero must not let the alias pass close as full
+ * success. Opens a distinct ADR-61 stage='script' ledger entry -- separate
+ * from stage='download', since the download itself genuinely succeeded and
+ * only the script failed. ADR-61 symmetric ownership: the paired close is
+ * pfb_list_script_failure_close() at the alias-pass end.
  *
- * issue #2059: the post-script call sites pass a NULL $update_marker. They
- * have no retry to arm -- pfb_list_script_reuse_decision() already re-runs a
- * configured script every pass (#1278), and both loops unlink
- * '{header}.update' further down the same iteration -- so a write here would
- * be dead. Everything else is identical: the same stage='script' key, the
- * same alias-pass state, the same paired close.
+ * $update_marker NULL writes no retry marker; the pre-script sites pass one
+ * because a row that entered the update branch via a '.fail' marker alone had
+ * that marker unlinked by the successful download, and without this write the
+ * next pass takes the verbatim-reuse fast path and never retries the
+ * transform. The write is best-effort (@-suppressed): ledger visibility must
+ * never depend on it. Post-script callers pass NULL -- see
+ * pfb_list_post_script_failure_record().
  */
 function pfb_list_script_failure_record(string $facility, string $item, string $message,
     string $ledger_dir, ?string $update_marker, ?array &$state = NULL): void {
@@ -566,6 +562,26 @@ function pfb_list_script_failure_record(string $facility, string $item, string $
 		@touch($update_marker);
 	}
 	pfb_sync_status_open($facility, $item, 'script', $message, $ledger_dir);
+}
+
+/**
+ * pfb_list_post_script_failure_record -- issue #2059: record a post-script's
+ * exit status, no-op on 0. Owning the status test here (rather than wrapping
+ * each call site in an `if`) is what makes "a clean post-script records
+ * nothing" testable off-appliance: the download loops themselves cannot be
+ * driven off the appliance (#993).
+ *
+ * No retry marker: pfb_list_script_reuse_decision() re-runs a configured pre
+ * OR post script every pass a local '.orig' baseline exists (#1278), so there
+ * is nothing to arm -- and on the non-stale paths that reach here both loops
+ * unlink '{header}.update' further down the same iteration anyway.
+ */
+function pfb_list_post_script_failure_record(int $exit_status, string $facility, string $item,
+    string $message, string $ledger_dir, ?array &$state = NULL): void {
+	if ($exit_status === 0) {
+		return;
+	}
+	pfb_list_script_failure_record($facility, $item, $message, $ledger_dir, NULL, $state);
 }
 
 function pfb_list_script_failure_close(string $facility, string $item, string $ledger_dir, array $state): void {
@@ -2591,16 +2607,13 @@ function sync_package_pfblockerng($cron=''): bool {
 								if ($pfb_row_script_post && is_file("{$pfb_row_script_post}")) {
 									pfb_logger("\nExecuting post-script: {$list['script_post']}\n", 1);
 									if (@copy("{$file_dwn}.orig", "{$file_dwn}.post")) {
-										if (pfb_list_script_exec($pfb_row_script_post, $list['script_post'], 'post', $header,
-										    escapeshellarg("{$file_dwn}.post") . " dnsbl {$elog}") !== 0) {
-											// issue #2059: the feed itself refreshed, but the script's own
-											// side effects did not complete -- mark the pass ('script' stage,
-											// never 'download'), else it closes as full success.
-											pfb_list_script_failure_record('dnsbl', $alias,
-											    "[ {$alias} - {$header} ] Post-script FAIL - feed updated, side effects incomplete",
-											    $pfb['dbdir'], NULL, $pfb_script_state);
-										}
+										$pfb_post_status = pfb_list_script_exec($pfb_row_script_post, $list['script_post'], 'post', $header,
+										    escapeshellarg("{$file_dwn}.post") . " dnsbl {$elog}");
 										unlink_if_exists("{$file_dwn}.post");
+										// issue #2059: 'script' stage, never 'download' -- the feed refreshed.
+										pfb_list_post_script_failure_record($pfb_post_status, 'dnsbl', $alias,
+										    "[ {$alias} - {$header} ] Post-script FAIL - feed updated, side effects incomplete",
+										    $pfb['dbdir'], $pfb_script_state);
 									} else {
 										pfb_logger("\n[ {$header} ] post-script '{$list['script_post']}' could not stage its input; skipping\n", 2);
 									}
@@ -2721,8 +2734,9 @@ function sync_package_pfblockerng($cron=''): bool {
 					// feed's success mask an earlier feed's still-live failure.
 					pfb_download_ledger_close_if_clean('dnsbl', $alias, $pfb_dl_failed, $pfb['dbdir']);
 
-					// issue #1958: ADR-61 symmetric ownership -- close the 'script' stage
-					// entry once for the WHOLE alias-pass, iff no row's pre-script failed.
+					// issue #1958/#2059: ADR-61 symmetric ownership -- close the 'script'
+					// stage entry once for the WHOLE alias-pass, iff no row's pre- or
+					// post-script failed.
 					pfb_dnsbl_script_failure_close($alias, $pfb['dbdir'], $pfb_script_state);
 
 					// ADR-12: record GENUINELY-changed DNSBL groups for
@@ -4000,20 +4014,19 @@ function sync_package_pfblockerng($cron=''): bool {
 								pfb_logger("\nExecuting post-script: {$list['script_post']}\n", 1);
 								$file_org_esc = escapeshellarg("{$file_dwn}.orig");
 								@copy("{$file_dwn}.orig", "{$file_dwn}.orig.post"); // Save original file for restoration
-								if (pfb_list_script_exec($pfb_script_post, $list['script_post'], 'post', $header,
-								    "{$file_org_esc} {$list['vtype']} {$elog}") !== 0) {
+								$pfb_post_status = pfb_list_script_exec($pfb_script_post, $list['script_post'], 'post', $header,
+								    "{$file_org_esc} {$list['vtype']} {$elog}");
+								if ($pfb_post_status !== 0) {
 									// issue #1927: restore the download now so the empty-feed check
 									// below reads it, not the failed script's leftovers.
 									if (file_exists("{$file_dwn}.orig.post")) {
 										@rename("{$file_dwn}.orig.post", "{$file_dwn}.orig");
 									}
-									// issue #2059: the feed itself refreshed, but the script's own
-									// side effects did not complete -- mark the pass ('script' stage,
-									// never 'download'), else it closes as full success.
-									pfb_list_script_failure_record('ip', $alias,
-									    "[ {$alias} - {$header} ] Post-script FAIL - feed updated, side effects incomplete",
-									    $pfb['dbdir'], NULL, $pfb_script_state);
 								}
+								// issue #2059: 'script' stage, never 'download' -- the feed refreshed.
+								pfb_list_post_script_failure_record($pfb_post_status, 'ip', $alias,
+								    "[ {$alias} - {$header} ] Post-script FAIL - feed updated, side effects incomplete",
+								    $pfb['dbdir'], $pfb_script_state);
 							}
 
 							// Check to see if list actually failed download or has no IPs listed.
@@ -4130,8 +4143,9 @@ function sync_package_pfblockerng($cron=''): bool {
 				// feed's success mask an earlier feed's still-live failure.
 				pfb_download_ledger_close_if_clean('ip', $alias, $pfb_dl_failed, $pfb['dbdir']);
 
-				// issue #1958: ADR-61 symmetric ownership -- close the 'script' stage
-				// entry once for the WHOLE alias-pass, iff no row's pre-script failed.
+				// issue #1958/#2059: ADR-61 symmetric ownership -- close the 'script'
+				// stage entry once for the WHOLE alias-pass, iff no row's pre- or
+				// post-script failed.
 				pfb_ip_script_failure_close($alias, $pfb['dbdir'], $pfb_script_state);
 			}
 		}

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
@@ -566,10 +566,9 @@ function pfb_list_script_failure_record(string $facility, string $item, string $
 
 /**
  * pfb_list_post_script_failure_record -- issue #2059: record a post-script's
- * exit status, no-op on 0. Owning the status test here (rather than wrapping
- * each call site in an `if`) is what makes "a clean post-script records
- * nothing" testable off-appliance: the download loops themselves cannot be
- * driven off the appliance (#993).
+ * exit status, no-op on 0. The status test lives here, not in an `if` at each
+ * call site, so "a clean post-script records nothing" is testable: the
+ * download loops cannot be driven off-appliance (#993).
  *
  * No retry marker: pfb_list_script_reuse_decision() re-runs a configured pre
  * OR post script every pass a local '.orig' baseline exists (#1278), so there

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
@@ -549,13 +549,22 @@ function pfb_ip_parse_line(string $raw_line, array $config): array {
  * transform. The marker write is best-effort (@-suppressed): ledger
  * visibility must never depend on it succeeding. ADR-61 symmetric ownership:
  * the paired close is pfb_list_script_failure_close() at the alias-pass end.
+ *
+ * issue #2059: the post-script call sites pass a NULL $update_marker. They
+ * have no retry to arm -- pfb_list_script_reuse_decision() already re-runs a
+ * configured script every pass (#1278), and both loops unlink
+ * '{header}.update' further down the same iteration -- so a write here would
+ * be dead. Everything else is identical: the same stage='script' key, the
+ * same alias-pass state, the same paired close.
  */
 function pfb_list_script_failure_record(string $facility, string $item, string $message,
-    string $ledger_dir, string $update_marker, ?array &$state = NULL): void {
+    string $ledger_dir, ?string $update_marker, ?array &$state = NULL): void {
 	if ($state !== NULL) {
 		$state['failed'] = TRUE;
 	}
-	@touch($update_marker);
+	if ($update_marker !== NULL) {
+		@touch($update_marker);
+	}
 	pfb_sync_status_open($facility, $item, 'script', $message, $ledger_dir);
 }
 
@@ -2582,8 +2591,15 @@ function sync_package_pfblockerng($cron=''): bool {
 								if ($pfb_row_script_post && is_file("{$pfb_row_script_post}")) {
 									pfb_logger("\nExecuting post-script: {$list['script_post']}\n", 1);
 									if (@copy("{$file_dwn}.orig", "{$file_dwn}.post")) {
-									pfb_list_script_exec($pfb_row_script_post, $list['script_post'], 'post', $header,
-										    escapeshellarg("{$file_dwn}.post") . " dnsbl {$elog}");
+										if (pfb_list_script_exec($pfb_row_script_post, $list['script_post'], 'post', $header,
+										    escapeshellarg("{$file_dwn}.post") . " dnsbl {$elog}") !== 0) {
+											// issue #2059: the feed itself refreshed, but the script's own
+											// side effects did not complete -- mark the pass ('script' stage,
+											// never 'download'), else it closes as full success.
+											pfb_list_script_failure_record('dnsbl', $alias,
+											    "[ {$alias} - {$header} ] Post-script FAIL - feed updated, side effects incomplete",
+											    $pfb['dbdir'], NULL, $pfb_script_state);
+										}
 										unlink_if_exists("{$file_dwn}.post");
 									} else {
 										pfb_logger("\n[ {$header} ] post-script '{$list['script_post']}' could not stage its input; skipping\n", 2);
@@ -3991,6 +4007,12 @@ function sync_package_pfblockerng($cron=''): bool {
 									if (file_exists("{$file_dwn}.orig.post")) {
 										@rename("{$file_dwn}.orig.post", "{$file_dwn}.orig");
 									}
+									// issue #2059: the feed itself refreshed, but the script's own
+									// side effects did not complete -- mark the pass ('script' stage,
+									// never 'download'), else it closes as full success.
+									pfb_list_script_failure_record('ip', $alias,
+									    "[ {$alias} - {$header} ] Post-script FAIL - feed updated, side effects incomplete",
+									    $pfb['dbdir'], NULL, $pfb_script_state);
 								}
 							}
 

--- a/tests/php/ListScriptFailureLedgerWiringTest.php
+++ b/tests/php/ListScriptFailureLedgerWiringTest.php
@@ -295,6 +295,33 @@ final class ListScriptFailureLedgerWiringTest extends TestCase
 		$this->assertTrue($state['failed']);
 	}
 
+	/**
+	 * $pfb_script_state accumulates across an alias's rows, so a LATER row's
+	 * clean post-script must not undo an earlier row's failure -- the alias
+	 * pass closes once, at the end, on the accumulated state.
+	 */
+	public function testACleanRowDoesNotUndoAnEarlierRowsPostScriptFailure(): void
+	{
+		$state = ['failed' => FALSE];
+		pfb_list_post_script_failure_record(3, 'ip', 'pfB_Example_v4',
+			'[ pfB_Example_v4 - row_a ] Post-script FAIL', $this->dir, $state);
+		// Before-state: row A genuinely marked the pass.
+		$this->assertTrue($state['failed']);
+		$this->assertCount(1, pfb_sync_status_list_open($this->dir, 'ip'));
+
+		pfb_list_post_script_failure_record(0, 'ip', 'pfB_Example_v4',
+			'row_b succeeded', $this->dir, $state);
+
+		$this->assertTrue($state['failed'],
+			"a clean row must leave an earlier row's failure state intact");
+		pfb_list_script_failure_close('ip', 'pfB_Example_v4', $this->dir, $state);
+
+		$open = pfb_sync_status_list_open($this->dir, 'ip');
+		$this->assertCount(1, $open, "row A's entry must survive the alias-pass close");
+		$this->assertStringContainsString('row_a', $open[0]['message'],
+			"the surviving entry must still be row A's, not row B's message");
+	}
+
 	/** @return array<string, array{0: string, 1: string}> */
 	public static function postScriptFacilities(): array
 	{

--- a/tests/php/ListScriptFailureLedgerWiringTest.php
+++ b/tests/php/ListScriptFailureLedgerWiringTest.php
@@ -251,11 +251,10 @@ final class ListScriptFailureLedgerWiringTest extends TestCase
 	}
 
 	/**
-	 * The other side of the same branch, and the reason the exit-status test
-	 * lives inside pfb_list_post_script_failure_record() rather than in an `if`
-	 * at each call site: a post-script that SUCCEEDS must leave the pass
-	 * reading as full success, which no off-appliance test could observe if the
-	 * decision stayed in the monolith (#993).
+	 * The other side of the same branch, and the reason
+	 * pfb_list_post_script_failure_record() owns the exit-status test (rationale
+	 * on that function): a post-script that SUCCEEDS must leave the pass
+	 * reading as full success.
 	 */
 	#[DataProvider('postScriptFacilities')]
 	public function testCleanPostScriptRecordsNothingAndLeavesTheAliasPassClean(string $facility, string $alias): void
@@ -284,17 +283,16 @@ final class ListScriptFailureLedgerWiringTest extends TestCase
 	 * read as success).
 	 */
 	#[DataProvider('postScriptStatuses')]
-	public function testEveryNonZeroPostScriptStatusOpensAnEntry(int $status, bool $expectOpen): void
+	public function testEveryNonZeroPostScriptStatusOpensAnEntry(int $status): void
 	{
 		$state = ['failed' => FALSE];
 
 		pfb_list_post_script_failure_record($status, 'ip', 'pfB_Example_v4',
 			"status {$status}", $this->dir, $state);
 
-		$open = pfb_sync_status_list_open($this->dir, 'ip');
-		$this->assertCount($expectOpen ? 1 : 0, $open,
-			"exit status {$status} must " . ($expectOpen ? 'open' : 'not open') . ' a ledger entry');
-		$this->assertSame($expectOpen, $state['failed']);
+		$this->assertCount(1, pfb_sync_status_list_open($this->dir, 'ip'),
+			"exit status {$status} must open a ledger entry");
+		$this->assertTrue($state['failed']);
 	}
 
 	/** @return array<string, array{0: string, 1: string}> */
@@ -306,14 +304,13 @@ final class ListScriptFailureLedgerWiringTest extends TestCase
 		];
 	}
 
-	/** @return array<string, array{0: int, 1: bool}> */
+	/** @return array<string, array{0: int}> */
 	public static function postScriptStatuses(): array
 	{
 		return [
-			'clean exit'         => [0, FALSE],
-			'plain non-zero'     => [3, TRUE],
-			'timeout(1) killed'  => [124, TRUE],
-			'exec never launched' => [-1, TRUE],
+			'plain non-zero'      => [3],
+			'timeout(1) killed'   => [124],
+			'exec never launched' => [-1],
 		];
 	}
 

--- a/tests/php/ListScriptFailureLedgerWiringTest.php
+++ b/tests/php/ListScriptFailureLedgerWiringTest.php
@@ -225,24 +225,22 @@ final class ListScriptFailureLedgerWiringTest extends TestCase
 	 * issue #2059 in-suite reproduction: a per-feed POST-process script that
 	 * exits non-zero must be visible in the ADR-61 ledger after the alias pass
 	 * closes, in BOTH loops. Drives the REAL pfb_list_script_exec() against a
-	 * genuinely failing script, then the real alias-pass close, so the fault is
-	 * produced the way the appliance produces it -- not injected.
+	 * genuinely failing script and feeds its real exit status to the recorder,
+	 * so the fault is produced the way the appliance produces it -- not injected.
 	 */
 	#[DataProvider('postScriptFacilities')]
 	public function testFailingPostScriptStaysVisibleAfterTheAliasPassCloses(string $facility, string $alias): void
 	{
-		$script = "{$this->dir}/fail_post.sh";
-		file_put_contents($script, "#!/bin/sh\nexit 3\n");
-		$this->assertTrue(chmod($script, 0755));
+		$script = $this->postScript('fail_post.sh', 'exit 3');
 		$state = ['failed' => FALSE];
 		$this->assertSame([], pfb_sync_status_list_open($this->dir, $facility), 'before: the ledger has no open entry');
 
-		// The loop's own sequence: run the post-script, honour its exit status.
-		$rc = pfb_list_script_exec($script, 'fail_post.sh', 'post', 'foo_feed', '', '');
-		$this->assertNotSame(0, $rc, 'the fixture must genuinely fail -- a zero exit proves nothing');
-		pfb_list_script_failure_record($facility, $alias,
+		// The loop's own sequence: run the post-script, hand its status over.
+		$status = pfb_list_script_exec($script, 'fail_post.sh', 'post', 'foo_feed', '', '');
+		$this->assertNotSame(0, $status, 'the fixture must genuinely fail -- a zero exit proves nothing');
+		pfb_list_post_script_failure_record($status, $facility, $alias,
 			"[ {$alias} - foo_feed ] Post-script FAIL - feed updated, side effects incomplete",
-			$this->dir, NULL, $state);
+			$this->dir, $state);
 		pfb_list_script_failure_close($facility, $alias, $this->dir, $state);
 
 		$open = pfb_sync_status_list_open($this->dir, $facility);
@@ -250,6 +248,53 @@ final class ListScriptFailureLedgerWiringTest extends TestCase
 		$this->assertSame($alias, $open[0]['item']);
 		$this->assertSame('script', $open[0]['stage']);
 		$this->assertStringContainsString('Post-script FAIL', $open[0]['message']);
+	}
+
+	/**
+	 * The other side of the same branch, and the reason the exit-status test
+	 * lives inside pfb_list_post_script_failure_record() rather than in an `if`
+	 * at each call site: a post-script that SUCCEEDS must leave the pass
+	 * reading as full success, which no off-appliance test could observe if the
+	 * decision stayed in the monolith (#993).
+	 */
+	#[DataProvider('postScriptFacilities')]
+	public function testCleanPostScriptRecordsNothingAndLeavesTheAliasPassClean(string $facility, string $alias): void
+	{
+		$script = $this->postScript('ok_post.sh', 'exit 0');
+		$state = ['failed' => FALSE];
+
+		$status = pfb_list_script_exec($script, 'ok_post.sh', 'post', 'foo_feed', '', '');
+		$this->assertSame(0, $status, 'the fixture must genuinely succeed');
+		pfb_list_post_script_failure_record($status, $facility, $alias,
+			'this message must never reach the ledger', $this->dir, $state);
+
+		$this->assertSame([], pfb_sync_status_list_open($this->dir, $facility),
+			'a post-script exiting 0 must open no entry');
+		$this->assertFalse($state['failed'],
+			'a clean post-script must leave the alias-pass state clean, so the paired close still fires');
+
+		pfb_list_script_failure_close($facility, $alias, $this->dir, $state);
+		$this->assertSame([], pfb_sync_status_list_open($this->dir, $facility));
+	}
+
+	/**
+	 * Every non-zero status class the runner can return is a failure: a plain
+	 * non-zero exit, timeout(1)'s 124, and -1 for an exec() that never launched
+	 * (pfblockerng.inc's #1927 contract -- a script that never ran must never
+	 * read as success).
+	 */
+	#[DataProvider('postScriptStatuses')]
+	public function testEveryNonZeroPostScriptStatusOpensAnEntry(int $status, bool $expectOpen): void
+	{
+		$state = ['failed' => FALSE];
+
+		pfb_list_post_script_failure_record($status, 'ip', 'pfB_Example_v4',
+			"status {$status}", $this->dir, $state);
+
+		$open = pfb_sync_status_list_open($this->dir, 'ip');
+		$this->assertCount($expectOpen ? 1 : 0, $open,
+			"exit status {$status} must " . ($expectOpen ? 'open' : 'not open') . ' a ledger entry');
+		$this->assertSame($expectOpen, $state['failed']);
 	}
 
 	/** @return array<string, array{0: string, 1: string}> */
@@ -261,11 +306,31 @@ final class ListScriptFailureLedgerWiringTest extends TestCase
 		];
 	}
 
+	/** @return array<string, array{0: int, 1: bool}> */
+	public static function postScriptStatuses(): array
+	{
+		return [
+			'clean exit'         => [0, FALSE],
+			'plain non-zero'     => [3, TRUE],
+			'timeout(1) killed'  => [124, TRUE],
+			'exec never launched' => [-1, TRUE],
+		];
+	}
+
+	private function postScript(string $name, string $body): string
+	{
+		$path = "{$this->dir}/{$name}";
+		file_put_contents($path, "#!/bin/sh\n{$body}\n");
+		$this->assertTrue(chmod($path, 0755));
+		return $path;
+	}
+
 	/**
-	 * issue #2059: both post-script branches must bind the recorder. #993: the
-	 * apply monolith owns feed download and appliance side effects, so its loop
-	 * cannot be driven off-appliance -- pin each live binding in its own route
-	 * scope; php_strip_whitespace() removes comments/docblocks from the source.
+	 * issue #2059: both post-script branches must hand their exit status to the
+	 * recorder. #993: the apply monolith owns feed download and appliance side
+	 * effects, so its loop cannot be driven off-appliance -- pin each live
+	 * binding in its own route scope; php_strip_whitespace() removes
+	 * comments/docblocks from the source under test.
 	 */
 	public function testEachFamilyBindsPostScriptFailureRecordOnce(): void
 	{
@@ -277,28 +342,36 @@ final class ListScriptFailureLedgerWiringTest extends TestCase
 		$dnsbl_post  = $this->applyScope($source, $dnsbl_start, $dnsbl_end);
 		$ip_post     = $this->applyScope($source, $ip_start, $ip_end);
 
-		$this->assertSame(1, substr_count($dnsbl_post, "pfb_list_script_failure_record('dnsbl', \$alias,"),
-			'the DNSBL post-script branch must record against its own alias');
-		$this->assertSame(1, substr_count($ip_post, "pfb_list_script_failure_record('ip', \$alias,"),
-			'the IP post-script branch must record against its own alias');
+		$dnsbl_needle = "pfb_list_post_script_failure_record(\$pfb_post_status, 'dnsbl', \$alias,";
+		$ip_needle    = "pfb_list_post_script_failure_record(\$pfb_post_status, 'ip', \$alias,";
 
-		// The trailing arguments are load-bearing: NULL suppresses a retry-marker
-		// write both loops would unlink further down the same iteration, and
-		// $pfb_script_state is what stops the alias-pass close wiping the entry.
+		$this->assertSame(1, substr_count($dnsbl_post, $dnsbl_needle),
+			'the DNSBL post-script branch must pass its own exit status and alias to the recorder');
+		$this->assertSame(1, substr_count($ip_post, $ip_needle),
+			'the IP post-script branch must pass its own exit status and alias to the recorder');
+
+		// $pfb_script_state is what stops the alias-pass close from wiping the
+		// entry the recorder just opened, and 'Post-script FAIL' is the marker an
+		// operator reads in the widget -- both are load-bearing arguments.
 		foreach (['dnsbl' => $dnsbl_post, 'ip' => $ip_post] as $family => $scope) {
-			$this->assertSame(1, substr_count($scope, "\$pfb['dbdir'], NULL, \$pfb_script_state);"),
-				"the {$family} post-script record must pass no retry marker and the alias-pass state");
+			$this->assertSame(1, substr_count($scope, "\$pfb['dbdir'], \$pfb_script_state);"),
+				"the {$family} post-script record must pass the alias-pass state");
+			$this->assertSame(1, substr_count($scope, 'Post-script FAIL'),
+				"the {$family} post-script record must carry the operator-facing marker");
+			// The status must come from THIS branch's own run, not a stale binding.
+			$this->assertSame(1, substr_count($scope, '$pfb_post_status = pfb_list_script_exec('),
+				"the {$family} post-script branch must bind its status from its own exec");
 		}
 
-		// Exactly two literal-facility call sites -- one post-script branch per
-		// loop. A third would double-report; the pre-script sites route through
-		// pfb_list_script_failure_continue() instead, which takes $facility.
-		$this->assertSame(2, substr_count($source, "pfb_list_script_failure_record('"),
-			'only the two post-script branches may call the recorder with a literal facility');
+		// Exactly two call sites -- one post-script branch per loop. A third
+		// would double-report; the pre-script sites route through
+		// pfb_list_script_failure_continue() instead.
+		$this->assertSame(2, substr_count($source, 'pfb_list_post_script_failure_record($pfb_post_status,'),
+			'only the two post-script branches may call the post-script recorder');
 
 		foreach ([
-			[$dnsbl_start, $dnsbl_end, "pfb_list_script_failure_record('dnsbl', \$alias,"],
-			[$ip_start, $ip_end, "pfb_list_script_failure_record('ip', \$alias,"],
+			[$dnsbl_start, $dnsbl_end, $dnsbl_needle],
+			[$ip_start, $ip_end, $ip_needle],
 		] as [$start, $end, $needle]) {
 			$removed = 0;
 			$mutant = str_replace($needle, '', $source, $removed);

--- a/tests/php/ListScriptFailureLedgerWiringTest.php
+++ b/tests/php/ListScriptFailureLedgerWiringTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -217,6 +218,97 @@ final class ListScriptFailureLedgerWiringTest extends TestCase
 			$mutant = substr_replace($mutant, $needle, $endPos + strlen($end), 0);
 			$mutantScope = $this->applyScope($mutant, $start, $end);
 			$this->assertSame(0, substr_count($mutantScope, $needle), "a {$needle} relocation after its loop boundary must fail the scope pin");
+		}
+	}
+
+	/**
+	 * issue #2059 in-suite reproduction: a per-feed POST-process script that
+	 * exits non-zero must be visible in the ADR-61 ledger after the alias pass
+	 * closes, in BOTH loops. Drives the REAL pfb_list_script_exec() against a
+	 * genuinely failing script, then the real alias-pass close, so the fault is
+	 * produced the way the appliance produces it -- not injected.
+	 */
+	#[DataProvider('postScriptFacilities')]
+	public function testFailingPostScriptStaysVisibleAfterTheAliasPassCloses(string $facility, string $alias): void
+	{
+		$script = "{$this->dir}/fail_post.sh";
+		file_put_contents($script, "#!/bin/sh\nexit 3\n");
+		$this->assertTrue(chmod($script, 0755));
+		$state = ['failed' => FALSE];
+		$this->assertSame([], pfb_sync_status_list_open($this->dir, $facility), 'before: the ledger has no open entry');
+
+		// The loop's own sequence: run the post-script, honour its exit status.
+		$rc = pfb_list_script_exec($script, 'fail_post.sh', 'post', 'foo_feed', '', '');
+		$this->assertNotSame(0, $rc, 'the fixture must genuinely fail -- a zero exit proves nothing');
+		pfb_list_script_failure_record($facility, $alias,
+			"[ {$alias} - foo_feed ] Post-script FAIL - feed updated, side effects incomplete",
+			$this->dir, NULL, $state);
+		pfb_list_script_failure_close($facility, $alias, $this->dir, $state);
+
+		$open = pfb_sync_status_list_open($this->dir, $facility);
+		$this->assertCount(1, $open, 'a failed post-script must survive the alias-pass close, not read as full success');
+		$this->assertSame($alias, $open[0]['item']);
+		$this->assertSame('script', $open[0]['stage']);
+		$this->assertStringContainsString('Post-script FAIL', $open[0]['message']);
+	}
+
+	/** @return array<string, array{0: string, 1: string}> */
+	public static function postScriptFacilities(): array
+	{
+		return [
+			'IP loop'    => ['ip', 'pfB_Example_v4'],
+			'DNSBL loop' => ['dnsbl', 'DNSBL_Example'],
+		];
+	}
+
+	/**
+	 * issue #2059: both post-script branches must bind the recorder. #993: the
+	 * apply monolith owns feed download and appliance side effects, so its loop
+	 * cannot be driven off-appliance -- pin each live binding in its own route
+	 * scope; php_strip_whitespace() removes comments/docblocks from the source.
+	 */
+	public function testEachFamilyBindsPostScriptFailureRecordOnce(): void
+	{
+		$source      = php_strip_whitespace(self::APPLY);
+		$dnsbl_start = 'if ($pfb_row_script_post && is_file("{$pfb_row_script_post}")) {';
+		$dnsbl_end   = 'if (isset($csvline)) {';
+		$ip_start    = 'if ($pfb_script_post && is_file("{$pfb_script_post}")) {';
+		$ip_end      = '$file_chk = pfb_ip_script_probe_staged(';
+		$dnsbl_post  = $this->applyScope($source, $dnsbl_start, $dnsbl_end);
+		$ip_post     = $this->applyScope($source, $ip_start, $ip_end);
+
+		$this->assertSame(1, substr_count($dnsbl_post, "pfb_list_script_failure_record('dnsbl', \$alias,"),
+			'the DNSBL post-script branch must record against its own alias');
+		$this->assertSame(1, substr_count($ip_post, "pfb_list_script_failure_record('ip', \$alias,"),
+			'the IP post-script branch must record against its own alias');
+
+		// The trailing arguments are load-bearing: NULL suppresses a retry-marker
+		// write both loops would unlink further down the same iteration, and
+		// $pfb_script_state is what stops the alias-pass close wiping the entry.
+		foreach (['dnsbl' => $dnsbl_post, 'ip' => $ip_post] as $family => $scope) {
+			$this->assertSame(1, substr_count($scope, "\$pfb['dbdir'], NULL, \$pfb_script_state);"),
+				"the {$family} post-script record must pass no retry marker and the alias-pass state");
+		}
+
+		// Exactly two literal-facility call sites -- one post-script branch per
+		// loop. A third would double-report; the pre-script sites route through
+		// pfb_list_script_failure_continue() instead, which takes $facility.
+		$this->assertSame(2, substr_count($source, "pfb_list_script_failure_record('"),
+			'only the two post-script branches may call the recorder with a literal facility');
+
+		foreach ([
+			[$dnsbl_start, $dnsbl_end, "pfb_list_script_failure_record('dnsbl', \$alias,"],
+			[$ip_start, $ip_end, "pfb_list_script_failure_record('ip', \$alias,"],
+		] as [$start, $end, $needle]) {
+			$removed = 0;
+			$mutant = str_replace($needle, '', $source, $removed);
+			$this->assertSame(1, $removed, "mutation fixture must remove {$needle} once");
+			$endPos = strpos($mutant, $end);
+			$this->assertNotFalse($endPos, "mutation fixture must retain {$end}");
+			$mutant = substr_replace($mutant, $needle, $endPos + strlen($end), 0);
+			$mutantScope = $this->applyScope($mutant, $start, $end);
+			$this->assertSame(0, substr_count($mutantScope, $needle),
+				"a {$needle} relocation after its post-script branch must fail the scope pin");
 		}
 	}
 }

--- a/tests/php/PfbListScriptFailureRecordTest.php
+++ b/tests/php/PfbListScriptFailureRecordTest.php
@@ -13,6 +13,10 @@ use PHPUnit\Framework\TestCase;
  * and (re)writes the '.update' retry marker so the next ordinary pass still
  * attempts the transform instead of taking the verbatim-reuse fast path.
  *
+ * issue #2059: the same write site serves the POST-script call sites, which
+ * pass a NULL marker because they have no retry marker to write (see the
+ * NULL-marker rows below).
+ *
  * Decision (brief section 5): production code suppresses the marker touch()
  * with '@' (matches the existing @rename/@copy best-effort idiom already used
  * for filesystem side-writes in this file). PfbNoPhpWarningTrait does NOT fit
@@ -107,6 +111,56 @@ final class PfbListScriptFailureRecordTest extends TestCase
 		$this->assertFileExists($marker, 'after: the marker must still exist');
 		$this->assertSame('pre-existing-marker-content', file_get_contents($marker),
 			'touch() must not truncate an already-present marker\'s content');
+	}
+
+	// -----------------------------------------------------------------------
+	// issue #2059 -- a NULL marker opens the ledger entry and touches nothing.
+	// The post-script call sites have no retry marker to write: #1278's reuse
+	// decision already re-runs a configured script every pass, and both
+	// download loops unlink '{header}.update' AFTER their post-script branch,
+	// so a marker written there would be a dead write.
+	// -----------------------------------------------------------------------
+
+	public function testNullRetryMarkerOpensTheLedgerEntryAndCreatesNoMarker(): void
+	{
+		$marker = "{$this->dir}/pfB_Example_v4.update";
+		$state  = ['failed' => FALSE];
+		// Before-state: mandatory -- neither the entry nor the marker exists yet.
+		$this->assertSame([], pfb_sync_status_list_open($this->dir, 'ip'), 'before: the ledger has no open entry');
+		$this->assertFileDoesNotExist($marker, 'before: no retry marker exists');
+
+		pfb_list_script_failure_record('ip', 'pfB_Example_v4',
+			'Post-script FAIL - feed updated, side effects incomplete', $this->dir, NULL, $state);
+
+		$open = pfb_sync_status_list_open($this->dir, 'ip');
+		$this->assertCount(1, $open, 'a post-script failure must open exactly one entry');
+		$this->assertSame('script', $open[0]['stage']);
+		$this->assertSame('Post-script FAIL - feed updated, side effects incomplete', $open[0]['message']);
+		$this->assertTrue($state['failed'],
+			'the alias-pass state must be marked, else the paired close wipes the entry in the same pass');
+		$this->assertFileDoesNotExist($marker, 'a NULL marker must create no retry marker at all');
+	}
+
+	public function testNullRetryMarkerLeavesAPreExistingMarkerUntouched(): void
+	{
+		$marker = "{$this->dir}/pfB_Example_v4.update";
+		$stamp  = 1000000000;
+		file_put_contents($marker, 'pre-existing-marker-content');
+		// An unchanged mtime is the ONLY thing that discriminates "not touched"
+		// from "touched": touch() never truncates, so content alone proves nothing.
+		$this->assertTrue(touch($marker, $stamp), 'before: pin the marker mtime to a known past value');
+		clearstatcache(TRUE, $marker);
+		$this->assertSame($stamp, filemtime($marker), 'before: the pinned mtime must have taken');
+
+		pfb_list_script_failure_record('ip', 'pfB_Example_v4', 'Post-script FAIL', $this->dir, NULL);
+
+		clearstatcache(TRUE, $marker);
+		$this->assertSame('pre-existing-marker-content', file_get_contents($marker),
+			'a NULL marker must leave an unrelated pre-existing marker byte-identical');
+		$this->assertSame($stamp, filemtime($marker),
+			'a NULL marker must not touch() the marker -- an unchanged mtime is the proof');
+		$this->assertCount(1, pfb_sync_status_list_open($this->dir, 'ip'),
+			'the ledger entry must still open when no marker is written');
 	}
 
 	// -----------------------------------------------------------------------

--- a/tests/php/PfbListScriptFailureRecordTest.php
+++ b/tests/php/PfbListScriptFailureRecordTest.php
@@ -13,9 +13,8 @@ use PHPUnit\Framework\TestCase;
  * and (re)writes the '.update' retry marker so the next ordinary pass still
  * attempts the transform instead of taking the verbatim-reuse fast path.
  *
- * issue #2059: the same write site serves the POST-script call sites, which
- * pass a NULL marker because they have no retry marker to write (see the
- * NULL-marker rows below).
+ * issue #2059: the same write site serves the POST-script call sites via
+ * pfb_list_post_script_failure_record(), which passes a NULL marker.
  *
  * Decision (brief section 5): production code suppresses the marker touch()
  * with '@' (matches the existing @rename/@copy best-effort idiom already used
@@ -114,11 +113,7 @@ final class PfbListScriptFailureRecordTest extends TestCase
 	}
 
 	// -----------------------------------------------------------------------
-	// issue #2059 -- a NULL marker opens the ledger entry and touches nothing.
-	// The post-script call sites have no retry marker to write: #1278's reuse
-	// decision already re-runs a configured script every pass, and both
-	// download loops unlink '{header}.update' AFTER their post-script branch,
-	// so a marker written there would be a dead write.
+	// issue #2059 -- a NULL marker opens the entry and touches nothing.
 	// -----------------------------------------------------------------------
 
 	public function testNullRetryMarkerOpensTheLedgerEntryAndCreatesNoMarker(): void

--- a/tests/php/PfbListScriptFailureRecordTest.php
+++ b/tests/php/PfbListScriptFailureRecordTest.php
@@ -163,6 +163,33 @@ final class PfbListScriptFailureRecordTest extends TestCase
 			'the ledger entry must still open when no marker is written');
 	}
 
+	public function testNullRetryMarkerRaisesNoTouchDiagnostic(): void
+	{
+		// Without the NULL guard the call degrades to '@touch(NULL)', which
+		// coerces to '' and merely returns FALSE today -- but it raises
+		// "touch(): Passing null to parameter #1" as an E_DEPRECATED that '@'
+		// hides from output and PHP 9 promotes to a TypeError. A custom handler
+		// still sees a suppressed diagnostic, so its absence is the only
+		// observable that discriminates "skipped the touch" from "did it anyway".
+		$diagnostics = [];
+		set_error_handler(static function (int $errno, string $errstr) use (&$diagnostics): bool {
+			$diagnostics[] = $errstr;
+			return TRUE;
+		}, E_DEPRECATED | E_WARNING);
+		try {
+			pfb_list_script_failure_record('ip', 'pfB_Example_v4', 'Post-script FAIL', $this->dir, NULL);
+		} finally {
+			restore_error_handler();
+		}
+
+		$touch = array_values(array_filter($diagnostics,
+			static fn (string $d): bool => str_contains($d, 'touch(')));
+		$this->assertSame([], $touch,
+			'a NULL marker must skip the touch() outright, raising no diagnostic: ' . implode('; ', $touch));
+		$this->assertCount(1, pfb_sync_status_list_open($this->dir, 'ip'),
+			'the ledger entry must still open');
+	}
+
 	// -----------------------------------------------------------------------
 	// Row 5 -- the opened entry is closeable by the paired ADR-61 close.
 	// -----------------------------------------------------------------------

--- a/tests/php/fixtures/function_inventory.json
+++ b/tests/php/fixtures/function_inventory.json
@@ -7654,7 +7654,7 @@
                 "name": "update_marker",
                 "byRef": false,
                 "variadic": false,
-                "type": "string",
+                "type": "?string",
                 "default": null
             },
             {

--- a/tests/php/fixtures/function_inventory.json
+++ b/tests/php/fixtures/function_inventory.json
@@ -7351,6 +7351,54 @@
             }
         ]
     },
+    "pfb_list_post_script_failure_record": {
+        "returnsRef": false,
+        "returnType": "void",
+        "params": [
+            {
+                "name": "exit_status",
+                "byRef": false,
+                "variadic": false,
+                "type": "int",
+                "default": null
+            },
+            {
+                "name": "facility",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "item",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "message",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "ledger_dir",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "state",
+                "byRef": true,
+                "variadic": false,
+                "type": "?array",
+                "default": "NULL"
+            }
+        ]
+    },
     "pfb_list_pre_script_run": {
         "returnsRef": false,
         "returnType": "array",


### PR DESCRIPTION
Fixes #2059

## What was wrong

Both download loops ran a per-feed **post**-process script through `pfb_list_script_exec()` and dropped its exit status. The IP loop used the non-zero result only to restore `.orig` from `.orig.post` (#1927); the DNSBL loop discarded the return value entirely. Nothing marked the pass, so the ADR-61 sync-status ledger closed the alias/group as full success and the widget reported no problem. The failure was visible only in the error log.

## The fork in #2059, and how it was resolved

#2059 asked whether a post-script failure should mark the ledger the way #1958 marks a pre-script failure, or whether the asymmetry is intentional. The issue carries no owner ruling — its only comment is CodeRabbit's — so the fork was resolved from the issue's own text and from #1958's precedent, not from a recorded decision: **mark it**, with one deliberate difference #2059 itself named.

A failed **pre**-script means the staged list was not refreshed, so #1958 also arms the `.update` retry marker. A failed **post**-script means the list *was* refreshed and only the script's own side effects did not complete. So the message is distinct (`Post-script FAIL - feed updated, side effects incomplete`) and **no retry marker is written**:

1. `pfb_list_script_reuse_decision()` already pushes a row with a configured pre **or** post script off the verbatim-reuse fast path every pass a local `.orig` baseline exists (#1960/#1278, `pfblockerng_apply.inc:684-708`). The post-script retries by construction; no marker makes that happen.
2. On the non-stale paths that reach here, both loops unlink `{header}.update` *further down the same iteration* — DNSBL through `pfb_dnsbl_update_marker_clear_active()`, IP through `pfb_ip_update_marker_clear_active()`, both **after** the post-script branch. A marker written in the branch would be unlinked before the pass ended. (Both unlinks are guarded by `!$orig_content_stale` (#1022/#1031); on the stale-`.orig` fallback path the guard skips them, and there the `.fail` marker plus the reparse route already force the re-run, so reason 1 still carries.)

## Why the exit-status test lives inside a function

Round 1 wrote `if (pfb_list_script_exec(...) !== 0) { pfb_list_script_failure_record(...); }` at each site. Adversarial review found that unprovable: the apply monolith owns feed download and appliance side effects, so its loop cannot be driven off-appliance (#993), and a source-text scope pin cannot see brace nesting — a mutant that inverted the condition, and one that moved the recorder into a bare block just outside it, both passed every test in the repo.

Round 2 lifts the decision into `pfb_list_post_script_failure_record(int $exit_status, ...)`, which no-ops on 0 and delegates to the single `stage='script'` write site with a NULL marker. "A clean post-script records nothing" is now a behavioural assertion. This is the house idiom, not an invention: `pfb_ip_update_marker_clear_active()`, `pfb_dnsbl_verbatim_reuse_active()`, `pfb_list_script_reparse_active()` and `pfb_ip_reuse_skip_active()` all exist to lift a one-line monolith decision somewhere a unit test can reach it. It is also shorter at the call sites than the `if` wrapper it replaces.

`pfb_list_script_failure_record()`'s `$update_marker` is `?string` so the one write site serves both the pre-script callers (which pass a marker) and the post-script recorder (which passes NULL). The `'script'` stage literal stays in exactly one production place.

## Hypotheses and the discriminating probe

- **H1** — a failing post-script is *omitted* from the ledger (nothing is ever recorded).
- **H2** — something *is* recorded and then wrongly closed by the alias-pass close, because `$pfb_script_state` stays clean.

Probe: replay each loop's post-script sequence with the real production functions against a real `exit 3` script, and read the ledger at two observation points — right after the branch, and after the alias-pass close. One script (`/tmp/pfb_probe_2059_acceptance.php`) runs unchanged against both trees; the base tree simply has no recorder to call, which is the defect.

**Before the fix** — untouched base `devel` `d3b24b87`:

```text
post-script recorder wired in this tree? NO

=== dnsbl loop post-script (apply.inc DNSBL branch) (post-script exits 3) ===
ledger before                      = NO OPEN ENTRIES
pfb_list_script_exec rc            = 3
ledger right after the branch      = NO OPEN ENTRIES
$pfb_script_state['failed']        = false
ledger after alias-pass close      = NO OPEN ENTRIES

=== ip loop post-script (apply.inc IP branch) (post-script exits 3) ===
ledger before                      = NO OPEN ENTRIES
pfb_list_script_exec rc            = 3
ledger right after the branch      = NO OPEN ENTRIES
$pfb_script_state['failed']        = false
ledger after alias-pass close      = NO OPEN ENTRIES

=== error log written by the failing post-scripts ===
2026-08-28 15:39:34 [ foo_feed ] post-script 'post_dnsbl_3.sh' exited non-zero [ 3 ]; discarding its output
2026-08-28 15:39:34 [ foo_feed ] post-script 'post_ip_3.sh' exited non-zero [ 3 ]; discarding its output
```

**H1 confirmed, H2 refuted:** the ledger is empty at *both* observation points in *both* loops, so nothing was ever recorded — while the error log carries the non-zero line, exactly the asymmetry #2059 describes.

**After the fix** — head `48dcb564`, same probe, same fixture:

```text
post-script recorder wired in this tree? YES

=== dnsbl loop post-script (apply.inc DNSBL branch) (post-script exits 3) ===
ledger before                      = NO OPEN ENTRIES
pfb_list_script_exec rc            = 3
ledger right after the branch      = dnsbl/DNSBL_Foo/script: [ DNSBL_Foo - foo_feed ] Post-script FAIL - feed updated, side effects incomplete
$pfb_script_state['failed']        = true
retry marker written?              = no (NULL marker -- nothing to strand)
ledger after alias-pass close      = dnsbl/DNSBL_Foo/script: [ DNSBL_Foo - foo_feed ] Post-script FAIL - feed updated, side effects incomplete

=== ip loop post-script (apply.inc IP branch) (post-script exits 3) ===
ledger before                      = NO OPEN ENTRIES
pfb_list_script_exec rc            = 3
ledger right after the branch      = ip/pfB_Foo_v4/script: [ pfB_Foo_v4 - foo_feed ] Post-script FAIL - feed updated, side effects incomplete
$pfb_script_state['failed']        = true
retry marker written?              = no (NULL marker -- nothing to strand)
ledger after alias-pass close      = ip/pfB_Foo_v4/script: [ pfB_Foo_v4 - foo_feed ] Post-script FAIL - feed updated, side effects incomplete

=== healthy pass regression check: a post-script that exits 0 ===
=== ip loop post-script, clean (post-script exits 0) ===
ledger before                      = NO OPEN ENTRIES
pfb_list_script_exec rc            = 0
ledger right after the branch      = NO OPEN ENTRIES
$pfb_script_state['failed']        = false
ledger after alias-pass close      = NO OPEN ENTRIES
```

Both loops now surface the failure and it survives the alias-pass close. The last block is the unregressed-healthy-pass axis, and it is also pinned by two in-suite rows rather than left as a probe observation.

## Test-first: frozen reproductions, RED then GREEN

**Round 1** — frozen at the red run (`git hash-object`), byte-identical at the green run, both at commit `91de2156`:

| File | Frozen blob at `91de2156` |
| --- | --- |
| `tests/php/PfbListScriptFailureRecordTest.php` | `b45d7b22e2f5f5eca9bc1df6e819586ca4cfde0f` |
| `tests/php/ListScriptFailureLedgerWiringTest.php` | `e9826fdc98bd4cee81f2c3a7f0530a940b96451a` |

```text
RED   ..........EEF....EE....                                     23 / 23 (100%)
      4x TypeError: pfb_list_script_failure_record(): Argument #5 ($update_marker)
         must be of type string, null given
      1x testEachFamilyBindsPostScriptFailureRecordOnce
         the DNSBL post-script branch must record against its own alias
         Failed asserting that 0 is identical to 1.
      Tests: 23, Assertions: 105, Errors: 4, Failures: 1.

GREEN .........................................                   41 / 41 (100%)
      OK (41 tests, 213 assertions)
```

Both files changed again afterwards — `389c2f01` added a row, `3fd71473` rewired them for the extracted recorder, `da7264d7` cut the redundant clean-exit provider row and `48dcb564` added the accumulated-state row — so the round-1 blobs are historical by design. That evidence stays verifiable at `91de2156`, and an independent test-honesty reviewer re-executed it there and confirmed both hashes. The branch has since been rebased, so `91de2156`, `389c2f01` and `3fd71473` are reachable objects but no longer commits on this PR; everything below is re-executed at the current head against the true merge-base.

**At head `48dcb564`, against the true merge-base `d3b24b87`** — this is the pair that matters, and it is stronger than the intermediate-commit reds the earlier rounds published. Only production moves; both test files stay at their head blobs, captured before the red run, immediately after it, and again after every mutant below:

| File | Blob at head `48dcb564`, unchanged across RED and GREEN |
| --- | --- |
| `tests/php/ListScriptFailureLedgerWiringTest.php` | `1c77ed1c64dd07a9c5815d388f9007093838b34c` |
| `tests/php/PfbListScriptFailureRecordTest.php` | `e1cf02a0b320d3f36c29087cfe2072908cb485b2` |

```text
$ git checkout d3b24b87 -- src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc \
                           tests/php/fixtures/function_inventory.json
$ git diff HEAD --numstat
20      55      src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
1       49      tests/php/fixtures/function_inventory.json
$ vendor/bin/phpunit --no-coverage tests/php/ListScriptFailureLedgerWiringTest.php \
                                   tests/php/PfbListScriptFailureRecordTest.php

RED   ..........EEEEEEEEF....EEE....                              30 / 30 (100%)
      8x Error: Call to undefined function pfb_list_post_script_failure_record()
         (both testFailingPostScriptStaysVisible rows, both
          testCleanPostScriptRecordsNothing rows, all three
          testEveryNonZeroPostScriptStatusOpensAnEntry rows, and
          testACleanRowDoesNotUndoAnEarlierRowsPostScriptFailure)
      3x TypeError: pfb_list_script_failure_record(): Argument #5 ($update_marker)
         must be of type string, null given          [apply.inc:554]
      1x testEachFamilyBindsPostScriptFailureRecordOnce
         the DNSBL post-script branch must pass its own exit status and alias
         to the recorder / Failed asserting that 0 is identical to 1.
      Tests: 30, Assertions: 116, Errors: 11, Failures: 1.
```

The three extra `TypeError`s are what a base-relative red buys over the earlier tables: the `?string` retype of `$update_marker` is also absent at the merge-base, so the NULL-marker rows fail at the type boundary rather than passing.

```text
$ git checkout 48dcb564 -- src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc \
                           tests/php/fixtures/function_inventory.json
$ git status --porcelain            # empty

GREEN ..............................                              30 / 30 (100%)
      OK (30 tests, 165 assertions)

# plus every neighbour that pins the same call sites or the reuse decision:
# FunctionInventoryParityTest, ListScriptExitStatusTest, ListPreScriptStageTest,
# ListScriptTransformRerunWiringTest, PfbListUserScriptActiveTest
GREEN ..............................................................  62 / 62 (100%)
      OK (62 tests, 280 assertions)
```

`tests/php/fixtures/function_inventory.json` is a generated production-signature mirror, not a reproduction test, so it moves with production in both directions. It is proven non-vacuous rather than decorative: reverting only the fixture while production stays at head turns `FunctionInventoryParityTest` red (`Tests: 1, Assertions: 5, Failures: 1.` at `FunctionInventoryParityTest.php:50`), against `OK (1 test, 6 assertions)` at head.

## Mutation kill table (re-executed at head `48dcb564`)

Each mutant is a single string replacement in `pfblockerng_apply.inc` whose anchor was programmatically asserted unique in the pristine head file, applied with a non-empty `git diff --numstat` verified, then reverted with the restored file asserted byte-identical and `git status --porcelain` asserted empty before the next. Every run targets the two changed test files. **Seven mutants, seven kills, zero survivors.**

| # | Mutant | numstat | Killed by | Quoted failure |
| --- | --- | --- | --- | --- |
| M1 | **Drop the post-script status capture in the DNSBL loop** — nothing marks the pass | `0 4` | `ListScriptFailureLedgerWiringTest::testEachFamilyBindsPostScriptFailureRecordOnce` | `the DNSBL post-script branch must pass its own exit status and alias to the recorder` · `Failed asserting that 0 is identical to 1.` |
| M2 | **Record without surfacing** — drop `$pfb_script_state` from the IP recorder call, so the alias-pass close wipes the entry | `1 1` | same test | `the ip post-script record must pass the alias-pass state` |
| M3 | **Surface in only one of the two loops** — drop the IP recorder call, leave DNSBL's | `0 4` | same test | `the IP post-script branch must pass its own exit status and alias to the recorder` |
| M4 | Drop the NULL guard — unconditional `@touch($update_marker)` | `1 3` | `PfbListScriptFailureRecordTest::testNullRetryMarkerRaisesNoTouchDiagnostic` | `a NULL marker must skip the touch() outright, raising no diagnostic: touch(): Passing null to parameter #1 ($filename) of type string is deprecated` |
| M5 | **Invert the exit-status guard** — record on success, stay silent on failure | `1 1` | 8 rows: `testFailingPostScriptStaysVisibleAfterTheAliasPassCloses` (IP + DNSBL), `testCleanPostScriptRecordsNothingAndLeavesTheAliasPassClean` (IP + DNSBL), `testEveryNonZeroPostScriptStatusOpensAnEntry` (3, 124, −1), `testACleanRowDoesNotUndoAnEarlierRowsPostScriptFailure` | `a failed post-script must survive the alias-pass close, not read as full success` · `a post-script exiting 0 must open no entry` · `exit status 3 must open a ledger entry` · `exit status 124 must open a ledger entry` · `exit status -1 must open a ledger entry` |
| M6 | **Drop the exit-status guard entirely** — record on every post-script pass | `0 3` | `testCleanPostScriptRecordsNothingAndLeavesTheAliasPassClean` (IP + DNSBL), `testACleanRowDoesNotUndoAnEarlierRowsPostScriptFailure` | `a post-script exiting 0 must open no entry` · `the surviving entry must still be row A's, not row B's message / Failed asserting that 'row_b succeeded' contains "row_a".` |
| M7 | **Clean-status early return also clears `$state['failed']`** — a later clean row silently wipes an earlier row's failure | `3 0` | `testACleanRowDoesNotUndoAnEarlierRowsPostScriptFailure` | `a clean row must leave an earlier row's failure state intact / Failed asserting that false is true.` |

M5 and M6 are the class round 1 could not kill: with the guard at the call sites, inverting it passed 24/24 and relocating the recorder into a bare block just outside it passed 62 tests across two runs. Both die now, because the extraction turned the polarity into a behavioural assertion. M7 is the class the final commit `48dcb564` exists to pin — a review mutant found that nothing failed when the clean-status early return also reset the accumulated state, which would lose an earlier row's failure on an alias whose next row succeeds.

M1, M2 and M3 are killed only by the source-scope wiring pin, and that coupling is deliberate: #993 means the apply monolith's download loops cannot be driven off-appliance, so "the loop passed the right arguments" has no behavioural observable. The pin compensates with per-family relocation sub-mutants that require it to fail when a needle moves past its branch boundary. The relocation mutant that motivated the extraction is no longer expressible against the same *behaviour* — there is no call-site guard left to escape — so it is pinned as a wiring regression instead.

## Gates

`scripts/agent/run-gates.sh --diff origin/devel`, run once on the branch worktree at head `48dcb564`:

```text
GATE PASS: python3 scripts/check_coverage_pairing.py --name-status-z
GATE PASS: uv run --locked python scripts/check_composer_vendor.py
GATE PASS: uv run --locked python scripts/check_toggle_registry.py --self-test && uv run --locked python scripts/check_toggle_registry.py
GATE PASS: php -l src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
GATE PASS: php -l tests/php/ListScriptFailureLedgerWiringTest.php
GATE PASS: php -l tests/php/PfbListScriptFailureRecordTest.php
GATE FAIL: vendor/bin/phpunit
GATE PASS: composer phpstan
GATE PASS: composer phpcs -- --standard=phpcs.xml.dist src/
GATES: FAIL
```

`vendor/bin/phpunit`'s single red is **#2765's** deterministic Darwin-only row, and it was proven pre-existing rather than assumed — the same full suite was executed on **untouched base `devel` `d3b24b87`** and produced the identical failure, alone, with identical warning/deprecation/notice/skip counts:

```text
branch (48dcb564)  There was 1 failure:
                   1) DownloadSizeCeilingTest::test_extract_cmd_ceiling_stops_a_child_that_writes_past_it
                   Darwin dd must surface RLIMIT_FSIZE as its EFBIG exit
                   Failed asserting that 153 is identical to 1.
                   Tests: 5752, Assertions: 33004, Failures: 1, Warnings: 29, Deprecations: 3, Notices: 1, Skipped: 3.

base    (d3b24b87)  There was 1 failure:
                   1) DownloadSizeCeilingTest::test_extract_cmd_ceiling_stops_a_child_that_writes_past_it
                   Darwin dd must surface RLIMIT_FSIZE as its EFBIG exit
                   Failed asserting that 153 is identical to 1.
                   Tests: 5740, Assertions: 32933, Failures: 1, Warnings: 29, Deprecations: 3, Notices: 1, Skipped: 3.
```

Same row, same assertion, same message; the 12-test delta is exactly this PR's new rows. `DownloadSizeCeilingTest` is download-family code this diff never touches. None of #2828's load-dependent flapping set fired on either run. CI on Linux is green on the exact head.

## Scope

- `tests/php/fixtures/function_inventory.json` carries the `?string` retype of `update_marker` and the new `pfb_list_post_script_failure_record` entry, both regenerated through the documented `PFB_UPDATE_FUNCTION_INVENTORY=1` path with the parity oracle green afterwards.
- The DNSBL branch's `pfb_list_script_exec(` line was re-indented because the change binds its result to a variable; the surrounding block is otherwise untouched, and `unlink_if_exists("{$file_dwn}.post")` still runs on both the zero and non-zero paths. #1927's restore block in the IP branch is byte-identical to base.
- **Deferred, now tracked as #2848:** the DNSBL post-script's staging-copy failure leg stays log-only. It is outside #2059's normative "Where", which names only the discarded exit status — but the stated reason in round 1 ("a staging failure rather than a failing script") was wrong: `pfb_list_pre_script_run()` returns `ok => FALSE` for a copy failure too, and both loops open a `stage='script'` entry for it, so the pre and post paths now disagree on that leg. #2848 carries the asymmetry, including whether the IP loop's unchecked `@copy(... '.orig.post')` is a second instance.
- **Not touched:** the `@param string $stage` enumerations on `pfb_sync_status_open()`/`close()` and ADR-61's stage table, both of which have under-enumerated `script` since #1958 landed. That is #2102's declared scope.
- **Related, not this PR:** `pfb_sync_status_close_removed_alias()` closes `download` only, so a `script` entry strands on alias deletion. This PR widens the affected population (a post-script-only feed could not previously hold a `script` entry) without introducing the mechanism. Tracked as #2060 and fixed in PR #2847.

🤖 Generated by Oh My Pi and posted on behalf of @andrebrait.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Post-script failures are now reliably recorded in the failure ledger.
  - Successful post-scripts no longer create failure entries.
  - Retry markers remain unchanged when they are not applicable.
  - Failure status remains visible after alias processing completes.

- **Tests**
  - Added coverage for successful and failed post-scripts, status variations, ledger persistence, and retry-marker behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->