### PR TITLE
tests: stop three sibling shims leaking PID-keyed temp dirs

### DIFF
--- a/tests/php/EditHooksPageWiringTest.php
+++ b/tests/php/EditHooksPageWiringTest.php
@@ -156,6 +156,7 @@ PHP;
 		fclose($pipes[1]);
 		fclose($pipes[2]);
 		$status = proc_close($process);
+		$this->assertSame('', trim((string) $stderr), (string) $stderr);
 		return ['status' => $status, 'stdout' => (string) $stdout, 'stderr' => (string) $stderr, 'pid' => $pid];
 	}
 

--- a/tests/php/EditHooksPageWiringTest.php
+++ b/tests/php/EditHooksPageWiringTest.php
@@ -9,6 +9,9 @@ final class EditHooksPageWiringTest extends TestCase
 {
 	private string $dir = '';
 
+	/** @var list<string> Stale shim paths planted by runDeniedPage(), swept after each test. */
+	private array $planted = [];
+
 	protected function setUp(): void
 	{
 		require_once dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng_hook_edit.inc';
@@ -22,6 +25,11 @@ final class EditHooksPageWiringTest extends TestCase
 			@unlink($path);
 		}
 		@rmdir($this->dir);
+		foreach ($this->planted as $path) {
+			@unlink($path . '/guiconfig.inc');
+			@rmdir($path);
+		}
+		$this->planted = [];
 	}
 
 	private function makeHook(string $name, string $body = "#!/bin/sh\nexit 0\n"): string
@@ -59,12 +67,69 @@ final class EditHooksPageWiringTest extends TestCase
 
 	public function testShippedPageDelegatesDeniedRequestToController(): void
 	{
+		$result = $this->runDeniedPage();
+		$this->assertSame(0, $result['status'], $result['stderr']);
+		$this->assertSame('shutdown', $result['stdout'], 'denied page must exit through the controller redirect');
+	}
+
+	/**
+	 * Scenario: the include shim is per-invocation scratch.
+	 * Given a request to the real Edit Hooks page,
+	 * When the subprocess exits,
+	 * Then the temp directory holds nothing keyed to that run -- a shim left
+	 * behind is what lets a later run on a recycled PID collide (issue #2834).
+	 */
+	public function testDeniedPageRunLeavesNoShimResidue(): void
+	{
+		// A checkout without this fix, sharing the host, can already hold a bare
+		// pfb_edit_hooks_shim_<pid>, so only what this run added counts.
+		$before = glob(sys_get_temp_dir() . '/pfb_edit_hooks_shim_*') ?: [];
+		$result = $this->runDeniedPage();
+		$this->assertSame(0, $result['status'], $result['stderr']);
+		$this->assertSame([], array_diff($this->shimResidue($result['pid']), $before));
+	}
+
+	/**
+	 * Scenario: the OS recycles a PID an earlier suite run already used.
+	 * Given a shim directory already sitting at this run's PID-keyed path,
+	 * When the real Edit Hooks page is requested,
+	 * Then it still exits through the controller redirect with nothing ahead of
+	 * its output, never writes into the directory it inherited, and adds no
+	 * residue of its own beside it.
+	 */
+	public function testDeniedPageSurvivesAShimLeftOverFromARecycledPid(): void
+	{
+		$result = $this->runDeniedPage(TRUE);
+		$this->assertSame(0, $result['status'], $result['stderr']);
+		$this->assertSame('shutdown', $result['stdout'], 'denied page must exit through the controller redirect');
+		$this->assertSame([], glob($this->planted[0] . '/*') ?: [], 'a per-invocation shim path must never adopt an inherited directory');
+		$this->assertSame([], array_diff($this->shimResidue($result['pid']), $this->planted));
+	}
+
+	/** @return list<string> Shim directories owned by child PID $pid, with or without a per-invocation suffix. */
+	private function shimResidue(int $pid): array
+	{
+		$prefix = sys_get_temp_dir() . '/pfb_edit_hooks_shim_' . $pid;
+		return array_merge(glob($prefix) ?: [], glob($prefix . '_*') ?: []);
+	}
+
+	/** @return array{status:int,stdout:string,stderr:string,pid:int} */
+	private function runDeniedPage(bool $plantStaleShim = FALSE): array
+	{
 		$root = var_export(dirname(__DIR__, 2), TRUE);
 		$page = var_export(dirname(__DIR__, 2) . '/src/usr/local/www/pfblockerng/pfblockerng_edit_hooks.php', TRUE);
 		$script = <<<PHP
+stream_get_contents(STDIN);
 require {$root} . '/tests/php/bootstrap.php';
-\$shim = sys_get_temp_dir() . '/pfb_edit_hooks_shim_' . getmypid();
-mkdir(\$shim, 0777, TRUE);
+\$shim = sys_get_temp_dir() . '/pfb_edit_hooks_shim_' . getmypid() . '_' . bin2hex(random_bytes(8));
+if (!mkdir(\$shim, 0700, TRUE)) {
+	fwrite(STDERR, "edit hooks include shim creation failed\\n");
+	exit(1);
+}
+register_shutdown_function(static function () use (\$shim): void {
+	@unlink(\$shim . '/guiconfig.inc');
+	@rmdir(\$shim);
+});
 file_put_contents(\$shim . '/guiconfig.inc', "<?php");
 set_include_path(\$shim . PATH_SEPARATOR . get_include_path());
 error_reporting(E_ERROR | E_PARSE);
@@ -73,17 +138,25 @@ register_shutdown_function(static function (): void { echo 'shutdown'; });
 require {$page};
 echo 'after-page';
 PHP;
-		$descriptors = [1 => ['pipe', 'w'], 2 => ['pipe', 'w']];
+		$descriptors = [0 => ['pipe', 'r'], 1 => ['pipe', 'w'], 2 => ['pipe', 'w']];
 		$process = proc_open([PHP_BINARY, '-r', $script], $descriptors, $pipes);
 		$this->assertIsResource($process);
+		$pid = (int) proc_get_status($process)['pid'];
+		if ($plantStaleShim) {
+			// The child blocks on STDIN until the pipe is closed below, so the
+			// plant always lands before it creates its own shim.
+			$residue = sys_get_temp_dir() . '/pfb_edit_hooks_shim_' . $pid;
+			$this->planted[] = $residue;
+			@mkdir($residue, 0777, TRUE);
+			$this->assertDirectoryExists($residue);
+		}
+		fclose($pipes[0]);
 		$stdout = stream_get_contents($pipes[1]);
 		$stderr = stream_get_contents($pipes[2]);
 		fclose($pipes[1]);
 		fclose($pipes[2]);
 		$status = proc_close($process);
-
-		$this->assertSame(0, $status, (string) $stderr);
-		$this->assertSame('shutdown', $stdout, 'denied page must exit through the controller redirect');
+		return ['status' => $status, 'stdout' => (string) $stdout, 'stderr' => (string) $stderr, 'pid' => $pid];
 	}
 
 	public function testControllerReturnsSuccessNoticesFromGet(): void

--- a/tests/php/WidgetGetTableArgOrderTest.php
+++ b/tests/php/WidgetGetTableArgOrderTest.php
@@ -56,8 +56,8 @@ final class WidgetGetTableArgOrderTest extends TestCase
 	 * Scenario: the OS recycles a PID an earlier suite run already used.
 	 * Given a shim directory already sitting at this run's PID-keyed path,
 	 * When the real widget renders,
-	 * Then it renders clean on a clean stderr, never writes into the directory
-	 * it inherited, and adds no residue of its own beside it.
+	 * Then it renders as usual, never writes into the directory it inherited,
+	 * and adds no residue of its own beside it.
 	 */
 	public function testWidgetSurvivesAShimLeftOverFromARecycledPid(): void
 	{

--- a/tests/php/WidgetGetTableArgOrderTest.php
+++ b/tests/php/WidgetGetTableArgOrderTest.php
@@ -9,6 +9,18 @@ final class WidgetGetTableArgOrderTest extends TestCase
 	private const ROOT = __DIR__ . '/../..';
 	private const WIDGET = self::ROOT . '/src/usr/local/www/widgets/widgets/pfblockerng.widget.php';
 
+	/** @var list<string> Stale shim paths planted by runWidget(), swept after each test. */
+	private array $planted = [];
+
+	protected function tearDown(): void
+	{
+		foreach ($this->planted as $path) {
+			@unlink($path . '/guiconfig.inc');
+			@rmdir($path);
+		}
+		$this->planted = [];
+	}
+
 	public function testAjaxWidgetBranchExecutesTheShippedTableCall(): void
 	{
 		$result = $this->runWidget(['getNewWidget' => '1'], []);
@@ -23,35 +35,93 @@ final class WidgetGetTableArgOrderTest extends TestCase
 		$this->assertStringContainsString('<tbody id="pfBNG-table">', $result['stdout']);
 	}
 
-	/** @return array{status:int,stdout:string,stderr:string} */
-	private function runWidget(array $get, array $post): array
+	/**
+	 * Scenario: the include shim is per-invocation scratch.
+	 * Given a render of the real widget,
+	 * When the subprocess exits,
+	 * Then the temp directory holds nothing keyed to that run -- a shim left
+	 * behind is what lets a later run on a recycled PID collide (issue #2834).
+	 */
+	public function testWidgetRunLeavesNoShimResidue(): void
+	{
+		// A checkout without this fix, sharing the host, can already hold a bare
+		// pfb_widget_shim_<pid>, so only what this run added counts.
+		$before = glob(sys_get_temp_dir() . '/pfb_widget_shim_*') ?: [];
+		$result = $this->runWidget([], []);
+		$this->assertSame(0, $result['status'], $result['stderr']);
+		$this->assertSame([], array_diff($this->shimResidue($result['pid']), $before));
+	}
+
+	/**
+	 * Scenario: the OS recycles a PID an earlier suite run already used.
+	 * Given a shim directory already sitting at this run's PID-keyed path,
+	 * When the real widget renders,
+	 * Then it renders clean on a clean stderr, never writes into the directory
+	 * it inherited, and adds no residue of its own beside it.
+	 */
+	public function testWidgetSurvivesAShimLeftOverFromARecycledPid(): void
+	{
+		$result = $this->runWidget([], [], TRUE);
+		$this->assertSame(0, $result['status'], $result['stderr']);
+		$this->assertStringContainsString('<tbody id="pfBNG-table">', $result['stdout']);
+		$this->assertSame([], glob($this->planted[0] . '/*') ?: [], 'a per-invocation shim path must never adopt an inherited directory');
+		$this->assertSame([], array_diff($this->shimResidue($result['pid']), $this->planted));
+	}
+
+	/** @return list<string> Shim directories owned by child PID $pid, with or without a per-invocation suffix. */
+	private function shimResidue(int $pid): array
+	{
+		$prefix = sys_get_temp_dir() . '/pfb_widget_shim_' . $pid;
+		return array_merge(glob($prefix) ?: [], glob($prefix . '_*') ?: []);
+	}
+
+	/** @return array{status:int,stdout:string,stderr:string,pid:int} */
+	private function runWidget(array $get, array $post, bool $plantStaleShim = FALSE): array
 	{
 		$root = var_export(self::ROOT, TRUE);
 		$widget = var_export(self::WIDGET, TRUE);
 		$getCode = var_export($get, TRUE);
 		$postCode = var_export($post, TRUE);
 		$script = <<<PHP
+stream_get_contents(STDIN);
 \$GLOBALS['argv'] = ['widget'];
 error_reporting(E_ERROR | E_PARSE);
 \$_GET = {$getCode};
 \$_POST = {$postCode};
 \$_SERVER = [];\$widgetname = 'pfblockerng';
-\$shim = sys_get_temp_dir() . '/pfb_widget_shim_' . getmypid();
-mkdir(\$shim, 0777, TRUE);
+\$shim = sys_get_temp_dir() . '/pfb_widget_shim_' . getmypid() . '_' . bin2hex(random_bytes(8));
+if (!mkdir(\$shim, 0700, TRUE)) {
+	fwrite(STDERR, "widget include shim creation failed\\n");
+	exit(1);
+}
+register_shutdown_function(static function () use (\$shim): void {
+	@unlink(\$shim . '/guiconfig.inc');
+	@rmdir(\$shim);
+});
 file_put_contents(\$shim . '/guiconfig.inc', "<?php");
 set_include_path(\$shim . PATH_SEPARATOR . get_include_path());
 require {$root} . '/tests/php/bootstrap.php';
 require {$widget};
 echo 'after-include';
 PHP;
-		$descriptors = [1 => ['pipe', 'w'], 2 => ['pipe', 'w']];
+		$descriptors = [0 => ['pipe', 'r'], 1 => ['pipe', 'w'], 2 => ['pipe', 'w']];
 		$process = proc_open([PHP_BINARY, '-r', $script], $descriptors, $pipes);
 		$this->assertIsResource($process);
+		$pid = (int) proc_get_status($process)['pid'];
+		if ($plantStaleShim) {
+			// The child blocks on STDIN until the pipe is closed below, so the
+			// plant always lands before it creates its own shim.
+			$residue = sys_get_temp_dir() . '/pfb_widget_shim_' . $pid;
+			$this->planted[] = $residue;
+			@mkdir($residue, 0777, TRUE);
+			$this->assertDirectoryExists($residue);
+		}
+		fclose($pipes[0]);
 		$stdout = stream_get_contents($pipes[1]);
 		$stderr = stream_get_contents($pipes[2]);
 		fclose($pipes[1]);
 		fclose($pipes[2]);
 		$status = proc_close($process);
-		return ['status' => $status, 'stdout' => (string) $stdout, 'stderr' => (string) $stderr];
+		return ['status' => $status, 'stdout' => (string) $stdout, 'stderr' => (string) $stderr, 'pid' => $pid];
 	}
 }

--- a/tests/php/WidgetPostAllowedTest.php
+++ b/tests/php/WidgetPostAllowedTest.php
@@ -87,8 +87,8 @@ final class WidgetPostAllowedTest extends TestCase
 	 * Scenario: the OS recycles a PID an earlier suite run already used.
 	 * Given a shim directory already sitting at this run's PID-keyed path,
 	 * When the real widget renders,
-	 * Then it renders clean on a clean stderr, never writes into the directory
-	 * it inherited, and adds no residue of its own beside it.
+	 * Then it renders as usual, never writes into the directory it inherited,
+	 * and adds no residue of its own beside it.
 	 */
 	public function testWidgetSurvivesAShimLeftOverFromARecycledPid(): void
 	{

--- a/tests/php/WidgetPostAllowedTest.php
+++ b/tests/php/WidgetPostAllowedTest.php
@@ -10,6 +10,18 @@ final class WidgetPostAllowedTest extends TestCase
 	private const ROOT = __DIR__ . '/../..';
 	private const WIDGET = self::ROOT . '/src/usr/local/www/widgets/widgets/pfblockerng.widget.php';
 
+	/** @var list<string> Stale shim paths planted by runWidget(), swept after each test. */
+	private array $planted = [];
+
+	protected function tearDown(): void
+	{
+		foreach ($this->planted as $path) {
+			@unlink($path . '/guiconfig.inc');
+			@rmdir($path);
+		}
+		$this->planted = [];
+	}
+
 	public static function setUpBeforeClass(): void
 	{
 		require_once dirname(__DIR__, 2) . '/src/usr/local/www/widgets/include/widget-pfblockerng.inc';
@@ -54,33 +66,91 @@ final class WidgetPostAllowedTest extends TestCase
 		$this->assertStringContainsString('<form id="formicons"', $result['stdout']);
 	}
 
-	/** @return array{status:int,stdout:string,stderr:string} */
-	private function runWidget(array $get, array $post): array
+	/**
+	 * Scenario: the include shim is per-invocation scratch.
+	 * Given a render of the real widget,
+	 * When the subprocess exits,
+	 * Then the temp directory holds nothing keyed to that run -- a shim left
+	 * behind is what lets a later run on a recycled PID collide (issue #2834).
+	 */
+	public function testWidgetRunLeavesNoShimResidue(): void
+	{
+		// A checkout without this fix, sharing the host, can already hold a bare
+		// pfb_widget_shim_<pid>, so only what this run added counts.
+		$before = glob(sys_get_temp_dir() . '/pfb_widget_shim_*') ?: [];
+		$result = $this->runWidget([], []);
+		$this->assertSame(0, $result['status'], $result['stderr']);
+		$this->assertSame([], array_diff($this->shimResidue($result['pid']), $before));
+	}
+
+	/**
+	 * Scenario: the OS recycles a PID an earlier suite run already used.
+	 * Given a shim directory already sitting at this run's PID-keyed path,
+	 * When the real widget renders,
+	 * Then it renders clean on a clean stderr, never writes into the directory
+	 * it inherited, and adds no residue of its own beside it.
+	 */
+	public function testWidgetSurvivesAShimLeftOverFromARecycledPid(): void
+	{
+		$result = $this->runWidget([], [], TRUE);
+		$this->assertSame(0, $result['status'], $result['stderr']);
+		$this->assertStringContainsString('<form id="formicons"', $result['stdout']);
+		$this->assertSame([], glob($this->planted[0] . '/*') ?: [], 'a per-invocation shim path must never adopt an inherited directory');
+		$this->assertSame([], array_diff($this->shimResidue($result['pid']), $this->planted));
+	}
+
+	/** @return list<string> Shim directories owned by child PID $pid, with or without a per-invocation suffix. */
+	private function shimResidue(int $pid): array
+	{
+		$prefix = sys_get_temp_dir() . '/pfb_widget_shim_' . $pid;
+		return array_merge(glob($prefix) ?: [], glob($prefix . '_*') ?: []);
+	}
+
+	/** @return array{status:int,stdout:string,stderr:string,pid:int} */
+	private function runWidget(array $get, array $post, bool $plantStaleShim = FALSE): array
 	{
 		$root = var_export(self::ROOT, TRUE);
 		$widget = var_export(self::WIDGET, TRUE);
 		$getCode = var_export($get, TRUE);
 		$postCode = var_export($post, TRUE);
 		$script = <<<PHP
+stream_get_contents(STDIN);
 \$_GET = {$getCode};
 \$_POST = {$postCode};
 \$_SERVER = [];
 \$widgetname = 'pfblockerng';
-\$shim = sys_get_temp_dir() . '/pfb_widget_shim_' . getmypid();
-mkdir(\$shim, 0777, TRUE);
+\$shim = sys_get_temp_dir() . '/pfb_widget_shim_' . getmypid() . '_' . bin2hex(random_bytes(8));
+if (!mkdir(\$shim, 0700, TRUE)) {
+	fwrite(STDERR, "widget include shim creation failed\\n");
+	exit(1);
+}
+register_shutdown_function(static function () use (\$shim): void {
+	@unlink(\$shim . '/guiconfig.inc');
+	@rmdir(\$shim);
+});
 file_put_contents(\$shim . '/guiconfig.inc', "<?php");
 set_include_path(\$shim . PATH_SEPARATOR . get_include_path());
 require {$root} . '/tests/php/bootstrap.php';
 require {$widget};
 PHP;
-		$descriptors = [1 => ['pipe', 'w'], 2 => ['pipe', 'w']];
+		$descriptors = [0 => ['pipe', 'r'], 1 => ['pipe', 'w'], 2 => ['pipe', 'w']];
 		$process = proc_open([PHP_BINARY, '-r', $script], $descriptors, $pipes);
 		$this->assertIsResource($process);
+		$pid = (int) proc_get_status($process)['pid'];
+		if ($plantStaleShim) {
+			// The child blocks on STDIN until the pipe is closed below, so the
+			// plant always lands before it creates its own shim.
+			$residue = sys_get_temp_dir() . '/pfb_widget_shim_' . $pid;
+			$this->planted[] = $residue;
+			@mkdir($residue, 0777, TRUE);
+			$this->assertDirectoryExists($residue);
+		}
+		fclose($pipes[0]);
 		$stdout = stream_get_contents($pipes[1]);
 		$stderr = stream_get_contents($pipes[2]);
 		fclose($pipes[1]);
 		fclose($pipes[2]);
 		$status = proc_close($process);
-		return ['status' => $status, 'stdout' => (string) $stdout, 'stderr' => (string) $stderr];
+		return ['status' => $status, 'stdout' => (string) $stdout, 'stderr' => (string) $stderr, 'pid' => $pid];
 	}
 }


### PR DESCRIPTION
Fixes #2834

## What was wrong

`WidgetGetTableArgOrderTest`, `WidgetPostAllowedTest` and `EditHooksPageWiringTest` each
spawned a `php -r` child that created its `guiconfig.inc` include shim at
`sys_get_temp_dir() . '/pfb_<kind>_shim_' . getmypid()` and never removed it. Every suite run
left directories behind, and once the OS recycled a PID a previous run had used the child's
`mkdir()` warned `File exists` — in `EditHooksPageWiringTest` that warning landed ahead of the
page's own output and failed the run on output it never expected.

#2612 fixed the identical defect in `LintEndpointWiringTest`; that fix landed through PR #2835 as
`e7d66d89` and is on `devel`. These three files were outside that issue's scope.

## Probe: which cause, and why the three files do not fail the same way

Two hypotheses, one probe. **H1** — a residual PID-keyed directory makes the child's `mkdir()`
fail, and the consequences reach the parent. **H2** — the pages emit output before their headers
regardless, so residue is not the producer.

The probe ran each class twice against unmodified code at base `3aafe4e8`: once clean, once with
a directory planted at the child's own PID-keyed path (a single `@mkdir(...getmypid()...)` line
inserted immediately ahead of the child's own `$shim =` line, so the plant always precedes it).

Leg (a), control — every class green, and **every class leaks**:

```
--- WidgetGetTableArgOrderTest  prefix=pfb_widget_shim_*      before=1388 after=1390  added=2
OK (2 tests, 6 assertions)
--- WidgetPostAllowedTest       prefix=pfb_widget_shim_*      before=1390 after=1395  added=5
OK (11 tests, 21 assertions)
--- EditHooksPageWiringTest     prefix=pfb_edit_hooks_shim_*  before=206  after=207   added=1
OK (23 tests, 129 assertions)
```

Leg (b), residue planted:

```
===== PLANTED RUN: WidgetGetTableArgOrderTest (exit 0) =====
OK (2 tests, 6 assertions)

===== PLANTED RUN: WidgetPostAllowedTest (exit 0) =====
OK (11 tests, 21 assertions)

===== PLANTED RUN: EditHooksPageWiringTest (exit 1) =====
1) EditHooksPageWiringTest::testShippedPageDelegatesDeniedRequestToController
denied page must exit through the controller redirect
Failed asserting that two strings are identical.
-'shutdown'
+'
+Warning: mkdir(): File exists in Command line code on line 4
+shutdown'
```

H1 is confirmed, H2 refuted — but only `EditHooksPageWiringTest` reddens on the collision
today, and the probe explains why the other two do not:

- `EditHooksPageWiringTest` calls `error_reporting(E_ERROR | E_PARSE)` *after* its `mkdir`, so the
  warning is displayed and lands ahead of the page output the test asserts on.
- `WidgetGetTableArgOrderTest` calls `error_reporting(E_ERROR | E_PARSE)` *before* its `mkdir`, so
  the warning is suppressed outright.
- `WidgetPostAllowedTest` does emit the warning, but its assertion is
  `assertStringContainsString('<form id="formicons"', ...)`, which a leading warning does not
  disturb.

So on two of the three the collision is silent today. That is worse, not better: the shim from a
dead run is inherited and written into, and the tests notice nothing. The reproduction tests
below are built to catch the silent form as well as the loud one.

Host residue accumulated before this work started: **1388** `pfb_widget_shim_*` and **206**
`pfb_edit_hooks_shim_*` (the issue reports 1248 / 183; it has kept growing since).

## The fix

Key each shim on a per-invocation random suffix, fail loudly when the `mkdir` does not take, and
drop the directory from a shutdown function — the same shape as
`tests/php/WidgetSubmitPostGuardTest.php:71-79` and as #2612's fix in `LintEndpointWiringTest`:

```php
\$shim = sys_get_temp_dir() . '/pfb_widget_shim_' . getmypid() . '_' . bin2hex(random_bytes(8));
if (!mkdir(\$shim, 0700, TRUE)) {
	fwrite(STDERR, "widget include shim creation failed\\n");
	exit(1);
}
register_shutdown_function(static function () use (\$shim): void {
	@unlink(\$shim . '/guiconfig.inc');
	@rmdir(\$shim);
});
```

No second mechanism is introduced: three files, one shape. The in-repo exemplar is
`WidgetSubmitPostGuardTest`, already carrying it on `devel` before this branch opened;
`LintEndpointWiringTest` received the same shape from #2612 via PR #2835, merged as `e7d66d89`,
which the final base `b55dba81` now contains. That merge is also what retires the
`pfb_lint_shim_*` positive control this PR originally leaned on — see "Residue counts, executed"
below. No production code is touched.

The plant seam the recycled-PID tests need has one prerequisite these three harnesses lacked and
`LintEndpointWiringTest` already had: a STDIN pipe. The child now opens with
`stream_get_contents(STDIN);` and the parent plants between `proc_open()` and the `fclose()` that
delivers EOF, so the plant is ordered before the child's `mkdir()` by the pipe rather than by
timing. `EditHooksPageWiringTest`'s subprocess block, previously inline in one test, is extracted
to a `runDeniedPage()` helper so both new tests can drive it.

## Test-first: RED before, GREEN after, frozen

Two tests per file pin the two properties: one asserts a run leaves nothing behind under its own
child PID, one plants a shim at the child's PID-keyed path and requires a clean run anyway. Both
residue assertions diff against a baseline — a `glob()` snapshot taken before the run in one test,
the deliberately planted directory in the other — so they speak only about what the invocation
itself created and cannot red on a leak from another checkout sharing the host. That matters more
here than it did for #2612: these prefixes carry 1388 and 206 accumulated directories on this
host, against the ~44 that lane faced.

Frozen test-file hashes at red time:

| File | `git hash-object` at red |
| --- | --- |
| `tests/php/WidgetGetTableArgOrderTest.php` | `fceace34f99f20c4346a210830de12af9e842441` |
| `tests/php/WidgetPostAllowedTest.php` | `3b979915405203ee29afe1760b33d29c93377f30` |
| `tests/php/EditHooksPageWiringTest.php` | `5d3e47463facce2f1953cad5dde6b2a39667fad5` |

The fix and the tests live in the same files, because the harness *is* the subject of the defect.
The freeze is therefore proven by reconstruction: reverting only the nine child-script lines back
to the original two reproduces each red-time hash exactly, so every other byte of all three files
is identical between the red and green runs.

**The reconstruction anchors at the fix commit** — `cb5f8ec5` today, `567d0065` before the rebases —
because that is the commit the RED run was taken at, before the second commit reworded the two
widget docblocks and added `EditHooksPageWiringTest`'s stderr assertion. It therefore does *not*
reconstruct at HEAD, by construction: splicing the base block into HEAD's files yields
`d89f8855` / `0a9bd7eb` / `24da6120`, since HEAD carries that second commit on top. Reproducing
this proof means checking out the fix commit's blobs, not HEAD's. Both anchors are given here so
the check is unambiguous either way.

```
=== 1. FREEZE PROOF: reconstruct each red-time file ===
    tests/php/WidgetGetTableArgOrderTest.php
      reconstructed red hash: fceace34f99f20c4346a210830de12af9e842441
      frozen red-time hash:   fceace34f99f20c4346a210830de12af9e842441
      MATCH: True
    tests/php/WidgetPostAllowedTest.php
      reconstructed red hash: 3b979915405203ee29afe1760b33d29c93377f30
      frozen red-time hash:   3b979915405203ee29afe1760b33d29c93377f30
      MATCH: True
    tests/php/EditHooksPageWiringTest.php
      reconstructed red hash: 5d3e47463facce2f1953cad5dde6b2a39667fad5
      frozen red-time hash:   5d3e47463facce2f1953cad5dde6b2a39667fad5
      MATCH: True
```

RED — the six new tests, on untouched harness code, 2/2 per file:

```
--- RED tests/php/WidgetGetTableArgOrderTest.php (exit 1)
..FF                                                                4 / 4 (100%)
1) WidgetGetTableArgOrderTest::testWidgetRunLeavesNoShimResidue
-Array &0 []
+Array &0 [
+    0 => '.../pfb_widget_shim_20548',
+]
2) WidgetGetTableArgOrderTest::testWidgetSurvivesAShimLeftOverFromARecycledPid
a per-invocation shim path must never adopt an inherited directory
-Array &0 []
+Array &0 [
+    0 => '.../pfb_widget_shim_20590/guiconfig.inc',
+]
Tests: 4, Assertions: 14, Failures: 2.

--- RED tests/php/WidgetPostAllowedTest.php (exit 1)
...........FF                                                     13 / 13 (100%)
1) WidgetPostAllowedTest::testWidgetRunLeavesNoShimResidue
+    0 => '.../pfb_widget_shim_20815',
2) WidgetPostAllowedTest::testWidgetSurvivesAShimLeftOverFromARecycledPid
a per-invocation shim path must never adopt an inherited directory
+    0 => '.../pfb_widget_shim_20819/guiconfig.inc',
Tests: 13, Assertions: 29, Failures: 2.

--- RED tests/php/EditHooksPageWiringTest.php (exit 1)
...FF....................                                         25 / 25 (100%)
1) EditHooksPageWiringTest::testDeniedPageRunLeavesNoShimResidue
+    0 => '.../pfb_edit_hooks_shim_20825',
2) EditHooksPageWiringTest::testDeniedPageSurvivesAShimLeftOverFromARecycledPid
denied page must exit through the controller redirect
-'shutdown'
+'
+Warning: mkdir(): File exists in Command line code on line 4
+shutdown'
Tests: 25, Assertions: 138, Failures: 2.
```

Note which assertion carries the red where, at red time. On `EditHooksPageWiringTest` it is the
header cascade the issue quotes. On the two widget files the collision is silent, and the red comes
from the `guiconfig.inc` the pre-fix child wrote into the directory it inherited — the direct
expression of "a second run on the same PID cannot collide".

Both figures above are anchored at the fix commit, which is where the RED run happened. Re-run at
the current head the same reversion still reds 2/2 per file, but `EditHooksPageWiringTest` reads
`Assertions: 139` rather than `138` and the red is carried one assertion earlier, by the stderr
assertion `39e93890` added, instead of by the outer stdout cascade. The signal is the same one:
PHP CLI writes the `mkdir(): File exists` warning to *both* streams, so either assertion sees it.

GREEN — same tests, zero edits, after the fix:

```
--- GREEN tests/php/WidgetGetTableArgOrderTest.php (exit 0)   OK (4 tests, 15 assertions)
--- GREEN tests/php/WidgetPostAllowedTest.php (exit 0)        OK (13 tests, 30 assertions)
--- GREEN tests/php/EditHooksPageWiringTest.php (exit 0)      OK (25 tests, 140 assertions)
```

## Mutation proof

Driver asserts each needle occurs exactly once, applies it, asserts `git diff` is non-empty, runs
the class, reverts, and asserts `git diff` is empty again before the next mutant. Baseline and
post-revert runs are green for all three files. Executed in a private detached clone at this head
with a private `TMPDIR`.

| Mutant | `WidgetGetTableArgOrderTest` | `WidgetPostAllowedTest` | `EditHooksPageWiringTest` |
| --- | --- | --- | --- |
| M1 remove the per-invocation uniqueness (PID-only path) | **killed** by `testWidgetSurvivesAShimLeftOverFromARecycledPid` — `widget include shim creation failed`, `Failures: 1` | **killed** by `testWidgetSurvivesAShimLeftOverFromARecycledPid` — `mkdir(): File exists` + `widget include shim creation failed`, `Failures: 1` | **killed** by `testDeniedPageSurvivesAShimLeftOverFromARecycledPid` — `mkdir(): File exists` + `edit hooks include shim creation failed`, `Failures: 1` |
| M2 remove the cleanup entirely | **killed** by both new tests — residue `pfb_widget_shim_20945_7bd5df875f088b33` / `..._20949_a1a393bfd983de89`, `Failures: 2` | **killed** by both — `..._21334_b773721277d76e34` / `..._21365_4ce592e9c04a7572`, `Failures: 2` | **killed** by both — `pfb_edit_hooks_shim_21642_5091da442f4593e5` / `..._21643_102b51f9d9229917`, `Failures: 2` |
| M3 cleanup off the failure path (trailing statement, not registered) | **survived** — `OK (4 tests, 15 assertions)` | **survived** — `OK (13 tests, 30 assertions)` | **killed** by both — `..._21656_82b6d859f42c031f` / `..._21659_d4a16e8a27a24580`, `Failures: 2` |
| M4 cleanup forgets the directory, keeps the `unlink` | **killed** by both — `..._21005_b79ad26242a8217e` / `..._21009_7a7db1f721fbe3a5`, `Failures: 2` | **killed** by both — `..._21526_8f89d31a4164eebc` / `..._21530_58e3b98f8bcc54c5`, `Failures: 2` | **killed** by both — `..._21667_b4f77eb28a2a2788` / `..._21705_53427d84d9da489a`, `Failures: 2` |

**M3 survives on the two widget files, and that is reported rather than papered over.** It
survives because on every path those two classes drive, the widget include *returns* to the child
and the script runs to its end, so a trailing statement cleans up there too.
`pfblockerng_edit_hooks.php` does not end in `exit` — it ends `include('foot.inc'); ?>` — but the
denied request the test drives never reaches that end. It leaves through the controller's redirect
`exit` at `pfblockerng_edit_hooks.php:111`, inside `if ($pfb_eh_state['redirect'] !== NULL)`, the
file's only `exit`. That is why M3 dies on the third file, and the test pins the mechanism
directly: the child ends `echo 'after-page';` while the assertion is
`assertSame('shutdown', $result['stdout'])`, so a `require` that returned would read
`after-pageshutdown`.

That raises the obvious question — is `register_shutdown_function` then redundant in the two
widget files? No, and this is measured rather than argued.
`src/usr/local/www/widgets/widgets/pfblockerng.widget.php` has five `exit(0)` branches (lines
183-221), reached whenever the POST guard is open — and `WidgetPostAllowedTest`'s own truth table
declares `same-origin` and `none` as the two states that open it. A probe opened the guard, posted
`pfb_submit` to drive the page's real `exit(0)`, and compared the two cleanup shapes on the
otherwise unchanged residue test:

```
--- LEG B: shipped fix (shutdown hook), page exits
exit 0
OK (1 test, 3 assertions)

--- LEG A: same test, cleanup demoted to a trailing statement (M3)
exit 1
1) WidgetPostAllowedTest::testWidgetRunLeavesNoShimResidue
-Array &0 []
+Array &0 [
+    0 => '/tmp/pfb2834_hookprobe_tmp/pfb_widget_shim_28051_e28614ac71df4e51',
+]
Tests: 1, Assertions: 3, Failures: 1.

=== VERDICT ===
shutdown hook, guard open, page exits : PASS (no residue)
trailing statement, same conditions  : FAIL (residue leaked)
hook is load-bearing on the page's exit path: True
```

So the hook is load-bearing on the same page these two classes load; M3's survival is a statement
about which paths *these* classes drive (deliberately, the guard-closed ones), not about the hook
being unnecessary. Driving the guard open in `WidgetPostAllowedTest` to kill M3 would contradict
that class's subject and duplicate `WidgetSubmitPostGuardTest`, so the mutant is left surviving
and the probe stands as the evidence. M4 — a same-class mutant on the cleanup body — kills on all
three files, so the cleanup's content is pinned everywhere; only the registration mechanism is
unpinned on the two widget files.

## Residue counts, executed

The blunt count on the shared host is unusable here: five sibling agents were running full suites
out of other worktrees against the same `$TMPDIR` throughout, and those checkouts still carry the
unfixed copies of these three files. A shared-host full-suite run measured by set difference shows
exactly that:

```
BEFORE full suite: 1691 entries across both prefixes
AFTER  full suite: 1700
=== ADDED ===
pfb_edit_hooks_shim_71491
pfb_edit_hooks_shim_72360
pfb_edit_hooks_shim_75599
pfb_widget_shim_50809
pfb_widget_shim_50812
pfb_widget_shim_50816
pfb_widget_shim_50822
pfb_widget_shim_50829
pfb_widget_shim_50833
```

Every added entry is **bare** `shim_<pid>`. The fixed code can only ever produce
`shim_<pid>_<16 hex>`, so none of these nine can be this branch's — and the two PID clusters
(50809-50833, 71491-75599) are not this run's children.

The measurement that does settle it is a private `TMPDIR` no sibling can reach, with the still-
unfixed `LintEndpointWiringTest` on this base acting as the built-in positive control — if the
method cannot see a known leak, a zero from it means nothing:

```
private tmp: /tmp/pfb2834_private_tmp
before: 0
OK (42 tests, 185 assertions)          <- the three classes together
after three classes: 0

full suite rc=1
Tests: 5735, Assertions: 32894, Failures: 2, ...
--- shim dirs left in the private TMPDIR by the WHOLE suite:
pfb_widget_shim:      0
pfb_edit_hooks_shim:  0
pfb_lint_shim:        5
```

Zero for both prefixes this PR owns, across the entire 5735-test suite; five for the prefix it does
not, from the same `find` in the same run. Taken standalone the control arm reproduced the same
figure — `pfb_lint_shim_*` 0 before, 5 after, `OK (3 tests, 25 assertions)`.

The branch nets zero by construction: each child removes its own shim from a shutdown function,
and the one path the harness deliberately creates — the planted directory in each recycled-PID
test — is swept by `tearDown()`.

That `pfb_lint_shim_* 5` control is dated to the original merge base `3aafe4e8`. #2612 has since
merged as `e7d66d89`, and this PR is now rebased onto `b55dba81`, which contains it — so that arm
reads zero on the current base and validates nothing. The measurement above is kept as taken
rather than re-run and quietly re-quoted; the control carrying the claim now is the base/head A/B
below.

The proof that does not depend on a dated control is the assertion itself. "Zero across the whole
prefix" needs a positive arm; "nothing new appeared under this run's own child PID, and removing
the cleanup makes it appear" carries its own — M2 and M4 turn exactly that assertion red, in the
same run, on all three files.

### Post-rebase A/B on the exact prefixes, same method on both sides

With the `pfb_lint_shim_*` arm retired, the positive control is the base itself. The same
measurement, the same two prefixes, run against the unfixed copies on the final base `b55dba81`
and against this head `ff1de2b7`, each in its own private `TMPDIR` no sibling can reach:

```
===== SIDE base  sha=b55dba8  TMPDIR=/tmp/pfb2834_final_base_tmp
BEFORE pfb_widget_shim_*     = 0
BEFORE pfb_edit_hooks_shim_* = 0
OK (36 tests, 156 assertions)
AFTER  pfb_widget_shim_*     = 7
AFTER  pfb_edit_hooks_shim_* = 1
--- names left behind:
pfb_widget_shim_97578  pfb_widget_shim_97581  pfb_widget_shim_97585  pfb_widget_shim_97590
pfb_widget_shim_97594  pfb_widget_shim_97601  pfb_widget_shim_97605  pfb_edit_hooks_shim_97576

===== SIDE head  sha=ff1de2b  TMPDIR=/tmp/pfb2834_final_head_tmp
BEFORE pfb_widget_shim_*     = 0
BEFORE pfb_edit_hooks_shim_* = 0
OK (42 tests, 188 assertions)
AFTER  pfb_widget_shim_*     = 0
AFTER  pfb_edit_hooks_shim_* = 0
--- names left behind:
(none)
```

The same pair measured 7/1 against 0/0 on the previous base `d3b24b87` as well, so the result is
not an artefact of one base.

The control passes on the prefixes this PR actually owns: the method sees eight leaked directories
on the unfixed base and zero on the head, and every base-side name is the bare `shim_<pid>` form
the fix retires. The mutation arm still bites on the rebased base too — M1 (uniqueness removed) and
M2 (cleanup removed), re-executed against live `devel`'s harness, each `git diff`-asserted
non-empty when applied and empty after revert:

```
=== WidgetGetTableArgOrderTest   baseline OK (4 tests, 15 assertions)
    M1  Tests: 4, Assertions: 12, Failures: 1.   | widget include shim creation failed
    M2  Tests: 4, Assertions: 15, Failures: 2.
    post-revert OK (4 tests, 15 assertions)
=== WidgetPostAllowedTest        baseline OK (13 tests, 30 assertions)
    M1  Tests: 13, Assertions: 27, Failures: 1.  | mkdir(): File exists + widget include shim creation failed
    M2  Tests: 13, Assertions: 30, Failures: 2.
    post-revert OK (13 tests, 30 assertions)
=== EditHooksPageWiringTest      baseline OK (25 tests, 143 assertions)
    M1  Tests: 25, Assertions: 139, Failures: 1. | mkdir(): File exists + edit hooks include shim creation failed
    M2  Tests: 25, Assertions: 143, Failures: 2.
    post-revert OK (25 tests, 143 assertions)
```

## Gates

Re-run on the final head `ff1de2b7`, against the live base `b55dba81`:

```
GATE PASS: python3 scripts/check_coverage_pairing.py --name-status-z
GATE PASS: uv run --locked python scripts/check_composer_vendor.py
GATE PASS: uv run --locked python scripts/check_toggle_registry.py --self-test && uv run --locked python scripts/check_toggle_registry.py
GATE PASS: php -l tests/php/EditHooksPageWiringTest.php
GATE PASS: php -l tests/php/WidgetGetTableArgOrderTest.php
GATE PASS: php -l tests/php/WidgetPostAllowedTest.php
GATE FAIL: vendor/bin/phpunit
GATE PASS: composer phpstan
GATE PASS: composer phpcs -- --standard=phpcs.xml.dist src/
GATES: FAIL
```

Eight of the nine pass. The `phpunit` row carries exactly one failure across 5746 tests, and it is
the documented Darwin-only red of #2765:

```
Tests: 5758, Assertions: 33036, Failures: 1, Warnings: 29, Deprecations: 3, Notices: 1, Skipped: 3.

1) DownloadSizeCeilingTest::test_extract_cmd_ceiling_stops_a_child_that_writes_past_it
Darwin dd must surface RLIMIT_FSIZE as its EFBIG exit
Failed asserting that 153 is identical to 1.
```


Full-suite evidence on the untouched base, same host, same private-`TMPDIR` method:

```
=== full suite, UNTOUCHED base d3b24b87, no branch code, private TMPDIR ===
ulimit -f = unlimited
There were 2 failures:
1) AlertsCnameLookupTimeoutTest::testTimeoutDiscardsPartialOutputAndLogsExpiry
Failed asserting that false is true.
2) DownloadSizeCeilingTest::test_extract_cmd_ceiling_stops_a_child_that_writes_past_it
Darwin dd must surface RLIMIT_FSIZE as its EFBIG exit
Failed asserting that 153 is identical to 1.
```

The #2765 row reds on the untouched base with the identical message and the identical `153`, so it
is not this branch's. The base run also reds an `AlertsCnameLookupTimeoutTest` row from the #2828
flapping set that the head's gates run did not — so against the base it lands on, this head is
strictly no worse, and in this pair cleaner by one row. `ulimit -f` was `unlimited` on both sides,
which rules out an inherited file-size limit as the cause.

That row is full-suite-only — standalone it is green on every base tried
(`OK (17 tests, 91 assertions)` on `d3b24b87` and again on `b55dba81`), which is why a filtered
re-run cannot see it and why the independent verifier's leg did not (ledger row 15).
`tests/php/DownloadSizeCeilingTest.php` is byte-identical on both bases (`63a1f123`), so the
untouched-base run above carries directly to the final base. Neither post-rebase gates run showed
any other flapper: one failure, the known one. No skip was added or changed, so
`tests/skip-allowlist.txt` is untouched.

CI is green on the final head `ff1de2b7` on every required check (both PHP 8.3 and 8.5 legs of
PHPUnit, PHPCS, PHPStan and `php -l`, plus pytest, Ruff, mypy, ShellCheck, shellspec, actionlint,
markdownlint, coverage pairing, comment narration, the webassets drift guard and the widget JS
tests). The two live-VM rows, `UI fan-out` and `Benchmark kill-gates`, are skipping — a test-only
PHP change reaches neither.

## Review fixes

`567d0065` is the fix and the six frozen tests. One commit follows.

**Post-rebase SHA map.** The branch was rebased twice while landing, as `devel` advanced under it —
first onto `d3b24b87`, then onto `b55dba81` once #2842 merged. So the two commits below now read
`cb5f8ec5` (was `e24993a5`, originally `567d0065`) and `ff1de2b7` (was `18923a7f`, originally
`39e93890`). Neither rebase carried content: across all three of them the file blobs are unchanged
(`9bf971dd`, `1bfa3dc0`, `0b142ac8`) and the full diff against the base hashes to the same
`sha256 597a6e49ada2e3efc4de37f706d2c2ae1d3e77a25995947f5c6d927b55a03cde`. The review legs' audit
comments therefore key on the same reviewed content under the older SHAs; the round-3 comments
below re-grade it, and every figure quoted in "Gates" and in the A/B above was re-executed on the
final head.

`39e93890` answers the one finding two legs raised independently: the two widget survival
docblocks promised "a clean stderr" that no assertion pinned, and the contract leg built an M5
mutant — the child writing an unexpected diagnostic to `STDERR` on the happy path — that survives
on all three files. Both legs offered the same two options: reword, or assert it the way
`LintEndpointWiringTest:152` does.

Asserting it in the shared harness was tried first and is refuted by evidence. Both widget
children legitimately write to stderr off-appliance:

```
1) WidgetGetTableArgOrderTest::testDefaultWidgetRenderExecutesTheShippedTableCall
grep: /var/log/pfblockerng/maxmind_ver: No such file or directory

1) WidgetPostAllowedTest::testEveryShippedMutationBranchStaysClosedWithoutFetchMetadata@settings with data ('pfb_submit')
PHP Warning:  Undefined array key "maxmind_locale" in .../pfblockerng.inc on line 3288
PHP Warning:  Undefined array key "asn_reporting" in .../pfblockerng.inc on line 3289
... 20 more, then:
grep: /var/log/pfblockerng/maxmind_ver: No such file or directory
```

A `grep(1)` miss on `/var/log/pfblockerng/maxmind_ver` plus a pile of pre-existing
`Undefined array key` warnings from the real production code under the doubles — none of it
related to #2834. Adding `assertSame('', trim($stderr))` there took the two classes from
`OK (4 tests, 15 assertions)` / `OK (13 tests, 30 assertions)` to `Failures: 3` / `Failures: 7`.
A clean stderr is simply not part of those two harnesses' contract, which makes M5 an equivalent
mutant on them rather than a coverage gap.

So the resolution is split by evidence: the two widget docblocks now claim only what is pinned
("renders as usual, never writes into the directory it inherited"), and
`EditHooksPageWiringTest`, which does hold the property, gains the assertion —
`OK (25 tests, 140 assertions)` becomes `OK (25 tests, 143 assertions)`, and M5 now dies there.
Stable over 20 consecutive runs with zero residue:

```
--- EditHooks stability, 20 runs with the new stderr assertion:
iterations=20 failures=0
residue left: 0
```

### The tests were not weakened by that commit

The freeze hashes above are anchored at `567d0065`, not at HEAD: `39e93890` edits test text after
green, which `.agents/policy/testing.md` permits, and the freeze deliberately does not reconstruct
at HEAD. The direct answer to "did the post-green edit soften anything" is to run the tests as
they stand at HEAD against the original, unfixed child scripts. They still catch it, 2/2 on every
file:

```
HEAD: 39e938905c23b89519d94b71deb5d703b68f8648
=== 2. RED RUN (untouched tests, child scripts reverted to pre-fix) ===
--- RED tests/php/WidgetGetTableArgOrderTest.php (exit 1)     Tests: 4,  Failures: 2.
--- RED tests/php/WidgetPostAllowedTest.php (exit 1)          Tests: 13, Failures: 2.
--- RED tests/php/EditHooksPageWiringTest.php (exit 1)        Tests: 25, Failures: 2.
```

The full five-mutant table re-run at `39e93890`:

| Mutant | `WidgetGetTableArgOrderTest` | `WidgetPostAllowedTest` | `EditHooksPageWiringTest` |
| --- | --- | --- | --- |
| M1 remove the uniqueness | killed | killed | killed |
| M2 remove the cleanup | killed | killed | killed |
| M3 cleanup off the failure path | survived (equivalent mutant, see above) | survived (equivalent mutant) | killed |
| M4 cleanup forgets the directory | killed | killed | killed |
| M5 unexpected diagnostic on STDERR | survived (equivalent mutant, stderr not in contract) | survived (equivalent mutant) | **killed** by `39e93890` |

Baselines and post-revert runs all green: `OK (4 tests, 15 assertions)`,
`OK (13 tests, 30 assertions)`, `OK (25 tests, 143 assertions)`.

## Findings ledger

| # | Leg | Finding | Outcome |
| --- | --- | --- | --- |
| 1 | contract N1, correctness nitpick | Widget survival docblocks promise a clean stderr that no assertion pins; M5 survives on all three | **fixed@`39e93890`** — asserted on `EditHooksPageWiringTest` (M5 now dies there); refuted for the two widget classes with executed evidence and their docblocks narrowed to what is pinned |
| 2 | test honesty N1 | `mkdir($shim, 0700, TRUE)` permission mode unasserted on all three files | **skipped** — the shim is removed by the child's own shutdown function before the parent regains control (the parent blocks on `stream_get_contents` until the child's pipes close), so the mode is unobservable post-run without an instrumentation hook this black-box harness does not have. Identical SKIP to the one accepted on PR #2835, and the exemplar `WidgetSubmitPostGuardTest` has no mode test either |
| 3 | test honesty N2 | The `fwrite(STDERR, "...failed\n")` diagnostic text is unasserted | **skipped**, and the round-2 test-honesty leg corrected this row's original wording, which claimed it fixed. `EditHooksPageWiringTest`'s new stderr assertion fires on the *happy* path, so it closes M5 (an unexpected diagnostic on success) but not N2's literal scenario: that leg stripped the `fwrite` line while keeping `exit(1)` and the class stayed green at `OK (25 tests, 143 assertions)`. Pinning the message text itself would mean asserting a literal string on a path only a mutant reaches. The guard's *behaviour* is pinned on all three files by M1, which dies on the `exit(1)`; only the wording is unpinned |
| 4 | test honesty N3 | `WidgetSubmitPostGuardTest`, the exemplar, has no residue assertion, so the M3 defence rests on a `/tmp` probe rather than on anything running in CI | **deferred: #2846** — that file is untouched here, and it is the only class that opens the POST guard and reaches the widget's `exit(0)`, so it is the only place the mechanism is observable. #2846 carries an executable acceptance condition: demoting its `:76-79` hook must fail the new test |
| 5 | contract O1 | PR body said "the two already-fixed siblings", but at merge base only `WidgetSubmitPostGuardTest` is fixed on `devel`; the lint fix is on unmerged PR #2835 | **fixed@body** — the sentence now names the exemplar as the only sibling fixed on `devel` |
| 6 | contract O2 | A wider PID-only temp-path axis exists: 9 test files, 11 sites, a different defect class (in-process fixture dirs, not `php -r` include shims) | **deferred: #2845** — enumerated in full, with each row's failure mode classified |
| 7 | correctness outside-diff, over-engineering outside-diff | `tests/php/bootstrap.php:30-34` leaks a PID-keyed `pfb_php_unit_<pid>` sandbox per process | **already tracked: #2836** — filed by the #2612 lane; its quoted block, line references and "never removed" claim were re-verified against this head |
| 8 | test honesty round 2 | Ledger row 3 overclaimed: the new stderr assertion closes M5, not N2's literal failure-path scenario | **fixed@body** — row 3 above now says so, with that leg's own mutant result |
| 9 | test honesty round 2, enhancement, explicitly not required | A narrower `assertStringNotContainsString('mkdir', $stderr)` is buildable and stable 3/3 on the two widget classes despite the off-appliance noise | **skipped** — no single realistic mutant reaches it. Dropping the guard alone leaves uniqueness intact, so no collision and no warning; dropping uniqueness alone is M1, which dies on the `exit(1)`. A `mkdir()` warning reaching stderr with every other assertion still passing needs *both* mutations at once, and that compound state is the pre-fix code, already caught by the inherited-directory and residue assertions. Adding an assertion with no unique kill is coverage without evidence |
| 10 | contract round 2 N2 | Issue #2845's counts were wrong: title said nine files, table listed seven files and eleven sites; the true axis is larger, and five sites were missing | **fixed@#2845** — re-derived from source at `devel` tip `59107c90` and rewritten: eleven files, fourteen sites, each row's `mkdir` form and teardown state read from source, plus an explicit examined-and-excluded section. My own enumeration also removed two rows that leg's round-1 wording had included: `V6CidrSubtractTest.php:521` and `:539` are PID-only but nothing ever creates them (`:527` asserts `assertFileDoesNotExist`), so no collision or residue is reachable there |
| 11 | contract round 2 N3 | The body's "the unmerged PR #2835" went stale nine minutes after this head was authored | **fixed@body** — the sentence now names the merge commit and keeps the merge-base statement it was fixing |
| 12 | over-engineering round 2 | `$result['stderr']` as the message argument on `EditHooksPageWiringTest.php:71,88,103` is now provably whitespace-only | **skipped** — that leg filed it explicitly as a zero-line nitpick with no action requested; it is the suite-wide idiom at 64 sites across 34 files, and dropping it saves nothing while losing the raw unescaped multi-line text ahead of PHPUnit's escaped diff |
| 13 | independent verifier N1 | The body's stated reason M3 dies on `EditHooksPageWiringTest` — "`pfblockerng_edit_hooks.php` ends in `exit`" — is factually wrong | **fixed@body** — re-read from source: the file ends `include('foot.inc'); ?>` and holds exactly one `exit`, at `pfblockerng_edit_hooks.php:111`, inside `if ($pfb_eh_state['redirect'] !== NULL)`. The conclusion was right and the mechanism wrong. The sentence now names the redirect `exit` the denied path actually leaves through — which the test pins directly: the child ends `echo 'after-page';` and the assertion is `assertSame('shutdown', $result['stdout'])`, so a `require` that returned would read `after-pageshutdown` |
| 14 | independent verifier N2 | "#2612 fixed the identical defect in `LintEndpointWiringTest`" and "at this branch's base it is still unfixed" both misstated the landed baseline — PR #2835 was still open when that leg reviewed `567d0065` | **fixed@body** — #2835 has since merged as `e7d66d89` and #2612 is closed; `LintEndpointWiringTest.php:119` on live `devel` carries the fixed shape. This PR is now rebased onto `b55dba81`, which contains that merge, so the base-relative clause had gone wrong in the other direction. Both sentences are corrected, and the `pfb_lint_shim_* 5` arm is explicitly retired as dated to `3aafe4e8` rather than re-quoted — replaced by a same-prefix base/head A/B taken on the rebased base |
| 15 | independent verifier N3 | The body's `GATE FAIL: vendor/bin/phpunit` attribution to #2765's `DownloadSizeCeilingTest` row did not reproduce for that leg, which saw `Top1mDccDetectorTest` instead | **skipped: attribution confirmed, non-observation explained** — both post-rebase gates runs red on exactly that #2765 row and nothing else (`Failures: 1`, across 5746 tests then 5758 now), so the body's attribution holds. The leg's non-observation is explained rather than waved off: the row is green standalone on every base tried (`OK (17 tests, 91 assertions)` on both `d3b24b87` and `b55dba81`) and only surfaces under full-suite conditions, so a filtered or standalone run structurally cannot see it. Base full-suite evidence in "Gates" above |
| 16 | test honesty round 3 | **Filed blocking**: the freeze-reconstruction proof does not reproduce; four independent methods agreed on `d89f8855` / `0a9bd7eb` / `24da6120` instead of the frozen hashes | **skipped: premise refuted by execution, and withdrawn by the leg itself** — that leg derived the reverted block from `git diff <base> <head>`, i.e. anchored at HEAD, but the freeze anchors at the fix commit, where the RED run was taken. Splicing the base block into HEAD's files yields precisely the three hashes it reported, while the fix commit (`cb5f8ec5` today, `e24993a5` at the time, `567d0065` before the rebases) yields the frozen values on all three files. The independent verifier had already reproduced MATCH at the fix commit in the same round. The leg re-tested against it, confirmed all three match, and posted a withdrawal, revising to approve. The documentation gap it exposed is real and is fixed@body: the freeze section now names the anchor and states outright that it does not reconstruct at HEAD, quoting the HEAD-anchored hashes so the next reader cannot repeat the mistake |
| 17 | test honesty round 3, independent verifier round 3 | The body's RED transcript (`Assertions: 138`, red carried by the outer stdout cascade on `EditHooksPageWiringTest`) reads differently at HEAD (`139`, red carried by the stderr assertion) | **fixed@body** — the RED figures are now explicitly labelled red-time-anchored, with the HEAD reading and its cause stated: PHP CLI writes the `mkdir(): File exists` warning to *both* streams, so either assertion sees the same signal. The 2/2-per-file claim is unaffected on either anchor |
| 18 | over-engineering round 3 | With #2612 landed on the base, four files now carry the full shim harness, and one shared trait measures net −30 lines tree-wide (−33 including the exemplar's preamble) | **deferred: #2849** — within this PR's three files the same extraction is −3, a wash, and taking it here would either leave `LintEndpointWiringTest` on the old shape or reach outside the diff. #2849 carries the executed measurement (`OK (49 tests, 248 assertions)` before and after the rewire, a trait-preamble mutant reddening one recycled-PID test per adopter), both implementation traps that leg hit, and an executable acceptance condition |
| 19 | over-engineering round 3 | The retirement of the `pfb_lint_shim_*` control is narrated four times, and the retired arm's standalone five-name block sits in full beside the A/B that replaces it | **fixed@body** — the standalone block is collapsed to one sentence that keeps its figure (`0` before, `5` after, `OK (3 tests, 25 assertions)`) |
| 20 | contract round 3 | Each of the six tests this PR adds spawns a child that `require`s `bootstrap.php`, so the PR adds six leaked `pfb_php_unit_<pid>` sandbox directories per suite run on #2836's axis — measured head 15 against base 9 | **already tracked: #2836** — not a narrowing of this issue's spec (the two prefixes #2834 scopes measure zero on the head against seven and one on the base) and not caused by the rebase; the mechanism is pre-existing and is row 7. The volume datum and the growth rule it implies were added to #2836 |
| 21 | independent verifier round 3, informational | The round-3 brief handed the legs a malformed 42-character pre-rebase head SHA, which `git rev-parse` rejects | **skipped: no published impact** — my error in the brief, not a defect in the PR or the code. All three round-3 leg comments resolved the correct SHA (`39e938905c23b89519d94b71deb5d703b68f8648`) themselves; a grep for the malformed form across all twelve comments on this PR returns zero hits |
| 22 | independent verifier round 3 | "#2612 fixed the identical defect in `LintEndpointWiringTest`, merged as `e7d66d89`" reads as though an issue merged | **fixed@body** — the sentence now says the fix landed through PR #2835 as `e7d66d89`. The SHA attribution itself was already correct: GitHub records `e7d66d89` as that PR's merge commit |

Round 3, run on head `18923a7f` after the first rebase, closed with four approves and the
independent verifier at `verified`, zero blocking findings standing. Nothing was left needing a
decision. The
over-engineering leg's round-1 measurement below still holds for this diff — its round-3 pass found
the same extraction now pays off tree-wide, which is row 18 — and it returned no actionable finding
against these three files in any round.
It executed five candidate simplifications (a shared trait for `shimResidue()`/`$planted`, a
generator for the child-script preamble, deleting the STDIN seam by having the child plant its own
collision, `glob($prefix . '*')` in place of the two-glob merge, and demoting the shutdown hook)
and measured every one of them as a regression or a net addition — `net: -0 lines possible`. It
also refuted the redundancy claim I most expected to land: deleting
`assertSame([], glob($this->planted[0] . '/*'))` leaves the survival test **green** against the
pre-fix child, because `array_diff(..., $this->planted)` structurally subtracts the planted path
and cannot see what is inside it. That assertion is the only thing catching the silent form of
this defect on the two widget classes.


🤖 Generated by Oh My Pi and posted on behalf of @andrebrait.





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved isolation of temporary resources used during page and widget rendering.
  - Prevented stale resources from interfering with later rendering operations.
  - Improved cleanup after completed or interrupted rendering processes.
  - Added safer handling for temporary directory creation failures.

- **Tests**
  - Expanded coverage for cleanup, process reuse, stale-resource scenarios, and rendering reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->