### PR TITLE
pfblockerng: close the script stage when our WebUI removes an alias (#2060)

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -6710,10 +6710,10 @@ function pfb_sync_status_dedup_check(string $log_path, string $ledger_dir): void
  * key shape (pfb_ip/dnsbl_download_ledger_update's own prefix/suffix rules); an empty
  * $aliasname or an unrecognized $gtype (e.g. 'geoip') is a no-op.
  *
- * 'download' and 'script' both close: their paired clears run at the end of the alias's
- * OWN pass, and a deleted alias never gets another one, so the entry would strand
- * (issue #1014/#1019, #2060). 'apply' stays tick-managed and 'parse' Python-managed --
- * those reconcile without the alias (ADR-61 §2.2 symmetric ownership).
+ * 'download' and 'script' both close: both are alias-pass-managed, and a removed alias
+ * never gets another pass to run their paired clears (issue #1014/#1019, #2060). 'apply'
+ * is tick-managed and 'parse' Python-managed -- both reconcile without the alias; 'dedup'
+ * is not alias-keyed at all (item='dedup'), so no $aliasname reaches it (ADR-61 §2.2).
  *
  * @param string $gtype     'ipv4' | 'ipv6' | 'dnsbl' (any other value is a no-op).
  * @param string $aliasname The REMOVED alias's raw aliasname (empty = no-op).
@@ -6744,9 +6744,8 @@ function pfb_sync_status_close_removed_alias(string $gtype, string $aliasname, s
 			return;
 	}
 
-	foreach (['download', 'script'] as $stage) {
-		pfb_sync_status_close($facility, $item, $stage, $ledger_dir);
-	}
+	pfb_sync_status_close($facility, $item, 'download', $ledger_dir);
+	pfb_sync_status_close($facility, $item, 'script', $ledger_dir);
 }
 
 /**

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -6705,13 +6705,15 @@ function pfb_sync_status_dedup_check(string $log_path, string $ledger_dir): void
 }
 
 /**
- * pfb_sync_status_close_removed_alias — close the stage=download ledger entry for an
- * IP/DNSBL alias removed by our own WebUI (renamed or deleted). $gtype selects the
- * download-key shape (pfb_ip/dnsbl_download_ledger_update's own prefix/suffix rules);
- * an empty $aliasname or an unrecognized $gtype (e.g. 'geoip') is a no-op.
+ * pfb_sync_status_close_removed_alias — close the ALIAS-PASS-managed ledger entries for
+ * an IP/DNSBL alias removed by our own WebUI (renamed or deleted). $gtype selects the
+ * key shape (pfb_ip/dnsbl_download_ledger_update's own prefix/suffix rules); an empty
+ * $aliasname or an unrecognized $gtype (e.g. 'geoip') is a no-op.
  *
- * Only the download stage closes -- apply/parse/dedup stay tick-managed (issue
- * #1014/#1019; ADR-61 §2.2 symmetric ownership).
+ * 'download' and 'script' both close: their paired clears run at the end of the alias's
+ * OWN pass, and a deleted alias never gets another one, so the entry would strand
+ * (issue #1014/#1019, #2060). 'apply' stays tick-managed and 'parse' Python-managed --
+ * those reconcile without the alias (ADR-61 §2.2 symmetric ownership).
  *
  * @param string $gtype     'ipv4' | 'ipv6' | 'dnsbl' (any other value is a no-op).
  * @param string $aliasname The REMOVED alias's raw aliasname (empty = no-op).
@@ -6726,17 +6728,24 @@ function pfb_sync_status_close_removed_alias(string $gtype, string $aliasname, s
 
 	switch ($gtype) {
 		case 'ipv4':
-			pfb_sync_status_close('ip', "pfB_{$aliasname}_v4", 'download', $ledger_dir);
+			$facility = 'ip';
+			$item     = "pfB_{$aliasname}_v4";
 			break;
 		case 'ipv6':
-			pfb_sync_status_close('ip', "pfB_{$aliasname}_v6", 'download', $ledger_dir);
+			$facility = 'ip';
+			$item     = "pfB_{$aliasname}_v6";
 			break;
 		case 'dnsbl':
-			pfb_sync_status_close('dnsbl', "DNSBL_{$aliasname}", 'download', $ledger_dir);
+			$facility = 'dnsbl';
+			$item     = "DNSBL_{$aliasname}";
 			break;
 		default:
-			// unknown gtype (e.g. 'geoip') -- no download ledger key shape defined, no-op
-			break;
+			// unknown gtype (e.g. 'geoip') -- no ledger key shape defined, no-op
+			return;
+	}
+
+	foreach (['download', 'script'] as $stage) {
+		pfb_sync_status_close($facility, $item, $stage, $ledger_dir);
 	}
 }
 

--- a/tests/php/PfbSyncStatusLedgerTest.php
+++ b/tests/php/PfbSyncStatusLedgerTest.php
@@ -764,7 +764,7 @@ final class PfbSyncStatusLedgerTest extends TestCase
 		$this->assertSame('pfB_Foo_v4', $open[0]['item']);
 	}
 
-	public function testCloseRemovedAliasOnlyClosesDownloadStageNeverApply(): void
+	public function testCloseRemovedAliasNeverClosesTheTickManagedApplyStage(): void
 	{
 		pfb_sync_status_open('ip', 'pfB_Foo_v4', 'download', 'HTTP 404', $this->dir, self::clockAt(1000));
 		pfb_sync_status_open('ip', 'pfB_Foo_v4', 'apply', '[pfctl] failed', $this->dir, self::clockAt(1000));
@@ -774,7 +774,7 @@ final class PfbSyncStatusLedgerTest extends TestCase
 		pfb_sync_status_close_removed_alias('ipv4', 'Foo', $this->dir);
 
 		$open = pfb_sync_status_list_open($this->dir, 'ip');
-		$this->assertCount(1, $open, 'only the download stage must close -- apply is tick-managed');
+		$this->assertCount(1, $open, 'the tick-managed apply stage must survive alias removal');
 		$this->assertSame('apply', $open[0]['stage'], 'the surviving entry must be the apply stage');
 	}
 
@@ -794,11 +794,8 @@ final class PfbSyncStatusLedgerTest extends TestCase
 	}
 
 	// -----------------------------------------------------------------------
-	// issue #2060: stage='script' (#1958) is ALIAS-PASS-managed, not
-	// tick-managed. Its paired close runs at the end of the alias's own
-	// download pass, and a deleted alias never gets another pass -- so removal
-	// has to close it alongside stage='download' or the entry strands and the
-	// widget keeps counting an open issue for an alias that no longer exists.
+	// issue #2060: stage='script' (#1958) is alias-pass-managed like 'download'
+	// -- removal must close it too, else no later pass runs its paired clear.
 	// -----------------------------------------------------------------------
 
 	public function testCloseRemovedAliasIpv4ClosesScriptEntry(): void

--- a/tests/php/PfbSyncStatusLedgerTest.php
+++ b/tests/php/PfbSyncStatusLedgerTest.php
@@ -794,6 +794,92 @@ final class PfbSyncStatusLedgerTest extends TestCase
 	}
 
 	// -----------------------------------------------------------------------
+	// issue #2060: stage='script' (#1958) is ALIAS-PASS-managed, not
+	// tick-managed. Its paired close runs at the end of the alias's own
+	// download pass, and a deleted alias never gets another pass -- so removal
+	// has to close it alongside stage='download' or the entry strands and the
+	// widget keeps counting an open issue for an alias that no longer exists.
+	// -----------------------------------------------------------------------
+
+	public function testCloseRemovedAliasIpv4ClosesScriptEntry(): void
+	{
+		pfb_sync_status_open('ip', 'pfB_Foo_v4', 'script', 'Pre-script FAIL - serving last known-good', $this->dir, self::clockAt(1000));
+		// Before-state: the script entry is genuinely open first.
+		$this->assertCount(1, pfb_sync_status_list_open($this->dir, 'ip'));
+
+		pfb_sync_status_close_removed_alias('ipv4', 'Foo', $this->dir);
+
+		$this->assertSame([], pfb_sync_status_list_open($this->dir), 'ipv4 removal must close pfB_Foo_v4/script');
+	}
+
+	public function testCloseRemovedAliasIpv6ClosesScriptEntry(): void
+	{
+		pfb_sync_status_open('ip', 'pfB_Foo_v6', 'script', 'Pre-script FAIL - serving last known-good', $this->dir, self::clockAt(1000));
+		$this->assertCount(1, pfb_sync_status_list_open($this->dir, 'ip'));
+
+		pfb_sync_status_close_removed_alias('ipv6', 'Foo', $this->dir);
+
+		$this->assertSame([], pfb_sync_status_list_open($this->dir), 'ipv6 removal must close pfB_Foo_v6/script');
+	}
+
+	public function testCloseRemovedAliasDnsblClosesScriptEntry(): void
+	{
+		pfb_sync_status_open('dnsbl', 'DNSBL_Foo', 'script', 'Pre-script FAIL - serving last known-good', $this->dir, self::clockAt(1000));
+		$this->assertCount(1, pfb_sync_status_list_open($this->dir, 'dnsbl'));
+
+		pfb_sync_status_close_removed_alias('dnsbl', 'Foo', $this->dir);
+
+		$this->assertSame([], pfb_sync_status_list_open($this->dir), 'dnsbl removal must close DNSBL_Foo/script');
+	}
+
+	public function testCloseRemovedAliasClosesEveryAliasPassManagedStageAndLeavesApplyOpen(): void
+	{
+		pfb_sync_status_open('ip', 'pfB_Foo_v4', 'download', 'HTTP 404', $this->dir, self::clockAt(1000));
+		pfb_sync_status_open('ip', 'pfB_Foo_v4', 'script', 'Post-script FAIL', $this->dir, self::clockAt(1000));
+		pfb_sync_status_open('ip', 'pfB_Foo_v4', 'apply', '[pfctl] failed', $this->dir, self::clockAt(1000));
+		// Before-state: all three stages genuinely open for the same item.
+		$this->assertCount(3, pfb_sync_status_list_open($this->dir, 'ip'));
+
+		pfb_sync_status_close_removed_alias('ipv4', 'Foo', $this->dir);
+
+		$open = pfb_sync_status_list_open($this->dir, 'ip');
+		$this->assertCount(1, $open,
+			'download and script are alias-pass-managed and must close; apply is tick-managed and must survive');
+		$this->assertSame('apply', $open[0]['stage'], 'the surviving entry must be the apply stage');
+	}
+
+	public function testCloseRemovedAliasScriptStageMatchesTheExactKeyOnly(): void
+	{
+		// Prefix-adjacent sibling proves EXACT-key match for the script stage too:
+		// deleting 'Foo' must never sweep the live pfB_FooBar_v4's own entry.
+		pfb_sync_status_open('ip', 'pfB_Foo_v4', 'script', 'Pre-script FAIL', $this->dir, self::clockAt(1000));
+		pfb_sync_status_open('ip', 'pfB_FooBar_v4', 'script', 'Pre-script FAIL', $this->dir, self::clockAt(2000));
+		$this->assertCount(2, pfb_sync_status_list_open($this->dir, 'ip'));
+
+		pfb_sync_status_close_removed_alias('ipv4', 'Foo', $this->dir);
+
+		$open = pfb_sync_status_list_open($this->dir, 'ip');
+		$this->assertCount(1, $open, 'closing Foo must close only its exact script key, leaving prefix-adjacent FooBar open');
+		$this->assertSame('pfB_FooBar_v4', $open[0]['item']);
+	}
+
+	public function testCloseRemovedAliasScriptStageDoesNotCrossFacilities(): void
+	{
+		// A DNSBL group and an IP alias may carry the same aliasname; removing
+		// one must never close the other facility's script entry.
+		pfb_sync_status_open('ip', 'pfB_Foo_v4', 'script', 'Pre-script FAIL', $this->dir, self::clockAt(1000));
+		pfb_sync_status_open('dnsbl', 'DNSBL_Foo', 'script', 'Pre-script FAIL', $this->dir, self::clockAt(1000));
+		$this->assertCount(2, pfb_sync_status_list_open($this->dir));
+
+		pfb_sync_status_close_removed_alias('dnsbl', 'Foo', $this->dir);
+
+		$open = pfb_sync_status_list_open($this->dir);
+		$this->assertCount(1, $open, 'removing the DNSBL group must leave the same-named IP alias untouched');
+		$this->assertSame('ip', $open[0]['facility']);
+		$this->assertSame('pfB_Foo_v4', $open[0]['item']);
+	}
+
+	// -----------------------------------------------------------------------
 	// issue #1780 F1/F2/F9 — read_all()'s $unavailable discrimination, and the
 	// two read-modify-write callers (open/close) failing closed on it.
 	// -----------------------------------------------------------------------


### PR DESCRIPTION
Fixes #2060

## What was wrong

`pfb_sync_status_close_removed_alias()` closed only the `stage='download'` ledger key for an alias our own WebUI removed or renamed. The `stage='script'` entry #1958 introduced is **alias-pass-managed** too: its paired close is `pfb_list_script_failure_close()` at the end of the alias's own download pass. A deleted alias never gets another pass, so the entry stranded and the widget kept counting an open issue whose deep link pointed at an alias that no longer existed.

## Hypotheses and the discriminating probe

- **H1** — the helper closes only `download`, so a `script` entry survives removal for every key shape.
- **H2** — something else on the delete path already cleans it (the helper closes all stages for the item, or `pfblockerng_category.php` / `pfblockerng_category_edit.php` call something further).

Probe: seed the ledger exactly as #1958's writer leaves it (`download` + `script` for the removed alias, plus `script` for an unrelated neighbour), run the real `pfb_sync_status_close_removed_alias()` for all three key shapes, and read the open set before and after. One script (`/tmp/pfb_probe_2060_acceptance.php`) runs unchanged against both trees.

**Before the fix** — untouched base `devel` `b55dba81`:

```text
=== gtype=ipv4 ===
before delete  = ip/pfB_Foo_v4/download | ip/pfB_Foo_v4/script | ip/pfB_Foo_v4_other/script
after  delete  = ip/pfB_Foo_v4/script | ip/pfB_Foo_v4_other/script

=== gtype=ipv6 ===
before delete  = ip/pfB_Foo_v6/download | ip/pfB_Foo_v6/script | ip/pfB_Foo_v6_other/script
after  delete  = ip/pfB_Foo_v6/script | ip/pfB_Foo_v6_other/script

=== gtype=dnsbl ===
before delete  = dnsbl/DNSBL_Foo/download | dnsbl/DNSBL_Foo/script | dnsbl/DNSBL_Foo_other/script
after  delete  = dnsbl/DNSBL_Foo/script | dnsbl/DNSBL_Foo_other/script
```

**H1 confirmed, H2 refuted:** `download` closes for all three shapes, `script` strands in all three — which is exactly #1958's entry stranding on alias deletion.

**After the fix** — head `23e91ec4`, same probe, same fixture:

```text
=== gtype=ipv4 ===
before delete  = ip/pfB_Foo_v4/download | ip/pfB_Foo_v4/script | ip/pfB_Foo_v4_other/script
after  delete  = ip/pfB_Foo_v4_other/script

=== gtype=ipv6 ===
before delete  = ip/pfB_Foo_v6/download | ip/pfB_Foo_v6/script | ip/pfB_Foo_v6_other/script
after  delete  = ip/pfB_Foo_v6_other/script

=== gtype=dnsbl ===
before delete  = dnsbl/DNSBL_Foo/download | dnsbl/DNSBL_Foo/script | dnsbl/DNSBL_Foo_other/script
after  delete  = dnsbl/DNSBL_Foo_other/script
```

Both alias-pass-managed stages close in every shape; the unrelated neighbour's entry survives untouched in every shape.


## The change

The `switch` resolves the ledger key once per `$gtype`, then both alias-pass-managed stages close:

```php
pfb_sync_status_close($facility, $item, 'download', $ledger_dir);
pfb_sync_status_close($facility, $item, 'script', $ledger_dir);
```

Resolving the key once is what makes it impossible for one of the three key shapes to diverge from the others — mutant MB below has to bolt on a facility conditional to express that regression at all. The `default:` arm became `return` rather than `break`, because falling through with an unresolved key is now a real hazard rather than a no-op; mutant ME proves that guard is load-bearing.

The docblock's stage rationale is amended, as #2060's Direction asks, to classify all five live stages: `download` and `script` are alias-pass-managed and close here; `apply` is tick-managed and `parse` Python-managed, both reconciling without the alias; `dedup` is not alias-keyed at all (`item='dedup'`), so no `$aliasname` reaches it.

## Test-first: frozen reproduction, RED then GREEN

The reproduction was written first and frozen at the red run (`git hash-object`), byte-identical at the green run, both at commit `57d7ca23`:

| File | Frozen blob at `57d7ca23` |
| --- | --- |
| `tests/php/PfbSyncStatusLedgerTest.php` | `696911ecad72be515fd39f1cabc47214fa552699` |

```text
RED   .......FFFFFF                                               13 / 13 (100%)
      Tests: 13, Assertions: 30, Failures: 6.

GREEN .............                                               13 / 13 (100%)
      OK (13 tests, 34 assertions)
```

The review round then renamed one pre-existing row whose name stated a contract this change contradicts, so the head blob is `423e78d1b3cdf5ab44c9a38a857e8e0bcf2a19d2` rather than the frozen one.

**Re-established at the current head `23e91ec4`, against the current base `b55dba81`.** Only production moves; the test file stays at its head blob, captured before the red run, immediately after it, and again after every mutant below:

```text
$ git hash-object tests/php/PfbSyncStatusLedgerTest.php
423e78d1b3cdf5ab44c9a38a857e8e0bcf2a19d2          # before RED
$ git checkout b55dba81 -- src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
$ git diff HEAD --numstat
11      19      src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
$ vendor/bin/phpunit --no-coverage --filter testCloseRemovedAlias tests/php/PfbSyncStatusLedgerTest.php

RED   .......FFFFFF                                               13 / 13 (100%)

1) testCloseRemovedAliasIpv4ClosesScriptEntry
   ipv4 removal must close pfB_Foo_v4/script
   Failed asserting that two arrays are identical.
   +        'item' => 'pfB_Foo_v4',
   +        'stage' => 'script',
2) testCloseRemovedAliasIpv6ClosesScriptEntry
   ipv6 removal must close pfB_Foo_v6/script
3) testCloseRemovedAliasDnsblClosesScriptEntry
   dnsbl removal must close DNSBL_Foo/script
4) testCloseRemovedAliasClosesEveryAliasPassManagedStageAndLeavesApplyOpen
   download and script are alias-pass-managed and must close; apply is tick-managed and must survive
   Failed asserting that actual size 2 matches expected size 1.
5) testCloseRemovedAliasScriptStageMatchesTheExactKeyOnly
   closing Foo must close only its exact script key, leaving prefix-adjacent FooBar open
6) testCloseRemovedAliasScriptStageDoesNotCrossFacilities
   removing the DNSBL group must leave the same-named IP alias untouched

      Tests: 13, Assertions: 30, Failures: 6.

$ git hash-object tests/php/PfbSyncStatusLedgerTest.php
423e78d1b3cdf5ab44c9a38a857e8e0bcf2a19d2          # after RED -- unchanged
$ git checkout 23e91ec4 -- src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
$ git status --porcelain                          # empty

GREEN .............                                               13 / 13 (100%)
      OK (13 tests, 34 assertions)

# and the whole file, unfiltered
GREEN .................................                           33 / 33 (100%)
      OK (33 tests, 120 assertions)

$ git hash-object tests/php/PfbSyncStatusLedgerTest.php
423e78d1b3cdf5ab44c9a38a857e8e0bcf2a19d2          # after GREEN -- unchanged
```

The 13 filtered rows are the six new ones plus the seven pre-existing removed-alias rows, which stay green: the download-stage closes, the empty-aliasname no-op, the unknown-gtype no-op, the apply-survives partition and the exact-key precision row are all unchanged behaviour.

## Mutation kill table (re-executed at head `23e91ec4`)

Each mutant is a single string replacement in `pfblockerng_extra.inc` whose anchor is programmatically asserted to occur exactly once in the pristine head file, applied with a non-empty `git diff --numstat` captured, then reverted with the restored file asserted byte-identical to `bb5fc7c7e43d2834bda7e77091d719f1ca88dc4c` and `git status --porcelain` asserted empty before the next. **Six mutants, six kills, zero survivors.**

| # | Mutant | numstat | Killed by | Quoted failure |
| --- | --- | --- | --- | --- |
| MA | **Clean every stage except the script stage** (pre-fix behaviour) | `0 1` | all six new rows: `...Ipv4ClosesScriptEntry`, `...Ipv6ClosesScriptEntry`, `...DnsblClosesScriptEntry`, `...ClosesEveryAliasPassManagedStageAndLeavesApplyOpen`, `...ScriptStageMatchesTheExactKeyOnly`, `...ScriptStageDoesNotCrossFacilities` | `ipv4 removal must close pfB_Foo_v4/script` · `ipv6 removal must close pfB_Foo_v6/script` · `dnsbl removal must close DNSBL_Foo/script` · `download and script are alias-pass-managed and must close; apply is tick-managed and must survive` · `closing Foo must close only its exact script key, leaving prefix-adjacent FooBar open` · `removing the DNSBL group must leave the same-named IP alias untouched` |
| MB | **Clean the script stage in only one loop** — gate it on `$facility === 'ip'`, so the DNSBL shape never closes it | `3 1` | `testCloseRemovedAliasDnsblClosesScriptEntry`, `...ScriptStageDoesNotCrossFacilities` | `dnsbl removal must close DNSBL_Foo/script` · `removing the DNSBL group must leave the same-named IP alias untouched` |
| MC | Also clean the **tick-managed** `apply` stage | `1 0` | `testCloseRemovedAliasNeverClosesTheTickManagedApplyStage` ‡, `...ClosesEveryAliasPassManagedStageAndLeavesApplyOpen` | `the tick-managed apply stage must survive alias removal` · `download and script are alias-pass-managed and must close; apply is tick-managed and must survive` |
| MD | Drop the empty-aliasname guard | `0 4` | `testCloseRemovedAliasEmptyAliasnameIsNoOp` (pre-existing, base line 739) | `an empty aliasname must be a no-op even when pfB__v4 happens to be open` |
| ME | Unknown `$gtype` falls through (`break`) instead of returning | `1 1` | `testCloseRemovedAliasUnknownGtypeIsNoOp` (pre-existing, base line 754) | killed as an **ERROR**, not a failure: `TypeError: pfb_sync_status_close(): Argument #1 ($facility) must be of type string, null given, called in …/pfblockerng_extra.inc on line 6747`, plus `Undefined variable $facility` / `Undefined variable $item` |
| MF | Drop the **download** stage, keep only `script` — regress the ORIGINAL behaviour | `0 1` | `...Ipv4ClosesDownloadEntry`, `...Ipv6ClosesDownloadEntry`, `...DnsblClosesDownloadEntry` (base lines 708/719/729), `...NeverClosesTheTickManagedApplyStage` ‡, `...KeyPrecisionLeavesOtherAliasesOpen` (base line 781), `...ClosesEveryAliasPassManagedStageAndLeavesApplyOpen` | `ipv4 removal must close pfB_Foo_v4/download` · `ipv6 removal must close pfB_Foo_v6/download` · `dnsbl removal must close DNSBL_Foo/download` · `the tick-managed apply stage must survive alias removal` · `closing Foo must close only its exact key, leaving prefix-adjacent FooBar open` |

‡ `testCloseRemovedAliasNeverClosesTheTickManagedApplyStage` is the **pre-existing row renamed by this PR** — it is `testCloseRemovedAliasOnlyClosesDownloadStageNeverApply` at base line 767, and the two bodies differ only in the method name and one assertion message. Its fixture, assertion count and every expected value are unchanged, which is why it still kills MC. The rename is in Scope below.

MC, MD, ME and five of MF's six killers are rows this PR did **not** write. That is the unregressed-behaviour axis: the pre-#2060 `download` contract is still guarded by exactly the tests that guarded it before.

## Gates

`scripts/agent/run-gates.sh --diff origin/devel`, run once on the branch worktree at the rebased head `23e91ec4`:

```text
GATE PASS: python3 scripts/check_coverage_pairing.py --name-status-z
GATE PASS: uv run --locked python scripts/check_composer_vendor.py
GATE PASS: uv run --locked python scripts/check_toggle_registry.py --self-test && uv run --locked python scripts/check_toggle_registry.py
GATE PASS: php -l src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
GATE PASS: php -l tests/php/PfbSyncStatusLedgerTest.php
GATE FAIL: vendor/bin/phpunit
GATE PASS: composer phpstan
GATE PASS: composer phpcs -- --standard=phpcs.xml.dist src/
GATES: FAIL
```

`vendor/bin/phpunit` reported two failures on that run. Both were probed rather than assumed, and neither belongs to this change.

**1. `DownloadSizeCeilingTest::test_extract_cmd_ceiling_stops_a_child_that_writes_past_it` — #2765, deterministic and Darwin-only.** Reproduced identically on **untouched base `devel` `b55dba81`**, alone, with identical warning/deprecation/notice/skip counts:

```text
branch (23e91ec4)  1) DownloadSizeCeilingTest::test_extract_cmd_ceiling_stops_a_child_that_writes_past_it
                   Darwin dd must surface RLIMIT_FSIZE as its EFBIG exit
                   Failed asserting that 153 is identical to 1.

base    (b55dba81) 1) DownloadSizeCeilingTest::test_extract_cmd_ceiling_stops_a_child_that_writes_past_it
                   Darwin dd must surface RLIMIT_FSIZE as its EFBIG exit
                   Failed asserting that 153 is identical to 1.
                   Tests: 5752, Assertions: 33004, Failures: 1, Warnings: 29, Deprecations: 3, Notices: 1, Skipped: 3.
```

**2. `Top1mDccDetectorTest::testExtractedDispatchSeamRunsExistingCronCommand` — #2828's load-dependent class, and it did not reproduce.** The gate run overlapped a CI poll and several sibling lanes, the exact condition #2828 names. Three probes, all executed:

```text
# the row alone, on the branch
$ vendor/bin/phpunit --no-coverage tests/php/Top1mDccDetectorTest.php
OK (22 tests, 215 assertions)

# the row alone, on untouched base b55dba81
$ vendor/bin/phpunit --no-coverage tests/php/Top1mDccDetectorTest.php
OK (22 tests, 215 assertions)

# the WHOLE suite again on the same branch head, without the concurrent load
Tests: 5758, Assertions: 33020, Failures: 1, Warnings: 29, Deprecations: 3, Notices: 1, Skipped: 3.
   -> the only red is #2765's row; Top1mDccDetectorTest did not fire
```

Its failure was `Failed asserting that actual size 0 matches expected size 1` at `Top1mDccDetectorTest.php:542`, inside an `assertEventually` poll of a log written by a spawned subprocess — a wall-clock race, not a state assertion. There is also no call path from it to this diff: the change touches only `pfb_sync_status_close_removed_alias()` in `pfblockerng_extra.inc` and its unit test, while that row drives `pfb_top1m_dispatch_if_changed()`.

CI on Linux is the authoritative verdict and is green on the exact rebased head `23e91ec4` — 23 checks, zero failures, pinned by SHA.

## Scope

- One production function, one test file. `www/pfblockerng/pfblockerng_category.php` and `pfblockerng_category_edit.php` already call this helper on delete/rename, so no call-site change was needed; neither file is touched.
- One pre-existing test row was renamed: `testCloseRemovedAliasOnlyClosesDownloadStageNeverApply` → `testCloseRemovedAliasNeverClosesTheTickManagedApplyStage`, because its old name and assertion message stated "only the download stage must close", which this change contradicts. Its fixture and assertions are otherwise unchanged, and it still kills mutant MC.
- **Not touched:** the `@param string $stage` enumerations on `pfb_sync_status_open()`/`pfb_sync_status_close()` and ADR-61's stage table, both of which have under-enumerated `script` since #1958 landed. That is #2102's declared scope. Three further stale spots found by review are recorded on #2102 for its pass rather than widened into here: the two `www/` call-site comments (`pfblockerng_category.php:161-162`, `pfblockerng_category_edit.php:829-830`) and `tests/smoke/ui/test_category_ledger_close.py`'s docstring, all of which still say "stage=download".
- `tests/smoke/ui/test_category_ledger_close.py` (live-VM tier) seeds a `download` entry only, so it passes unchanged; no `www/` surface changed, so no ADR-14 UI tier is triggered.
- Out of scope, recorded for enumeration completeness: package-owned items (`pfB_DNSBLIP_v4`/`_v6`, `dnsbl/top1m`) can hold `download` and `script` entries but are not user rows, so they never reach this helper. That is exactly symmetric with the pre-existing `download` behaviour scoped out by #1014/#1019; this PR neither introduces nor widens it.
- **Rebased onto `b55dba81`** after PR #2842 landed (`da984286` → `23e91ec4`). Content-free: both changed files hash the same before and after, both are byte-identical at the old and new base, and `git diff <base> <head> | shasum -a 256` is the same value across the move (`94fc9ddf7ece…`). The four leg audits and the independent verifier reviewed those exact bytes, and the RED/GREEN pair and the whole kill table above were nonetheless re-executed at the rebased head rather than cited.

🤖 Generated by Oh My Pi and posted on behalf of @andrebrait.

