### PR TITLE
build: reject non-string frozen lifecycle scripts

### DIFF
--- a/scripts/build-frozen-v3.py
+++ b/scripts/build-frozen-v3.py
@@ -344,8 +344,20 @@ def validate_artifact(pkg_path: Path, export_dir: Path, target: FrozenTarget, ro
         raise ArtifactValidationError(f"{pkg_path.name}: missing derived dependency name(s): {', '.join(missing_deps)}")
 
     scripts = manifest.get("scripts")
-    if not isinstance(scripts, dict) or not scripts.get("install") or not scripts.get("deinstall"):
+    if not isinstance(scripts, dict):
         raise ArtifactValidationError(f"{pkg_path.name}: manifest scripts.install/scripts.deinstall missing or empty")
+    for field in ("install", "deinstall"):
+        if field not in scripts:
+            raise ArtifactValidationError(
+                f"{pkg_path.name}: manifest scripts.install/scripts.deinstall missing or empty"
+            )
+        script = scripts[field]
+        if not isinstance(script, str):
+            raise ArtifactValidationError(f"{pkg_path.name}: manifest scripts.{field} must be a string, got {script!r}")
+        if not script:
+            raise ArtifactValidationError(
+                f"{pkg_path.name}: manifest scripts.install/scripts.deinstall missing or empty"
+            )
     install_sha = hashlib.sha256(scripts["install"].encode()).hexdigest()
     deinstall_sha = hashlib.sha256(scripts["deinstall"].encode()).hexdigest()
 

--- a/tests/test_build_frozen_v3.py
+++ b/tests/test_build_frozen_v3.py
@@ -1533,38 +1533,56 @@ def test_issue_2021_stripped_real_payload_is_rejected_and_oracle_unchanged(
 def test_issue_2061_cli_rejects_non_string_script_without_rewriting_report(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
-    capsys: pytest.CaptureFixture[str],
     report_exists: bool,
 ) -> None:
     stage, matrix_file, report_path = _issue_2021_build_fixture(tmp_path, monkeypatch)
     original = report_path.read_bytes()
     if not report_exists:
         report_path.unlink()
-    pkg_path, _ = _happy_fixture(
+    pkg_path, export_dir = _happy_fixture(
         tmp_path / "malformed",
         STABLE,
         ROW_15,
         scripts={**DEMO_SCRIPTS, "install": ["unexpected"]},
     )
-    monkeypatch.setattr(bfv, "_invoke_build_leg", lambda argv, *, cwd: str(pkg_path))
-    capsys.readouterr()
+    runner = f"""
+import importlib.util
+import shutil
+import sys
+from pathlib import Path
 
-    rc = bfv.main(
-        [
-            "--out",
-            str(stage),
-            "--matrix-cmd",
-            f"cat {matrix_file}",
-            "--repo",
-            str(tmp_path),
-            "--no-deterministic-check",
-        ]
-    )
+tool_path = Path({str(_TOOL)!r})
+sys.path.insert(0, str(tool_path.parent))
+spec = importlib.util.spec_from_file_location("build_frozen_v3_subprocess", tool_path)
+assert spec is not None and spec.loader is not None
+tool = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = tool
+spec.loader.exec_module(tool)
+tool.FROZEN_TARGETS = (tool.FrozenTarget(
+    channel={STABLE.channel!r},
+    tag={STABLE.tag!r},
+    commit={STABLE.commit!r},
+    portname={STABLE.portname!r},
+    portversion={STABLE.portversion!r},
+),)
+tool.resolve_tag_commit = lambda repo, tag, expected_commit: expected_commit
+tool.export_tag = lambda repo, commit, dest: shutil.copytree(
+    Path({str(export_dir)!r}), dest, dirs_exist_ok=True
+)
+tool._invoke_build_leg = lambda argv, cwd: {str(pkg_path)!r}
+sys.exit(tool.main([
+    "--out", {str(stage)!r},
+    "--matrix-cmd", "cat " + {str(matrix_file)!r},
+    "--repo", {str(tmp_path)!r},
+    "--no-deterministic-check",
+]))
+"""
 
-    assert rc != 0
-    stderr = capsys.readouterr().err
-    assert "scripts.install must be a string" in stderr
-    assert "Traceback" not in stderr
+    result = subprocess.run([sys.executable, "-c", runner], capture_output=True, text=True, check=False)
+
+    assert result.returncode != 0
+    assert "scripts.install must be a string" in result.stderr
+    assert "Traceback" not in result.stderr
     if report_exists:
         assert report_path.read_bytes() == original
     else:

--- a/tests/test_build_frozen_v3.py
+++ b/tests/test_build_frozen_v3.py
@@ -20,6 +20,7 @@ import json
 import subprocess
 import sys
 import tarfile
+from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
@@ -60,7 +61,7 @@ def _write_pkg(
     abi: str = "FreeBSD:15:*",
     arch: str = "freebsd:15:*",
     deps: dict[str, dict[str, str]] | None = None,
-    scripts: dict[str, object] | None = None,
+    scripts: Mapping[str, object] | None = None,
     files: dict[str, bytes] | None = None,
     omit_compact: bool = False,
     omit_manifest: bool = False,

--- a/tests/test_build_frozen_v3.py
+++ b/tests/test_build_frozen_v3.py
@@ -60,7 +60,7 @@ def _write_pkg(
     abi: str = "FreeBSD:15:*",
     arch: str = "freebsd:15:*",
     deps: dict[str, dict[str, str]] | None = None,
-    scripts: dict[str, str] | None = None,
+    scripts: dict[str, object] | None = None,
     files: dict[str, bytes] | None = None,
     omit_compact: bool = False,
     omit_manifest: bool = False,
@@ -689,6 +689,27 @@ def test_empty_lifecycle_script_rejected(tmp_path: Path) -> None:
     scripts = {"install": "", "deinstall": "echo bye\n"}
     pkg_path, export_dir = _happy_fixture(tmp_path, STABLE, ROW_15, scripts=scripts)
     with pytest.raises(bfv.ArtifactValidationError, match="scripts"):
+        bfv.validate_artifact(pkg_path, export_dir, STABLE, ROW_15)
+
+
+@pytest.mark.parametrize("field", ["install", "deinstall"])
+@pytest.mark.parametrize(
+    "value",
+    [
+        pytest.param(["unexpected"], id="truthy-list"),
+        pytest.param([], id="empty-list"),
+        pytest.param({"unexpected": "value"}, id="dict"),
+        pytest.param(0, id="zero"),
+        pytest.param(False, id="false"),
+        pytest.param(None, id="null"),
+    ],
+)
+def test_non_string_lifecycle_script_rejected_with_named_type_error(tmp_path: Path, field: str, value: object) -> None:
+    scripts: dict[str, object] = dict(DEMO_SCRIPTS)
+    scripts[field] = value
+    pkg_path, export_dir = _happy_fixture(tmp_path, STABLE, ROW_15, scripts=scripts)
+
+    with pytest.raises(bfv.ArtifactValidationError, match=rf"scripts\.{field} must be a string"):
         bfv.validate_artifact(pkg_path, export_dir, STABLE, ROW_15)
 
 
@@ -1505,6 +1526,48 @@ def test_issue_2021_stripped_real_payload_is_rejected_and_oracle_unchanged(
     original = report_path.read_bytes()
     assert _run_issue_2021_verify(stage, matrix_file, tmp_path) == 1
     assert report_path.read_bytes() == original
+
+
+@pytest.mark.parametrize("report_exists", [True, False], ids=["existing-report", "absent-report"])
+def test_issue_2061_cli_rejects_non_string_script_without_rewriting_report(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    report_exists: bool,
+) -> None:
+    stage, matrix_file, report_path = _issue_2021_build_fixture(tmp_path, monkeypatch)
+    original = report_path.read_bytes()
+    if not report_exists:
+        report_path.unlink()
+    pkg_path, _ = _happy_fixture(
+        tmp_path / "malformed",
+        STABLE,
+        ROW_15,
+        scripts={**DEMO_SCRIPTS, "install": ["unexpected"]},
+    )
+    monkeypatch.setattr(bfv, "_invoke_build_leg", lambda argv, *, cwd: str(pkg_path))
+    capsys.readouterr()
+
+    rc = bfv.main(
+        [
+            "--out",
+            str(stage),
+            "--matrix-cmd",
+            f"cat {matrix_file}",
+            "--repo",
+            str(tmp_path),
+            "--no-deterministic-check",
+        ]
+    )
+
+    assert rc != 0
+    stderr = capsys.readouterr().err
+    assert "scripts.install must be a string" in stderr
+    assert "Traceback" not in stderr
+    if report_exists:
+        assert report_path.read_bytes() == original
+    else:
+        assert not report_path.exists()
 
 
 def test_issue_2021_artifact_checksum_mismatch_rejected_independently(


### PR DESCRIPTION
Fixes #2061.

## What changed

- Validate `+MANIFEST` `scripts.install` and `scripts.deinstall` as non-empty strings before hashing.
- Raise a named `ArtifactValidationError` instead of leaking `AttributeError` from `.encode()`.
- Cover both fields across list, map, integer, Boolean, null, and falsy non-string values using real zstd/USTAR package fixtures.
- Pin the public CLI contract through a subprocess: nonzero exit, no traceback, and no identity-report creation or rewrite.

The frozen-v3 validator remains a live producer path: `validate_artifact()` is called by both `build_all()` and `verify_staged()`.

## Test-first proof

The focused 14-row regression suite failed against untouched production code: truthy list/map values raised raw `AttributeError`; falsy non-string values hit the old generic missing/empty error. Current tests were then frozen and passed unchanged after the fix.

| Frozen RED test | git hash-object | RED run tail |
| --- | --- | --- |
| `tests/test_build_frozen_v3.py` | `39a188f1ca6d4795183e4a4dd53e39f6b79e0860` | `14 failed: truthy list/map rows and subprocess CLI leaked AttributeError; falsy non-string rows missed the required named-field diagnostic` |

## Verification

- `scripts/agent/run-gates.sh --diff f9197caf25b0387fb240eca6cdd212bcbac130ac` — PASS (`pytest`, `ruff check`, `ruff format --check`, `mypy tests/`).
- `uv run pytest -q tests/test_build_frozen_v3.py` — 193 passed, zero skips before the review-fix commit; the focused final selector is 14 passed.
- Independent gate reconstructed final RED (14 failed for the expected reasons), restored production, then GREEN (14 passed) with the same committed test blob.

## Review follow-up

Hostile review found a separate pre-existing lone-surrogate string crash; it is tracked by #2853 rather than folded into this PR.