### PR TITLE
image-upgrade: validate decimal wait inputs

### DIFF
--- a/scripts/image-upgrade.sh
+++ b/scripts/image-upgrade.sh
@@ -830,11 +830,10 @@ PFB_METADATA_PROBE='if /bin/test -f /var/run/pfSense_version.rc; then echo prese
 pfb_wait_pkg_metadata() {
     _pwpm_timeout="${1:-${METADATA_TIMEOUT:-600}}"
     _pwpm_interval="${METADATA_INTERVAL:-5}"
-    # An unusable interval pins the elapsed counter and an unusable cap makes the
-    # deadline test error on every iteration ("Illegal number"); either way the
-    # loop never reaches its failure path, i.e. an unbounded wait. Floor both.
-    [ "$_pwpm_interval" -ge 1 ] 2>/dev/null || _pwpm_interval=5
-    [ "$_pwpm_timeout" -ge 0 ] 2>/dev/null || _pwpm_timeout=600
+    # Validate before comparison/arithmetic; whitespace-bearing decimal text is
+    # not a configured integer and must fall back to the documented finite cap.
+    case "$_pwpm_interval" in '' | *[!0-9]* | 0) _pwpm_interval=5 ;; esac
+    case "$_pwpm_timeout" in '' | *[!0-9]*) _pwpm_timeout=600 ;; esac
     _pwpm_elapsed=0
     _pwpm_seen=0
     log "waiting for the pfSense package metadata refresh to settle"
@@ -909,6 +908,8 @@ pfb_wait_upgraded_box() {
 # metadata wait belongs here, once, rather than at each call site (issue #2458).
 wait_guest_ssh() {
     _wgs_timeout="$1"
+    # issue #2488: validate before the AND-list can hide test(1)'s numeric error.
+    case "$_wgs_timeout" in '' | *[!0-9]*) _wgs_timeout=600 ;; esac
     _wgs_console="${2:-console.log}"
     _wgs_elapsed=0
     while ! ssh_guest true 2>/dev/null; do

--- a/scripts/image-upgrade.sh
+++ b/scripts/image-upgrade.sh
@@ -101,9 +101,10 @@
 #   PROMOTE_INTERVAL — seconds to wait / poll step for pfSense's own boot
 #   verification to promote the new BE (defaults: 300 / 10); METADATA_TIMEOUT /
 #   METADATA_INTERVAL — seconds to wait / poll step for pfSense's post-boot
-#   package metadata refresh to settle (defaults: 600 / 5). Every boot wait adds
-#   the metadata wait to its own budget, so a boot wait's worst case is its own
-#   timeout PLUS METADATA_TIMEOUT.
+#   package metadata refresh to settle (defaults: 600 / 5). VERIFY_BOOT_TIMEOUT
+#   and METADATA_TIMEOUT accept 0..86400; METADATA_INTERVAL accepts 1..3600;
+#   invalid values use their defaults. Every boot wait adds the metadata wait to
+#   its own budget, so the worst case is its own timeout PLUS METADATA_TIMEOUT.
 #   --upgrade-pkgs   before pfSense-upgrade, run `pkg update -f` + `pkg upgrade -y`
 #                    to upgrade baked deps (qemu-guest-agent, etc.) to their latest
 #                    versions; reboots the guest and waits for SSH before proceeding.
@@ -830,10 +831,17 @@ PFB_METADATA_PROBE='if /bin/test -f /var/run/pfSense_version.rc; then echo prese
 pfb_wait_pkg_metadata() {
     _pwpm_timeout="${1:-${METADATA_TIMEOUT:-600}}"
     _pwpm_interval="${METADATA_INTERVAL:-5}"
-    # Validate before comparison/arithmetic; whitespace-bearing decimal text is
-    # not a configured integer and must fall back to the documented finite cap.
+    # Validate before comparison/arithmetic; only bounded decimal values are
+    # configured integers, so whitespace, zero intervals and shell overflows fall
+    # back before they can hide the deadline or pin the elapsed counter.
     case "$_pwpm_interval" in '' | *[!0-9]* | 0) _pwpm_interval=5 ;; esac
+    if ! [ "$_pwpm_interval" -ge 1 ] 2>/dev/null || ! [ "$_pwpm_interval" -le 3600 ] 2>/dev/null; then
+        _pwpm_interval=5
+    fi
     case "$_pwpm_timeout" in '' | *[!0-9]*) _pwpm_timeout=600 ;; esac
+    if ! [ "$_pwpm_timeout" -le 86400 ] 2>/dev/null; then
+        _pwpm_timeout=600
+    fi
     _pwpm_elapsed=0
     _pwpm_seen=0
     log "waiting for the pfSense package metadata refresh to settle"
@@ -910,6 +918,9 @@ wait_guest_ssh() {
     _wgs_timeout="$1"
     # issue #2488: validate before the AND-list can hide test(1)'s numeric error.
     case "$_wgs_timeout" in '' | *[!0-9]*) _wgs_timeout=600 ;; esac
+    if ! [ "$_wgs_timeout" -le 86400 ] 2>/dev/null; then
+        _wgs_timeout=600
+    fi
     _wgs_console="${2:-console.log}"
     _wgs_elapsed=0
     while ! ssh_guest true 2>/dev/null; do

--- a/scripts/image-upgrade.sh
+++ b/scripts/image-upgrade.sh
@@ -102,9 +102,10 @@
 #   verification to promote the new BE (defaults: 300 / 10); METADATA_TIMEOUT /
 #   METADATA_INTERVAL — seconds to wait / poll step for pfSense's post-boot
 #   package metadata refresh to settle (defaults: 600 / 5). VERIFY_BOOT_TIMEOUT
-#   and METADATA_TIMEOUT accept 0..86400; METADATA_INTERVAL accepts 1..3600;
-#   invalid values use their defaults. Every boot wait adds the metadata wait to
-#   its own budget, so the worst case is its own timeout PLUS METADATA_TIMEOUT.
+#   and METADATA_TIMEOUT accept 0..86400; METADATA_INTERVAL accepts canonical
+#   decimal 1..3600 with no leading zeros; invalid values use their defaults.
+#   Every boot wait adds the metadata wait to its own budget, so the worst case
+#   is its own timeout PLUS METADATA_TIMEOUT.
 #   --upgrade-pkgs   before pfSense-upgrade, run `pkg update -f` + `pkg upgrade -y`
 #                    to upgrade baked deps (qemu-guest-agent, etc.) to their latest
 #                    versions; reboots the guest and waits for SSH before proceeding.
@@ -831,9 +832,9 @@ PFB_METADATA_PROBE='if /bin/test -f /var/run/pfSense_version.rc; then echo prese
 pfb_wait_pkg_metadata() {
     _pwpm_timeout="${1:-${METADATA_TIMEOUT:-600}}"
     _pwpm_interval="${METADATA_INTERVAL:-5}"
-    # Validate before comparison/arithmetic; only bounded decimal values are
-    # configured integers, so whitespace, zero intervals and shell overflows fall
-    # back before they can hide the deadline or pin the elapsed counter.
+    # Validate before comparison/arithmetic; only bounded canonical decimal values
+    # are configured integers, so whitespace, leading zeros, zero intervals and
+    # shell overflows fall back before they can hide the deadline or pin the counter.
     case "$_pwpm_interval" in '' | *[!0-9]* | 0 | 0[0-9]*) _pwpm_interval=5 ;; esac
     if ! [ "$_pwpm_interval" -ge 1 ] 2>/dev/null || ! [ "$_pwpm_interval" -le 3600 ] 2>/dev/null; then
         _pwpm_interval=5

--- a/scripts/image-upgrade.sh
+++ b/scripts/image-upgrade.sh
@@ -104,8 +104,9 @@
 #   package metadata refresh to settle (defaults: 600 / 5). VERIFY_BOOT_TIMEOUT
 #   and METADATA_TIMEOUT accept 0..86400; METADATA_INTERVAL accepts canonical
 #   decimal 1..3600 with no leading zeros; invalid values use their defaults.
-#   Every boot wait adds the metadata wait to its own budget, so the worst case
-#   is its own timeout PLUS METADATA_TIMEOUT.
+#   Boot waits add the metadata budget to their own configured budget. Wall-clock
+#   time also includes connection/probe latency, fixed initial sleeps and up to
+#   one final poll interval; these knobs are elapsed-counter caps, not kill timers.
 #   --upgrade-pkgs   before pfSense-upgrade, run `pkg update -f` + `pkg upgrade -y`
 #                    to upgrade baked deps (qemu-guest-agent, etc.) to their latest
 #                    versions; reboots the guest and waits for SSH before proceeding.
@@ -829,6 +830,9 @@ PFB_METADATA_PROBE='if /bin/test -f /var/run/pfSense_version.rc; then echo prese
 # means "not started yet" until a `running` probe has been seen and "exited without the
 # sentinel" after one. Only `present` is success; both failure shapes die loudly rather
 # than let the caller proceed against an unsettled box (#2458).
+#
+# TIMEOUT caps the elapsed counter. Each probe precedes the deadline check and each
+# sleep follows it, so wall clock may exceed TIMEOUT by probe latency plus one interval.
 pfb_wait_pkg_metadata() {
     _pwpm_timeout="${1:-${METADATA_TIMEOUT:-600}}"
     _pwpm_interval="${METADATA_INTERVAL:-5}"
@@ -871,7 +875,8 @@ pfb_wait_pkg_metadata() {
 # pfb_wait_upgraded_box OLD_VERSION LOG — block until the box pfSense-upgrade
 # rebooted comes back reporting a version other than OLD_VERSION, then until its
 # package metadata refresh has settled. Sets the global NEW_VER; dies if the
-# version never changes within UPGRADE_TIMEOUT.
+# version never changes within the configured UPGRADE_TIMEOUT counter. Wall clock
+# also includes the initial 20s reboot sleep, probe latency and one final 15s poll.
 #
 # This path never reaches wait_guest_ssh, so it needs its own settle gate. The
 # version poll is not one: /etc/version is written by the installer BEFORE
@@ -907,9 +912,10 @@ pfb_wait_upgraded_box() {
 # wait_guest_ssh TIMEOUT [CONSOLE] — poll until root SSH answers or TIMEOUT
 # seconds elapse, then until the package metadata refresh has settled; CONSOLE
 # names the boot's console log for the failure message (the verification boot
-# writes verify-console.log, not console.log). TIMEOUT bounds the SSH poll only,
-# so the call's worst case is TIMEOUT + METADATA_TIMEOUT — both hard caps, and
-# both end by dying rather than returning.
+# writes verify-console.log, not console.log). TIMEOUT bounds the SSH poll's
+# elapsed counter; the configured call budget is TIMEOUT + METADATA_TIMEOUT.
+# Wall clock may additionally include one SSH attempt plus metadata probe latency
+# and one final metadata interval. Both exhausted counters die rather than return.
 #
 # Answering SSH is not a settled box. Every caller here goes straight on to read
 # pkg's ABI, apply a pkg upgrade, sample the exported artifact's ABI, or power the

--- a/scripts/image-upgrade.sh
+++ b/scripts/image-upgrade.sh
@@ -834,7 +834,7 @@ pfb_wait_pkg_metadata() {
     # Validate before comparison/arithmetic; only bounded decimal values are
     # configured integers, so whitespace, zero intervals and shell overflows fall
     # back before they can hide the deadline or pin the elapsed counter.
-    case "$_pwpm_interval" in '' | *[!0-9]* | 0) _pwpm_interval=5 ;; esac
+    case "$_pwpm_interval" in '' | *[!0-9]* | 0 | 0[0-9]*) _pwpm_interval=5 ;; esac
     if ! [ "$_pwpm_interval" -ge 1 ] 2>/dev/null || ! [ "$_pwpm_interval" -le 3600 ] 2>/dev/null; then
         _pwpm_interval=5
     fi

--- a/tests/shell/image_upgrade_metadata_wait_spec.sh
+++ b/tests/shell/image_upgrade_metadata_wait_spec.sh
@@ -217,6 +217,13 @@ Describe 'image-upgrade.sh package-metadata wait'
     The stdout should include 'waiting for the pfSense package metadata refresh'
   End
 
+  It 'falls back when the metadata interval has a leading zero'
+    When call run_wait_interval_once 09
+    The status should be success
+    The contents of file "$SLEEP_ARG" should equal '5'
+    The contents of file "$COUNT" should equal '2'
+  End
+
   It 'falls back when the metadata interval exceeds shell integer range'
     When call run_wait_interval_once 99999999999999999999999999
     The status should be success

--- a/tests/shell/image_upgrade_metadata_wait_spec.sh
+++ b/tests/shell/image_upgrade_metadata_wait_spec.sh
@@ -1,5 +1,5 @@
 #shellcheck shell=sh
-# image_upgrade_metadata_wait_spec.sh — issue #2458.
+# image_upgrade_metadata_wait_spec.sh — issues #2458, #2488.
 #
 # image-upgrade.sh reads `pkg config ABI`, runs `pkg upgrade`, samples the
 # exported artifact's ABI and powers the verify VM off, each one immediately
@@ -133,15 +133,16 @@ Describe 'image-upgrade.sh package-metadata wait'
     ' _ "$SCRIPT"
   }
 
-  # run_wait_counted TIMEOUT_ARG — same stub, but counting probes and letting the
-  # interval fall back too, so the number of probes before the wait dies is a
-  # direct readout of the effective cap: probes = cap / interval + 1.
+  # run_wait_counted TIMEOUT_ARG [INTERVAL] — same stub, but counting probes,
+  # so the number before the wait dies directly reports both effective values:
+  # probes = cap / interval + 1.
   run_wait_counted() {
-    _arg="$1" timeout 20 sh -c '
+    _arg="$1" _interval="${2:-5}" timeout 20 sh -c '
       set -e
       log()  { printf "==> %s\n" "$*"; }
       die()  { printf "ERROR: %s\n" "$*" >&2; exit 1; }
       eval "$(sed -n "/^# pfb_wait_pkg_metadata BEGIN/,/^# pfb_wait_pkg_metadata END/p" "$1")"
+      METADATA_INTERVAL="$_interval"
       sleep() { :; }
       ssh_guest() {
         _n=$(cat "$COUNT"); _n=$((_n + 1)); printf "%s\n" "$_n" > "$COUNT"
@@ -168,6 +169,16 @@ Describe 'image-upgrade.sh package-metadata wait'
     The status should be failure
     The stderr should include 'did not settle'
     The contents of file "$COUNT" should equal '1'
+    The stdout should include 'waiting for the pfSense package metadata refresh'
+  End
+
+  It 'falls back to the documented 5s interval when it has trailing whitespace'
+    # With a 20s cap, interval 5 dies on probe 5; whitespace-bearing 7 dies on
+    # probe 4. The count distinguishes strict decimal validation from test(1).
+    When call run_wait_counted 20 '7 '
+    The status should be failure
+    The stderr should include 'did not settle'
+    The contents of file "$COUNT" should equal '5'
     The stdout should include 'waiting for the pfSense package metadata refresh'
   End
 
@@ -199,6 +210,63 @@ Describe 'image-upgrade.sh package-metadata wait'
       wait_guest_ssh 30
     ' _ "$SCRIPT"
   }
+
+  # run_ssh_wait_counted TIMEOUT — keep SSH unreachable and count every probe.
+  # The real outer timeout is only a salvage guard for an unbounded regression;
+  # the crafted failure plus exact count are the behavioural oracle.
+  run_ssh_wait_counted() {
+    _timeout="$1" timeout 10 sh -c '
+      set -e
+      die()  { printf "ERROR: %s\n" "$*" >&2; exit 1; }
+      eval "$(sed -n "/^# wait_guest_ssh BEGIN/,/^# wait_guest_ssh END/p" "$1")"
+      REMOTE_DIR=/tmp
+      sleep() { :; }
+      ssh_guest() {
+        _n=$(cat "$COUNT"); _n=$((_n + 1)); printf "%s\n" "$_n" > "$COUNT"
+        return 1
+      }
+      pfb_wait_pkg_metadata() { printf "metadata-waited\n"; }
+      wait_guest_ssh "$_timeout"
+    ' _ "$SCRIPT"
+    _status=$?
+    if [ "$_status" -eq 124 ]; then
+      printf 'stuck/environment: wait_guest_ssh exceeded salvage cap\n' >&2
+      return 125
+    fi
+    return "$_status"
+  }
+
+  It 'falls back to the documented 600s SSH cap when timeout is nonnumeric'
+    When call run_ssh_wait_counted not-a-number
+    The status should be failure
+    The stderr should include 'VM did not answer SSH within 600s'
+    The contents of file "$COUNT" should equal '121'
+    The output should not include 'metadata-waited'
+  End
+
+  It 'falls back to the documented 600s SSH cap when timeout has trailing whitespace'
+    When call run_ssh_wait_counted '7 '
+    The status should be failure
+    The stderr should include 'VM did not answer SSH within 600s'
+    The contents of file "$COUNT" should equal '121'
+    The output should not include 'metadata-waited'
+  End
+
+  It 'treats a zero SSH timeout as fail-on-first-probe'
+    When call run_ssh_wait_counted 0
+    The status should be failure
+    The stderr should include 'VM did not answer SSH within 0s'
+    The contents of file "$COUNT" should equal '1'
+    The output should not include 'metadata-waited'
+  End
+
+  It 'honours a positive decimal SSH timeout'
+    When call run_ssh_wait_counted 10
+    The status should be failure
+    The stderr should include 'VM did not answer SSH within 10s'
+    The contents of file "$COUNT" should equal '3'
+    The output should not include 'metadata-waited'
+  End
 
   It 'waits for package metadata before any caller reads pkg state'
     When call run_ssh_wait

--- a/tests/shell/image_upgrade_metadata_wait_spec.sh
+++ b/tests/shell/image_upgrade_metadata_wait_spec.sh
@@ -22,8 +22,9 @@ Describe 'image-upgrade.sh package-metadata wait'
   setup() {
     WORK="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/upgmeta.XXXXXX")"
     COUNT="${WORK}/count"
+    SLEEP_ARG="${WORK}/sleep-arg"
     printf '0\n' > "$COUNT"
-    export WORK COUNT
+    export WORK COUNT SLEEP_ARG
   }
   teardown() { rm -rf "$WORK"; }
   BeforeEach 'setup'
@@ -152,10 +153,36 @@ Describe 'image-upgrade.sh package-metadata wait'
     ' _ "$SCRIPT"
   }
 
+  # run_wait_interval_once INTERVAL — settle on probe two and record the one
+  # effective sleep argument, so an overflow fallback is observable under dash.
+  run_wait_interval_once() {
+    _interval="$1" sh -c '
+      set -e
+      log()  { :; }
+      die()  { printf "ERROR: %s\n" "$*" >&2; exit 1; }
+      eval "$(sed -n "/^# pfb_wait_pkg_metadata BEGIN/,/^# pfb_wait_pkg_metadata END/p" "$1")"
+      METADATA_INTERVAL="$_interval"
+      sleep() { printf "%s\n" "$1" > "$SLEEP_ARG"; }
+      ssh_guest() {
+        _n=$(cat "$COUNT"); _n=$((_n + 1)); printf "%s\n" "$_n" > "$COUNT"
+        if [ "$_n" -eq 1 ]; then printf "gone\r\n"; else printf "present\r\n"; fi
+      }
+      pfb_wait_pkg_metadata 20
+    ' _ "$SCRIPT"
+  }
+
   It 'falls back to the documented 600s cap when the timeout is unusable'
     # Pins the fallback VALUE, not just that something bounded happens: with the
     # 5s interval fallback, a 600s cap is 121 probes. A fallback of 0 would be 1.
     When call run_wait_counted not-a-number
+    The status should be failure
+    The stderr should include 'did not settle'
+    The contents of file "$COUNT" should equal '121'
+    The stdout should include 'waiting for the pfSense package metadata refresh'
+  End
+
+  It 'falls back when the metadata timeout exceeds shell integer range'
+    When call run_wait_counted 99999999999999999999999999
     The status should be failure
     The stderr should include 'did not settle'
     The contents of file "$COUNT" should equal '121'
@@ -180,6 +207,21 @@ Describe 'image-upgrade.sh package-metadata wait'
     The stderr should include 'did not settle'
     The contents of file "$COUNT" should equal '5'
     The stdout should include 'waiting for the pfSense package metadata refresh'
+  End
+
+  It 'falls back when the metadata interval is zero-padded zero'
+    When call run_wait_counted 20 00
+    The status should be failure
+    The stderr should include 'did not settle'
+    The contents of file "$COUNT" should equal '5'
+    The stdout should include 'waiting for the pfSense package metadata refresh'
+  End
+
+  It 'falls back when the metadata interval exceeds shell integer range'
+    When call run_wait_interval_once 99999999999999999999999999
+    The status should be success
+    The contents of file "$SLEEP_ARG" should equal '5'
+    The contents of file "$COUNT" should equal '2'
   End
 
   It 'stays bounded when the timeout is not a number'
@@ -246,6 +288,14 @@ Describe 'image-upgrade.sh package-metadata wait'
 
   It 'falls back to the documented 600s SSH cap when timeout has trailing whitespace'
     When call run_ssh_wait_counted '7 '
+    The status should be failure
+    The stderr should include 'VM did not answer SSH within 600s'
+    The contents of file "$COUNT" should equal '121'
+    The output should not include 'metadata-waited'
+  End
+
+  It 'falls back when the SSH timeout exceeds shell integer range'
+    When call run_ssh_wait_counted 99999999999999999999999999
     The status should be failure
     The stderr should include 'VM did not answer SSH within 600s'
     The contents of file "$COUNT" should equal '121'


### PR DESCRIPTION
Fixes #2488.

## What changed

- Validate `wait_guest_ssh` timeout input as a bounded decimal before deadline comparison/arithmetic.
- Fall empty, nonnumeric, whitespace-bearing, zero-padded/leading-zero interval, or shell-overflow values back to documented finite defaults.
- Tighten package-metadata timeout/interval ingestion with POSIX `case` validation plus numeric range belts.
- Accept SSH and metadata timeouts in `0..86400`; accept canonical metadata intervals in `1..3600`.
- Preserve timeout `0` as a deliberate probe-once/fail value and preserve positive in-range caps exactly.

No external parser, regex process, or dependency was added. The only fail-open `-ge ... && die` deadline shape in `image-upgrade.sh` is now validated before entering its loop; other configured deadline shapes exit to existing explicit failure/activation paths and were not expanded into this ticket.

## Test-first proof

The original five-row selector failed three rows against untouched production: nonnumeric SSH timeout hit the outer salvage cap instead of the crafted 600-second failure; trailing-whitespace SSH timeout was accepted as 7 seconds; trailing-whitespace metadata interval was accepted as 7 instead of falling to 5. Zero and positive controls passed before and after.

Review then found all-digit overflow, zero-padded-zero, and octal-shaped interval classes. Five added frozen rows failed against the prior implementations for exact reasons: huge metadata/SSH timeouts looped, `00` pinned elapsed at zero, huge interval reached the raw sleep value, and `09` aborted in shell arithmetic. They pass after bounded decimal validation.

| Frozen RED test | git hash-object | RED run tail |
| --- | --- | --- |
| `tests/shell/image_upgrade_metadata_wait_spec.sh` | `db9273b32369b6f725b7205dc04445ca98ca602c` | `review RED layers: original selector 5/3 failures; overflow/00 selector 4/4; leading-zero interval row 1/1` |

## Verification

- Final full targeted file: 22 examples, 0 failures under `dash`.
- `sh -n scripts/image-upgrade.sh` and `shellcheck --severity=info scripts/image-upgrade.sh` — PASS.
- Canonical gates passed at the preceding head; final exact-head CI and incremental gate/review cover the octal fix.
- Independent review reconstructed each RED layer and verified the only fail-open sibling shape was the ticketed `wait_guest_ssh` AND-list.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for metadata timeout and polling interval settings.
  * Invalid, zero-padded, whitespace-containing, out-of-range, or overflow values now safely fall back to defaults.
  * Improved SSH wait timeout handling, including safe fallback behavior for invalid values.
  * Zero-second SSH timeouts now fail immediately, while valid positive decimal values are honored.
* **Tests**
  * Expanded coverage for configuration validation and timeout behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->