### PR TITLE
image-upgrade: validate remaining wait knobs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -257,6 +257,12 @@ tar -xzf shellspec-dist.tar.gz -C "$HOME"   # then put "$HOME/shellspec" on PATH
 or use `brew install shellspec` (macOS) and check `shellspec --version`. The
 pre-commit hook and CI run it automatically when `shellspec` is present (coverage
 is informational, no floor).
+
+Several shell specs use `timeout(1)` only as a salvage guard so a wait-loop
+regression fails instead of hanging the suite. Linux and FreeBSD provide it;
+on macOS install GNU coreutils (`brew install coreutils`) and put
+`$(brew --prefix coreutils)/libexec/gnubin` on `PATH` so `timeout` is available
+under that name. A missing `timeout` is a test-environment failure, not a skip.
 See [`tests/shell/README.md`](tests/shell/README.md) for the harness contracts
 (the `iprange` PATH shim, the AWS fixture, and the `PFB_SOURCED` source-for-test
 pattern).

--- a/scripts/image-upgrade.sh
+++ b/scripts/image-upgrade.sh
@@ -93,17 +93,23 @@
 # equal those secrets — a wrong NDI can burn the license. CE uses public defaults.
 #   --compression T  qcow2 compression for the published image: zstd|zlib|off (default: zstd)
 #   --upgrade-timeout S  MAX seconds to wait for the pfSense-upgrade+reboot
-#                    (default: 1200). The poll exits the instant /etc/version
-#                    changes, so this only bounds how long a STUCK upgrade waits
-#                    before the run fails — it is not added to a successful run.
+#                    (default: 1200; accepted range: 0..86400). Invalid values
+#                    are rejected before the upgrade starts. The poll exits the
+#                    instant /etc/version changes, so this only bounds how long
+#                    a STUCK upgrade waits before the run fails — it is not
+#                    added to a successful run.
 #   Env knobs (mainly for the spec): VERIFY_BOOT_TIMEOUT — seconds to wait for
 #   the artifact-verification boot's SSH (default: 600); PROMOTE_TIMEOUT /
 #   PROMOTE_INTERVAL — seconds to wait / poll step for pfSense's own boot
 #   verification to promote the new BE (defaults: 300 / 10); METADATA_TIMEOUT /
 #   METADATA_INTERVAL — seconds to wait / poll step for pfSense's post-boot
-#   package metadata refresh to settle (defaults: 600 / 5). VERIFY_BOOT_TIMEOUT
-#   and METADATA_TIMEOUT accept 0..86400; METADATA_INTERVAL accepts canonical
-#   decimal 1..3600 with no leading zeros; invalid values use their defaults.
+#   package metadata refresh to settle (defaults: 600 / 5); LOCK_RETRIES /
+#   LOCK_INTERVAL — attempts / delay for a held pfSense-upgrade lock (defaults:
+#   20 / 15). VERIFY_BOOT_TIMEOUT, PROMOTE_TIMEOUT and METADATA_TIMEOUT accept
+#   0..86400; PROMOTE_INTERVAL and METADATA_INTERVAL accept canonical decimal
+#   1..3600 with no leading zeros; LOCK_RETRIES and LOCK_INTERVAL accept
+#   canonical decimal 1..20 and 0..15, respectively. Invalid env values use
+#   their defaults.
 #   Boot waits add the metadata budget to their own configured budget. Wall-clock
 #   time also includes connection/probe latency, fixed initial sleeps and up to
 #   one final poll interval; these knobs are elapsed-counter caps, not kill timers.
@@ -233,7 +239,14 @@ while [ $# -gt 0 ]; do
         --mac)             MAC="$2"; shift 2 ;;
         --smbios-uuid)     SMBIOS_UUID="$2"; shift 2 ;;
         --compression)     COMPRESSION="$2"; shift 2 ;;
-        --upgrade-timeout) UPGRADE_TIMEOUT="$2"; shift 2 ;;
+        --upgrade-timeout)
+            UPGRADE_TIMEOUT="$2"
+            case "$UPGRADE_TIMEOUT" in
+                '' | *[!0-9]*) die "--upgrade-timeout must be a decimal integer from 0 to 86400" ;;
+            esac
+            [ "$UPGRADE_TIMEOUT" -le 86400 ] 2>/dev/null \
+                || die "--upgrade-timeout must be a decimal integer from 0 to 86400"
+            shift 2 ;;
         --upgrade-pkgs)    UPGRADE_PKGS=1; shift ;;
         --branch)          BRANCH="$2"; shift 2 ;;
         --facts-out)       FACTS_OUT="$2"; shift 2 ;;
@@ -412,11 +425,22 @@ pfb_switch_branch() {
 # refused upgrade look like a started one and turned a short lock into the
 # version-poll timeout (issue #1844). An unclearable lock dies loudly here,
 # before any downstream step can misread it. Echoes the successful output.
-# LOCK_RETRIES / LOCK_INTERVAL are overridable for the spec.
+# LOCK_RETRIES / LOCK_INTERVAL are overridable for the spec; invalid or
+# out-of-range values use the documented 20 / 15 defaults.
 pfb_upgrade_run() {
     _pur_cmd="$1"; _pur_label="$2"; _pur_log="${3:-}"
+    _pur_retries="${LOCK_RETRIES:-20}"
+    _pur_interval="${LOCK_INTERVAL:-15}"
+    case "$_pur_retries" in '' | *[!0-9]* | 0 | 0[0-9]*) _pur_retries=20 ;; esac
+    if ! [ "$_pur_retries" -ge 1 ] 2>/dev/null || ! [ "$_pur_retries" -le 20 ] 2>/dev/null; then
+        _pur_retries=20
+    fi
+    case "$_pur_interval" in '' | *[!0-9]* | 0[0-9]*) _pur_interval=15 ;; esac
+    if ! [ "$_pur_interval" -ge 0 ] 2>/dev/null || ! [ "$_pur_interval" -le 15 ] 2>/dev/null; then
+        _pur_interval=15
+    fi
     _pur_i=0
-    while [ "$_pur_i" -lt "${LOCK_RETRIES:-20}" ]; do
+    while [ "$_pur_i" -lt "$_pur_retries" ]; do
         _pur_out=$(ssh_guest "$_pur_cmd" 2>&1 || true)
         # Persist EVERY attempt (append) so an unclearable lock still leaves the
         # refusal text in the log — the old `| tee` path recorded it, and the
@@ -425,8 +449,8 @@ pfb_upgrade_run() {
         case "$_pur_out" in
             *"Another instance is already running"*)
                 _pur_i=$((_pur_i + 1))
-                warn "${_pur_label}: pfSense-upgrade lock held (attempt ${_pur_i}/${LOCK_RETRIES:-20}); retrying"
-                sleep "${LOCK_INTERVAL:-15}"
+                warn "${_pur_label}: pfSense-upgrade lock held (attempt ${_pur_i}/${_pur_retries}); retrying"
+                sleep "$_pur_interval"
                 ;;
             *)
                 printf '%s\n' "$_pur_out"
@@ -434,7 +458,7 @@ pfb_upgrade_run() {
                 ;;
         esac
     done
-    die "${_pur_label}: pfSense-upgrade lock never cleared after ${LOCK_RETRIES:-20} attempts — refusing to continue"
+    die "${_pur_label}: pfSense-upgrade lock never cleared after ${_pur_retries} attempts — refusing to continue"
 }
 # pfb_upgrade_run END
 
@@ -779,8 +803,19 @@ pfb_boot_artifact_version() {
 # booted the archived pre-upgrade BE (issue #1858: :26.07 shipped a 26.03.1
 # disk). Wait for that promotion, fall back to doing it ourselves if the box
 # never gets there, and fail closed if the disk would still boot the old system.
-# PROMOTE_TIMEOUT / PROMOTE_INTERVAL are overridable for the spec.
+# PROMOTE_TIMEOUT / PROMOTE_INTERVAL are overridable for the spec; invalid or
+# out-of-range values use the documented 300 / 10 defaults.
 pfb_promote_be() {
+    _pbe_timeout="${PROMOTE_TIMEOUT:-300}"
+    _pbe_interval="${PROMOTE_INTERVAL:-10}"
+    case "$_pbe_interval" in '' | *[!0-9]* | 0 | 0[0-9]*) _pbe_interval=10 ;; esac
+    if ! [ "$_pbe_interval" -ge 1 ] 2>/dev/null || ! [ "$_pbe_interval" -le 3600 ] 2>/dev/null; then
+        _pbe_interval=10
+    fi
+    case "$_pbe_timeout" in '' | *[!0-9]*) _pbe_timeout=300 ;; esac
+    if ! [ "$_pbe_timeout" -le 86400 ] 2>/dev/null; then
+        _pbe_timeout=300
+    fi
     # Parse locally (-H: headerless, script-stable fields), so this works the
     # same on any pfSense and is drivable in the spec.
     _pbe_running=$(ssh_guest 'bectl list -H' 2>/dev/null | tr -d '\r' \
@@ -789,17 +824,17 @@ pfb_promote_be() {
         || die "could not identify the running boot environment from 'bectl list' — refusing to promote a guess"
     log "waiting for pfSense to make boot environment '${_pbe_running}' permanent"
     _pbe_elapsed=0
-    while [ "$_pbe_elapsed" -lt "${PROMOTE_TIMEOUT:-300}" ]; do
+    while [ "$_pbe_elapsed" -lt "$_pbe_timeout" ]; do
         pfb_be_is_permanent "$_pbe_running" && {
             log "boot environment '${_pbe_running}' is active on reboot"
             return 0
         }
-        sleep "${PROMOTE_INTERVAL:-10}"
-        _pbe_elapsed=$((_pbe_elapsed + ${PROMOTE_INTERVAL:-10}))
+        sleep "$_pbe_interval"
+        _pbe_elapsed=$((_pbe_elapsed + _pbe_interval))
     done
     # No automatic promotion (manual verification configured, or a boot that
     # never finished): do what pfSense-rc would have done, then re-check.
-    warn "no automatic boot verification after ${PROMOTE_TIMEOUT:-300}s — activating '${_pbe_running}' explicitly"
+    warn "no automatic boot verification after ${_pbe_timeout}s — activating '${_pbe_running}' explicitly"
     ssh_guest "bectl activate '${_pbe_running}'" >/dev/null 2>&1 || true
     pfb_be_is_permanent "$_pbe_running" \
         || die "boot environment '${_pbe_running}' is not active on reboot — refusing to publish a disk that boots the pre-upgrade system"

--- a/tests/shell/image_upgrade_be_spec.sh
+++ b/tests/shell/image_upgrade_be_spec.sh
@@ -211,7 +211,7 @@ Describe 'image-upgrade.sh pre-push artifact verification'
   End
 End
 
-Describe 'image-upgrade.sh --expect-freebsd-major option parsing'
+Describe 'image-upgrade.sh option parsing'
   SCRIPT="${PFB_ROOT}/scripts/image-upgrade.sh"
 
   # run_optparse ARGS... — drive the shipped option-parsing loop in isolation
@@ -223,6 +223,7 @@ Describe 'image-upgrade.sh --expect-freebsd-major option parsing'
       die() { printf "ERROR: %s\n" "$*" >&2; exit 1; }
       _self="$1"; shift
       eval "$(sed -n "/^while \[ \$# -gt 0 \]; do\$/,/^done\$/p" "$_self")"
+      printf "UPGRADE_TIMEOUT=%s\n" "${UPGRADE_TIMEOUT:-<unset>}"
       printf "REACHED-AFTER-PARSE\n"
     ' _ "$SCRIPT" "$@"
   }
@@ -237,6 +238,48 @@ Describe 'image-upgrade.sh --expect-freebsd-major option parsing'
   It 'accepts a numeric --expect-freebsd-major'
     When call run_optparse --expect-freebsd-major 16
     The status should be success
+    The output should include 'REACHED-AFTER-PARSE'
+  End
+
+  It 'rejects a nonnumeric --upgrade-timeout before starting the upgrade'
+    When call run_optparse --upgrade-timeout not-a-number
+    The status should be failure
+    The stderr should include '--upgrade-timeout must be a decimal integer from 0 to 86400'
+    The output should not include 'REACHED-AFTER-PARSE'
+  End
+
+  It 'rejects an overflowing --upgrade-timeout before starting the upgrade'
+    When call run_optparse --upgrade-timeout 99999999999999999999999999
+    The status should be failure
+    The stderr should include '--upgrade-timeout must be a decimal integer from 0 to 86400'
+    The output should not include 'REACHED-AFTER-PARSE'
+  End
+
+  It 'rejects an --upgrade-timeout above 86400 before starting the upgrade'
+    When call run_optparse --upgrade-timeout 86401
+    The status should be failure
+    The stderr should include '--upgrade-timeout must be a decimal integer from 0 to 86400'
+    The output should not include 'REACHED-AFTER-PARSE'
+  End
+
+  It 'accepts zero as an immediate --upgrade-timeout boundary'
+    When call run_optparse --upgrade-timeout 0
+    The status should be success
+    The output should include 'UPGRADE_TIMEOUT=0'
+    The output should include 'REACHED-AFTER-PARSE'
+  End
+
+  It 'accepts the 86400 upper --upgrade-timeout boundary'
+    When call run_optparse --upgrade-timeout 86400
+    The status should be success
+    The output should include 'UPGRADE_TIMEOUT=86400'
+    The output should include 'REACHED-AFTER-PARSE'
+  End
+
+  It 'preserves a valid positive --upgrade-timeout'
+    When call run_optparse --upgrade-timeout 45
+    The status should be success
+    The output should include 'UPGRADE_TIMEOUT=45'
     The output should include 'REACHED-AFTER-PARSE'
   End
 
@@ -261,7 +304,11 @@ Describe 'image-upgrade.sh boot-environment promotion'
     WORK="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/upgbe.XXXXXX")"
     CMDS="${WORK}/guest-cmds"
     POLLS="${WORK}/polls"
-    export WORK CMDS POLLS
+    SLEEP_ARG="${WORK}/sleep-arg"
+    SLEEP_COUNT="${WORK}/sleep-count"
+    : > "$SLEEP_ARG"
+    printf '0\n' > "$SLEEP_COUNT"
+    export WORK CMDS POLLS SLEEP_ARG SLEEP_COUNT
   }
   teardown() { rm -rf "$WORK"; }
   BeforeEach 'setup'
@@ -273,14 +320,19 @@ Describe 'image-upgrade.sh boot-environment promotion'
   #   slow  — never promotes on its own; the fallback activate makes it stick
   #   stuck — never promotes, not even after the fallback activate
   run_promote() {
-    _mode="$1" sh -c '
+    _mode="$1" _timeout="${2-30}" _interval="${3-10}" timeout 10 sh -c '
       set -e
       log()  { printf "==> %s\n" "$*"; }
       warn() { printf "WARNING: %s\n" "$*" >&2; }
       die()  { printf "ERROR: %s\n" "$*" >&2; exit 1; }
-      sleep() { true; }          # no real waiting in the spec
-      PROMOTE_TIMEOUT=30
-      PROMOTE_INTERVAL=10
+      sleep() {
+        _sleep_n=$(cat "$SLEEP_COUNT")
+        _sleep_n=$((_sleep_n + 1))
+        printf "%s\n" "$_sleep_n" > "$SLEEP_COUNT"
+        printf "%s\n" "$1" > "$SLEEP_ARG"
+      }
+      PROMOTE_TIMEOUT="$_timeout"
+      PROMOTE_INTERVAL="$_interval"
       eval "$(sed -n "/^# pfb_promote_be BEGIN/,/^# pfb_promote_be END/p" "$1")"
       ssh_guest() {
         printf "%s\n" "$*" >> "$CMDS"
@@ -325,7 +377,151 @@ Describe 'image-upgrade.sh boot-environment promotion'
       pfb_promote_be
       printf "REACHED-AFTER-PROMOTE\n"
     ' _ "$SCRIPT"
+    _status=$?
+    if [ "$_status" -eq 124 ]; then
+      printf 'stuck/environment: pfb_promote_be exceeded salvage cap\n' >&2
+      return 125
+    fi
+    return "$_status"
   }
+
+  It 'uses the documented promotion defaults when both knobs are empty'
+    When call run_promote slow '' ''
+    The status should be success
+    The output should include 'REACHED-AFTER-PROMOTE'
+    The stderr should include 'after 300s'
+    The contents of file "$SLEEP_ARG" should equal '10'
+    The contents of file "$SLEEP_COUNT" should equal '30'
+    The contents of file "$POLLS" should equal '32'
+  End
+
+  It 'falls back to 300s when the promotion timeout is nonnumeric'
+    When call run_promote slow not-a-number 10
+    The status should be success
+    The output should include 'REACHED-AFTER-PROMOTE'
+    The stderr should include 'after 300s'
+    The contents of file "$SLEEP_ARG" should equal '10'
+    The contents of file "$SLEEP_COUNT" should equal '30'
+    The contents of file "$POLLS" should equal '32'
+  End
+
+  It 'falls back to 10s when the promotion interval is nonnumeric'
+    When call run_promote slow 30 not-a-number
+    The status should be success
+    The output should include 'REACHED-AFTER-PROMOTE'
+    The stderr should include 'after 30s'
+    The contents of file "$SLEEP_ARG" should equal '10'
+    The contents of file "$SLEEP_COUNT" should equal '3'
+    The contents of file "$POLLS" should equal '5'
+  End
+
+  It 'falls back to 10s when the promotion interval is zero'
+    When call run_promote slow 30 0
+    The status should be success
+    The output should include 'REACHED-AFTER-PROMOTE'
+    The stderr should include 'after 30s'
+    The contents of file "$SLEEP_ARG" should equal '10'
+    The contents of file "$SLEEP_COUNT" should equal '3'
+    The contents of file "$POLLS" should equal '5'
+  End
+
+  It 'falls back to 10s when the promotion interval is zero-padded zero'
+    When call run_promote slow 30 00
+    The status should be success
+    The output should include 'REACHED-AFTER-PROMOTE'
+    The stderr should include 'after 30s'
+    The contents of file "$SLEEP_ARG" should equal '10'
+    The contents of file "$SLEEP_COUNT" should equal '3'
+    The contents of file "$POLLS" should equal '5'
+  End
+
+  It 'falls back to 10s when the promotion interval is zero-padded 09'
+    When call run_promote slow 30 09
+    The status should be success
+    The output should include 'REACHED-AFTER-PROMOTE'
+    The stderr should include 'after 30s'
+    The contents of file "$SLEEP_ARG" should equal '10'
+    The contents of file "$SLEEP_COUNT" should equal '3'
+    The contents of file "$POLLS" should equal '5'
+  End
+
+  It 'falls back to 10s when the promotion interval is octal-shaped 010'
+    When call run_promote slow 30 010
+    The status should be success
+    The output should include 'REACHED-AFTER-PROMOTE'
+    The stderr should include 'after 30s'
+    The contents of file "$SLEEP_ARG" should equal '10'
+    The contents of file "$SLEEP_COUNT" should equal '3'
+    The contents of file "$POLLS" should equal '5'
+  End
+
+  It 'preserves the upper promotion timeout and interval boundaries'
+    When call run_promote slow 86400 3600
+    The status should be success
+    The output should include 'REACHED-AFTER-PROMOTE'
+    The stderr should include 'after 86400s'
+    The contents of file "$SLEEP_ARG" should equal '3600'
+    The contents of file "$SLEEP_COUNT" should equal '24'
+    The contents of file "$POLLS" should equal '26'
+  End
+
+  It 'falls back when the promotion timeout is above 86400'
+    When call run_promote slow 86401 10
+    The status should be success
+    The output should include 'REACHED-AFTER-PROMOTE'
+    The stderr should include 'after 300s'
+    The contents of file "$SLEEP_COUNT" should equal '30'
+    The contents of file "$POLLS" should equal '32'
+  End
+
+  It 'falls back when the promotion interval is above 3600'
+    When call run_promote slow 30 3601
+    The status should be success
+    The output should include 'REACHED-AFTER-PROMOTE'
+    The stderr should include 'after 30s'
+    The contents of file "$SLEEP_ARG" should equal '10'
+    The contents of file "$SLEEP_COUNT" should equal '3'
+    The contents of file "$POLLS" should equal '5'
+  End
+
+  It 'falls back when the promotion timeout exceeds shell integer range'
+    When call run_promote slow 99999999999999999999999999 10
+    The status should be success
+    The output should include 'REACHED-AFTER-PROMOTE'
+    The stderr should include 'after 300s'
+    The contents of file "$SLEEP_COUNT" should equal '30'
+    The contents of file "$POLLS" should equal '32'
+  End
+
+  It 'falls back when the promotion interval exceeds shell integer range'
+    When call run_promote slow 30 99999999999999999999999999
+    The status should be success
+    The output should include 'REACHED-AFTER-PROMOTE'
+    The stderr should include 'after 30s'
+    The contents of file "$SLEEP_ARG" should equal '10'
+    The contents of file "$SLEEP_COUNT" should equal '3'
+    The contents of file "$POLLS" should equal '5'
+  End
+
+  It 'treats a zero promotion timeout as immediate explicit fallback'
+    When call run_promote slow 0 10
+    The status should be success
+    The output should include 'REACHED-AFTER-PROMOTE'
+    The stderr should include 'after 0s'
+    The contents of file "$SLEEP_ARG" should equal ''
+    The contents of file "$SLEEP_COUNT" should equal '0'
+    The contents of file "$POLLS" should equal '2'
+  End
+
+  It 'preserves valid positive promotion values'
+    When call run_promote slow 30 15
+    The status should be success
+    The output should include 'REACHED-AFTER-PROMOTE'
+    The stderr should include 'after 30s'
+    The contents of file "$SLEEP_ARG" should equal '15'
+    The contents of file "$SLEEP_COUNT" should equal '2'
+    The contents of file "$POLLS" should equal '4'
+  End
 
   It 'waits for pfSense to promote the BE itself and does not touch bectl activate'
     # the box promotes its own running BE at the end of pfSense-rc; forcing an

--- a/tests/shell/image_upgrade_be_spec.sh
+++ b/tests/shell/image_upgrade_be_spec.sh
@@ -306,7 +306,7 @@ Describe 'image-upgrade.sh boot-environment promotion'
     POLLS="${WORK}/polls"
     SLEEP_ARG="${WORK}/sleep-arg"
     SLEEP_COUNT="${WORK}/sleep-count"
-    : > "$SLEEP_ARG"
+    true > "$SLEEP_ARG"
     printf '0\n' > "$SLEEP_COUNT"
     export WORK CMDS POLLS SLEEP_ARG SLEEP_COUNT
   }

--- a/tests/shell/image_upgrade_be_spec.sh
+++ b/tests/shell/image_upgrade_be_spec.sh
@@ -248,6 +248,13 @@ Describe 'image-upgrade.sh option parsing'
     The output should not include 'REACHED-AFTER-PARSE'
   End
 
+  It 'rejects a negative --upgrade-timeout before starting the upgrade'
+    When call run_optparse --upgrade-timeout -5
+    The status should be failure
+    The stderr should include '--upgrade-timeout must be a decimal integer from 0 to 86400'
+    The output should not include 'REACHED-AFTER-PARSE'
+  End
+
   It 'rejects an overflowing --upgrade-timeout before starting the upgrade'
     When call run_optparse --upgrade-timeout 99999999999999999999999999
     The status should be failure
@@ -403,6 +410,14 @@ Describe 'image-upgrade.sh boot-environment promotion'
     The contents of file "$SLEEP_ARG" should equal '10'
     The contents of file "$SLEEP_COUNT" should equal '30'
     The contents of file "$POLLS" should equal '32'
+  End
+
+  It 'falls back to 300s when the promotion timeout is negative'
+    When call run_promote slow -5 10
+    The status should be success
+    The output should include 'REACHED-AFTER-PROMOTE'
+    The stderr should include 'after 300s'
+    The contents of file "$SLEEP_ARG" should include '10'
   End
 
   It 'falls back to 10s when the promotion interval is nonnumeric'

--- a/tests/shell/image_upgrade_lock_spec.sh
+++ b/tests/shell/image_upgrade_lock_spec.sh
@@ -19,7 +19,7 @@ Describe 'image-upgrade.sh upgrade-lock retry'
     COUNT="${WORK}/count"
     SLEEP_ARG="${WORK}/sleep-arg"
     printf '0\n' > "$COUNT"
-    : > "$SLEEP_ARG"
+    true > "$SLEEP_ARG"
     export WORK COUNT SLEEP_ARG
   }
   teardown() { rm -rf "$WORK"; }

--- a/tests/shell/image_upgrade_lock_spec.sh
+++ b/tests/shell/image_upgrade_lock_spec.sh
@@ -17,8 +17,10 @@ Describe 'image-upgrade.sh upgrade-lock retry'
   setup() {
     WORK="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/upglock.XXXXXX")"
     COUNT="${WORK}/count"
+    SLEEP_ARG="${WORK}/sleep-arg"
     printf '0\n' > "$COUNT"
-    export WORK COUNT
+    : > "$SLEEP_ARG"
+    export WORK COUNT SLEEP_ARG
   }
   teardown() { rm -rf "$WORK"; }
   BeforeEach 'setup'
@@ -29,14 +31,15 @@ Describe 'image-upgrade.sh upgrade-lock retry'
   #   clears-after-2 — two refusals, then the real output
   #   always-locked  — every attempt refused
   run_helper() {
-    _mode="$1" sh -c '
+    _mode="$1" _retries="${2-3}" _interval="${3-0}" timeout 10 sh -c '
       log()  { printf "==> %s\n" "$*"; }
       warn() { printf "WARNING: %s\n" "$*" >&2; }
       die()  { printf "ERROR: %s\n" "$*" >&2; exit 1; }
       # The helper under test, lifted verbatim from the script.
       eval "$(sed -n "/^# pfb_upgrade_run BEGIN/,/^# pfb_upgrade_run END/p" "$1")"
-      LOCK_RETRIES=3
-      LOCK_INTERVAL=0
+      LOCK_RETRIES="$_retries"
+      LOCK_INTERVAL="$_interval"
+      sleep() { printf "%s\n" "$1" > "$SLEEP_ARG"; }
       ssh_guest() {
         _n=$(cat "$COUNT"); _n=$((_n + 1)); printf "%s\n" "$_n" > "$COUNT"
         case "$_mode" in
@@ -52,6 +55,12 @@ Describe 'image-upgrade.sh upgrade-lock retry'
       }
       pfb_upgrade_run "pfSense-upgrade -c" "upgrade check"
     ' _ "$SCRIPT"
+    _status=$?
+    if [ "$_status" -eq 124 ]; then
+      printf 'stuck/environment: pfb_upgrade_run exceeded salvage cap\n' >&2
+      return 125
+    fi
+    return "$_status"
   }
 
   It 'retries until the lock clears and returns the real output'
@@ -66,6 +75,97 @@ Describe 'image-upgrade.sh upgrade-lock retry'
     When call run_helper always-locked
     The status should be failure
     The stderr should include 'lock'
+  End
+
+  It 'uses the documented lock retry defaults when both knobs are empty'
+    When call run_helper always-locked '' ''
+    The status should be failure
+    The stderr should include 'after 20 attempts'
+    The contents of file "$COUNT" should equal '20'
+    The contents of file "$SLEEP_ARG" should equal '15'
+  End
+
+  It 'falls back to 20 retries when LOCK_RETRIES is nonnumeric'
+    When call run_helper always-locked not-a-number 0
+    The status should be failure
+    The stderr should include 'after 20 attempts'
+    The contents of file "$COUNT" should equal '20'
+  End
+
+  It 'falls back to 20 retries when LOCK_RETRIES is zero'
+    When call run_helper always-locked 0 0
+    The status should be failure
+    The stderr should include 'after 20 attempts'
+    The contents of file "$COUNT" should equal '20'
+  End
+
+  It 'falls back to 20 retries when LOCK_RETRIES has a leading zero'
+    When call run_helper always-locked 03 0
+    The status should be failure
+    The stderr should include 'after 20 attempts'
+    The contents of file "$COUNT" should equal '20'
+  End
+
+  It 'falls back to 20 retries when LOCK_RETRIES is above 20'
+    When call run_helper always-locked 21 0
+    The status should be failure
+    The stderr should include 'after 20 attempts'
+    The contents of file "$COUNT" should equal '20'
+  End
+
+  It 'falls back when LOCK_RETRIES exceeds shell integer range'
+    When call run_helper always-locked 99999999999999999999999999 0
+    The status should be failure
+    The stderr should include 'after 20 attempts'
+    The contents of file "$COUNT" should equal '20'
+  End
+
+  It 'falls back to 15s when LOCK_INTERVAL is nonnumeric'
+    When call run_helper always-locked 2 not-a-number
+    The status should be failure
+    The stderr should include 'after 2 attempts'
+    The contents of file "$COUNT" should equal '2'
+    The contents of file "$SLEEP_ARG" should equal '15'
+  End
+
+  It 'preserves zero as a finite lock retry interval'
+    When call run_helper always-locked 2 0
+    The status should be failure
+    The stderr should include 'after 2 attempts'
+    The contents of file "$COUNT" should equal '2'
+    The contents of file "$SLEEP_ARG" should equal '0'
+  End
+
+  It 'falls back to 15s when LOCK_INTERVAL has a leading zero'
+    When call run_helper always-locked 2 09
+    The status should be failure
+    The stderr should include 'after 2 attempts'
+    The contents of file "$COUNT" should equal '2'
+    The contents of file "$SLEEP_ARG" should equal '15'
+  End
+
+  It 'falls back to 15s when LOCK_INTERVAL is above 15'
+    When call run_helper always-locked 2 16
+    The status should be failure
+    The stderr should include 'after 2 attempts'
+    The contents of file "$COUNT" should equal '2'
+    The contents of file "$SLEEP_ARG" should equal '15'
+  End
+
+  It 'falls back when LOCK_INTERVAL exceeds shell integer range'
+    When call run_helper always-locked 2 99999999999999999999999999
+    The status should be failure
+    The stderr should include 'after 2 attempts'
+    The contents of file "$COUNT" should equal '2'
+    The contents of file "$SLEEP_ARG" should equal '15'
+  End
+
+  It 'preserves valid positive lock retry values'
+    When call run_helper always-locked 4 7
+    The status should be failure
+    The stderr should include 'after 4 attempts'
+    The contents of file "$COUNT" should equal '4'
+    The contents of file "$SLEEP_ARG" should equal '7'
   End
 
   # run_call_site MODE — drive the helper through the REAL call-site shape.


### PR DESCRIPTION
Fixes #2865.

## What changed

- Validate `--upgrade-timeout` before any upgrade starts; accept `0..86400`, reject invalid/overflow/above-max input cleanly.
- Normalize `PROMOTE_TIMEOUT` once to `0..86400` (default 300) and `PROMOTE_INTERVAL` once to canonical `1..3600` (default 10) before comparison, sleep or arithmetic.
- Normalize `LOCK_RETRIES` once to canonical `1..20` (default 20) and `LOCK_INTERVAL` once to canonical `0..15` (default 15); zero lock interval remains valid because retry count is finite.
- Preserve existing explicit boot-environment activation fallback and every valid configured value.

The source sweep also classified the remaining wait values: `HEALTH_TIMEOUT` is a fixed source literal; `PKG_LOCK_RETRIES` / `PKG_LOCK_INTERVAL` already validate and fail closed; #2488's SSH/metadata paths are untouched.

## Test-first proof

With current tests and base production, the two touched ShellSpec files produced 63 examples / 22 failures: invalid upgrade timeout reached after-parse code; promotion zero/nonnumeric intervals busy-looped; 09 aborted arithmetic; 010 drifted sleep/counter values; lock knobs reached raw sleep/comparisons. The same frozen files pass unchanged on this head.

| Frozen RED test | git hash-object | RED run tail |
| --- | --- | --- |
| `tests/shell/image_upgrade_be_spec.sh` | `d5cb1f17dd18f9733fab32e5c3432fb565393931` | `base production: 63-row suite had 22 failures; final negative option/promotion selector failed 2/2` |
| `tests/shell/image_upgrade_lock_spec.sh` | `12b37855f1e0cc68b50b2b1a4174288207e165e1` | `base production: lock retries/interval hostile rows reached raw values and failed` |

## Verification

- RED: 63 examples, 22 failures against base production.
- GREEN: 63 examples, 0 failures; targeted suite with truncate guard: 75 examples, 0 failures.
- `scripts/agent/run-gates.sh --diff ecdbcfb9fa3b96de8e8c4f1bddc9e0c75dc8aa10` — PASS: coverage pairing, checker, shell syntax, ShellCheck, full ShellSpec.
- Independent gate confirmed both frozen hashes and reconstructed RED/GREEN; final structural blocker fixed by replacing two retired `: >` fixture truncations with `true >`.
- `git range-diff ecdbcfb9..5223a291 046118e9..5f7ca841` reports both commits patch-identical after rebase onto current `devel`.



## Review follow-up

Mutation review found two guard blind spots in otherwise-correct production: negative `--upgrade-timeout` and negative `PROMOTE_TIMEOUT` would survive if their digit guards were removed while upper-bound checks remained. Commit `a06b0209` adds frozen rows for both; against base production they fail 2/2, and at head the full boot-environment suite passes 46/46.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation for upgrade timeout, lock retry, and promotion timing settings.
  * Documented supported ranges, defaults, and fallback behavior in the command help.

* **Bug Fixes**
  * Invalid or out-of-range settings now safely fall back to documented defaults.
  * Improved timeout handling and failure diagnostics during upgrades and promotions.

* **Tests**
  * Expanded coverage for default, boundary, invalid, and custom configuration values.
  * Added verification for retry intervals and timeout behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->