### PR TITLE
docs: complete sync-status stage vocabulary

### DIFF
--- a/docs/misc/architecture-notes.md
+++ b/docs/misc/architecture-notes.md
@@ -1670,12 +1670,14 @@ next success. Open is idempotent-by-key: opening an already-open key refreshes
 
 | Facility | Stage | Writer/clearer site | Notes |
 | --- | --- | --- | --- |
-| `ip` | `download` | `pfb_ip_download_ledger_update()` at the IP feed-download call site (`pfblockerng.inc`) | paired with the download success path |
-| `ip` | `dedup` | `pfb_sync_status_dedup_check()` (`pfblockerng_extra.inc`), reads the shell's `Sanity check [ PASSED / FAILED ]` line the same way the old widget grep did | replaces that grep entirely |
-| `ip` | `apply` | wired **inside** `pfb_pfctl_table_op()` itself (`pfblockerng.inc`) — a deliberate choice covering every one of that function's callers (delta apply, force-replace, aggregate build/teardown) at one choke point | issue #980's logging-level fix (level 2) is untouched; this ADR only adds the ledger write alongside it |
-| `dnsbl` | `download` | `pfb_dnsbl_download_ledger_update()` at the DNSBL feed-download call site (`pfblockerng.inc`) | paired with the download success path; issue #998 follow-up, mirrors the IP download writer |
-| `dnsbl` | `apply` | `pfb_dnsbl_apply_ledger_update()` + the pure `pfb_dnsbl_converged(): bool` helper (sentinel/applied generation match, Unbound running, `unbound.conf` still wires `pfb_unbound.py`), wired at `pfb_reload_unbound()`'s zero-downtime-success return and its shared-restart tail (mode-gated) | the swap-not-confirmed → restart-fallback branch never opens an entry by itself (fail-safe by design, not an error) |
-| `dnsbl` | `parse` | Python-owned, 8 sites in `pfb_unbound.py`: the zone/data/whitelist/hsts/SafeSearch loaders and the `pfb_unbound.ini` config read (each extracted into its own testable `_load_*` function) plus the DNSBL manifest load (`dnsbl_build_from_manifest()`, both its callers) | 7 further `sys.stderr.write` sites (module-capability imports, per-pattern REGEX-ini rows, background-thread bring-up) are deliberately left freetext-only — no stable per-run item identity / no natural clear site; still visible in `py_error.log` as before |
+| `ip` | `download` | `pfb_ip_download_ledger_update()` (`pfblockerng_extra.inc`) | alias-pass-managed; paired with the whole-alias download success path |
+| `ip` | `script` | `pfb_list_script_failure_record()` / `pfb_list_script_failure_close()` (`pfblockerng_apply.inc`) | alias-pass-managed; same alias key shape as download |
+| `ip` | `dedup` | `pfb_sync_status_dedup_check()` (`pfblockerng_extra.inc`); the dedup-off branch of `sync_package_pfblockerng()` final reporting clears the same key | global constant key `ip` / `dedup` / `dedup`; never alias-keyed |
+| `ip` | `apply` | `pfb_pfctl_table_op()` (`pfblockerng.inc`) | one choke point covers delta apply, force-replace and aggregate build/teardown; issue #980 logging level remains unchanged |
+| `dnsbl` | `download` | `pfb_dnsbl_download_ledger_update()` (`pfblockerng_extra.inc`) | alias-pass-managed; paired with the whole-alias download success path |
+| `dnsbl` | `script` | `pfb_list_script_failure_record()` / `pfb_list_script_failure_close()` (`pfblockerng_apply.inc`) | alias-pass-managed; same alias key shape as download |
+| `dnsbl` | `apply` | `pfb_dnsbl_apply_ledger_update()` and `pfb_reload_unbound()` (`pfblockerng.inc`) | convergence paths update the key; disabled-mode teardown clears it |
+| `dnsbl` | `parse` | Python-owned `pfb_py_status_open()` / `pfb_py_status_close()` sites in `pfb_unbound.py` | loader/build failures with stable item identities use the Python ledger; capability and background-thread errors remain free text |
 
 ### Tick-driven reconciliation — apply stage only
 

--- a/legacy/ADRs/ADR_61_Sync_Status_Ledger/ADR.md
+++ b/legacy/ADRs/ADR_61_Sync_Status_Ledger/ADR.md
@@ -504,3 +504,26 @@ downgrade is unsupported; no inverse ledger conversion or downgrade-only test is
 The `pfb_tick_interval` wording in §7 step 3 is historical. "Within one tick interval" now means
 within one fixed 15-minute tick; there is no registered `pfb_tick_interval` config/CLI knob. A stale
 raw value may remain in `config.xml`, but scheduling ignores it.
+
+## Amendment — 2026-08-29: five-stage ownership (issue #2102)
+
+The live, source-backed stage vocabulary now has five members:
+
+- `download` is alias-pass-managed. `pfb_ip_download_ledger_update()` and
+  `pfb_dnsbl_download_ledger_update()` write its per-alias keys; the pass closes
+  a key only when no feed row for that alias failed.
+- `script` is alias-pass-managed. `pfb_list_script_failure_record()` opens it, and
+  `pfb_list_script_failure_close()` performs the paired alias-pass close.
+- `parse` is Python-managed. `pfb_unbound.py` writes it through
+  `pfb_py_status_open()` and `pfb_py_status_close()`.
+- `apply` is tick-managed. `pfb_pfctl_table_op()` and
+  `pfb_dnsbl_apply_ledger_update()` write it, and `pfblockerng_tick()` reconciles
+  only this stage.
+- `dedup` is written by `pfb_sync_status_dedup_check()` under the global constant
+  key `ip` / `dedup` / `dedup`; it is never keyed by alias.
+
+Alias removal therefore closes `download` and `script`: both use the removed
+alias's key shape, and neither can receive its ordinary paired close after that
+alias loses its next pass. Removal never closes `parse` or `apply`, whose Python
+and tick owners reconcile without the alias, and it never closes `dedup`, whose
+constant key cannot be reached through an alias-removal path.

--- a/legacy/ADRs/ADR_61_Sync_Status_Ledger/ADR.md
+++ b/legacy/ADRs/ADR_61_Sync_Status_Ledger/ADR.md
@@ -516,11 +516,13 @@ The live, source-backed stage vocabulary now has five members:
   `pfb_list_script_failure_close()` performs the paired alias-pass close.
 - `parse` is Python-managed. `pfb_unbound.py` writes it through
   `pfb_py_status_open()` and `pfb_py_status_close()`.
-- `apply` is tick-managed. `pfb_pfctl_table_op()` and
-  `pfb_dnsbl_apply_ledger_update()` write it, and `pfblockerng_tick()` reconciles
-  only this stage.
-- `dedup` is written by `pfb_sync_status_dedup_check()` under the global constant
-  key `ip` / `dedup` / `dedup`; it is never keyed by alias.
+- `apply` is tick-managed. `pfb_pfctl_table_op()`,
+  `pfb_dnsbl_apply_ledger_update()`, and `pfb_reload_unbound()` write it, and
+  `pfblockerng_tick()` reconciles only this stage.
+- `dedup` uses the global constant key `ip` / `dedup` / `dedup`.
+  `pfb_sync_status_dedup_check()` writes and closes it, while
+  `sync_package_pfblockerng()` clears the same key when dedup is disabled; it is
+  never keyed by alias.
 
 Alias removal therefore closes `download` and `script`: both use the removed
 alias's key shape, and neither can receive its ordinary paired close after that

--- a/legacy/ADRs/ADR_61_Sync_Status_Ledger/ADR.md
+++ b/legacy/ADRs/ADR_61_Sync_Status_Ledger/ADR.md
@@ -516,13 +516,14 @@ The live, source-backed stage vocabulary now has five members:
   `pfb_list_script_failure_close()` performs the paired alias-pass close.
 - `parse` is Python-managed. `pfb_unbound.py` writes it through
   `pfb_py_status_open()` and `pfb_py_status_close()`.
-- `apply` is tick-managed. `pfb_pfctl_table_op()`,
-  `pfb_dnsbl_apply_ledger_update()`, and `pfb_reload_unbound()` write it, and
-  `pfblockerng_tick()` reconciles only this stage.
+- `apply` is tick-managed. `pfb_pfctl_table_op()` and
+  `pfb_dnsbl_apply_ledger_update()` write it; `pfb_reload_unbound()` also clears
+  it during disabled-mode teardown. `pfblockerng_tick()` reconciles only this
+  stage.
 - `dedup` uses the global constant key `ip` / `dedup` / `dedup`.
-  `pfb_sync_status_dedup_check()` writes and closes it, while
-  `sync_package_pfblockerng()` clears the same key when dedup is disabled; it is
-  never keyed by alias.
+  `pfb_sync_status_dedup_check()` writes and closes it, while the dedup-off
+  branch of `sync_package_pfblockerng()` final reporting clears the same key; it
+  is never keyed by alias.
 
 Alias removal therefore closes `download` and `script`: both use the removed
 alias's key shape, and neither can receive its ordinary paired close after that

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -6604,7 +6604,7 @@ function pfb_sync_status_locked(string $ledger_dir, callable $fn, float $timeout
  *
  * @param string        $facility   'ip' | 'dnsbl'.
  * @param string        $item       The alias/group/feed name the entry is about.
- * @param string        $stage      'download' | 'parse' | 'apply' | 'dedup'.
+ * @param string        $stage      'download' | 'script' | 'parse' | 'apply' | 'dedup'.
  * @param string        $message    Human-readable failure description.
  * @param string        $ledger_dir Directory that contains pfb_sync_status.json.
  * @param callable|null $clock_fn   Returns the current epoch timestamp; defaults to time().
@@ -6651,7 +6651,7 @@ function pfb_sync_status_open(
  *
  * @param string $facility   'ip' | 'dnsbl'.
  * @param string $item       The alias/group/feed name the entry is about.
- * @param string $stage      'download' | 'parse' | 'apply' | 'dedup'.
+ * @param string $stage      'download' | 'script' | 'parse' | 'apply' | 'dedup'.
  * @param string $ledger_dir Directory that contains pfb_sync_status.json.
  * @param float  $timeout_s  Bounded lock-acquire budget in seconds (issue #1780; injectable for tests).
  * @return void

--- a/src/usr/local/www/pfblockerng/pfblockerng_category.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_category.php
@@ -158,8 +158,8 @@ if (!empty($action) && isset($gtype) && isset($rowid)) {
 			// Delete Table row (via POST)
 			$name = pfb_filter($rowdata[$rowid]['aliasname'], PFB_FILTER_WORD, 'Category');
 			if (!empty($name) && isset($rowdata[$rowid])) {
-				// issue #1014/#1019: close the deleted alias's stage=download ledger entry
-				// before the row config node is gone -- else it orphans forever.
+				// issue #1014/#1019/#2060: close the deleted alias's alias-pass-managed
+				// ledger entries (download, script) before the row config node is gone.
 				pfb_sync_status_close_removed_alias($gtype, $name, $pfb['dbdir']);
 				unset($rowdata[$rowid]);
 				if (isset($rowdata_path)) {

--- a/src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
@@ -825,8 +825,8 @@ if ($_POST && isset($_POST['save'])) {
 	}
 
 	if (!$input_errors) {
-		// issue #1014/#1019: close the OLD alias's stage=download ledger entry before
-		// the aliasname is overwritten below -- a renamed alias must not orphan it.
+		// issue #1014/#1019/#2060: close the OLD alias's alias-pass-managed ledger entries
+		// (download, script) before aliasname is overwritten -- a rename must not orphan them.
 		$pfb_old_aliasname = config_get_path("installedpackages/{$conf_type}/config/{$rowid}/aliasname", '');
 		if ($pfb_old_aliasname !== '' && $pfb_old_aliasname !== ($_POST['aliasname'] ?: '')) {
 			pfb_sync_status_close_removed_alias($gtype, $pfb_old_aliasname, $pfb['dbdir']);

--- a/tests/php/PfbSyncStatusLedgerTest.php
+++ b/tests/php/PfbSyncStatusLedgerTest.php
@@ -701,8 +701,8 @@ final class PfbSyncStatusLedgerTest extends TestCase
 	}
 
 	// -----------------------------------------------------------------------
-	// pfb_sync_status_close_removed_alias() — issue #1014/#1019: close an
-	// orphaned stage=download entry when our own WebUI renames/deletes an alias.
+	// pfb_sync_status_close_removed_alias() — issue #1014/#1019/#2060: close an
+	// alias's orphaned alias-pass-managed entries (download, script) on rename/delete.
 	// -----------------------------------------------------------------------
 
 	public function testCloseRemovedAliasIpv4ClosesDownloadEntry(): void

--- a/tests/smoke/ui/test_category_ledger_close.py
+++ b/tests/smoke/ui/test_category_ledger_close.py
@@ -1,13 +1,13 @@
-"""issue #1014/#1019 -- Tier-B coverage: WebUI alias rename/delete closes the
-orphaned sync-status ledger ``stage=download`` entry (ADR-61 mechanism: a WebUI
-event hook, NOT tick reconciliation).
+"""issue #1014/#1019/#2060 -- Tier-B coverage: WebUI alias rename/delete
+routes the selected facility/alias key shape through
+``pfb_sync_status_close_removed_alias()``. The helper closes both
+alias-pass-managed keys (``download`` and ``script``); this is a WebUI event
+hook, not tick reconciliation.
 
-Before this fix, deleting or renaming an IP/DNSBL alias via pfBlockerNG's OWN
-category pages left its ``facility=ip|dnsbl stage=download`` ledger entry open
-forever -- nothing else ever closes a download key for a REMOVED alias (the
-tick only ever re-opens/closes keys for aliases that still EXIST). The new
-``pfb_sync_status_close_removed_alias()`` call at both WebUI mutation sites
-closes exactly that key.
+Without this hook, deleting or renaming an IP/DNSBL alias via pfBlockerNG's
+own category pages could leave its alias-pass-managed ledger entries open
+forever because a removed alias never receives another pass. Both mutation
+sites call the helper before the row's alias key disappears.
 
 Ledger seeding/probing reuses ``test_render_widget_ledger.py``'s own
 conventions (``_ledger_open()`` over the REAL ``pfb_sync_status_open()``,
@@ -18,12 +18,14 @@ writer, not a hand-rolled JSON blob. Row seeding/mutation reuses
 NOT the form-scrape helper -- the row's own JS-fired AJAX envelope) and
 ``test_category_edit.py``'s full-form-POST save drive for the rename case.
 
-Every flow is a TRUE transition test (CLAUDE.md): it seeds a row + opens its
-download ledger entry, asserts OPEN, drives the WebUI mutation, then asserts
-CLOSED -- proving the mutation CAUSED the close, not that the ledger merely
-started empty. ``clean_ledger`` wipes+restores the ledger files around every
-test regardless of outcome, so a failed assertion never leaks an open entry
-into a sibling test.
+Each smoke flow deliberately seeds only a ``download`` entry, so these rows
+prove that the WebUI call sites reach the helper for the original regression;
+they do not claim a seeded ``script`` transition. The helper's two-key
+contract is covered by ``PfbSyncStatusLedgerTest``. Each flow is a true
+transition test: it asserts OPEN, drives the mutation, then asserts CLOSED,
+proving the mutation caused the close. ``clean_ledger`` wipes and restores the
+ledger files around every test regardless of outcome, so a failed assertion
+never leaks an open entry into a sibling test.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
Fixes #2102.

## What changed

- Add `script` to both `pfb_sync_status_open()` / `close()` stage docblocks.
- Correct category delete/rename comments: alias removal closes alias-pass-managed `download` and `script` entries, not download alone.
- Correct the smoke module description while explicitly noting its rows seed only `download`.
- Append a dated 2026-08-29 amendment to implemented ADR-61; the accepted body is byte-identical to the base prefix.

The amendment records the five source-derived ownership classes: alias-pass-managed `download`/`script`; Python-managed `parse`; tick-managed `apply`; global constant-key `dedup`. Runtime helper behavior is unchanged.

no-test-needed: every changed PHP/Python line is a docblock, comment, module docstring, or append-only ADR amendment; no observable UI/runtime/test behavior changes.

## Verification

- Independent source enumeration matched every changed sentence to its live writer/owner.
- ADR prefix before the appended amendment is byte-identical to base.
- `scripts/agent/run-gates.sh --diff 65d99f950492a4112c878cd12082b80a816634a2` — PASS for path-derived PHP, Python, smoke-contract and documentation gates.
- PHP syntax and relevant sync-status ledger/smoke contracts pass; no Tier-A/B UI coverage is owed for comment-only `www/` edits.



## Review follow-up

Review found one remaining stale test-section header and incomplete apply/dedup writer lists. Commits `eb0829d3` and `e45b09c6` now name download+script in the ledger test header, distinguish writers from close-only teardown sites, and reconcile the durable architecture writer table with the five-stage amendment. `PfbSyncStatusLedgerTest` remains 33/33 green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified supported synchronization stages to include script processing.
  * Updated ledger cleanup documentation for alias deletion and renaming to cover download and script entries.
  * Expanded test documentation to distinguish WebUI cleanup flows from reconciliation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->