### PR TITLE
tests: isolate PHPUnit bootstrap sandbox

### DIFF
--- a/tests/php/BootstrapSandboxTest.php
+++ b/tests/php/BootstrapSandboxTest.php
@@ -1,0 +1,169 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/** Process-level contracts for the PHPUnit bootstrap sandbox (issue #2836). */
+final class BootstrapSandboxTest extends TestCase
+{
+	private const ROOT = __DIR__ . '/../..';
+	private const SALVAGE_CAP_NS = 10_000_000_000;
+	private string $tmp;
+
+	protected function setUp(): void
+	{
+		$this->tmp = sys_get_temp_dir() . '/pfb_bootstrap_process_' . bin2hex(random_bytes(8));
+		$this->assertTrue(mkdir($this->tmp, 0700, TRUE));
+	}
+
+	protected function tearDown(): void
+	{
+		rmdir_recursive($this->tmp);
+	}
+
+	/**
+	 * Scenario: every bootstrap process owns fresh scratch state.
+	 * Given a stale PID-only sandbox and two child bootstrap invocations,
+	 * When both children exit,
+	 * Then neither adopts the stale state, their roots differ, and both roots are removed.
+	 */
+	public function testEachBootstrapInvocationOwnsAFreshDisposableSandbox(): void
+	{
+		$first = $this->runBootstrap($this->tmp, TRUE);
+		$this->assertSame(0, $first['status'], $first['stderr']);
+		$firstRecord = json_decode($first['stdout'], TRUE, flags: JSON_THROW_ON_ERROR);
+		$this->assertIsArray($firstRecord);
+
+		$this->assertNotSame($first['legacy_root'], $firstRecord['root'],
+			'a bootstrap must not adopt a stale PID-only sandbox');
+		$this->assertSame('legacy sentinel', file_get_contents($first['legacy_root'] . '/sentinel'),
+			'the bootstrap must not write into or clean a sandbox it does not own');
+		$this->assertSandboxPaths($firstRecord);
+		$this->assertDirectoryDoesNotExist($firstRecord['root'],
+			'the first child must remove its whole sandbox at shutdown');
+
+		$second = $this->runBootstrap($this->tmp);
+		$this->assertSame(0, $second['status'], $second['stderr']);
+		$secondRecord = json_decode($second['stdout'], TRUE, flags: JSON_THROW_ON_ERROR);
+		$this->assertIsArray($secondRecord);
+		$this->assertSandboxPaths($secondRecord);
+		$this->assertNotSame($firstRecord['root'], $secondRecord['root'],
+			'two bootstrap invocations must never share a sandbox root');
+		$this->assertDirectoryDoesNotExist($secondRecord['root'],
+			'the second child must remove its whole sandbox at shutdown');
+	}
+
+	public function testSandboxCreationFailureIsLoud(): void
+	{
+		$notDirectory = $this->tmp . '/not-a-directory';
+		$this->assertSame(1, file_put_contents($notDirectory, 'x'));
+
+		$result = $this->runBootstrap($notDirectory);
+
+		$this->assertStringContainsString('mkdir()', $result['stderr'],
+			'sandbox creation warnings must not be @-suppressed');
+		$this->assertNotSame(0, $result['status'],
+			'sandbox creation failure must stop the child before tests run');
+	}
+
+	public function testShutdownCleanupPreservesChildExitStatus(): void
+	{
+		$result = $this->runBootstrap($this->tmp, FALSE, 23);
+		$record = json_decode($result['stdout'], TRUE, flags: JSON_THROW_ON_ERROR);
+		$this->assertIsArray($record);
+
+		$this->assertSame(23, $result['status'], $result['stderr']);
+		$this->assertDirectoryDoesNotExist($record['root'],
+			'shutdown cleanup must remove the sandbox without replacing the child status');
+	}
+
+	/** @param array{root:string,db:string,log:string,tmp:string} $record */
+	private function assertSandboxPaths(array $record): void
+	{
+		$this->assertStringStartsWith($this->tmp . '/pfb_php_unit_', $record['root']);
+		$this->assertSame($record['root'] . '/db', $record['db']);
+		$this->assertSame($record['root'] . '/log', $record['log']);
+		$this->assertSame($record['root'] . '/tmp', $record['tmp']);
+	}
+
+	/**
+	 * @return array{status:int,stdout:string,stderr:string,pid:int,legacy_root:string}
+	 */
+	private function runBootstrap(string $tmpdir, bool $plantLegacy = FALSE, int $exitCode = 0): array
+	{
+		$bootstrap = var_export(self::ROOT . '/tests/php/bootstrap.php', TRUE);
+		$script = <<<PHP
+stream_get_contents(STDIN);
+require {$bootstrap};
+echo json_encode([
+	'root' => \$pfb_test_tmp,
+	'db' => \$GLOBALS['g']['vardb_path'],
+	'log' => \$GLOBALS['g']['varlog_path'],
+	'tmp' => \$GLOBALS['g']['tmp_path'],
+], JSON_THROW_ON_ERROR);
+exit({$exitCode});
+PHP;
+		$descriptors = [0 => ['pipe', 'r'], 1 => ['pipe', 'w'], 2 => ['pipe', 'w']];
+		$environment = getenv();
+		$this->assertIsArray($environment);
+		$environment['TMPDIR'] = $tmpdir;
+		$process = proc_open([PHP_BINARY, '-r', $script], $descriptors, $pipes, self::ROOT, $environment);
+		$this->assertIsResource($process);
+		stream_set_blocking($pipes[1], FALSE);
+		stream_set_blocking($pipes[2], FALSE);
+
+		$processStatus = proc_get_status($process);
+		$pid = (int) $processStatus['pid'];
+		$legacyRoot = "{$tmpdir}/pfb_php_unit_{$pid}";
+		if ($plantLegacy) {
+			$this->assertTrue(mkdir($legacyRoot, 0700, TRUE));
+			$this->assertSame(15, file_put_contents($legacyRoot . '/sentinel', 'legacy sentinel'));
+		}
+		fclose($pipes[0]);
+
+		$stdout = '';
+		$stderr = '';
+		$timedOut = FALSE;
+		$closeStatus = -1;
+		try {
+			$deadline = hrtime(TRUE) + self::SALVAGE_CAP_NS;
+			do {
+				$read = [$pipes[1], $pipes[2]];
+				$write = $except = NULL;
+				@stream_select($read, $write, $except, 0, 100000);
+				$stdout .= stream_get_contents($pipes[1]);
+				$stderr .= stream_get_contents($pipes[2]);
+				$processStatus = proc_get_status($process);
+				if (!$processStatus['running']) {
+					break;
+				}
+			} while (hrtime(TRUE) < $deadline);
+			$timedOut = $processStatus['running'];
+			if ($timedOut) {
+				proc_terminate($process);
+				usleep(50000);
+				if (proc_get_status($process)['running']) {
+					proc_terminate($process, 9);
+				}
+			}
+		} finally {
+			$stdout .= stream_get_contents($pipes[1]);
+			$stderr .= stream_get_contents($pipes[2]);
+			fclose($pipes[1]);
+			fclose($pipes[2]);
+			$closeStatus = proc_close($process);
+		}
+		if ($timedOut) {
+			$this->fail('STUCK/ENVIRONMENT: bootstrap child exceeded the 10-second salvage cap');
+		}
+		$status = $processStatus['exitcode'] !== -1 ? $processStatus['exitcode'] : $closeStatus;
+		return [
+			'status' => $status,
+			'stdout' => $stdout,
+			'stderr' => $stderr,
+			'pid' => $pid,
+			'legacy_root' => $legacyRoot,
+		];
+	}
+}

--- a/tests/php/BootstrapSandboxTest.php
+++ b/tests/php/BootstrapSandboxTest.php
@@ -78,6 +78,16 @@ final class BootstrapSandboxTest extends TestCase
 			'shutdown cleanup must remove the sandbox without replacing the child status');
 	}
 
+	public function testForkedChildCannotRemoveParentSandbox(): void
+	{
+		$result = $this->runBootstrap($this->tmp, FALSE, 0, TRUE);
+		$this->assertSame(0, $result['status'], $result['stderr']);
+		$record = json_decode($result['stdout'], TRUE, flags: JSON_THROW_ON_ERROR);
+		$this->assertIsArray($record);
+		$this->assertDirectoryDoesNotExist($record['root'],
+			'the owner process must remove its sandbox only when the owner exits');
+	}
+
 	/** @param array{root:string,db:string,log:string,tmp:string} $record */
 	private function assertSandboxPaths(array $record): void
 	{
@@ -90,12 +100,32 @@ final class BootstrapSandboxTest extends TestCase
 	/**
 	 * @return array{status:int,stdout:string,stderr:string,pid:int,legacy_root:string}
 	 */
-	private function runBootstrap(string $tmpdir, bool $plantLegacy = FALSE, int $exitCode = 0): array
-	{
+	private function runBootstrap(
+	    string $tmpdir, bool $plantLegacy = FALSE, int $exitCode = 0, bool $forkChild = FALSE
+	): array {
 		$bootstrap = var_export(self::ROOT . '/tests/php/bootstrap.php', TRUE);
+		$forkScript = '';
+		if ($forkChild) {
+			$forkScript = <<<'PHP'
+$forkPid = pcntl_fork();
+if ($forkPid === -1) {
+	fwrite(STDERR, "pcntl_fork failed\n");
+	exit(91);
+}
+if ($forkPid === 0) {
+	exit(0);
+}
+pcntl_waitpid($forkPid, $forkStatus);
+if (!is_dir($pfb_test_tmp)) {
+	fwrite(STDERR, "forked child removed owner sandbox\n");
+	exit(92);
+}
+PHP;
+		}
 		$script = <<<PHP
 stream_get_contents(STDIN);
 require {$bootstrap};
+{$forkScript}
 echo json_encode([
 	'root' => \$pfb_test_tmp,
 	'db' => \$GLOBALS['g']['vardb_path'],

--- a/tests/php/BootstrapSandboxTest.php
+++ b/tests/php/BootstrapSandboxTest.php
@@ -80,6 +80,9 @@ final class BootstrapSandboxTest extends TestCase
 
 	public function testForkedChildCannotRemoveParentSandbox(): void
 	{
+		if (!function_exists('pcntl_fork') || !function_exists('pcntl_waitpid')) {
+			$this->markTestSkipped('pcntl is required to prove fork-inherited shutdown ownership.');
+		}
 		$result = $this->runBootstrap($this->tmp, FALSE, 0, TRUE);
 		$this->assertSame(0, $result['status'], $result['stderr']);
 		$record = json_decode($result['stdout'], TRUE, flags: JSON_THROW_ON_ERROR);
@@ -138,7 +141,13 @@ PHP;
 		$environment = getenv();
 		$this->assertIsArray($environment);
 		$environment['TMPDIR'] = $tmpdir;
-		$process = proc_open([PHP_BINARY, '-r', $script], $descriptors, $pipes, self::ROOT, $environment);
+		$process = proc_open(
+			[PHP_BINARY, '-d', 'display_errors=stderr', '-r', $script],
+			$descriptors,
+			$pipes,
+			self::ROOT,
+			$environment
+		);
 		$this->assertIsResource($process);
 		stream_set_blocking($pipes[1], FALSE);
 		stream_set_blocking($pipes[2], FALSE);

--- a/tests/php/IpPrefetchTest.php
+++ b/tests/php/IpPrefetchTest.php
@@ -56,8 +56,8 @@ use PHPUnit\Framework\TestCase;
  *     the tail after its first ':' happens to equal some host's raw_entry.
  *
  *   Scenario: B3 -- a failed batched grep pass must never seed a false negative
- *     A child `php` process with `open_basedir` whitelisting only the repo tree (so
- *     sys_get_temp_dir()'s real system temp dir is off-limits) genuinely fails
+ *     A child `php` process with `open_basedir` whitelisting the repo tree and its
+ *     bootstrap sandbox (but not sys_get_temp_dir()'s real system temp dir) genuinely fails
  *     tempnam() -- the exact pattern-file-creation failure pfb_ip_prefetch_grep_lines()
  *     can hit in production. pfb_ip_prefetch() must leave the affected rows entirely
  *     UNSEEDED rather than caching a wrong/placeholder result.
@@ -897,6 +897,7 @@ final class IpPrefetchTest extends TestCase
 			// Apply the restriction after bootstrap creates its own sandbox. Keep that exact
 			// tree allowed so its shutdown cleanup works, while sys_get_temp_dir() itself
 			// remains outside open_basedir and the body still exercises tempnam() failure.
+			// issue #896: stderr routing keeps PHP 8.5's tempnam() warning out of JSON stdout.
 			$cmd = 'php -d display_errors=stderr ' . escapeshellarg($probe) . ' 2>/dev/null';
 			$output = shell_exec($cmd);
 		} finally {

--- a/tests/php/IpPrefetchTest.php
+++ b/tests/php/IpPrefetchTest.php
@@ -889,15 +889,15 @@ final class IpPrefetchTest extends TestCase
 		$this->assertNotFalse($probe, 'precondition: failed to create the sandbox probe script');
 
 		try {
-			$code = "<?php\nrequire " . var_export("{$repo}/tests/php/bootstrap.php", true) . ";\n" . $phpBody;
+			$code = "<?php\nrequire " . var_export("{$repo}/tests/php/bootstrap.php", TRUE) . ";\n"
+				. 'ini_set(\'open_basedir\', ' . var_export($repo, TRUE) . ' . PATH_SEPARATOR . $pfb_test_tmp);' . "\n"
+				. $phpBody;
 			file_put_contents($probe, $code);
 
-			// issue #896: route PHP engine diagnostics to stderr (dropped by the 2>/dev/null
-			// below) so the child's stdout stays pure JSON. Under open_basedir the child's
-			// tempnam() emits a Warning; on PHP 8.5 it lands on STDOUT (not stderr), prepending
-			// non-JSON text that breaks json_decode() — green on 8.3, red on 8.5 without this.
-			$cmd = 'php -d open_basedir=' . escapeshellarg($repo)
-				. ' -d display_errors=stderr ' . escapeshellarg($probe) . ' 2>/dev/null';
+			// Apply the restriction after bootstrap creates its own sandbox. Keep that exact
+			// tree allowed so its shutdown cleanup works, while sys_get_temp_dir() itself
+			// remains outside open_basedir and the body still exercises tempnam() failure.
+			$cmd = 'php -d display_errors=stderr ' . escapeshellarg($probe) . ' 2>/dev/null';
 			$output = shell_exec($cmd);
 		} finally {
 			@unlink($probe);

--- a/tests/php/bootstrap.php
+++ b/tests/php/bootstrap.php
@@ -27,13 +27,18 @@ require_once __DIR__ . '/pfsense_doubles.php';
 set_include_path(__DIR__ . '/shims' . PATH_SEPARATOR . get_include_path());
 
 // 3. Writable per-invocation sandbox for any load-time/log file writes.
-$pfb_test_tmp = sys_get_temp_dir() . '/pfb_php_unit_' . getmypid() . '_' . bin2hex(random_bytes(8));
+$pfb_test_owner_pid = getmypid();
+$pfb_test_tmp = sys_get_temp_dir() . '/pfb_php_unit_' . $pfb_test_owner_pid . '_' . bin2hex(random_bytes(8));
 if (!mkdir($pfb_test_tmp, 0777, TRUE)) {
 	throw new RuntimeException("PHPUnit sandbox creation failed: {$pfb_test_tmp}");
 }
-register_shutdown_function(static function () use ($pfb_test_tmp): void {
-	rmdir_recursive($pfb_test_tmp);
+register_shutdown_function(static function () use ($pfb_test_tmp, $pfb_test_owner_pid): void {
+	// pcntl_fork() inherits shutdown callbacks; only the process that created this tree owns it.
+	if (getmypid() === $pfb_test_owner_pid) {
+		rmdir_recursive($pfb_test_tmp);
+	}
 });
+unset($pfb_test_owner_pid);
 foreach (['db', 'log', 'tmp'] as $pfb_test_subdir) {
 	$pfb_test_path = "{$pfb_test_tmp}/{$pfb_test_subdir}";
 	if (!mkdir($pfb_test_path, 0777, TRUE)) {

--- a/tests/php/bootstrap.php
+++ b/tests/php/bootstrap.php
@@ -26,12 +26,21 @@ require_once __DIR__ . '/pfsense_doubles.php';
 // 1. Shims for the eight pfSense includes required at the top of pfblockerng.inc.
 set_include_path(__DIR__ . '/shims' . PATH_SEPARATOR . get_include_path());
 
-// 3. Writable sandbox for any load-time/log file writes.
-$pfb_test_tmp = sys_get_temp_dir() . '/pfb_php_unit_' . getmypid();
-@mkdir($pfb_test_tmp, 0777, true);
-@mkdir("{$pfb_test_tmp}/db", 0777, true);
-@mkdir("{$pfb_test_tmp}/log", 0777, true);
-@mkdir("{$pfb_test_tmp}/tmp", 0777, true);
+// 3. Writable per-invocation sandbox for any load-time/log file writes.
+$pfb_test_tmp = sys_get_temp_dir() . '/pfb_php_unit_' . getmypid() . '_' . bin2hex(random_bytes(8));
+if (!mkdir($pfb_test_tmp, 0777, TRUE)) {
+	throw new RuntimeException("PHPUnit sandbox creation failed: {$pfb_test_tmp}");
+}
+register_shutdown_function(static function () use ($pfb_test_tmp): void {
+	rmdir_recursive($pfb_test_tmp);
+});
+foreach (['db', 'log', 'tmp'] as $pfb_test_subdir) {
+	$pfb_test_path = "{$pfb_test_tmp}/{$pfb_test_subdir}";
+	if (!mkdir($pfb_test_path, 0777, TRUE)) {
+		throw new RuntimeException("PHPUnit sandbox directory creation failed: {$pfb_test_path}");
+	}
+}
+unset($pfb_test_path, $pfb_test_subdir);
 
 $GLOBALS['g'] = [
 	'vardb_path'  => "{$pfb_test_tmp}/db",


### PR DESCRIPTION
## Summary

- give each PHPUnit bootstrap invocation a random-suffixed sandbox
- fail loudly on sandbox creation errors and remove the owned tree at shutdown
- prevent forked children from running the parent's inherited cleanup callback
- preserve the restricted-temp IpPrefetch child tests under strict bootstrap creation

## Verification

- RED: `BootstrapSandboxTest.php` failed against the original PID-only/no-cleanup bootstrap; the fork regression failed with `forked child removed owner sandbox`
- GREEN: `BootstrapSandboxTest.php` — 4 tests, 42 assertions
- GREEN: restricted-temp IpPrefetch regression pair — 2 tests, 9 assertions
- GREEN: `scripts/agent/run-gates.sh --diff origin/devel`
- Independent contract, correctness, test-honesty, and standards reviews passed; targeted rechecks passed after review fixes

Closes #2836

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Test runs now use isolated, per-process temporary sandboxes.
  - Temporary sandbox files are automatically removed after each run.
  - Sandbox cleanup no longer affects parent processes or changes test exit statuses.
  - Sandbox creation failures now report clear errors instead of failing silently.
  - Restricted test environments continue to allow required bootstrap files while blocking unintended temporary-directory access.

- **Tests**
  - Added coverage for sandbox isolation, cleanup, failure handling, process forking, and exit-status preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->