### PR TITLE
tests: assert the smoke reload actually started a feed pass

### DIFF
--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -3337,6 +3337,7 @@ def reload(
     # scheduled tick dispatches no pass at all, so it is the one scope with no banner to wait for.
     assert_started = scope != "tick"
     start_before = count_log_marker(vm, PFB_LOG, PASS_START_MARKERS) if assert_started else 0
+    deferred_before = count_log_marker(vm, PFB_LOG, PASS_DEFERRED_MARKERS) if assert_started else 0
     swap_before = count_log_marker(vm, PFB_LOG, SWAP_LOG_MARKER) if data_path else 0
     deadline = time.monotonic() + timeout
     if scope in ("cron", "tick"):
@@ -3353,14 +3354,29 @@ def reload(
             f"reload({scope}) failed: rc={result.returncode} stdout={result.stdout[-2000:]!r} stderr={result.stderr!r}"
         )
     if assert_started:
+        deferred_after = count_log_marker(vm, PFB_LOG, PASS_DEFERRED_MARKERS)
         start_after = count_log_marker(vm, PFB_LOG, PASS_START_MARKERS)
+        evidence = (
+            f"in {PFB_LOG}: pass-start banners {list(PASS_START_MARKERS)} "
+            f"before={start_before} after={start_after}; "
+            f"deferral lines {list(PASS_DEFERRED_MARKERS)} "
+            f"before={deferred_before} after={deferred_after}"
+        )
+        # The deferral line is the signal this dispatch OWNS. The banner count is global to the
+        # log, so a CONCURRENT pass's banner can satisfy the rise below on a dispatch that was
+        # itself stood down — check the attributable signal first.
+        if deferred_after > deferred_before:
+            raise RuntimeError(
+                f"reload({scope}) exited 0 but the feed pass did not start: it was deferred — the pass "
+                f"lost the dispatcher or feed-pass lock race and stood down, and this request shape "
+                f"STILL exits 0 (issue #2591), so nothing was reloaded. Evidence {evidence}. The "
+                f"pfBlockerNG log tail in the smoke diagnostics names which lock."
+            )
         if start_after <= start_before:
             raise RuntimeError(
-                f"reload({scope}) exited 0 but the feed pass did not start: expected a NEW pass-start "
-                f"banner in {PFB_LOG} (before={start_before}, after={start_after}), searched for "
-                f"{list(PASS_START_MARKERS)}. A pass that loses the dispatcher or feed-pass lock race "
-                f"stands down and STILL exits 0 for this request shape (issue #2591), so nothing was "
-                f"reloaded — see the pfBlockerNG log tail in the smoke diagnostics for the deferral line."
+                f"reload({scope}) exited 0 but the feed pass did not start: no new pass-start banner "
+                f"was written, and no deferral line either, so the verb returned without ever reaching "
+                f"its pass. Evidence {evidence}. See the pfBlockerNG log tail in the smoke diagnostics."
             )
     if data_path:
         # Forward the caller's remaining budget so a slow box honours `timeout` instead
@@ -4264,6 +4280,21 @@ SWAP_LOG_MARKER = "[ zero-downtime swap ]"
 # A lock deferral returns from those guards BEFORE any banner and — for the unattended
 # `trigger=cron force=false` shape (PR #2589) — exits 0, which is why rc alone cannot see it.
 PASS_START_MARKERS = ("UPDATE PROCESS START", "**Saving configuration**", "CRON  PROCESS  START")
+# The mirror image: the lines a funnel writes INSTEAD of a banner when it stands the pass
+# down. A pass writes exactly one of these or one of PASS_START_MARKERS, so a NEW deferral
+# line is attributable to OUR dispatch — the banner count is global to the log, and a
+# concurrent pass's banner would otherwise satisfy the count rise on a reload that was
+# itself deferred (CodeRabbit, PR #2875). Three cover all four sites, because
+# pfb_feed_pass_begin() is the shared choke point for both funnels' feed-pass guards and
+# both of pfblockerng_sync_cron()'s guards share a prefix:
+#   "sync aborted: dispatcher lock unavailable"          pfblockerng_apply.inc:746
+#   "skipped -- another pfBlockerNG feed pass is running" pfblockerng.inc:18784 (sync + cron)
+#   "Scheduled feed pass deferred:"                       pfblockerng_cron.inc:266 and :293
+PASS_DEFERRED_MARKERS = (
+    "sync aborted: dispatcher lock unavailable",
+    "skipped -- another pfBlockerNG feed pass is running",
+    "Scheduled feed pass deferred:",
+)
 # The DNSBL per-line parse-error log: pfb_parse_fail_log() appends one CSV record
 # ({date},{header},{line},{oline},{lineno}) here for every rejected line — including
 # an ADR-22 strict-mode scheme/path skip. Mirrors $pfb['dnsbl_parse_err'] (inc:91,

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -3283,11 +3283,6 @@ _SCOPE_TO_PFBTRIGGER: dict[str, tuple[str, str, str]] = {
     "updatednsbl": ("dnsbl", "true", "force"),
 }
 
-# issue #2591: the reload() scopes whose verb MUST run a feed pass to completion before the
-# CLI exits, so a clean exit without a new PASS_START_MARKERS banner means the pass never
-# started. "tick" is deliberately absent: an IDLE scheduled tick dispatches no pass at all.
-_PASS_START_SCOPES = frozenset({"update", "updateip", "updatednsbl", "cron"})
-
 
 @timed_step(lambda vm, scope="update", **_k: f"reload:{scope}")
 def reload(
@@ -3338,7 +3333,9 @@ def reload(
     """
     if scope not in _SCOPE_TO_PFBTRIGGER and scope not in ("cron", "tick"):
         raise ValueError(f"reload scope must be update/updateip/updatednsbl/cron/tick, got {scope!r}")
-    assert_started = scope in _PASS_START_SCOPES
+    # Every verb but the tick runs a feed pass to completion before the CLI exits; an IDLE
+    # scheduled tick dispatches no pass at all, so it is the one scope with no banner to wait for.
+    assert_started = scope != "tick"
     start_before = count_log_marker(vm, PFB_LOG, PASS_START_MARKERS) if assert_started else 0
     swap_before = count_log_marker(vm, PFB_LOG, SWAP_LOG_MARKER) if data_path else 0
     deadline = time.monotonic() + timeout

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -3283,6 +3283,11 @@ _SCOPE_TO_PFBTRIGGER: dict[str, tuple[str, str, str]] = {
     "updatednsbl": ("dnsbl", "true", "force"),
 }
 
+# issue #2591: the reload() scopes whose verb MUST run a feed pass to completion before the
+# CLI exits, so a clean exit without a new PASS_START_MARKERS banner means the pass never
+# started. "tick" is deliberately absent: an IDLE scheduled tick dispatches no pass at all.
+_PASS_START_SCOPES = frozenset({"update", "updateip", "updatednsbl", "cron"})
+
 
 @timed_step(lambda vm, scope="update", **_k: f"reload:{scope}")
 def reload(
@@ -3323,9 +3328,18 @@ def reload(
     is pure wasted wall-clock there. Pair it with :func:`apply_filter_sync` so the live pf
     ruleset is authoritative on the next read. The ``data_path=True`` path ignores this flag:
     it must wait on the zero-downtime swap signal regardless.
+
+    Every scope but ``tick`` also asserts the pass ACTUALLY STARTED (issue #2591): a lock
+    deferral exits 0 for the unattended ``trigger=cron force=false`` shape this helper
+    dispatches (PR #2589) and for the ``cron`` verb (PR #2504), so ``rc == 0`` alone cannot
+    tell a completed pass from one that stood down. A NEW banner from
+    :data:`PASS_START_MARKERS` is required, and its absence raises HERE — at the reload call
+    site — instead of surfacing later as an unrelated assertion far from the cause.
     """
     if scope not in _SCOPE_TO_PFBTRIGGER and scope not in ("cron", "tick"):
         raise ValueError(f"reload scope must be update/updateip/updatednsbl/cron/tick, got {scope!r}")
+    assert_started = scope in _PASS_START_SCOPES
+    start_before = count_log_marker(vm, PFB_LOG, PASS_START_MARKERS) if assert_started else 0
     swap_before = count_log_marker(vm, PFB_LOG, SWAP_LOG_MARKER) if data_path else 0
     deadline = time.monotonic() + timeout
     if scope in ("cron", "tick"):
@@ -3341,6 +3355,16 @@ def reload(
         raise RuntimeError(
             f"reload({scope}) failed: rc={result.returncode} stdout={result.stdout[-2000:]!r} stderr={result.stderr!r}"
         )
+    if assert_started:
+        start_after = count_log_marker(vm, PFB_LOG, PASS_START_MARKERS)
+        if start_after <= start_before:
+            raise RuntimeError(
+                f"reload({scope}) exited 0 but the feed pass did not start: expected a NEW pass-start "
+                f"banner in {PFB_LOG} (before={start_before}, after={start_after}), searched for "
+                f"{list(PASS_START_MARKERS)}. A pass that loses the dispatcher or feed-pass lock race "
+                f"stands down and STILL exits 0 for this request shape (issue #2591), so nothing was "
+                f"reloaded — see the pfBlockerNG log tail in the smoke diagnostics for the deferral line."
+            )
     if data_path:
         # Forward the caller's remaining budget so a slow box honours `timeout` instead
         # of wait_zero_downtime_swap's shorter default.
@@ -4234,6 +4258,15 @@ PY_ERROR_LOG = f"{PFB_LOGDIR}/py_error.log"
 # bare phrase "the zero-downtime swap", so matching the unbracketed substring would
 # false-positive on a fallback (restart) as if the swap had been taken.
 SWAP_LOG_MARKER = "[ zero-downtime swap ]"
+# issue #2591: the banners a feed pass writes to PFB_LOG ONCE it holds both the dispatcher
+# and the feed-pass lock — a NEW one is positive proof the pass actually started. Three,
+# because the pass logs a different banner per state and reload() reaches all three:
+#   " UPDATE PROCESS START [ <ver> ]"  sync_package_pfblockerng, master ON, not save-only
+#   "**Saving configuration**"         sync_package_pfblockerng, master OFF or save-only
+#   " CRON  PROCESS  START [ <ver> ]"  pfblockerng_sync_cron (the `cron` verb's own funnel)
+# A lock deferral returns from those guards BEFORE any banner and — for the unattended
+# `trigger=cron force=false` shape (PR #2589) — exits 0, which is why rc alone cannot see it.
+PASS_START_MARKERS = ("UPDATE PROCESS START", "**Saving configuration**", "CRON  PROCESS  START")
 # The DNSBL per-line parse-error log: pfb_parse_fail_log() appends one CSV record
 # ({date},{header},{line},{oline},{lineno}) here for every rejected line — including
 # an ADR-22 strict-mode scheme/path skip. Mirrors $pfb['dnsbl_parse_err'] (inc:91,
@@ -4264,23 +4297,26 @@ def unbound_pid(vm: SmokeVM, *, timeout: float = 30.0) -> int:
         raise RuntimeError(f"unbound_pid: {UNBOUND_PID_FILE} not an integer: {text!r}") from exc
 
 
-def count_log_marker(vm: SmokeVM, path: str, marker: str, *, timeout: float = 30.0) -> int:
-    """Count lines in the file ``path`` on the guest that CONTAIN ``marker``.
+def count_log_marker(vm: SmokeVM, path: str, marker: str | Sequence[str], *, timeout: float = 30.0) -> int:
+    """Count occurrences in the file ``path`` on the guest of ``marker`` — one fixed string,
+    or a sequence of them counted together in ONE grep (their total, e.g. a set of
+    mutually-exclusive banners of which a pass writes exactly one).
 
     Capture this BEFORE a no-restart data update and pass the value as ``since`` to
     :func:`wait_zero_downtime_swap`: a NEW matching line (count strictly greater than
     the captured baseline) proves the swap log line was appended AFTER the trigger,
-    not left over from an earlier reload. ``grep -Fc`` does a fixed-string (non-regex)
-    count; a missing file / no match yields 0 (grep exits non-zero) — never raises.
+    not left over from an earlier reload. Matching is fixed-string (non-regex); a missing
+    file / no match yields 0 (grep exits non-zero) — never raises.
     """
     # Count OCCURRENCES, not matching lines: the Python module writes its failure strings
     # to py_error.log via sys.stderr.write WITHOUT a trailing newline (pfb_unbound.py:3679),
     # so two failures can share a physical line — `grep -c` (line count) would under-count
     # them. `grep -Fo` prints one line per match; `wc -l` counts those. Run as ONE shell
     # string (the guest login shell handles the pipe); a missing file / no match -> 0.
-    quoted_marker = shlex.quote(marker)
+    markers = [marker] if isinstance(marker, str) else list(marker)
+    patterns = " ".join(f"-e {shlex.quote(m)}" for m in markers)
     quoted_path = shlex.quote(path)
-    cmd = f"/usr/bin/grep -Fo {quoted_marker} {quoted_path} 2>/dev/null | /usr/bin/wc -l"
+    cmd = f"/usr/bin/grep -Fo {patterns} {quoted_path} 2>/dev/null | /usr/bin/wc -l"
     result = vm.ssh(cmd, timeout=timeout)
     text = result.stdout.strip()
     try:

--- a/tests/test_smoke_reload_pass_start.py
+++ b/tests/test_smoke_reload_pass_start.py
@@ -1,0 +1,262 @@
+"""``reload()`` must prove the feed pass STARTED, not merely that the CLI exited 0.
+
+Issue #2591 (follow-up to PR #2589 / issue #2505): a lock deferral now exits 0 for the
+unattended request shape ``pfb_trigger scope=... force=false trigger=cron`` — exactly what
+``reload(vm, "update")`` dispatches — and ``pfblockerng_sync_cron()`` does the same for the
+``cron`` verb. ``reload()`` raised only on ``rc != 0``, so a pass that lost the dispatcher or
+feed-pass lock race returned silently, the readiness wait was trivially satisfied, and the
+failure surfaced later as a misleading assertion far from its cause.
+
+The pinned contract: after a clean exit, ``reload()`` requires a NEW pass-start banner in
+``/var/log/pfblockerng/pfblockerng.log`` for every scope that must run a pass synchronously,
+and fails at the reload call site naming the missing evidence when there is none.
+
+Off-VM (no VM I/O; ``tests.smoke.helpers`` is import-safe — precedent:
+``test_smoke_unbound_ready.py``). The fake guest emulates the helper's own ``grep -Fo``
+count over an in-memory log, and each dispatch appends the VERBATIM line production writes
+on that path, so a row passes only if the helper's marker literals match production's.
+"""
+
+from __future__ import annotations
+
+import shlex
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import pytest
+
+from tests.smoke import helpers
+
+_SRC = Path(__file__).resolve().parents[1] / "src" / "usr" / "local" / "pkg" / "pfblockerng"
+
+# Verbatim lines production appends to pfblockerng.log, with the pfb_logger() ISO stamp
+# in front (pfb_logger() inserts it after any leading newlines — pfblockerng.inc:4884).
+_STAMP = "2026-08-20 16:51:19 "
+# sync_package_pfblockerng(), master switch ON and not a save-only pass (apply.inc:925).
+_STARTED_ENABLED = f"{_STAMP} UPDATE PROCESS START [ 3.2.5_1 ]\n"
+# sync_package_pfblockerng(), master switch OFF or save-only pass (apply.inc:929) — the
+# branch test_dns_redirect.py, test_dot_doq_block.py and test_smoke_tick.py reload through
+# after h.set_package_enabled(vm, False).
+_STARTED_SAVING = f"\n{_STAMP}**Saving configuration**\n"
+# pfblockerng_sync_cron() (cron.inc:365), written before its tail call into sync_package.
+_STARTED_CRON = f"{_STAMP} CRON  PROCESS  START [ 3.2.5_1 ]\n"
+# The two deferral lines that replace a pass start, both now exiting 0 for the unattended
+# shape: apply.inc:746 (dispatcher lock) and pfblockerng.inc:18784 (feed-pass lock).
+_DEFERRED_DISPATCHER = f"\n{_STAMP} sync aborted: dispatcher lock unavailable; pending changes retained.\n"
+_DEFERRED_FEED_PASS = f"\n{_STAMP}Feed pass [ sync ] skipped -- another pfBlockerNG feed pass is running.\n"
+# pfb_reload_unbound()'s zero-downtime fast-path line, for the data_path=True row.
+_SWAP_LINE = f"{_STAMP} DNSBL update [ zero-downtime swap ]\n"
+
+
+@dataclass
+class _FakeResult:
+    """Stand-in for ``subprocess.CompletedProcess[str]`` (the shape ``SmokeVM.ssh`` returns)."""
+
+    returncode: int
+    stdout: str = ""
+    stderr: str = ""
+
+
+@dataclass
+class _FakeVM:
+    """Fake guest: emulates the helper's ``grep -Fo … | wc -l`` count over an in-memory log.
+
+    ``appends`` is what the dispatched CLI writes to the log — the verbatim production line
+    for the path under test — and ``rc`` is the exit code it reports. Anything the helper
+    runs that is neither the count pipeline nor the CLI dispatch answers rc=0 (the readiness
+    poll), so a row never depends on call ordering it does not pin.
+    """
+
+    log: str = ""
+    appends: str = ""
+    rc: int = 0
+    dispatches: list[tuple[str, ...]] = field(default_factory=list)
+
+    def ssh(self, *remote: str, timeout: float = 60.0) -> _FakeResult:
+        if len(remote) == 1 and "grep -Fo" in remote[0]:
+            return _FakeResult(returncode=0, stdout=f"{self._count(remote[0])}\n")
+        if remote and remote[0] == helpers.PHP_BIN:
+            self.dispatches.append(remote)
+            self.log += self.appends
+            return _FakeResult(returncode=self.rc, stdout="", stderr="")
+        return _FakeResult(returncode=0)
+
+    def _count(self, command: str) -> int:
+        """Count marker OCCURRENCES exactly as ``grep -Fo <patterns> <path> | wc -l`` does.
+
+        Handles both shapes the helper can build — a bare single pattern and repeated
+        ``-e`` patterns — so a row pins the COUNT contract, not the flag spelling.
+        """
+        words = [w for w in shlex.split(command.split("|")[0]) if not w.startswith("2>")]
+        if "-e" in words:
+            patterns = [words[i + 1] for i, word in enumerate(words) if word == "-e"]
+        else:
+            patterns = words[2:-1]  # /usr/bin/grep -Fo <pattern>… <path>
+        return sum(self.log.count(pattern) for pattern in patterns)
+
+
+def _reload(vm: _FakeVM, scope: str = "update", **kwargs: object) -> None:
+    helpers.reload(vm, scope, wait_unbound=False, **kwargs)  # type: ignore[arg-type]
+
+
+# --------------------------------------------------------------------------- #
+# The defect: a deferred pass exits 0 and must fail HERE
+# --------------------------------------------------------------------------- #
+
+
+def test_feed_pass_lock_deferral_with_rc0_fails_at_the_reload_call_site() -> None:
+    """Given the feed-pass lock is held, so the unattended pfb_trigger dispatch stands the
+    pass down and exits 0 with only the deferral line logged,
+    When reload(vm, "update") runs,
+    Then it raises at the reload call site instead of returning silently (issue #2591).
+    """
+    vm = _FakeVM(appends=_DEFERRED_FEED_PASS, rc=0)
+
+    with pytest.raises(RuntimeError, match="did not start"):
+        _reload(vm)
+
+
+def test_dispatcher_lock_deferral_with_rc0_fails_for_the_cron_verb() -> None:
+    """Given the dispatcher lock is held, so the `cron` verb stands its pass down and exits 0
+        (pfblockerng_sync_cron() returns !$force_all — the same benign-deferral rc=0 shape),
+    When reload(vm, "cron") runs,
+    Then it raises rather than returning as if the cron pass had run.
+    """
+    vm = _FakeVM(appends=_DEFERRED_DISPATCHER, rc=0)
+
+    with pytest.raises(RuntimeError, match="did not start"):
+        _reload(vm, "cron")
+
+
+def test_a_stale_pass_start_banner_does_not_satisfy_the_assertion() -> None:
+    """Given the log ALREADY carries a pass-start banner from an earlier reload,
+    When a deferred pass exits 0 and appends nothing,
+    Then reload still raises — the evidence must be a NEW banner, not a present one.
+    """
+    vm = _FakeVM(log=_STARTED_ENABLED, appends="", rc=0)
+
+    with pytest.raises(RuntimeError, match="did not start"):
+        _reload(vm)
+
+
+def test_deferral_diagnostic_names_the_missing_start_evidence() -> None:
+    """The failure must be diagnosable without reading the harness: it names the scope, the
+    before/after counts (expected vs actual), and every banner it searched for."""
+    vm = _FakeVM(log=_STARTED_ENABLED, appends=_DEFERRED_FEED_PASS, rc=0)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        _reload(vm)
+
+    message = str(excinfo.value)
+    assert "update" in message
+    assert helpers.PFB_LOG in message
+    for marker in helpers.PASS_START_MARKERS:
+        assert marker in message, f"diagnostic omits the {marker!r} banner it searched for: {message}"
+    assert "before=1" in message and "after=1" in message, (
+        f"diagnostic omits the before/after banner counts (expected vs actual): {message}"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# No false failures: every started pass, on every branch that writes a banner
+# --------------------------------------------------------------------------- #
+
+
+def test_started_pass_with_master_switch_on_is_accepted() -> None:
+    """A pass that logs ` UPDATE PROCESS START [ … ]` returns normally."""
+    vm = _FakeVM(appends=_STARTED_ENABLED, rc=0)
+
+    _reload(vm)
+
+
+def test_started_pass_with_master_switch_off_is_accepted() -> None:
+    """Master OFF logs `**Saving configuration**` instead of the UPDATE banner (apply.inc:929).
+
+    Three live call sites reload in exactly this state — test_dns_redirect.py:1109,
+    test_dot_doq_block.py:1261 and test_smoke_tick.py:324 all reload right after
+    h.set_package_enabled(vm, False) — so a marker set covering only the enabled branch would
+    red them all.
+    """
+    vm = _FakeVM(appends=_STARTED_SAVING, rc=0)
+
+    _reload(vm)
+
+
+def test_started_cron_pass_is_accepted() -> None:
+    """The cron funnel's own ` CRON  PROCESS  START [ … ]` banner counts as a pass start."""
+    vm = _FakeVM(appends=_STARTED_CRON, rc=0)
+
+    _reload(vm, "cron")
+
+
+@pytest.mark.parametrize("scope", ["updateip", "updatednsbl"])
+def test_started_force_scope_pass_is_accepted(scope: str) -> None:
+    """The force scopes share sync_package_pfblockerng()'s banner — no false failure there."""
+    vm = _FakeVM(appends=_STARTED_ENABLED, rc=0)
+
+    _reload(vm, scope)
+
+
+def test_idle_tick_is_exempt_from_the_pass_start_assertion() -> None:
+    """An IDLE scheduled tick dispatches no pass at all — that is its documented behaviour
+    (pfblockerng_tick() only execs a due job), so `tick` must NOT require a pass-start
+    banner or every idle-tick caller reds."""
+    vm = _FakeVM(appends="", rc=0)
+
+    _reload(vm, "tick")
+
+
+def test_data_path_reload_still_waits_on_the_swap_after_proving_the_pass_started() -> None:
+    """data_path=True keeps its zero-downtime-swap wait; the pass-start check rides alongside
+    it without disturbing the swap baseline."""
+    vm = _FakeVM(appends=_STARTED_ENABLED + _SWAP_LINE, rc=0)
+
+    helpers.reload(vm, "update", data_path=True, timeout=30.0)  # type: ignore[arg-type]
+
+
+def test_nonzero_exit_still_reports_the_exit_code_failure() -> None:
+    """An operator-initiated deferral still exits 1; that path keeps its own rc diagnostic
+    and must not be masked by the new pass-start check."""
+    vm = _FakeVM(appends=_DEFERRED_FEED_PASS, rc=1)
+
+    with pytest.raises(RuntimeError, match=r"reload\('updateip'\) failed|reload\(updateip\) failed"):
+        _reload(vm, "updateip")
+
+
+# --------------------------------------------------------------------------- #
+# Non-goals: the trigger shape and the marker literals must not drift
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    ("scope", "expected"),
+    [
+        ("update", ("scope=both", "force=false", "trigger=cron")),
+        ("updateip", ("scope=ip", "force=true", "trigger=force")),
+        ("updatednsbl", ("scope=dnsbl", "force=true", "trigger=force")),
+    ],
+)
+def test_trigger_shape_is_unchanged(scope: str, expected: tuple[str, ...]) -> None:
+    """Issue #2591 explicitly does NOT remap reload("update") to trigger=manual: doing so
+    would flip the hooks' PFB_TRIGGER from `cron` to `update` and break the coverage
+    test_smoke_hooks.py pins. The dispatched argv stays byte-identical."""
+    vm = _FakeVM(appends=_STARTED_ENABLED, rc=0)
+
+    _reload(vm, scope)
+
+    assert len(vm.dispatches) == 1
+    assert vm.dispatches[0] == (helpers.PHP_BIN, helpers.PFB_CLI, "pfb_trigger", *expected)
+
+
+def test_every_pass_start_marker_still_exists_in_production() -> None:
+    """Tripwire: each banner the helper counts must still be a literal production writes.
+
+    A rename would otherwise make every reload fail on the live box only — this catches it
+    in the hermetic suite, where it costs no VM.
+    """
+    sources = "".join(
+        (_SRC / name).read_text(encoding="utf-8")
+        for name in ("pfblockerng.inc", "pfblockerng_apply.inc", "pfblockerng_cron.inc")
+    )
+    for marker in helpers.PASS_START_MARKERS:
+        assert marker in sources, f"pass-start banner {marker!r} no longer exists in the package sources"

--- a/tests/test_smoke_reload_pass_start.py
+++ b/tests/test_smoke_reload_pass_start.py
@@ -260,3 +260,93 @@ def test_every_pass_start_marker_still_exists_in_production() -> None:
     )
     for marker in helpers.PASS_START_MARKERS:
         assert marker in sources, f"pass-start banner {marker!r} no longer exists in the package sources"
+
+
+# --------------------------------------------------------------------------- #
+# CodeRabbit review, PR #2875: a global banner count cannot attribute the start
+# to THIS dispatch, so reject our own deferral independently of other passes
+# --------------------------------------------------------------------------- #
+
+
+def test_own_deferral_is_rejected_even_when_another_pass_logs_a_banner() -> None:
+    """Given a CONCURRENT feed pass logs its own pass-start banner during our dispatch,
+        And our dispatch loses the lock race and stands down with rc=0,
+    When reload(vm, "update") runs,
+    Then it still raises: the banner count rose, but the rise belongs to the other pass.
+
+    The banner count is global to the log, so a rise alone cannot attribute the start to
+    this dispatch. Our own deferral always writes a deferral line, so rejecting a NEW
+    deferral line closes the gap regardless of what any other pass logged.
+    """
+    vm = _FakeVM(appends=_STARTED_ENABLED + _DEFERRED_FEED_PASS, rc=0)
+
+    with pytest.raises(RuntimeError, match="deferred"):
+        _reload(vm)
+
+
+@pytest.mark.parametrize(
+    ("scope", "deferral"),
+    [
+        # sync_package_pfblockerng(), dispatcher lock (pfblockerng_apply.inc:746).
+        ("update", f"\n{_STAMP} sync aborted: dispatcher lock unavailable; pending changes retained.\n"),
+        # pfb_feed_pass_begin('sync'), the shared choke point (pfblockerng.inc:18784).
+        ("update", f"\n{_STAMP}Feed pass [ sync ] skipped -- another pfBlockerNG feed pass is running.\n"),
+        # pfblockerng_sync_cron(), dispatcher lock (pfblockerng_cron.inc:266).
+        (
+            "cron",
+            f"\n{_STAMP} Scheduled feed pass deferred: dispatcher lock unavailable; "
+            "durable pending occurrences retained.\n",
+        ),
+        # pfblockerng_sync_cron(), feed lock (pfblockerng_cron.inc:293).
+        (
+            "cron",
+            f"\n{_STAMP} Scheduled feed pass deferred: feed lock unavailable; durable pending occurrences retained.\n",
+        ),
+        # pfb_feed_pass_begin('cron'), the same choke point under the cron funnel's label.
+        ("cron", f"\n{_STAMP}Feed pass [ cron ] skipped -- another pfBlockerNG feed pass is running.\n"),
+    ],
+)
+def test_every_funnel_deferral_line_is_rejected(scope: str, deferral: str) -> None:
+    """Each of the four deferral lines the two funnels can write must be recognised, even
+    when a concurrent pass's banner would otherwise satisfy the count rise."""
+    vm = _FakeVM(appends=_STARTED_ENABLED + deferral, rc=0)
+
+    with pytest.raises(RuntimeError, match="deferred"):
+        _reload(vm, scope)
+
+
+def test_deferral_diagnostic_names_the_deferral_evidence() -> None:
+    """The deferral failure names the scope and every deferral line it matched on, so the
+    reader sees WHICH lock stood the pass down without opening the guest log."""
+    vm = _FakeVM(appends=_STARTED_ENABLED + _DEFERRED_DISPATCHER, rc=0)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        _reload(vm)
+
+    message = str(excinfo.value)
+    assert "update" in message
+    assert helpers.PFB_LOG in message
+    for marker in helpers.PASS_DEFERRED_MARKERS:
+        assert marker in message, f"diagnostic omits the {marker!r} deferral line it searched for: {message}"
+
+
+def test_a_stale_deferral_line_does_not_fail_a_started_pass() -> None:
+    """Given the log ALREADY carries a deferral line from an earlier reload,
+    When this pass genuinely starts,
+    Then reload returns — the rejection keys on a NEW deferral line, not a present one,
+    so an earlier deferral cannot red every later reload in the module.
+    """
+    vm = _FakeVM(log=_DEFERRED_FEED_PASS, appends=_STARTED_ENABLED, rc=0)
+
+    _reload(vm)
+
+
+def test_every_deferral_marker_still_exists_in_production() -> None:
+    """Tripwire sibling of the pass-start one: a reworded deferral line must fail here, in
+    the hermetic suite, rather than silently stop being recognised on a live box."""
+    sources = "".join(
+        (_SRC / name).read_text(encoding="utf-8")
+        for name in ("pfblockerng.inc", "pfblockerng_apply.inc", "pfblockerng_cron.inc")
+    )
+    for marker in helpers.PASS_DEFERRED_MARKERS:
+        assert marker in sources, f"deferral line {marker!r} no longer exists in the package sources"


### PR DESCRIPTION
Fixes #2591. Follow-up to PR #2589 (issue #2505), contract-conformance leg finding N2.

## Problem

PR #2589 made a lock deferral exit 0 for the unattended request shape `pfb_trigger scope=... force=false trigger=cron` — exactly what the smoke workhorse `reload(vm, "update")` dispatches. `reload()` raised only on `rc != 0`, so a reload that lost the dispatcher or feed-pass lock race returned silently, the subsequent unbound-readiness wait was trivially satisfied, and the failure surfaced later as a misleading assertion far from its cause.

The same hole exists for `reload(vm, "cron")`: `pfblockerng_sync_cron()` returns `!$force_all` from both of its lock guards (PR #2504, issue #2491), so the unattended `cron` verb also exits 0 on a deferral. Fixing only the `pfb_trigger` path would have left the sibling caller broken.

## Change

`reload()` now requires a **positive pass-start signal** after a clean exit, not just `rc == 0`: a NEW pass-start banner in `/var/log/pfblockerng/pfblockerng.log`, counted before the dispatch and again after it.

Three banners, because the pass logs a different one per state and `reload()` reaches all three — the marker set is not "the one the ticket's path writes":

| Banner | Written by | Reached by |
| ------ | ---------- | ---------- |
| ` UPDATE PROCESS START [ <ver> ]` | `sync_package_pfblockerng()` (`pfblockerng_apply.inc:925`) | master switch ON, not save-only |
| `**Saving configuration**` | `sync_package_pfblockerng()` (`pfblockerng_apply.inc:929`) | master switch OFF or save-only |
| ` CRON  PROCESS  START [ <ver> ]` | `pfblockerng_sync_cron()` (`pfblockerng_cron.inc:365`) | the `cron` verb's own funnel |

All three are written **after** both lock guards, so a deferral returns before any of them — which is precisely what makes a new banner proof the pass started.

That count is global to the log, though, so a *concurrent* pass's banner could satisfy the rise on a dispatch that had itself been stood down — the exact silent-deferral case this check exists to catch (CodeRabbit, `8e93968e`). A pass writes **exactly one** of a start banner or a deferral line, and the deferral line is written by the deferring process, so a NEW deferral line is the signal this dispatch *owns*. `reload()` rejects on that first, independently of any other pass's banner:

| Deferral line | Written by |
| ------------- | ---------- |
| `sync aborted: dispatcher lock unavailable` | `pfblockerng_apply.inc:746` |
| `skipped -- another pfBlockerNG feed pass is running` | `pfblockerng.inc:18784` — the `pfb_feed_pass_begin()` choke point, labels `sync` and `cron` |
| `Scheduled feed pass deferred:` | `pfblockerng_cron.inc:266` and `:293` |

Both failures lead with the same verdict (`the feed pass did not start`) and carry both counters, since they are two reasons for one outcome. Correlating the *banner* to a specific dispatch is not reachable from the harness: `pfb_logger()` mirrors to stdout only when `pfb_run_streams_to_stdout()` is true (lifecycle callback or TTY), and `SmokeVM.ssh` runs `subprocess.run(capture_output=True)` with no PTY.

`tick` is deliberately exempt: an idle scheduled tick dispatches no pass at all, so requiring a banner there would red every idle-tick caller.

**Trigger semantics are unchanged** (the ticket's explicit non-goal): `reload("update")` still dispatches `pfb_trigger scope=both force=false trigger=cron`, so the hooks' `PFB_TRIGGER` stays `cron` and `test_smoke_hooks.py`'s coverage is untouched. A parametrised row pins the exact argv for all three `pfb_trigger` scopes.

`count_log_marker()` gained a sequence form so the three banners are counted in ONE `grep -Fo -e … -e …` — two extra SSH round-trips per reload, not six. Its five existing single-marker callers are unaffected.

## Why the master-OFF branch is in the marker set (executed probe)

Hypothesis A: `UPDATE PROCESS START` alone suffices. Discriminating probe — grep for `reload()` calls made while the master switch is off:

```
tests/smoke/test_dns_redirect.py:1108   h.set_package_enabled(vm, False)
tests/smoke/test_dns_redirect.py:1109   h.reload(vm, "update", wait_unbound=False)
tests/smoke/test_dot_doq_block.py:1260  h.set_package_enabled(vm, False)
tests/smoke/test_dot_doq_block.py:1261  h.reload(vm, "update", wait_unbound=False)
tests/smoke/test_smoke_tick.py:323      h.set_package_enabled(vm, False)
tests/smoke/test_smoke_tick.py:324      h.reload(vm, "update")
```

Hypothesis A REFUTED: three live call sites reload with `enable_cb=''`, where the pass logs `**Saving configuration**` instead. An enabled-branch-only marker set would have redded all three.

## Red→green proof

`tests/test_smoke_reload_pass_start.py` executed RED on untouched production code, `git hash-object` = `81bed2dee99f08e3135867e5b45ac98de1fb88e6`:

```
FAILED test_feed_pass_lock_deferral_with_rc0_fails_at_the_reload_call_site - Failed: DID NOT RAISE RuntimeError
FAILED test_dispatcher_lock_deferral_with_rc0_fails_for_the_cron_verb - Failed: DID NOT RAISE RuntimeError
FAILED test_deferral_diagnostic_names_the_missing_start_evidence - Failed: DID NOT RAISE RuntimeError
FAILED test_a_stale_pass_start_banner_does_not_satisfy_the_assertion - Failed: DID NOT RAISE RuntimeError
FAILED test_every_pass_start_marker_still_exists_in_production - AttributeError: module 'tests.smoke.helpers' has no attribute 'PASS_START_MARKERS'
========================= 5 failed, 11 passed in 0.55s =========================
```

Frozen byte-identical (hash re-verified at green and in commit `5ffc7e71`), then GREEN with zero test edits:

```
============================== 16 passed in 0.51s ==============================
```

The 11 rows green on both sides are the no-false-failure and preserved-behaviour guards (started pass accepted on each branch, idle tick exempt, `rc != 0` still reported, trigger shape unchanged).

The review fix (`8e93968e`) carries its own test-first proof — five more rows, RED on the same untouched production, `git hash-object` = `6846de37bc764f75445c04ab5a0d58fd436db4dd`:

```
FAILED test_own_deferral_is_rejected_even_when_another_pass_logs_a_banner - Failed: DID NOT RAISE RuntimeError
FAILED test_every_funnel_deferral_line_is_rejected[…]  (5 parametrised rows, one per deferral site)
FAILED test_deferral_diagnostic_names_the_deferral_evidence - Failed: DID NOT RAISE RuntimeError
FAILED test_every_deferral_marker_still_exists_in_production - AttributeError: no attribute 'PASS_DEFERRED_MARKERS'
========================= 8 failed, 17 passed in 0.56s =========================
```

then GREEN, hash unchanged: `25 passed`. The round-1 proof stays independently checkable at `5ffc7e71:tests/test_smoke_reload_pass_start.py`.

The test is hermetic — no VM. The fake guest emulates the helper's own `grep -Fo … | wc -l` over an in-memory log, and each dispatch appends the **verbatim** line production writes on that path, so a row passes only if the helper's marker literals match production's. A tripwire row additionally asserts each banner still exists in the package sources, so a rename fails in the hermetic suite instead of on a live box only.

## Mutation proof (assertions fail on regression)

Each mutation applied to `helpers.py`, suite re-run, then reverted:

| Mutation | Killed by |
| -------- | --------- |
| drop `**Saving configuration**` from the marker set | `test_started_pass_with_master_switch_off_is_accepted` |
| drop `CRON  PROCESS  START` from the marker set | `test_started_cron_pass_is_accepted` |
| `start_after <= start_before` → `<` (accept unchanged count) | 4 rows incl. both deferral rows |
| add `tick` to the asserting-scope set | `test_idle_tick_is_exempt_from_the_pass_start_assertion` |
| drop the pre-dispatch baseline (stale banner would satisfy) | `test_a_stale_pass_start_banner_does_not_satisfy_the_assertion` |
| remap `reload("update")` to `trigger=manual` | `test_trigger_shape_is_unchanged[update]` |
| `assert_started` forced `True` / `False` | idle-tick row / 4 deferral rows |
| remove the deferral rejection | 7 rows |
| deferral `>` → `>=` (reject a stale line too) | 10 rows, incl. every started-pass row |
| drop any one of the three deferral literals | its own funnel row |

Restored tree: `25 passed`.

## Diagnostic

A deferred pass now fails at the reload call site with expected-vs-actual, naming both signals:

```
RuntimeError: reload(update) exited 0 but the feed pass did not start: it was deferred —
the pass lost the dispatcher or feed-pass lock race and stood down, and this request shape
STILL exits 0 (issue #2591), so nothing was reloaded. Evidence in
/var/log/pfblockerng/pfblockerng.log: pass-start banners ['UPDATE PROCESS START',
'**Saving configuration**', 'CRON  PROCESS  START'] before=1 after=1; deferral lines
['sync aborted: dispatcher lock unavailable', 'skipped -- another pfBlockerNG feed pass is
running', 'Scheduled feed pass deferred:'] before=0 after=1. The pfBlockerNG log tail in
the smoke diagnostics names which lock.
```

## Live-VM verification

The marker literals are read out of the sources, so the load-bearing question is whether they appear on a real box through `reload()`. Focused live leg on head `8e93968e`, box `root@10.0.0.36`:

```
================ 9 passed, 1032 deselected in 243.28s (0:04:03) ================
```

Zero skips. Covers every branch: master ON *and* OFF (`test_dns_redirect_master_disable_…`), the `cron` funnel (`test_cron_detects_changed_local_feed`, `…_same_second`), `data_path=True` plus a force scope (`test_dnsbl_feed_update_no_restart`), the idle-tick exemption (`test_log_max_days_zero_…`), the lock funnel itself (`test_cron_verb_proceeds_when_lock_free`), and — for the deferral check's false-RED risk — the three `test_smoke_hooks.py` rows that are the suite's only source of concurrent `trigger=cron` dispatches, including `test_hooks_trigger_values`, which pins `PFB_TRIGGER=cron`.

No `www/` surface touched; `tests/smoke/**` harness only.

🤖 Generated by Oh My Pi and posted on behalf of @andrebrait.
