### PR TITLE
pfblockerng: serialize Alerts single-op mutations

### DIFF
--- a/graphify-out/memory/query_20260829_180640_how_do_users_reach_the_four_alerts_single_operatio.md
+++ b/graphify-out/memory/query_20260829_180640_how_do_users_reach_the_four_alerts_single_operatio.md
@@ -1,0 +1,17 @@
+---
+type: "query"
+date: "2026-08-29T18:06:40.528401+00:00"
+question: "How do users reach the four Alerts single-operation mutations delete_ip re-add, delete_ipwhitelist delete, ip_remove lock re-add, and ip_white add, and which tests cover their UI and feed-pass lock interactions?"
+contributor: "graphify"
+outcome: "useful"
+---
+
+# Q: How do users reach the four Alerts single-operation mutations delete_ip re-add, delete_ipwhitelist delete, ip_remove lock re-add, and ip_white add, and which tests cover their UI and feed-pass lock interactions?
+
+## Answer
+
+The graph located the existing Alerts mutation coverage in tests/php/AlertsPfctlCheckedSitesTest.php and reachable UI coverage in tests/smoke/ui/test_alerts.py, narrowing production analysis to the Alerts page.
+
+## Outcome
+
+- Signal: useful

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -7902,14 +7902,26 @@ function pfb_alerts_ip_action($action, string $ip, string $table, string $descr,
 	}
 
 	if ($action === 'lock') {
-		$apply = pfb_pfctl_checked_op($pfb['pfctl'], $table, 'add', $ip);
-		if ($apply['ok']) {
-			pfb_unlock('lock', 'ip', $ip_unlock, $ip, $table);
-			$result['savemsg'] = "The IP [ {$ip} ] has been re-locked into table [ {$table} ]!";
-		} else {
-			$result['savemsg'] = "The live re-lock of IP [ {$ip} ] failed [ {$apply['fail']} ] -- table [ {$table} ] does not block it; see the pfBlockerNG log.";
+		$was_held = isset($GLOBALS['pfb_feed_pass_lock']) && is_resource($GLOBALS['pfb_feed_pass_lock']);
+		if (!pfb_feed_pass_acquire()) {
+			$result['savemsg'] = "Table [ {$table} ] is mid-update -- please retry the re-lock once the current run finishes.";
+			return $result;
 		}
-		return $result;
+
+		try {
+			$apply = pfb_pfctl_checked_op($pfb['pfctl'], $table, 'add', $ip);
+			if ($apply['ok']) {
+				pfb_unlock('lock', 'ip', $ip_unlock, $ip, $table);
+				$result['savemsg'] = "The IP [ {$ip} ] has been re-locked into table [ {$table} ]!";
+			} else {
+				$result['savemsg'] = "The live re-lock of IP [ {$ip} ] failed [ {$apply['fail']} ] -- table [ {$table} ] does not block it; see the pfBlockerNG log.";
+			}
+			return $result;
+		} finally {
+			if (!$was_held) {
+				pfb_feed_pass_release();
+			}
+		}
 	}
 
 	if ($action === 'ip_white') {
@@ -7928,30 +7940,42 @@ function pfb_alerts_ip_action($action, string $ip, string $table, string $descr,
 			return $result;
 		}
 
-		$apply = pfb_pfctl_checked_op($pfb['pfctl'], $table, 'add', $ip);
-		if (!$apply['ok']) {
-			$result['savemsg'] = "The add of [ {$ip} ] to aliastable [ {$table} ] failed [ {$apply['fail']} ] -- see the pfBlockerNG log.";
+		$was_held = isset($GLOBALS['pfb_feed_pass_lock']) && is_resource($GLOBALS['pfb_feed_pass_lock']);
+		if (!pfb_feed_pass_acquire()) {
+			$result['savemsg'] = "Table [ {$table} ] is mid-update -- please retry adding [ {$ip} ] to the Permit Alias once the current run finishes.";
 			return $result;
 		}
 
-		@file_put_contents("{$pfb['aliasdir']}/{$table}.txt", "\n{$ip}", LOCK_EX);
-		$whitelist_string = !empty($descr) ? "{$ip} # {$descr}\r\n" : "{$ip}\r\n";
-		$custom = '';
-		foreach ($data as $line) {
-			$custom .= "{$line}";
+		try {
+			$apply = pfb_pfctl_checked_op($pfb['pfctl'], $table, 'add', $ip);
+			if (!$apply['ok']) {
+				$result['savemsg'] = "The add of [ {$ip} ] to aliastable [ {$table} ] failed [ {$apply['fail']} ] -- see the pfBlockerNG log.";
+				return $result;
+			}
+
+			@file_put_contents("{$pfb['aliasdir']}/{$table}.txt", "\n{$ip}", LOCK_EX);
+			$whitelist_string = !empty($descr) ? "{$ip} # {$descr}\r\n" : "{$ip}\r\n";
+			$custom = '';
+			foreach ($data as $line) {
+				$custom .= "{$line}";
+			}
+			$custom .= $whitelist_string;
+			$clists[$list_key][$table]['base64'] = pfb_text_area_encode($custom);
+			$base64_idx = $metadata['base64_idx'];
+			// foreign structure: pfblockernglistsv4/v6/config/{row}/custom is a dynamic per-row key, not a registered config field
+			config_set_path("installedpackages/pfblockernglistsv{$vtype}/config/{$base64_idx}/custom", $clists[$list_key][$table]['base64']);
+			write_config("pfBlockerNG: Added [ {$ip} ] to [ {$table} ] Whitelist", FALSE);
+			$aname = substr(substr($table, 4), 0, -3);
+			touch("{$pfb['permitdir']}/{$aname}_custom_v{$vtype}.update");
+			$result['savemsg'] = "The IP [ {$ip} ] has been added to the [ {$table} ] Permit Alias customlist.";
+			// issue #2670: durable permit replaces the temporary unlock row
+			pfb_unlock('lock', 'ip', $ip_unlock, $ip, $table);
+			return $result;
+		} finally {
+			if (!$was_held) {
+				pfb_feed_pass_release();
+			}
 		}
-		$custom .= $whitelist_string;
-		$clists[$list_key][$table]['base64'] = pfb_text_area_encode($custom);
-		$base64_idx = $metadata['base64_idx'];
-		// foreign structure: pfblockernglistsv4/v6/config/{row}/custom is a dynamic per-row key, not a registered config field
-		config_set_path("installedpackages/pfblockernglistsv{$vtype}/config/{$base64_idx}/custom", $clists[$list_key][$table]['base64']);
-		write_config("pfBlockerNG: Added [ {$ip} ] to [ {$table} ] Whitelist", FALSE);
-		$aname = substr(substr($table, 4), 0, -3);
-		touch("{$pfb['permitdir']}/{$aname}_custom_v{$vtype}.update");
-		$result['savemsg'] = "The IP [ {$ip} ] has been added to the [ {$table} ] Permit Alias customlist.";
-		// issue #2670: durable permit replaces the temporary unlock row
-		pfb_unlock('lock', 'ip', $ip_unlock, $ip, $table);
-		return $result;
 	}
 
 	$result['savemsg'] = gettext('Cannot Lock/Unlock - Invalid action.');

--- a/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
@@ -1215,6 +1215,7 @@ if (isset($_POST) && !empty($_POST)) {
 
 		$pfb_found = TRUE;
 		$dnsbl_py_changes = FALSE;
+		$config_flushed = FALSE;
 
 		switch ($_POST['entry_delete']) {
 			case 'delete_domain':
@@ -1312,28 +1313,43 @@ if (isset($_POST) && !empty($_POST)) {
 				// the old /32-before-/24 precedence.
 				$match = pfb_ip_suppressed_match($ip, array_keys($clists[$supp_key]['data']));
 				if ($match !== NULL) {
-					// issue #1505: check the re-add before touching the customlist --
-					// a failed re-add must leave the suppression entry in place.
-					$apply = pfb_pfctl_checked_op($pfb['pfctl'], trim($table, "'"), 'add', $match);
-					if ($apply['ok']) {
-						unset($clists[$supp_key]['data'][$match]);
-
-						$data = '';
-						foreach ($clists[$supp_key]['data'] as $line) {
-							$data .= "{$line}";
-						}
-						$clists[$supp_key]['base64'] = pfb_text_area_encode($data);
-						PfbConfig::write($cfg_key_path, $clists[$supp_key]['base64']);
-
-						// Keep pfbsuppression(_v6).txt in step with the config edit --
-						// same in-memory refresh the addsuppress handler applies.
-						$pfb['ipconfig'][$cfg_key] = $clists[$supp_key]['base64'];
-						pfb_create_suppression_file();
-
-						$savemsg = "Removed [ {$match} ] from {$type} customlist and re-added it back into the aliastable [ {$table} ]";
-					} else {
+					$was_held = isset($GLOBALS['pfb_feed_pass_lock']) && is_resource($GLOBALS['pfb_feed_pass_lock']);
+					if (!pfb_feed_pass_acquire()) {
 						$pfb_found = FALSE;
-						$savemsg = "The re-add of [ {$match} ] into aliastable [ {$table} ] failed [ {$apply['fail']} ] -- the {$type} customlist entry was kept; see the pfBlockerNG log.";
+						$savemsg = "Table [ {$table} ] is mid-update -- please retry removing [ {$match} ] from the {$type} customlist once the current run finishes.";
+						break;
+					}
+
+					try {
+						// issue #1505: check the re-add before touching the customlist --
+						// a failed re-add must leave the suppression entry in place.
+						$apply = pfb_pfctl_checked_op($pfb['pfctl'], trim($table, "'"), 'add', $match);
+						if ($apply['ok']) {
+							unset($clists[$supp_key]['data'][$match]);
+
+							$data = '';
+							foreach ($clists[$supp_key]['data'] as $line) {
+								$data .= "{$line}";
+							}
+							$clists[$supp_key]['base64'] = pfb_text_area_encode($data);
+							PfbConfig::write($cfg_key_path, $clists[$supp_key]['base64']);
+
+							// Keep pfbsuppression(_v6).txt in step with the config edit --
+							// same in-memory refresh the addsuppress handler applies.
+							$pfb['ipconfig'][$cfg_key] = $clists[$supp_key]['base64'];
+							pfb_create_suppression_file();
+							write_config("pfBlockerNG: Deleted [ {$entry} ] from {$type} customlist", FALSE);
+							$config_flushed = TRUE;
+
+							$savemsg = "Removed [ {$match} ] from {$type} customlist and re-added it back into the aliastable [ {$table} ]";
+						} else {
+							$pfb_found = FALSE;
+							$savemsg = "The re-add of [ {$match} ] into aliastable [ {$table} ] failed [ {$apply['fail']} ] -- the {$type} customlist entry was kept; see the pfBlockerNG log.";
+						}
+					} finally {
+						if (!$was_held) {
+							pfb_feed_pass_release();
+						}
 					}
 				}
 				else {
@@ -1352,26 +1368,41 @@ if (isset($_POST) && !empty($_POST)) {
 				$ix	= ip_explode(trim($entry, "'"));	// Explode IP into evaluation strings
 
 				if (isset($clists['ipwhitelist' . $vtype][$table_2]['data'][$ix[0]])) {
-					// issue #1505: check the delete before touching the customlist --
-					// a failed delete must leave the Permit entry in place.
-					$apply = pfb_pfctl_checked_op($pfb['pfctl'], $table_2, 'delete', trim($entry, "'"));
-					if ($apply['ok']) {
-						unset($clists['ipwhitelist' . $vtype][$table_2]['data'][$ix[0]]);
-
-						$data = '';
-						foreach ($clists['ipwhitelist' . $vtype][$table_2]['data'] as $line) {
-							$data .= "{$line}";
-						}
-
-						$clists['ipwhitelist' . $vtype][$table_2]['base64'] = pfb_text_area_encode($data);
-						// foreign structure: pfblockernglistsv4/v6/config/{row}/custom is a dynamic per-row key, not in registry
-						config_set_path("installedpackages/pfblockernglistsv{$vtype}/config/{$clists['ipwhitelist' . $vtype][$table_2]['base64_idx']}/custom", $clists['ipwhitelist' . $vtype][$table_2]['base64']);
-						$aname = substr(substr($table_2, 4),0, -3);					// Remove 'pfB_' and '_v4'
-						touch("{$pfb['permitdir']}/{$aname}_custom_v{$vtype}.update");			// Set Flag for Cron/Update process
-						$savemsg = "The IP [ {$entry} ] has been deleted from the [ {$table} ] Permit Alias customlist.";
-					} else {
+					$was_held = isset($GLOBALS['pfb_feed_pass_lock']) && is_resource($GLOBALS['pfb_feed_pass_lock']);
+					if (!pfb_feed_pass_acquire()) {
 						$pfb_found = FALSE;
-						$savemsg = "The delete of [ {$entry} ] from aliastable [ {$table} ] failed [ {$apply['fail']} ] -- the {$type} customlist entry was kept; see the pfBlockerNG log.";
+						$savemsg = "Table [ {$table} ] is mid-update -- please retry deleting [ {$entry} ] from the {$type} customlist once the current run finishes.";
+						break;
+					}
+
+					try {
+						// issue #1505: check the delete before touching the customlist --
+						// a failed delete must leave the Permit entry in place.
+						$apply = pfb_pfctl_checked_op($pfb['pfctl'], $table_2, 'delete', trim($entry, "'"));
+						if ($apply['ok']) {
+							unset($clists['ipwhitelist' . $vtype][$table_2]['data'][$ix[0]]);
+
+							$data = '';
+							foreach ($clists['ipwhitelist' . $vtype][$table_2]['data'] as $line) {
+								$data .= "{$line}";
+							}
+
+							$clists['ipwhitelist' . $vtype][$table_2]['base64'] = pfb_text_area_encode($data);
+							// foreign structure: pfblockernglistsv4/v6/config/{row}/custom is a dynamic per-row key, not in registry
+							config_set_path("installedpackages/pfblockernglistsv{$vtype}/config/{$clists['ipwhitelist' . $vtype][$table_2]['base64_idx']}/custom", $clists['ipwhitelist' . $vtype][$table_2]['base64']);
+							$aname = substr(substr($table_2, 4),0, -3);					// Remove 'pfB_' and '_v4'
+							touch("{$pfb['permitdir']}/{$aname}_custom_v{$vtype}.update");			// Set Flag for Cron/Update process
+							write_config("pfBlockerNG: Deleted [ {$entry} ] from {$type} customlist", FALSE);
+							$config_flushed = TRUE;
+							$savemsg = "The IP [ {$entry} ] has been deleted from the [ {$table} ] Permit Alias customlist.";
+						} else {
+							$pfb_found = FALSE;
+							$savemsg = "The delete of [ {$entry} ] from aliastable [ {$table} ] failed [ {$apply['fail']} ] -- the {$type} customlist entry was kept; see the pfBlockerNG log.";
+						}
+					} finally {
+						if (!$was_held) {
+							pfb_feed_pass_release();
+						}
 					}
 				}
 				else {
@@ -1385,7 +1416,7 @@ if (isset($_POST) && !empty($_POST)) {
 				break;
 		}
 
-		if ($pfb_found) {
+		if ($pfb_found && !$config_flushed) {
 			write_config("pfBlockerNG: Deleted [ {$entry} ] from {$type} customlist", FALSE);
 			if ($dnsbl_py_changes) {
 				pfb_unbound_python_whitelist('alerts');

--- a/tests/php/AlertsPfctlCheckedSitesTest.php
+++ b/tests/php/AlertsPfctlCheckedSitesTest.php
@@ -25,6 +25,44 @@ use PHPUnit\Framework\Attributes\DataProvider;
  * failures) since pfb_pfctl_checked_op() ultimately execs through the same
  * `pfctl -t <table> -T <op> <entry>` shape.
  */
+final class AlertsFeedPassLockProbeStream
+{
+	/** @var resource|null */
+	public $context;
+	/** @var list<bool> */
+	public static array $lockHeldDuringWrite = [];
+
+	public function stream_open(string $path, string $mode, int $options, ?string &$openedPath): bool
+	{
+		return TRUE;
+	}
+
+	public function stream_write(string $data): int
+	{
+		$probe = fopen("{$GLOBALS['pfb']['dbdir']}/pfb_feed_pass.lock", 'c');
+		if ($probe === FALSE) {
+			throw new RuntimeException('test probe: failed to open the feed-pass lock');
+		}
+		$acquired = flock($probe, LOCK_EX | LOCK_NB);
+		if ($acquired) {
+			flock($probe, LOCK_UN);
+		}
+		fclose($probe);
+		self::$lockHeldDuringWrite[] = !$acquired;
+		return strlen($data);
+	}
+
+	/** @return array<string, int> */
+	public function stream_stat(): array
+	{
+		return [];
+	}
+
+	public function stream_close(): void
+	{
+	}
+}
+
 final class AlertsPfctlCheckedSitesTest extends TestCase
 {
 	private string $tmp;
@@ -67,10 +105,11 @@ final class AlertsPfctlCheckedSitesTest extends TestCase
 			$region = substr($src, $start + strlen("case 'delete_ip':"), $end - $start - strlen("case 'delete_ip':"));
 			eval(
 				'function pfb_alerts_oracle_delete_ip(string $entry, string $table, array &$clists): array {'
-				. ' global $pfb; $pfb_found = TRUE; $savemsg = \'\'; $type = \'\';'
+				. ' global $pfb; $pfb_found = TRUE; $savemsg = \'\'; $type = \'\'; $config_flushed = FALSE;'
 				. ' switch (1) { case 1:'
 				. $region
 				. ' }'
+				. ' if ($pfb_found && !$config_flushed) { write_config("pfBlockerNG: Deleted [ {$entry} ] from {$type} customlist", FALSE); }'
 				. ' return [\'pfb_found\' => $pfb_found, \'savemsg\' => $savemsg]; }'
 			);
 		}
@@ -85,11 +124,11 @@ final class AlertsPfctlCheckedSitesTest extends TestCase
 			$region = substr($src, $start + strlen("case 'delete_ipwhitelist':"), $end - $start - strlen("case 'delete_ipwhitelist':"));
 			eval(
 				'function pfb_alerts_oracle_delete_ipwhitelist(string $entry, string $table, array &$clists): array {'
-				. ' global $pfb; $pfb_found = TRUE; $savemsg = \'\'; $type = \'\';'
+				. ' global $pfb; $pfb_found = TRUE; $savemsg = \'\'; $type = \'\'; $config_flushed = FALSE;'
 				. ' switch (1) { case 1:'
 				. $region
 				. ' }'
-				. ' if ($pfb_found) { write_config("pfBlockerNG: Deleted [ {$entry} ] from {$type} customlist", FALSE); }'
+				. ' if ($pfb_found && !$config_flushed) { write_config("pfBlockerNG: Deleted [ {$entry} ] from {$type} customlist", FALSE); }'
 				. ' return [\'pfb_found\' => $pfb_found, \'savemsg\' => $savemsg]; }'
 			);
 		}
@@ -153,6 +192,7 @@ final class AlertsPfctlCheckedSitesTest extends TestCase
 		putenv('PFB_TEST_SHOW_ENTRY');
 		rmdir_recursive($this->tmp);
 		unset($GLOBALS['pfb_test_write_config_calls']);
+		unset($GLOBALS['pfb_test_write_config_hook']);
 
 		// issue #1666: restore every $pfb key overridden in setUp() -- otherwise
 		// every later test class inherits $pfb['log'] etc. pointing at the tree
@@ -227,6 +267,51 @@ SH
 		file_put_contents($this->rulesPath, "{$op}|{$entry}|{$rc}|{$err}\n", FILE_APPEND);
 	}
 
+	private function withFeedPassContention(callable $action): mixed
+	{
+		$holder = fopen("{$GLOBALS['pfb']['dbdir']}/pfb_feed_pass.lock", 'c');
+		$this->assertNotFalse($holder, 'test setup: failed to open the feed-pass lock');
+		$this->assertTrue(flock($holder, LOCK_EX | LOCK_NB), 'test setup: failed to hold the feed-pass lock');
+		try {
+			return $action();
+		} finally {
+			flock($holder, LOCK_UN);
+			fclose($holder);
+		}
+	}
+
+	private function feedPassLockIsHeld(): bool
+	{
+		$probe = fopen("{$GLOBALS['pfb']['dbdir']}/pfb_feed_pass.lock", 'c');
+		$this->assertNotFalse($probe, 'test probe: failed to open the feed-pass lock');
+		$acquired = flock($probe, LOCK_EX | LOCK_NB);
+		if ($acquired) {
+			flock($probe, LOCK_UN);
+		}
+		fclose($probe);
+		return !$acquired;
+	}
+
+	private function withWriteConfigLockProbe(callable $action): mixed
+	{
+		$writeSeen = FALSE;
+		$GLOBALS['pfb_test_write_config_hook'] = function () use (&$writeSeen): void {
+			$writeSeen = TRUE;
+			$this->assertTrue(
+				$this->feedPassLockIsHeld(),
+				'the feed-pass lock must still be held when write_config() commits the durable change'
+			);
+		};
+		try {
+			$result = $action();
+		} finally {
+			unset($GLOBALS['pfb_test_write_config_hook']);
+		}
+		$this->assertTrue($writeSeen, 'the successful mutation must reach write_config()');
+		$this->assertFalse($this->feedPassLockIsHeld(), 'the mutation must release its feed-pass lock after the commit');
+		return $result;
+	}
+
 	// =====================================================================
 	// delete_ip
 	// =====================================================================
@@ -247,11 +332,32 @@ SH
 		);
 	}
 
+	public function testDeleteIpBusyKeepsSuppressionEntryAndSkipsPfctlAndWrites(): void
+	{
+		$clists = ['ipsuppression' => ['data' => ['198.51.100.5' => "198.51.100.5\r\n"]]];
+
+		$result = $this->withFeedPassContention(
+			function () use (&$clists): array {
+				return pfb_alerts_oracle_delete_ip("'198.51.100.5'", "'pfB_Deny_v4'", $clists);
+			}
+		);
+
+		$this->assertFalse($result['pfb_found']);
+		$this->assertStringContainsString('mid-update', $result['savemsg']);
+		$this->assertArrayHasKey('198.51.100.5', $clists['ipsuppression']['data']);
+		$this->assertFileDoesNotExist($this->logPath, 'a busy mutation must not call pfctl');
+		$this->assertSame([], $GLOBALS['pfb_test_write_config_calls'] ?? [], 'a busy mutation must not persist config');
+	}
+
 	public function testDeleteIpV4SuccessRemovesEntryAndWrites(): void
 	{
 		$clists = ['ipsuppression' => ['data' => ['198.51.100.5' => "198.51.100.5\r\n"]]];
 
-		$result = pfb_alerts_oracle_delete_ip("'198.51.100.5'", "'pfB_Deny_v4'", $clists);
+		$result = $this->withWriteConfigLockProbe(
+			function () use (&$clists): array {
+				return pfb_alerts_oracle_delete_ip("'198.51.100.5'", "'pfB_Deny_v4'", $clists);
+			}
+		);
 
 		$this->assertTrue($result['pfb_found']);
 		$this->assertStringContainsString('Removed', $result['savemsg']);
@@ -319,11 +425,32 @@ SH
 		);
 	}
 
+	public function testDeleteIpWhitelistBusyKeepsEntryAndSkipsPfctlAndWrites(): void
+	{
+		$clists = ['ipwhitelist4' => ['pfB_Permit_v4' => ['base64_idx' => 0, 'data' => ['198.51.100.9' => "198.51.100.9\r\n"]]]];
+
+		$result = $this->withFeedPassContention(
+			function () use (&$clists): array {
+				return pfb_alerts_oracle_delete_ipwhitelist("'198.51.100.9'", "'pfB_Permit_v4'", $clists);
+			}
+		);
+
+		$this->assertFalse($result['pfb_found']);
+		$this->assertStringContainsString('mid-update', $result['savemsg']);
+		$this->assertArrayHasKey('198.51.100.9', $clists['ipwhitelist4']['pfB_Permit_v4']['data']);
+		$this->assertFileDoesNotExist($this->logPath, 'a busy mutation must not call pfctl');
+		$this->assertSame([], $GLOBALS['pfb_test_write_config_calls'] ?? [], 'a busy mutation must not persist config');
+	}
+
 	public function testDeleteIpWhitelistV4SuccessRemovesEntryAndWrites(): void
 	{
 		$clists = ['ipwhitelist4' => ['pfB_Permit_v4' => ['base64_idx' => 0, 'data' => ['198.51.100.9' => "198.51.100.9\r\n"]]]];
 
-		$result = pfb_alerts_oracle_delete_ipwhitelist("'198.51.100.9'", "'pfB_Permit_v4'", $clists);
+		$result = $this->withWriteConfigLockProbe(
+			function () use (&$clists): array {
+				return pfb_alerts_oracle_delete_ipwhitelist("'198.51.100.9'", "'pfB_Permit_v4'", $clists);
+			}
+		);
 
 		$this->assertTrue($result['pfb_found']);
 		$this->assertStringContainsString('deleted', $result['savemsg']);
@@ -385,6 +512,23 @@ SH
 		$this->assertSame($before, file_get_contents($GLOBALS['pfb']['ip_unlock']));
 	}
 
+	public function testIpRemoveLockBusyKeepsUnlockStoreAndSkipsPfctl(): void
+	{
+		$ip = '198.51.100.20';
+		$before = "{$ip},pfB_Deny_v4\nkeepme.example,pfB_Keep_v4\n";
+		$ip_unlock = [$ip => 'pfB_Deny_v4', 'keepme.example' => 'pfB_Keep_v4'];
+		file_put_contents($GLOBALS['pfb']['ip_unlock'], $before);
+
+		$result = $this->withFeedPassContention(
+			static fn (): array => pfb_alerts_ip_action('lock', $ip, 'pfB_Deny_v4', '', [], $ip_unlock)
+		);
+
+		$this->assertStringContainsString('mid-update', $result['savemsg']);
+		$this->assertTrue($result['redirect']);
+		$this->assertSame($before, file_get_contents($GLOBALS['pfb']['ip_unlock']));
+		$this->assertFileDoesNotExist($this->logPath, 'a busy re-lock must not call pfctl');
+	}
+
 	public function testIpRemoveLockSuccessAppliesUnlockStoreWrite(): void
 	{
 		$ip_unlock = ['198.51.100.20' => 'pfB_Deny_v4', 'keepme.example' => 'pfB_Keep_v4'];
@@ -399,6 +543,35 @@ SH
 		$content = file_get_contents($GLOBALS['pfb']['ip_unlock']);
 		$this->assertStringContainsString('keepme.example', $content, 'the untouched leftover entry must survive the rewrite');
 		$this->assertStringNotContainsString('198.51.100.20', $content, 'the re-locked IP must be removed from the unlock store');
+	}
+
+	public function testIpRemoveLockHoldsFeedPassLockThroughUnlockStoreWrite(): void
+	{
+		$scheme = 'pfbalertslockprobe';
+		$this->assertTrue(stream_wrapper_register($scheme, AlertsFeedPassLockProbeStream::class));
+		try {
+			AlertsFeedPassLockProbeStream::$lockHeldDuringWrite = [];
+			$GLOBALS['pfb']['ip_unlock'] = "{$scheme}://store";
+			$result = pfb_alerts_ip_action(
+				'lock',
+				'198.51.100.20',
+				'pfB_Deny_v4',
+				'',
+				[],
+				['198.51.100.20' => 'pfB_Deny_v4', 'keepme.example' => 'pfB_Keep_v4']
+			);
+
+			$this->assertStringContainsString('re-locked', $result['savemsg']);
+			$this->assertNotEmpty(AlertsFeedPassLockProbeStream::$lockHeldDuringWrite);
+			$this->assertNotContains(
+				FALSE,
+				AlertsFeedPassLockProbeStream::$lockHeldDuringWrite,
+				'the feed-pass lock must remain held through every unlock-store write'
+			);
+			$this->assertFalse($this->feedPassLockIsHeld(), 'the re-lock must release its feed-pass lock after the store write');
+		} finally {
+			stream_wrapper_unregister($scheme);
+		}
 	}
 
 	public function testIpRemoveLockV6SuccessRemovesExactHostOnly(): void
@@ -556,11 +729,33 @@ SH
 		);
 	}
 
+	public function testIpWhiteBusySkipsPfctlAndAllDurableWrites(): void
+	{
+		$table = 'pfB_Whitelist_v4';
+		$clists = ['ipwhitelist4' => [$table => ['base64_idx' => 0, 'data' => []]]];
+
+		$result = $this->withFeedPassContention(
+			static fn (): array => pfb_alerts_ip_action('ip_white', '198.51.100.30', $table, '', $clists, [])
+		);
+
+		$this->assertStringContainsString('mid-update', $result['savemsg']);
+		$this->assertTrue($result['redirect']);
+		$this->assertFileDoesNotExist($this->logPath, 'a busy whitelist add must not call pfctl');
+		$this->assertFileDoesNotExist("{$GLOBALS['pfb']['aliasdir']}/{$table}.txt");
+		$this->assertArrayNotHasKey('installedpackages', $GLOBALS['config'] ?? []);
+		$this->assertSame([], $GLOBALS['pfb_test_write_config_calls'] ?? []);
+		$this->assertFileDoesNotExist("{$GLOBALS['pfb']['permitdir']}/Whitelist_custom_v4.update");
+	}
+
 	public function testIpWhiteV4SuccessAppendsAndWrites(): void
 	{
 		$clists = ['ipwhitelist4' => ['pfB_Whitelist_v4' => ['base64_idx' => 0, 'data' => []]]];
 
-		$result = pfb_alerts_ip_action('ip_white', '198.51.100.31', 'pfB_Whitelist_v4', '', $clists, []);
+		$result = $this->withWriteConfigLockProbe(
+			function () use (&$clists): array {
+				return pfb_alerts_ip_action('ip_white', '198.51.100.31', 'pfB_Whitelist_v4', '', $clists, []);
+			}
+		);
 
 		$this->assertStringContainsString('added', $result['savemsg']);
 		$this->assertTrue($result['redirect']);

--- a/tests/php/pfsense_doubles.php
+++ b/tests/php/pfsense_doubles.php
@@ -497,6 +497,9 @@ if (!function_exists('write_config')) {
 	// Persisting is out of scope off-appliance; record the call (so tests can
 	// assert whether a code path wrote config) and report success like pfSense.
 	function write_config($desc = 'Unknown', $backup = true, $write_config_only = false) {
+		if (isset($GLOBALS['pfb_test_write_config_hook']) && is_callable($GLOBALS['pfb_test_write_config_hook'])) {
+			$GLOBALS['pfb_test_write_config_hook']($desc);
+		}
 		$GLOBALS['pfb_test_write_config_calls'][] = $desc;
 		return true;
 	}

--- a/tests/smoke/ui/test_alerts.py
+++ b/tests/smoke/ui/test_alerts.py
@@ -1229,7 +1229,47 @@ def test_ip_unlock_v4_carves_containing_range_relock_restores_and_spares_sibling
             f"expected {IP_UNLOCK_STORE} to record the exact host {target!r} -> {table!r}, got {unlocked!r}"
         )
 
-        # WHEN: re-lock the same host.
+        # WHEN: a scheduled feed pass owns the serialization lock, a re-lock POST
+        # must refuse the mutation and leave both live state and durable truth alone.
+        holder = "/tmp/pfb_alerts_relock_holder.php"
+        ready = "/tmp/pfb_alerts_relock_ready"
+        stop = "/tmp/pfb_alerts_relock_stop"
+        holder_php = f"""<?php
+require_once('/usr/local/pkg/pfblockerng/pfblockerng.inc');
+require_once('/usr/local/pkg/pfblockerng/pfblockerng_extra.inc');
+pfb_global();
+if (!pfb_feed_pass_acquire()) {{
+    exit(2);
+}}
+touch('{ready}');
+for ($i = 0; $i < 1200 && !file_exists('{stop}'); $i++) {{
+    usleep(100000);
+}}
+@unlink('{ready}');
+"""
+        launch = vm.ssh(f"rm -f {ready} {stop}; cat > {holder} << 'PFBEOF'\n{holder_php}\nPFBEOF")
+        assert launch.returncode == 0, f"failed to write feed-pass holder: {launch.stderr!r}"
+        launch = vm.ssh(f"nohup /usr/local/bin/php {holder} >/dev/null 2>&1 &")
+        assert launch.returncode == 0, f"failed to launch feed-pass holder: {launch.stderr!r}"
+        assert helpers.wait_until(lambda: vm.ssh("test", "-f", ready).returncode == 0, timeout=30.0), (
+            "feed-pass holder never acquired the lock"
+        )
+        try:
+            resp = _post_action(webui, {"ip_remove": "lock", "ip": target, "table": table})
+            assert not looks_like_login_page(resp.text), "busy ip_remove=lock POST returned the login form"
+            assert "mid-update" in resp.text, f"busy re-lock feedback missing from Alerts response: {resp.text[:500]!r}"
+            matched, raw = helpers.pfctl_table_test_raw(vm, table, target)
+            assert not matched, f"{target} was re-locked while the feed-pass lock was busy; pfctl said: {raw!r}"
+            assert _ip_unlock_hosts(vm).get(target) == table, (
+                f"busy re-lock removed {target!r} from {IP_UNLOCK_STORE}: {_ip_unlock_hosts(vm)!r}"
+            )
+        finally:
+            vm.ssh("touch", stop)
+            assert helpers.wait_until(lambda: vm.ssh("test", "!", "-f", ready).returncode == 0, timeout=30.0), (
+                "feed-pass holder did not release after the stop signal"
+            )
+
+        # WHEN: the lock is free, re-lock the same host.
         resp = _post_action(webui, {"ip_remove": "lock", "ip": target, "table": table})
         assert not looks_like_login_page(resp.text), "ip_remove=lock POST returned the login form (session lost)"
 


### PR DESCRIPTION
## Summary
- hold the feed-pass lock across each of the four Alerts checked `pfctl` mutations and its existing durable commit
- return explicit busy feedback without changing live or durable state
- preserve the existing store shapes and future #1508 TTL/store design space

## Coverage
- `delete_ip` re-add
- `delete_ipwhitelist` delete
- `ip_remove=lock` re-add
- `ip_white` add

## Evidence
- Frozen tests: `7cb10bf34301208b73770aa3409c4c90ba427c4d`, `4301390982138d2997941fc22ee069c6f266af63`, `b145d494232d0ab617a230726ec2948b61538471`
- RED on pre-fix production: 58 tests, 231 assertions, 8 expected serialization failures
- GREEN: 58 tests, 277 assertions
- Release-before-commit mutation: relevant lock-at-commit assertion failed
- `scripts/agent/run-gates.sh --diff HEAD`: PASS
- Reachable UI busy-POST coverage added; local execution skipped because no pfSense image was configured

Fixes #1513

🤖 Generated by Oh My Pi and posted on behalf of @andrebrait.