### PR TITLE
ci: recover stale local-smoke git locks

### DIFF
--- a/scripts/local-smoke.sh
+++ b/scripts/local-smoke.sh
@@ -294,25 +294,43 @@ _bootstrap="cd '$_ONBOX_REPO_ROOT_Q' \
               printf 'local-smoke: box hygiene: ownership ambiguous for .git/HEAD.lock (not a regular file); box unhealthy\n' >&2; \
               exit 75; \
           fi; \
-          if [ ! -d \"\$proc/1/fd\" ] || [ ! -r \"\$proc/1/fd\" ]; then \
+          if [ ! -d \"\$proc/1/fd\" ] || [ ! -r \"\$proc/1/fd\" ] || [ ! -x \"\$proc/1/fd\" ]; then \
               printf 'local-smoke: box hygiene: ownership ambiguous for .git/HEAD.lock (process view unavailable); box unhealthy\n' >&2; \
               exit 75; \
           fi; \
-          before=\$(stat -Lc '%d:%i' \"\$lock\" 2>/dev/null) || { \
+          before=\$(stat -c '%d:%i' \"\$lock\" 2>/dev/null) || { \
               printf 'local-smoke: box hygiene: ownership ambiguous for .git/HEAD.lock (stat failed); box unhealthy\n' >&2; \
               exit 75; \
           }; \
           owner_pid=''; ambiguous=0; \
-          for fd in \"\$proc\"/[0-9]*/fd/*; do \
-              [ -L \"\$fd\" ] || continue; \
-              if target=\$(readlink \"\$fd\" 2>/dev/null); then \
-                  if [ \"\$target\" = \"\$lock\" ]; then \
-                      pid=\${fd#\"\$proc\"/}; pid=\${pid%%/*}; owner_pid=\$pid; break; \
+          for pid_dir in \"\$proc\"/[0-9]*; do \
+              [ -d \"\$pid_dir\" ] || continue; \
+              pid=\${pid_dir#\"\$proc\"/}; \
+              case \"\$pid\" in *[!0-9]*) continue ;; esac; \
+              fd_dir=\"\$pid_dir/fd\"; \
+              if [ ! -d \"\$fd_dir\" ] || [ ! -r \"\$fd_dir\" ] || [ ! -x \"\$fd_dir\" ]; then \
+                  if [ -d \"\$pid_dir\" ]; then ambiguous=2; break; fi; \
+                  continue; \
+              fi; \
+              for fd in \"\$fd_dir\"/*; do \
+                  [ -L \"\$fd\" ] || continue; \
+                  if target=\$(readlink \"\$fd\" 2>/dev/null); then \
+                      if [ \"\$target\" = \"\$lock\" ]; then \
+                          owner_pid=\$pid; break; \
+                      fi; \
+                  elif [ -L \"\$fd\" ]; then \
+                      ambiguous=1; break; \
                   fi; \
-              elif [ -L \"\$fd\" ]; then \
-                  ambiguous=1; break; \
+              done; \
+              if [ -n \"\$owner_pid\" ] || [ \"\$ambiguous\" -ne 0 ]; then break; fi; \
+              if [ ! -d \"\$fd_dir\" ] || [ ! -r \"\$fd_dir\" ] || [ ! -x \"\$fd_dir\" ]; then \
+                  if [ -d \"\$pid_dir\" ]; then ambiguous=2; break; fi; \
               fi; \
           done; \
+          if [ \"\$ambiguous\" -eq 2 ]; then \
+              printf 'local-smoke: box hygiene: ownership ambiguous for .git/HEAD.lock (process descriptor view unavailable); box unhealthy\n' >&2; \
+              exit 75; \
+          fi; \
           if [ -n \"\$owner_pid\" ]; then \
               printf 'local-smoke: box hygiene: live owner pid=%s for .git/HEAD.lock; box unhealthy\n' \"\$owner_pid\" >&2; \
               exit 75; \
@@ -321,7 +339,11 @@ _bootstrap="cd '$_ONBOX_REPO_ROOT_Q' \
               printf 'local-smoke: box hygiene: ownership ambiguous for .git/HEAD.lock (descriptor unreadable); box unhealthy\n' >&2; \
               exit 75; \
           fi; \
-          after=\$(stat -Lc '%d:%i' \"\$lock\" 2>/dev/null) || { \
+          if [ -L \"\$lock\" ] || [ ! -f \"\$lock\" ]; then \
+              printf 'local-smoke: box hygiene: ownership ambiguous for .git/HEAD.lock (changed during inspection; not a regular file); box unhealthy\n' >&2; \
+              exit 75; \
+          fi; \
+          after=\$(stat -c '%d:%i' \"\$lock\" 2>/dev/null) || { \
               printf 'local-smoke: box hygiene: .git/HEAD.lock changed during inspection; box unhealthy\n' >&2; \
               exit 75; \
           }; \

--- a/scripts/local-smoke.sh
+++ b/scripts/local-smoke.sh
@@ -63,6 +63,9 @@
 #                   never sets either, so the check stays on.
 #   PFB_LS_REMOTE   override the `git ls-remote` binary (same argv:
 #                   --exit-code <remote> <ref>). Spec injects a fake.
+#   PFB_ONBOX_REPO_ROOT  override /root/pfBlockerNG for bootstrap fixture tests.
+#   PFB_ONBOX_PROC_ROOT  override /proc for ownership fixture tests. Production
+#                   never sets either value.
 #
 # The leased box runs scripts/smoke-on-box.sh, which:
 #   - checks out the requested ref
@@ -236,6 +239,8 @@ if [ "$_skip_ls" -eq 0 ]; then
 fi
 
 _sq() { printf '%s' "$1" | sed "s/'/'\\\\''/g"; }
+_ONBOX_REPO_ROOT_Q="$(_sq "${PFB_ONBOX_REPO_ROOT:-/root/pfBlockerNG}")"
+_ONBOX_PROC_ROOT_Q="$(_sq "${PFB_ONBOX_PROC_ROOT:-/proc}")"
 
 _REF_Q="$(_sq "$_REF")"
 _GIT_REMOTE_Q="$(_sq "$_GIT_REMOTE")"
@@ -282,7 +287,54 @@ if [ "$_NO_TWO_VM" -eq 1 ]; then
     _ob_flags="$_ob_flags --no-two-vm"
 fi
 
-_bootstrap="cd /root/pfBlockerNG \
+_bootstrap="cd '$_ONBOX_REPO_ROOT_Q' \
+ && (lock='$_ONBOX_REPO_ROOT_Q/.git/HEAD.lock'; proc='$_ONBOX_PROC_ROOT_Q'; \
+      if [ -e \"\$lock\" ] || [ -L \"\$lock\" ]; then \
+          if [ -L \"\$lock\" ] || [ ! -f \"\$lock\" ]; then \
+              printf 'local-smoke: box hygiene: ownership ambiguous for .git/HEAD.lock (not a regular file); box unhealthy\n' >&2; \
+              exit 75; \
+          fi; \
+          if [ ! -d \"\$proc/1/fd\" ] || [ ! -r \"\$proc/1/fd\" ]; then \
+              printf 'local-smoke: box hygiene: ownership ambiguous for .git/HEAD.lock (process view unavailable); box unhealthy\n' >&2; \
+              exit 75; \
+          fi; \
+          before=\$(stat -Lc '%d:%i' \"\$lock\" 2>/dev/null) || { \
+              printf 'local-smoke: box hygiene: ownership ambiguous for .git/HEAD.lock (stat failed); box unhealthy\n' >&2; \
+              exit 75; \
+          }; \
+          owner_pid=''; ambiguous=0; \
+          for fd in \"\$proc\"/[0-9]*/fd/*; do \
+              [ -L \"\$fd\" ] || continue; \
+              if target=\$(readlink \"\$fd\" 2>/dev/null); then \
+                  if [ \"\$target\" = \"\$lock\" ]; then \
+                      pid=\${fd#\"\$proc\"/}; pid=\${pid%%/*}; owner_pid=\$pid; break; \
+                  fi; \
+              elif [ -L \"\$fd\" ]; then \
+                  ambiguous=1; break; \
+              fi; \
+          done; \
+          if [ -n \"\$owner_pid\" ]; then \
+              printf 'local-smoke: box hygiene: live owner pid=%s for .git/HEAD.lock; box unhealthy\n' \"\$owner_pid\" >&2; \
+              exit 75; \
+          fi; \
+          if [ \"\$ambiguous\" -ne 0 ]; then \
+              printf 'local-smoke: box hygiene: ownership ambiguous for .git/HEAD.lock (descriptor unreadable); box unhealthy\n' >&2; \
+              exit 75; \
+          fi; \
+          after=\$(stat -Lc '%d:%i' \"\$lock\" 2>/dev/null) || { \
+              printf 'local-smoke: box hygiene: .git/HEAD.lock changed during inspection; box unhealthy\n' >&2; \
+              exit 75; \
+          }; \
+          if [ \"\$before\" != \"\$after\" ]; then \
+              printf 'local-smoke: box hygiene: .git/HEAD.lock changed during inspection; box unhealthy\n' >&2; \
+              exit 75; \
+          fi; \
+          if ! rm -f \"\$lock\" || [ -e \"\$lock\" ] || [ -L \"\$lock\" ]; then \
+              printf 'local-smoke: box hygiene: stale .git/HEAD.lock recovery failed; box unhealthy\n' >&2; \
+              exit 75; \
+          fi; \
+          printf 'local-smoke: box hygiene: recovered proven-stale .git/HEAD.lock\n' >&2; \
+      fi) \
  && git sparse-checkout init --cone \
  && git sparse-checkout set src scripts stubs/python tests/smoke \
  && git fetch --quiet '$_GIT_REMOTE_Q' '$_REF_Q' \

--- a/tests/shell/local_smoke_head_lock_spec.sh
+++ b/tests/shell/local_smoke_head_lock_spec.sh
@@ -1,0 +1,202 @@
+#shellcheck shell=sh
+# issue #2038: bootstrap may inherit a HEAD lock from an earlier box user. The
+# verdict must come from the on-box descriptor view before the checkout mutates anything.
+Describe 'local-smoke.sh git HEAD lock hygiene (issue #2038)'
+  SCRIPT="${PFB_ROOT}/scripts/local-smoke.sh"
+
+  setup() {
+    scrub_git_env
+    WORK="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/localsmokelock.XXXXXX")"
+    BOX_REPO="${WORK}/box repo"
+    PROC_ROOT="${WORK}/proc"
+    REMOTE_BIN="${WORK}/bin"
+    REMOTE_EVENTS="${WORK}/events"
+    mkdir -p "${BOX_REPO}/.git" "${BOX_REPO}/scripts" \
+      "${PROC_ROOT}/1/fd" "$REMOTE_BIN" "$REMOTE_EVENTS"
+
+    cat > "${BOX_REPO}/scripts/smoke-on-box.sh" <<'SMOKE'
+#!/bin/sh
+printf 'reached\n' > "$REMOTE_EVENTS/handoff"
+SMOKE
+
+    REAL_READLINK="$(command -v readlink)"
+    REAL_RM="$(command -v rm)"
+    REAL_MV="$(command -v mv)"
+    export REAL_READLINK REAL_RM REAL_MV
+
+    cat > "${REMOTE_BIN}/git" <<'GIT'
+#!/bin/sh
+printf '%s\n' "$*" >> "$REMOTE_EVENTS/git"
+if [ -e "${BOX_REPO}/.git/HEAD.lock" ] || [ -L "${BOX_REPO}/.git/HEAD.lock" ]; then
+  printf 'fatal: Unable to create %s: File exists.\n' "${BOX_REPO}/.git/HEAD.lock" >&2
+  exit 128
+fi
+exit 0
+GIT
+    cat > "${REMOTE_BIN}/sysctl" <<'SYSCTL'
+#!/bin/sh
+exit 0
+SYSCTL
+    cat > "${REMOTE_BIN}/stat" <<'STAT'
+#!/bin/sh
+printf 'stat\n' >> "$REMOTE_EVENTS/stat"
+if [ -f "$REMOTE_EVENTS/raced" ]; then
+  printf 'changed\n'
+else
+  printf 'original\n'
+fi
+STAT
+    cat > "${REMOTE_BIN}/readlink" <<'READLINK'
+#!/bin/sh
+if [ "${RACE_LOCK:-0}" = 1 ] && [ ! -f "$REMOTE_EVENTS/raced" ]; then
+  "$REAL_MV" "${BOX_REPO}/.git/HEAD.lock" "${BOX_REPO}/.git/HEAD.lock.old"
+  printf 'replacement\n' > "${BOX_REPO}/.git/HEAD.lock"
+  "$REAL_RM" "${BOX_REPO}/.git/HEAD.lock.old"
+  printf 'raced\n' > "$REMOTE_EVENTS/raced"
+fi
+exec "$REAL_READLINK" "$@"
+READLINK
+    cat > "${REMOTE_BIN}/rm" <<'RM'
+#!/bin/sh
+printf 'rm\n' >> "$REMOTE_EVENTS/mutations"
+exec "$REAL_RM" "$@"
+RM
+    chmod +x "${REMOTE_BIN}/git" "${REMOTE_BIN}/sysctl" \
+      "${REMOTE_BIN}/stat" "${REMOTE_BIN}/readlink" "${REMOTE_BIN}/rm"
+
+    FAKE_SELECT_BOX="${WORK}/fake-select-box.sh"
+    cat > "$FAKE_SELECT_BOX" <<'SELECT'
+#!/bin/sh
+[ "${1:-}" = -- ] && shift
+cmd="$*"
+# Let untouched local-smoke.sh reach the fixture so RED is about HEAD.lock,
+# not its production-only /root path. The implemented test seam needs no rewrite.
+cmd="$(printf '%s\n' "$cmd" | sed 's|cd /root/pfBlockerNG|cd "$BOX_REPO"|')"
+PATH="${REMOTE_BIN}:$PATH" sh -c "$cmd"
+SELECT
+    chmod +x "$FAKE_SELECT_BOX"
+
+    PFB_SELECT_BOX="$FAKE_SELECT_BOX"
+    PFB_BOXES="dummy@dummy"
+    PFB_REF_PREFLIGHT=0
+    PFB_ONBOX_REPO_ROOT="$BOX_REPO"
+    PFB_ONBOX_PROC_ROOT="$PROC_ROOT"
+    export BOX_REPO PROC_ROOT REMOTE_BIN REMOTE_EVENTS
+    export PFB_SELECT_BOX PFB_BOXES PFB_REF_PREFLIGHT
+    export PFB_ONBOX_REPO_ROOT PFB_ONBOX_PROC_ROOT
+    unset RACE_LOCK
+  }
+
+  teardown() {
+    rm -rf "$WORK"
+  }
+
+  BeforeEach 'setup'
+  AfterEach 'teardown'
+
+  make_lock() {
+    printf 'leftover\n' > "${BOX_REPO}/.git/HEAD.lock"
+  }
+
+  run_and_diag() {
+    _out="$(sh "$SCRIPT" --ref dummy 2>&1)"
+    _rc=$?
+    _git_calls=0
+    _mutations=0
+    _stat_calls=0
+    [ ! -f "$REMOTE_EVENTS/git" ] || _git_calls="$(wc -l < "$REMOTE_EVENTS/git" | tr -d ' ')"
+    [ ! -f "$REMOTE_EVENTS/mutations" ] || _mutations="$(wc -l < "$REMOTE_EVENTS/mutations" | tr -d ' ')"
+    [ ! -f "$REMOTE_EVENTS/stat" ] || _stat_calls="$(wc -l < "$REMOTE_EVENTS/stat" | tr -d ' ')"
+    printf 'status=%s\n' "$_rc"
+    if [ -e "${BOX_REPO}/.git/HEAD.lock" ] || [ -L "${BOX_REPO}/.git/HEAD.lock" ]; then
+      printf 'lock=present\n'
+    else
+      printf 'lock=absent\n'
+    fi
+    printf 'git_calls=%s\n' "$_git_calls"
+    printf 'mutations=%s\n' "$_mutations"
+    printf 'stat_calls=%s\n' "$_stat_calls"
+    if [ -f "$REMOTE_EVENTS/handoff" ]; then
+      printf 'handoff=reached\n'
+    else
+      printf 'handoff=blocked\n'
+    fi
+    printf '%s\n' "$_out"
+    return 0
+  }
+
+  stale_lock() {
+    make_lock
+    run_and_diag
+  }
+
+  It 'removes a proven-stale unchanged lock'
+    When call stale_lock
+    The line 1 of output should equal 'status=0'
+    The line 2 of output should equal 'lock=absent'
+    The line 4 of output should equal 'mutations=1'
+    The output should include 'box hygiene: recovered proven-stale .git/HEAD.lock'
+  End
+
+  It 'continues through checkout and the smoke handoff after stale recovery'
+    When call stale_lock
+    The line 1 of output should equal 'status=0'
+    The line 3 of output should not equal 'git_calls=0'
+    The line 6 of output should equal 'handoff=reached'
+  End
+
+  live_lock() {
+    make_lock
+    mkdir -p "${PROC_ROOT}/4242/fd"
+    ln -s "${BOX_REPO}/.git/HEAD.lock" "${PROC_ROOT}/4242/fd/9"
+    run_and_diag
+  }
+
+  It 'leaves a lock with a live descriptor owner untouched'
+    When call live_lock
+    The line 1 of output should equal 'status=75'
+    The line 2 of output should equal 'lock=present'
+    The line 3 of output should equal 'git_calls=0'
+    The line 4 of output should equal 'mutations=0'
+    The output should include 'live owner pid=4242'
+    The output should include 'box unhealthy'
+  End
+
+  ambiguous_lock() {
+    make_lock
+    rm -rf "${PROC_ROOT}/1/fd"
+    run_and_diag
+  }
+
+  It 'leaves the lock untouched when process ownership is ambiguous'
+    When call ambiguous_lock
+    The line 1 of output should equal 'status=75'
+    The line 2 of output should equal 'lock=present'
+    The line 3 of output should equal 'git_calls=0'
+    The line 4 of output should equal 'mutations=0'
+    The output should include 'ownership ambiguous'
+    The output should include 'process view unavailable'
+    The output should include 'box unhealthy'
+  End
+
+  raced_lock() {
+    make_lock
+    mkdir -p "${PROC_ROOT}/99/fd"
+    ln -s /dev/null "${PROC_ROOT}/99/fd/3"
+    RACE_LOCK=1
+    export RACE_LOCK
+    run_and_diag
+  }
+
+  It 'does not mutate a lock that changes before the stale verdict'
+    When call raced_lock
+    The line 1 of output should equal 'status=75'
+    The line 2 of output should equal 'lock=present'
+    The line 3 of output should equal 'git_calls=0'
+    The line 4 of output should equal 'mutations=0'
+    The line 5 of output should equal 'stat_calls=2'
+    The line 6 of output should equal 'handoff=blocked'
+    The output should include 'changed during inspection'
+    The output should include 'box unhealthy'
+  End
+End

--- a/tests/shell/local_smoke_spec.sh
+++ b/tests/shell/local_smoke_spec.sh
@@ -458,3 +458,108 @@ FAKEEOF
     End
   End
 End
+
+Describe 'local-smoke.sh incomplete PID descriptor view (issue #2038)'
+  SCRIPT="${PFB_ROOT}/scripts/local-smoke.sh"
+
+  setup_pid_fd() {
+    scrub_git_env
+    PIDFD_WORK="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/localsmokepidfd.XXXXXX")"
+    PIDFD_REPO="${PIDFD_WORK}/box repo"
+    PIDFD_PROC="${PIDFD_WORK}/proc"
+    PIDFD_BIN="${PIDFD_WORK}/bin"
+    PIDFD_EVENTS="${PIDFD_WORK}/events"
+    mkdir -p "${PIDFD_REPO}/.git" "${PIDFD_REPO}/scripts" \
+      "${PIDFD_PROC}/1/fd" "${PIDFD_PROC}/4242" "$PIDFD_BIN" "$PIDFD_EVENTS"
+    printf 'leftover\n' > "${PIDFD_REPO}/.git/HEAD.lock"
+
+    cat > "${PIDFD_REPO}/scripts/smoke-on-box.sh" <<'SMOKE'
+#!/bin/sh
+printf 'reached\n' > "$PIDFD_EVENTS/handoff"
+SMOKE
+    cat > "${PIDFD_BIN}/git" <<'GIT'
+#!/bin/sh
+printf 'git\n' >> "$PIDFD_EVENTS/git"
+exit 0
+GIT
+    cat > "${PIDFD_BIN}/stat" <<'STAT'
+#!/bin/sh
+printf 'unchanged\n'
+STAT
+    cat > "${PIDFD_BIN}/rm" <<'RM'
+#!/bin/sh
+printf 'rm\n' >> "$PIDFD_EVENTS/mutations"
+exec "$REAL_RM" "$@"
+RM
+    cat > "${PIDFD_BIN}/sysctl" <<'SYSCTL'
+#!/bin/sh
+exit 0
+SYSCTL
+    chmod +x "${PIDFD_REPO}/scripts/smoke-on-box.sh" \
+      "${PIDFD_BIN}/git" "${PIDFD_BIN}/stat" "${PIDFD_BIN}/rm" \
+      "${PIDFD_BIN}/sysctl"
+
+    PIDFD_SELECT_BOX="${PIDFD_WORK}/fake-select-box.sh"
+    cat > "$PIDFD_SELECT_BOX" <<'SELECT'
+#!/bin/sh
+[ "${1:-}" = -- ] && shift
+PATH="${PIDFD_BIN}:$PATH" sh -c "$*"
+SELECT
+    chmod +x "$PIDFD_SELECT_BOX"
+
+    REAL_RM="$(command -v rm)"
+    PFB_SELECT_BOX="$PIDFD_SELECT_BOX"
+    PFB_BOXES="dummy@dummy"
+    PFB_REF_PREFLIGHT=0
+    PFB_ONBOX_REPO_ROOT="$PIDFD_REPO"
+    PFB_ONBOX_PROC_ROOT="$PIDFD_PROC"
+    export PIDFD_REPO PIDFD_PROC PIDFD_BIN PIDFD_EVENTS REAL_RM
+    export PFB_SELECT_BOX PFB_BOXES PFB_REF_PREFLIGHT
+    export PFB_ONBOX_REPO_ROOT PFB_ONBOX_PROC_ROOT
+  }
+
+  teardown_pid_fd() {
+    rm -rf "$PIDFD_WORK"
+  }
+
+  BeforeEach 'setup_pid_fd'
+  AfterEach 'teardown_pid_fd'
+
+  run_pid_fd_diag() {
+    _out="$(sh "$SCRIPT" --ref dummy 2>&1)"
+    _rc=$?
+    _git_calls=0
+    _mutations=0
+    [ ! -f "$PIDFD_EVENTS/git" ] ||
+      _git_calls="$(wc -l < "$PIDFD_EVENTS/git" | tr -d ' ')"
+    [ ! -f "$PIDFD_EVENTS/mutations" ] ||
+      _mutations="$(wc -l < "$PIDFD_EVENTS/mutations" | tr -d ' ')"
+    printf 'status=%s\n' "$_rc"
+    if [ -e "${PIDFD_REPO}/.git/HEAD.lock" ]; then
+      printf 'lock=present\n'
+    else
+      printf 'lock=absent\n'
+    fi
+    printf 'git_calls=%s\n' "$_git_calls"
+    printf 'mutations=%s\n' "$_mutations"
+    if [ -f "$PIDFD_EVENTS/handoff" ]; then
+      printf 'handoff=reached\n'
+    else
+      printf 'handoff=blocked\n'
+    fi
+    printf '%s\n' "$_out"
+    return 0
+  }
+
+  It 'fails closed when a live PID descriptor tree cannot be inspected'
+    When call run_pid_fd_diag
+    The line 1 of output should equal 'status=75'
+    The line 2 of output should equal 'lock=present'
+    The line 3 of output should equal 'git_calls=0'
+    The line 4 of output should equal 'mutations=0'
+    The line 5 of output should equal 'handoff=blocked'
+    The output should include 'ownership ambiguous'
+    The output should include 'process descriptor view unavailable'
+    The output should include 'box unhealthy'
+  End
+End


### PR DESCRIPTION
## Summary

- classify an inherited on-box `.git/HEAD.lock` before local-smoke performs any git mutation
- remove only an unchanged regular lock with no live descriptor owner
- leave live, ambiguous, raced, non-regular, or partially inspectable process views untouched and return status 75

## Evidence

- Actual leased-box probe: `/proc/[0-9]*/fd/*` found a controlled open lock descriptor, then found none after the owner exited; `/proc/1/fd` was readable/searchable.
- Controlled end-to-end local smoke on `root@10.0.0.35`: planted an ownerless repository lock under an exclusive lease, then ran this branch through `scripts/local-smoke.sh --filter test_dns_assert_helpers_pure --no-two-vm`; bootstrap printed `recovered proven-stale .git/HEAD.lock`, the selected smoke test passed (`1 passed, 1040 deselected`), and the lease released.
- Controlled live-owner probe on the same box: a background process held fd 9 on `.git/HEAD.lock`; local-smoke exited 75 with `live owner pid=6236 ... box unhealthy`, released the lease, and a follow-up exclusive lease proved the lock remained before fixture cleanup.
- Review-fix probe: a persistent numeric PID with an unavailable fd tree previously produced status 0, removed the lock, made five Git calls, and reached handoff; the unchanged new test now returns status 75 with the lock present and zero Git calls/removals.
- Independent corrected gate: frozen original RED 5/5 and GREEN 5/0; review-fix RED 27/1 and GREEN 27/0; hostile live/EACCES/non-regular/readlink probes all passed.
- Canonical shell gates: `sh scripts/agent/run-gates.sh --diff origin/devel` → `GATES: PASS`.

| Frozen RED test | git hash-object | RED run tail |
| --- | --- | --- |
| `tests/shell/local_smoke_head_lock_spec.sh` | `cb5339ae93de5f2e07f5439d3466e82fa42321e5` | `5 examples, 5 failures; stale status=128 lock=present mutations=0; live/ambiguous/race reached git` |
| `tests/shell/local_smoke_spec.sh` | `c83a16536cc2184fdbcddcf5553ef4f16df1f788` | `1 example, 1 failure; status=0 lock=absent git_calls=5 mutations=1 handoff=reached` |

Fixes #2038

🤖 Generated by Oh My Pi and posted on behalf of @andrebrait.
