### PR TITLE
test: repair the UI coverage the DNSBL/IP tab reorganisation broke

### DIFF
--- a/tests/smoke/ui/test_browser_dnsbl.py
+++ b/tests/smoke/ui/test_browser_dnsbl.py
@@ -118,9 +118,12 @@ def _shot(page: Page, screenshot_dir: Path, name: str) -> None:
 def _expand_section(page: Page, section_id: str) -> None:
     """Expand a COLLAPSIBLE|SEC_CLOSED Form_Section so rows inside are observable.
 
-    Form_Section body id is ``{id}_panel-body``. The outer panel stays in the
-    tree when collapsed; the body does not display. A locator of ``#{id}-panel``
-    matches nothing, so this must use the ``_panel-body`` suffix.
+    The body id is ``{id}_panel-body`` (pfSense Section.class.php), not ``#{id}-panel``:
+    that selector matches nothing, and a ``count() == 0`` guard turns it into a silent
+    success. Assert the body is attached so a wrong selector fails here, loudly.
+
+    Keep this byte-identical to the copy in test_browser_ip.py -- the two drifting apart
+    is what left the IP page with the broken selector after the DNSBL page was fixed.
     """
     panel = page.locator(f"#{section_id}")
     expect(panel).to_be_attached(timeout=JS_TIMEOUT_MS)
@@ -405,8 +408,6 @@ def test_action_select_toggles_advanced_firewall_sections(
     """
     page = browser_page
     _open(page, webui, DNSBL_PAGE)
-    # The controls below moved into the collapsed "dnsbl_ips" section in the DNSBL
-    # tab reorganisation; a closed panel is attached but not interactable.
     _expand_section(page, "dnsbl_ips")
 
     action = page.locator("#action")
@@ -942,8 +943,6 @@ def test_fill_buttons_populate_interface_selects(
         )
 
         _open(page, webui, DNSBL_PAGE)
-        # The controls below moved into the collapsed "dnsbl_bypass" section in the DNSBL
-        # tab reorganisation; a closed panel is attached but not interactable.
         _expand_section(page, "dnsbl_bypass")
 
         # DNS Redirect fill.
@@ -1008,8 +1007,6 @@ def test_exception_fields_have_alias_autocomplete(
         )
 
         _open(page, webui, DNSBL_PAGE)
-        # The controls below moved into the collapsed "dnsbl_bypass" section in the DNSBL
-        # tab reorganisation; a closed panel is attached but not interactable.
         _expand_section(page, "dnsbl_bypass")
 
         # The alias name must have reached the page's JS source array.

--- a/tests/smoke/ui/test_browser_dnsbl.py
+++ b/tests/smoke/ui/test_browser_dnsbl.py
@@ -122,11 +122,9 @@ def _expand_section(page: Page, section_id: str) -> None:
     that selector matches nothing, and a ``count() == 0`` guard turns it into a silent
     success. Assert the body is attached so a wrong selector fails here, loudly.
 
-    Keep this byte-identical to the copy in test_browser_ip.py -- the two drifting apart
-    is what left the IP page with the broken selector after the DNSBL page was fixed.
+    Keep the two copies of this helper byte-identical -- them drifting apart is what left
+    the IP page on the broken selector after the DNSBL page was fixed.
     """
-    panel = page.locator(f"#{section_id}")
-    expect(panel).to_be_attached(timeout=JS_TIMEOUT_MS)
     body = page.locator(f"#{section_id}_panel-body")
     expect(body).to_be_attached(timeout=JS_TIMEOUT_MS)
     if "in" not in (body.get_attribute("class") or ""):

--- a/tests/smoke/ui/test_browser_dnsbl.py
+++ b/tests/smoke/ui/test_browser_dnsbl.py
@@ -405,6 +405,9 @@ def test_action_select_toggles_advanced_firewall_sections(
     """
     page = browser_page
     _open(page, webui, DNSBL_PAGE)
+    # The controls below moved into the collapsed "dnsbl_ips" section in the DNSBL
+    # tab reorganisation; a closed panel is attached but not interactable.
+    _expand_section(page, "dnsbl_ips")
 
     action = page.locator("#action")
     adv_in = page.locator("#advinboundsettings")
@@ -939,6 +942,9 @@ def test_fill_buttons_populate_interface_selects(
         )
 
         _open(page, webui, DNSBL_PAGE)
+        # The controls below moved into the collapsed "dnsbl_bypass" section in the DNSBL
+        # tab reorganisation; a closed panel is attached but not interactable.
+        _expand_section(page, "dnsbl_bypass")
 
         # DNS Redirect fill.
         _assert_fill_button_populates(
@@ -1002,6 +1008,9 @@ def test_exception_fields_have_alias_autocomplete(
         )
 
         _open(page, webui, DNSBL_PAGE)
+        # The controls below moved into the collapsed "dnsbl_bypass" section in the DNSBL
+        # tab reorganisation; a closed panel is attached but not interactable.
+        _expand_section(page, "dnsbl_bypass")
 
         # The alias name must have reached the page's JS source array.
         alias_names = page.evaluate("pfb_alias_names")

--- a/tests/smoke/ui/test_browser_ip.py
+++ b/tests/smoke/ui/test_browser_ip.py
@@ -61,11 +61,9 @@ def _expand_section(page: Page, section_id: str) -> None:
     that selector matches nothing, and a ``count() == 0`` guard turns it into a silent
     success. Assert the body is attached so a wrong selector fails here, loudly.
 
-    Keep this byte-identical to the copy in test_browser_ip.py -- the two drifting apart
-    is what left the IP page with the broken selector after the DNSBL page was fixed.
+    Keep the two copies of this helper byte-identical -- them drifting apart is what left
+    the IP page on the broken selector after the DNSBL page was fixed.
     """
-    panel = page.locator(f"#{section_id}")
-    expect(panel).to_be_attached(timeout=JS_TIMEOUT_MS)
     body = page.locator(f"#{section_id}_panel-body")
     expect(body).to_be_attached(timeout=JS_TIMEOUT_MS)
     if "in" not in (body.get_attribute("class") or ""):

--- a/tests/smoke/ui/test_browser_ip.py
+++ b/tests/smoke/ui/test_browser_ip.py
@@ -55,13 +55,21 @@ JS_TIMEOUT_MS = 10_000
 
 
 def _expand_section(page: Page, section_id: str) -> None:
-    """Expand a COLLAPSIBLE|SEC_CLOSED Form_Section body so fields inside are visible."""
+    """Expand a COLLAPSIBLE|SEC_CLOSED Form_Section body so fields inside are visible.
+
+    Form_Section body id is ``{id}_panel-body`` (Section.class.php:107-113) --
+    underscore, and ``_panel-body`` rather than ``-panel``. A locator of
+    ``#{id}-panel`` matches NOTHING, and the old ``body.count() == 0`` guard
+    turned that into a silent early return: the helper reported success, the
+    section stayed closed, and the caller failed later on a hidden control.
+    Assert the body is attached instead, so a wrong selector fails loudly here.
+    """
     panel = page.locator(f"#{section_id}")
     expect(panel).to_be_attached(timeout=JS_TIMEOUT_MS)
-    body = page.locator(f"#{section_id}-panel")
-    if body.count() == 0 or body.is_visible():
-        return
-    panel.locator("a[data-toggle='collapse']").first.click()
+    body = page.locator(f"#{section_id}_panel-body")
+    expect(body).to_be_attached(timeout=JS_TIMEOUT_MS)
+    if "in" not in (body.get_attribute("class") or ""):
+        page.locator(f'a[data-toggle="collapse"][href="#{section_id}_panel-body"]').click()
     expect(body).to_be_visible(timeout=JS_TIMEOUT_MS)
 
 

--- a/tests/smoke/ui/test_browser_ip.py
+++ b/tests/smoke/ui/test_browser_ip.py
@@ -55,14 +55,14 @@ JS_TIMEOUT_MS = 10_000
 
 
 def _expand_section(page: Page, section_id: str) -> None:
-    """Expand a COLLAPSIBLE|SEC_CLOSED Form_Section body so fields inside are visible.
+    """Expand a COLLAPSIBLE|SEC_CLOSED Form_Section so rows inside are observable.
 
-    Form_Section body id is ``{id}_panel-body`` (Section.class.php:107-113) --
-    underscore, and ``_panel-body`` rather than ``-panel``. A locator of
-    ``#{id}-panel`` matches NOTHING, and the old ``body.count() == 0`` guard
-    turned that into a silent early return: the helper reported success, the
-    section stayed closed, and the caller failed later on a hidden control.
-    Assert the body is attached instead, so a wrong selector fails loudly here.
+    The body id is ``{id}_panel-body`` (pfSense Section.class.php), not ``#{id}-panel``:
+    that selector matches nothing, and a ``count() == 0`` guard turns it into a silent
+    success. Assert the body is attached so a wrong selector fails here, loudly.
+
+    Keep this byte-identical to the copy in test_browser_ip.py -- the two drifting apart
+    is what left the IP page with the broken selector after the DNSBL page was fixed.
     """
     panel = page.locator(f"#{section_id}")
     expect(panel).to_be_attached(timeout=JS_TIMEOUT_MS)

--- a/tests/smoke/ui/test_render_smoke.py
+++ b/tests/smoke/ui/test_render_smoke.py
@@ -81,19 +81,13 @@ class Page:
 PAGE_TABLE: tuple[Page, ...] = (
     # "Advanced Text Editor" is the issue #1888 label of the pfb_syntax_highlight checkbox
     # (renamed from "Syntax Highlighting") — a third marker for the rendered field label.
-    # "Block Private-Address Exceptions" is the pfb_feed_internal_allowlist textarea label
-    # added by the General reorg — the general row's only marker that did not already exist
-    # before it, so the row pins the reorg rather than passing on pre-reorg text alone.
+    # The reorg-introduced label is pinned by test_general_private_address_label_renders,
+    # not added here: the oracle matches markers with any(), so a fifth marker beside four
+    # already-present ones would gate nothing.
     Page(
         "general",
         "/pfblockerng/pfblockerng_general.php",
-        (
-            "pfBlockerNG",
-            "General Settings",
-            "Scheduling",
-            "Advanced Text Editor",
-            "Block Private-Address Exceptions",
-        ),
+        ("pfBlockerNG", "General Settings", "Scheduling", "Advanced Text Editor"),
     ),
     # "Aggregated Aliases" is the ADR-11 pfb_agg_types multi-select label (rendered
     # verbatim) — a third marker so the gate also proves that field renders on the IP page.
@@ -484,8 +478,6 @@ def test_page_renders_clean(page: Page, webui: WebUI, php_error_log_guard: PhpEr
 # Each url is a stable href in the named page's source.
 _NOOPENER_RENDER_CASES: tuple[tuple[str, str], ...] = (
     ("/pfblockerng/pfblockerng_general.php", "https://pfblockerng.com"),
-    # The Support byline moved from the Netgate forum to GitHub in the General
-    # reorganisation, and gained a co-author; both carry the same rel requirement.
     ("/pfblockerng/pfblockerng_general.php", "https://github.com/BBcan177"),
     ("/pfblockerng/pfblockerng_general.php", "https://github.com/andrebrait"),
     # ?type=geoip: the MaxMind attribution callout only prints in the category page's
@@ -1746,6 +1738,28 @@ def test_alerts_unified_log_colour_fields_render(
             "write_config('pfBlockerNG smoke: restore DNSBL toggle');\n"
             "echo 'OK';",
         )
+
+
+def test_general_private_address_label_renders(webui: WebUI, php_error_log_guard: PhpErrorLogGuard) -> None:
+    """The General reorg renamed the pfb_feed_internal_allowlist textarea label from
+    "Internal Feed Host Exemptions" to "Block Private-Address Exceptions".
+
+    A dedicated assertion rather than a PAGE_TABLE marker because the render oracle matches
+    markers with ``any()``: a fifth marker beside four that already render would pass whether
+    or not the label survives (coverage theater). Asserting the new string present AND the old
+    absent gives an unambiguous fail-before / pass-after for the rename.
+    """
+    path = "/pfblockerng/pfblockerng_general.php"
+    resp = webui.get(path)
+    result = evaluate_render(path, resp.status_code, resp.text, ("General Settings",))
+    assert result.ok, f"General render oracle failed: {result.detail}"
+    body = resp.text
+    assert "Block Private-Address Exceptions" in body, (
+        "General page is missing the 'Block Private-Address Exceptions' textarea label"
+    )
+    assert "Internal Feed Host Exemptions" not in body, (
+        "General page still renders the pre-reorg 'Internal Feed Host Exemptions' label"
+    )
 
 
 def test_feeds_custom_panel_heading_renders(webui: WebUI, php_error_log_guard: PhpErrorLogGuard) -> None:

--- a/tests/smoke/ui/test_render_smoke.py
+++ b/tests/smoke/ui/test_render_smoke.py
@@ -484,7 +484,10 @@ def test_page_renders_clean(page: Page, webui: WebUI, php_error_log_guard: PhpEr
 # Each url is a stable href in the named page's source.
 _NOOPENER_RENDER_CASES: tuple[tuple[str, str], ...] = (
     ("/pfblockerng/pfblockerng_general.php", "https://pfblockerng.com"),
-    ("/pfblockerng/pfblockerng_general.php", "https://forum.netgate.com/user/bbcan177"),
+    # The Support byline moved from the Netgate forum to GitHub in the General
+    # reorganisation, and gained a co-author; both carry the same rel requirement.
+    ("/pfblockerng/pfblockerng_general.php", "https://github.com/BBcan177"),
+    ("/pfblockerng/pfblockerng_general.php", "https://github.com/andrebrait"),
     # ?type=geoip: the MaxMind attribution callout only prints in the category page's
     # GeoIP view (source guards it with `$gtype == 'geoip'`).
     ("/pfblockerng/pfblockerng_category.php?type=geoip", "https://www.maxmind.com"),

--- a/tests/smoke/ui/test_render_smoke.py
+++ b/tests/smoke/ui/test_render_smoke.py
@@ -81,10 +81,19 @@ class Page:
 PAGE_TABLE: tuple[Page, ...] = (
     # "Advanced Text Editor" is the issue #1888 label of the pfb_syntax_highlight checkbox
     # (renamed from "Syntax Highlighting") — a third marker for the rendered field label.
+    # "Block Private-Address Exceptions" is the pfb_feed_internal_allowlist textarea label
+    # added by the General reorg — the general row's only marker that did not already exist
+    # before it, so the row pins the reorg rather than passing on pre-reorg text alone.
     Page(
         "general",
         "/pfblockerng/pfblockerng_general.php",
-        ("pfBlockerNG", "General Settings", "Scheduling", "Advanced Text Editor"),
+        (
+            "pfBlockerNG",
+            "General Settings",
+            "Scheduling",
+            "Advanced Text Editor",
+            "Block Private-Address Exceptions",
+        ),
     ),
     # "Aggregated Aliases" is the ADR-11 pfb_agg_types multi-select label (rendered
     # verbatim) — a third marker so the gate also proves that field renders on the IP page.


### PR DESCRIPTION
## What this fixes

The DNSBL/IP tab reorganisation moved controls into `COLLAPSIBLE|SEC_CLOSED`
sections and moved two pieces of text. Five browser tests and one render test
were left pointing at the old shape. This repairs the tests only — **no
production behaviour is touched**.

Found by running the `ui_browser` and `ui_render` tiers against merged `devel`.
CI does not run those tiers on a PR, so none of this was visible at merge time.

## The substantive one: a helper that silently did nothing

`tests/smoke/ui/test_browser_ip.py` located a section body as `#{id}-panel`.
The real id is `{id}_panel-body` (`Section.class.php:107-113`), so that selector
matched **nothing** — and the guard around it turned that into a silent success:

```python
body = page.locator(f"#{section_id}-panel")
if body.count() == 0 or body.is_visible():
    return
```

`count() == 0` is true for a selector that matches nothing, so the helper
returned as if it had expanded the section. The section stayed shut and the
caller failed ~30s later against a hidden control, pointing at the control
rather than at the helper.

The equivalent fix already existed in `test_browser_dnsbl.py`; it was never
applied to the sibling file. Both helpers are now identical and **assert the
body is attached**, so a wrong selector fails loudly at the helper instead of
degrading to a no-op.

Swept the tree afterwards: the only remaining `-panel"` matches are the
unrelated `pfb-software-panel` marker, and both `_expand_section` definitions
are now correct.

## The rest

- Three DNSBL tests called no expand helper at all; they now open the section
  their controls live in. Panel membership was read off the **rendered page**,
  not inferred from the source:

  | control | panel |
  | --- | --- |
  | `action` | `dnsbl_ips` |
  | `pfb_redir_fill`, `pfb_dot_block_fill`, `dnsbl_redir_exclude`, `dnsbl_dot_block_exclude`, `dnsbl_redir_int`, `dnsbl_dot_block_int` | `dnsbl_bypass` |
  | `pfb_agg_types`, `pfb_alias_delta_mode` | `ip_advanced` |

  `advinboundsettings`/`advoutboundsettings` are sibling `Form_Section`s, shown and
  hidden by `enable_dnsblip()` rather than by the panel — the test asserts their
  visibility through that JS gate, not through `_expand_section`.

- The Tier-A `general` row's markers (`pfBlockerNG`, `General Settings`,
  `Scheduling`, `Advanced Text Editor`) **all pre-date the reorganisation**, so
  the row passed identically before and after and pinned nothing about it. Note
  the obvious repair does not work either: `general.php`'s `Form_Section` titles
  are byte-identical before and after — and neither does adding a fifth marker,
  because `evaluate_render` matches markers with `any()`, so a new marker beside
  four already-present ones gates nothing. Pinned by a dedicated
  `test_general_private_address_label_renders` instead, asserting the reorg's
  `Block Private-Address Exceptions` present **and** the pre-reorg
  `Internal Feed Host Exemptions` absent — the shape
  `test_feeds_custom_panel_heading_renders` already uses for a rename.

- The Support byline moved from the Netgate forum to GitHub and gained a
  co-author, so the noopener case named a URL the page no longer renders.
  Repointed, and the second href added since it carries the same `rel`
  requirement.

## Verification

Run on a live pfSense VM, not simulated:

| tier | before | after |
| --- | --- | --- |
| `ui_browser` | 5 failed, 149 passed | **154 passed, 1 skipped** |
| `ui_render`  | 2 failed, 217 passed | 1 failed, 219 passed |

## Known-failing test NOT addressed here

`test_dnsbl_page_renders_tld_pickers` still fails:

```
AssertionError: DNSBL page is missing the '(N TLDs available)' help text
```

This is **pre-existing on `devel`, not introduced by this PR**, and it is not a
test bug. The reorganisation moved the TLD Allow checkbox above the
`$tld_list` arrays and `$tld_total`, so the count is no longer in scope where
that control is built and the figure was dropped. Restoring the text in place
renders `(0 TLDs available)` and logs an `Undefined variable` warning plus a
`number_format(null)` deprecation on every page load — measured, not assumed.

Fixing it requires a production change (moving the TLD data above the GUI
block), which is deliberately kept out of this test-only PR and will follow
separately.

Worth noting the test is well built: the regex alone matches `(0 TLDs
available)`, but its `tld_count >= 1000` plausibility check — written to catch a
blanked `$tld_list` — is what rejects the broken value. That guard should be
preserved by whatever fixes this.



## Review

Two legs found the same blocking defect independently: the Tier-A marker described
above gated nothing under the oracle's `any()` semantics, so the row stayed exactly the
coverage theater this PR set out to fix. Replaced with the dedicated assertion, verified
to fail on a reverted label and pass otherwise. Round 2 returned no blocking findings.

Also from review: the two `_expand_section` copies are now byte-identical **including**
docstrings, so a future drift is one `diff` away from visible — their drifting apart is
what left the IP page on the broken selector after the DNSBL page was fixed. Extraction
to a shared module was considered and deferred: the same panel-expand idiom exists in at
least five places under `tests/smoke/ui/`, and both existing shared modules there
document an "imports nothing third-party at module scope" invariant that a
Playwright-typed helper would break. A narrow two-file extraction would not have closed
the drift class.
