### PR TITLE
www: define the TLD data before the GUI block, restoring the TLD Allow count

### DIFF
--- a/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
@@ -1028,424 +1028,9 @@ if ($_POST) {
 	}
 }
 
-$pgtitle = array(gettext('Firewall'), gettext('pfBlockerNG'), gettext('DNSBL'));
-$pglinks = array('', '/pfblockerng/pfblockerng_dnsbl.php', '@self');
-$shortcut_section = 'pfblockerng';
-include_once('head.inc');
-
-if ($input_errors) {
-	print_input_errors($input_errors);
-}
-
-// Define default Alerts Tab href link (Top row)
-$get_req = pfb_alerts_default_page();
-
-$tab_array	= array();
-$tab_array[]	= array(gettext('General'),	FALSE,	'/pfblockerng/pfblockerng_general.php');
-$tab_array[]	= array(gettext('IP'),		FALSE,	'/pfblockerng/pfblockerng_ip.php');
-$tab_array[]	= array(gettext('DNSBL'),	TRUE,	'/pfblockerng/pfblockerng_dnsbl.php');
-$tab_array[]	= array(gettext('Update'),	FALSE,	'/pfblockerng/pfblockerng_update.php');
-$tab_array[]	= array(gettext('Reports'),	FALSE,	"/pfblockerng/pfblockerng_alerts.php{$get_req}");
-$tab_array[]	= array(gettext('Feeds'),	FALSE,	'/pfblockerng/pfblockerng_feeds.php');
-$tab_array[]	= array(gettext('Logs'),	FALSE,	'/pfblockerng/pfblockerng_log.php');
-$tab_array[]	= array(gettext('Sync'),	FALSE,	'/pfblockerng/pfblockerng_sync.php');
-pfb_software_add_tab($tab_array);
-display_top_tabs($tab_array, TRUE);
-
-$tab_array	= array();
-$tab_array[]	= array(gettext('DNSBL Groups'),	FALSE,		'/pfblockerng/pfblockerng_category.php?type=dnsbl');
-$tab_array[]	= array(gettext('DNSBL Category'),	FALSE,		'/pfblockerng/pfblockerng_blacklist.php');
-$tab_array[]	= array(gettext('DNSBL SafeSearch'),	FALSE,		'/pfblockerng/pfblockerng_safesearch.php');
-display_top_tabs($tab_array, TRUE);
-pfb_print_pending_changes_box();
-
-if (isset($_REQUEST['savemsg'])) {
-	$savemsg = htmlspecialchars($_REQUEST['savemsg']);
-	print_info_box($savemsg);
-}
-
-$form = new Form('Save DNSBL settings');
-
-$section = new Form_Section('DNSBL');
-$section->addInput(new Form_StaticText(
-	'Links',
-	'<small>'
-	. '<a href="/firewall_aliases.php" target="_blank" rel="noopener noreferrer">Firewall Aliases</a>&emsp;'
-	. '<a href="/firewall_rules.php" target="_blank" rel="noopener noreferrer">Firewall Rules</a>&emsp;'
-	. '<a href="/status_logs_filter.php" target="_blank" rel="noopener noreferrer">Firewall Logs</a></small>'
-));
-
-$dnsbl_text = '<div class="infoblock">'
-		. '<div id="dnsbl_eval_order">'
-		. '<strong>DNSBL evaluation order</strong> (first match wins):'
-		. '<ol>'
-		. '<li><strong>Feed lists, exact name</strong> — a listed domain is blocked (logged as DNSBL).</li>'
-		. '<li><strong>Feed lists, wildcard/zone</strong> — Wildcard Blocking classifies registrable domains (logged as TLD).</li>'
-		. '<li><strong>TLD Allow</strong> — when enabled, a name whose suffix is not selected is blocked here (logged as TLD_Allow).</li>'
-		. '<li><strong>IDN Blocking</strong> — Off / Confusable / Always. Confusable can raise a non-blocking alert instead of a block.</li>'
-		. '<li><strong>Regex Blocking</strong> — user regex and ABP feed block-regex.</li>'
-		. '</ol>'
-		. 'Feed exact and wildcard matching (1–2) run only while DNSBL blocking is enabled; TLD Allow, IDN, and Regex (3–5) still run.<br /><br />'
-		. 'If a block is found, a whitelist entry, an ABP allow rule (@@) or an allow-regex can override it. Once an ABP feed loads $important rules, block and allow are resolved by priority rather than allow-always-wins.<br /><br />'
-		. 'If the name is still blocked, the reply is shaped last: HSTS may use null-blocking to avoid browser certificate errors; NXDOMAIN replies (logged or silent) replace a VIP or null answer; a hit via a CNAME chain is tagged _CNAME. Null-blocking is not a property of which stage matched.<br /><br />'
-		. 'CNAME Validation and no-AAAA are separate features, not steps in this order. Feed-at-suffix (PSL) policies, the regex cap, and Download Schemes shape what is loaded, not the per-query order.'
-		. '</div><br /><br />'
-		. '<span class="text-danger">Note: </span>'
-		. 'DNSBL requires the DNS Resolver (Unbound) to be used as the DNS service.<br />'
-		. 'How a blocked name is answered depends on the <strong>Global Logging/Blocking Mode</strong> and on each DNSBL Group\'s own Logging/Blocking setting:<br />'
-		. '&#8226 <strong>DNSBL WebServer/VIP</strong> - the request is redirected to the DNSBL Virtual IP, where a Lighttpd instance records the hit and returns a \'1x1\' GIF. For a root domain the customizable Blocked Webpage is shown instead.<br />'
-		. '&#8226 <strong>Null Blocking</strong> - the name is answered with \'0.0.0.0\'. No Virtual IP, no web server and no block page are involved.<br />'
-		. '&#8226 <strong>NXDOMAIN</strong> - the name is answered NXDOMAIN and the block page is bypassed.<br /><br />'
-		. 'If browsing is slow <strong>in VIP mode</strong>, check for Firewall LAN Rules/Limiters that might be blocking access to the DNSBL VIP.<br /><br />'
-		. '<span class="text-danger">Note: </span>'
-		. 'DNSBL will block and <u>partially</u> log Alerts for HTTPS requests. '
-		. 'To debug issues with \'False Positives\', the following tools below can be used:<br />'
-		. '<ol>'
-		. '<li>Browser Developer tools, Console tab, for error messages.</li>'
-		. '<li>Execute the following from the pfSense Shell, substituting your LAN interface for \'re1\' and the DNSBL Virtual IP listed under <strong>DNSBL Webserver Configuration</strong> above:<br />'
-		. '&emsp;<strong>tcpdump -nnvli re1 port 53 | grep -B1 \'A &lt;VIP&gt;\'</strong></li>'
-		. '<li>Packet capture software such as Wireshark.</li>'
-		. '</ol>'
-		. '</div>';
-
-$section->addInput(new Form_Checkbox(
-	'pfb_dnsbl',
-	gettext('DNSBL'),
-	'Enable DNSBL',
-	pfb_cfg_toggle_read($pconfig['pfb_dnsbl']) === PfbToggle::On,
-	'on'
-))->setHelp('This will enable DNS Block List for Malicious and/or unwanted Adverts Domains<br />'
-		. 'To Utilize, <strong>Unbound DNS Resolver</strong> must be enabled. Also ensure that pfBlockerNG is enabled.'
-		. "{$dnsbl_text}"
-);
-
-$tld_wildcard_text = 'Block listed domains and their subdomains. '
-		. pfb_list_section_help_note(['TLD Exclusion List', 'TLD Blacklist'], TRUE)
-		. '<div id="dnsbl_tld_info" class="infoblock">
-
-		<strong>Definition: Public suffix</strong> -
-		&emsp;a domain suffix under which the public may register names, per the
-		<a href="https://publicsuffix.org/" target="_blank" rel="noopener noreferrer">Public Suffix List</a>. IE: <strong>com</strong>,
-		<strong>co.uk</strong>, <strong>github.io</strong><br /><br />
-
-		<strong>Definition: Registrable domain</strong> -
-		&emsp;a public suffix plus exactly one additional label. IE: example.com (suffix = com), example.co.uk (suffix = co.uk)<br /><br />
-
-		When enabled and after all downloads for DNSBL Feeds have completed; this process will classify the listed Domains.<br />
-		A Domain listed at its <strong>registrable domain</strong> is wildcard blocked (Block all sub-Domains).<br />
-		A Domain that is itself a <strong>public suffix</strong> is <strong>never</strong> wildcard blocked (blocking it would block every registrant under it).<br />
-		A Domain listed <strong>deeper</strong> than its registrable domain stays an exact block (only that specific name).<br />
-		The Public Suffix List authority can be found in &emsp;<u>/usr/local/pkg/pfblockerng/dnsbl_psl</u><br /><br />
-
-		To exclude a suffix/Domain from this process, add it to the <strong>TLD Exclusion</strong> custom list:<br />
-		&#8226&emsp;This only excludes the domain from the process, it doesn\'t whitelist the domain.<br />
-		&#8226&emsp;Only the specific Sub-Domains/Domains listed in the DNSBL Feeds will be blocked.<br />
-		&#8226&emsp;Changes to the TLD Exclusion take effect on the next DNSBL update.<br /><br />
-		<strong>Note:</strong>
-		&emsp;A specific sub-Domain added to the <strong>Custom Domain Whitelist</strong> is exempted from a
-		Wildcard Blocked domain (that exact name resolves).<br />
-		&emsp;&emsp;&emsp;&emsp;To exempt the whole domain (all sub-Domains), add it to the TLD Exclusion, or add a wildcard Whitelist entry for the domain.<br /><br />
-
-		<strong>TLD Blacklist</strong>, can be used to block whole TLDs. &emsp;IE: <strong>xyz</strong><br />
-
-		Enabling or disabling this option takes effect on the next DNSBL update.<br /><br />
-
-	</div>';
-
-$section->addInput(new Form_Checkbox(
-	'tld_wildcard',
-	gettext('Wildcard Blocking'),
-	'Enable',
-	pfb_cfg_toggle_read($pconfig['tld_wildcard']) === PfbToggle::On,
-	'on'
-))->setHelp($tld_wildcard_text);
-
-$section->addInput(new Form_Checkbox(
-	'pfb_py_reply',
-	gettext('DNS Reply Logging'),
-	'Enable',
-	pfb_dnsbl_toggle_enabled($pconfig['pfb_py_reply'] ?? NULL),
-	'on'
-))->setHelp('Enable the logging of all DNS Replies that were not blocked via DNSBL.');
-
-$section->addInput(new Form_Checkbox(
-	'pfb_hsts',
-	gettext('HSTS mode'),
-	'Enable',
-	pfb_dnsbl_toggle_enabled($pconfig['pfb_hsts'] ?? NULL),
-	'on'
-))->setHelp('Answer HSTS-preload domains with 0.0.0.0 instead of the DNSBL VIP, which may avoid browser certificate errors.'
-	. '<div class="infoblock">'
-	. 'Enable the DNSBL <strong title="Utilizes 0.0.0.0 instead of the DNSBL VIP">Null Blocking mode</strong> for HSTS domains.<br />'
-	. 'Blocked domains that are in the <a target=_"blank" href="https://hstspreload.org/">HSTS preload</a> browser'
-	. ' <a target=_"blank" href="https://raw.githubusercontent.com/chromium/chromium/master/net/http/transport_security_state_static.json">list</a>'
-	. ' will use the Null Blocking Mode which *may* prevent Browser Certificate Errors.<br />'
-	. '<span class="text-danger">Note:</span> This option will not block HSTS domains, unless those Domains are added via the Feeds/Customlists.'
-	. '</div>'
-);
-
-$section->addInput(new Form_Select(
-	'pfb_idn',
-	gettext('IDN Blocking'),
-	$pconfig['pfb_idn'],
-	array(
-		'off'		=> 'Off',
-		'confusable'	=> 'Confusable',
-		'on'		=> 'Always',
-	)
-))->setHelp('How IDN / xn-- names are handled (Off, Confusable, or Always). Not regex-based.'
-		. '<div class="infoblock">'
-		. 'IDN handling (not Regex based).<ul>'
-		. '<li><strong>Off</strong> - no IDN action.</li>'
-		. '<li><strong>Confusable</strong> - block only cross-script homoglyphs (Latin/Cyrillic/Greek mixes, '
-		. 'including Cyrillic+Greek).<br />Does not catch whole-script confusables or pure-ASCII typosquats.</li>'
-		. '<li><strong>Always</strong> - block every IDN/\'xn--\' domain (blunt).</li></ul>'
-		. '</div>');
-
-$section->addInput(new Form_Checkbox(
-	'pfb_idn_block_malicious',
-	gettext('Block clearly-malicious homoglyphs'),
-	'Enable',
-	pfb_dnsbl_toggle_enabled($pconfig['pfb_idn_block_malicious'] ?? NULL),
-	'on'
-))->setHelp('Confusable mode: block names that mix confusable scripts in one label (clearly malicious). Disable to alert only. '
-		. 'Applies in Confusable mode.');
-
-$section->addInput(new Form_Checkbox(
-	'pfb_idn_escalate_suspicious',
-	gettext('Block suspicious mixed-script'),
-	'Enable',
-	pfb_dnsbl_toggle_enabled($pconfig['pfb_idn_escalate_suspicious'] ?? NULL),
-	'on'
-))->setHelp('Confusable mode: escalate suspicious mixed-script names to a block. Default alerts only (no block). '
-		. 'Applies in Confusable mode.');
-
-$section->addInput(new Form_Checkbox(
-	'pfb_regex',
-	gettext('Regex Blocking'),
-	'Enable',
-	pfb_cfg_toggle_read($pconfig['pfb_regex']) === PfbToggle::On,
-	'on'
-))->setHelp('Enable the Regex blocking feature. '
-		. pfb_list_section_help_note(['Regex List'], TRUE));
-
-$section->addInput(new Form_Checkbox(
-	'pfb_regex_cap',
-	gettext('Limit long/complex regex'),
-	'Enable',
-	pfb_cfg_toggle_read($pconfig['pfb_regex_cap']) === PfbToggle::On,
-	'on'
-))->setHelp('Best-effort ReDoS safeguard (opt-in): over-long or catastrophic-backtracking regex patterns are dropped at load, before they run. '
-		. 'Applies when Regex Blocking is enabled.'
-		. '<div class="infoblock">From both feeds (ABP) and the Regex List below (each drop is logged). '
-		. 'An always-on runtime guard additionally warns on, then evicts, any pattern whose match runs too slow.</div>');
-
-$section->addInput(new Form_Checkbox(
-	'pfb_cname',
-	gettext('CNAME Validation'),
-	'Enable',
-	pfb_cfg_toggle_read($pconfig['pfb_cname']) === PfbToggle::On,
-	'on'
-))->setHelp('Also check CNAME targets against DNSBL.'
-		. '<div class="infoblock">'
-		. 'Enable the CNAME Validation feature. All CNAMES will be evaluated against DNSBL database and blocked.<br />'
-		. 'Events are logged with a "_CNAME" suffix in the DNSBL Log.'
-		. '</div>');
-
-$section->addInput(new Form_Checkbox(
-	'pfb_noaaaa',
-	gettext('no-AAAA'),
-	'Enable',
-	pfb_cfg_toggle_read($pconfig['pfb_noaaaa']) === PfbToggle::On,
-	'on'
-))->setHelp('Enable the no-AAAA feature. This will block all (IPv6) AAAA DNS requests for the defined domains. '
-		. pfb_list_section_help_note(['no-AAAA List'], TRUE));
-
-$section->addInput(new Form_Checkbox(
-	'pfb_gp',
-	gettext('DNSBL Group Policy'),
-	'Enable',
-	pfb_cfg_toggle_read($pconfig['pfb_gp']) === PfbToggle::On,
-	'on'
-))->setHelp('Enable the Group Policy functionality to allow certain Local LAN IPs to bypass DNSBL. '
-		. pfb_list_section_help_note(['DNSBL Group Policy'], TRUE));
-
-$section->addInput(new Form_Checkbox(
-	'pfb_dnsbl_lenient',
-	gettext('Download Schemes'),
-	'Enable',
-	pfb_cfg_toggle_read($pconfig['pfb_dnsbl_lenient']) === PfbToggle::On,
-	'on'
-))->setHelp('How feed lines are parsed: strip scheme:// and URL paths, or skip those lines.'
-		. '<div class="infoblock">'
-		. 'Parse DNSBL feed lines permissively: any <strong>scheme://</strong> is stripped and URL paths are removed.<br />'
-		. 'When disabled (strict), lines with an invalid scheme (e.g. <strong>123://</strong>) or a URL path are skipped and logged.<br />'
-		. 'New installs default to disabled (strict); upgraded installs keep the permissive behaviour.'
-		. '</div>');
-
-$section->addInput(new Form_Select(
-	'global_log',
-	'Global Logging/Blocking Mode',
-	$pconfig['global_log'],
-	$options_global_log
-))->setHelp($options_global_log_txt)
-  ->setAttribute('style', 'width: auto');
-
-$section->addInput(new Form_Checkbox(
-	'tld_allow',
-	gettext('Allow Only Selected Domain Suffixes'),
-	'Enable',
-	pfb_cfg_toggle_read($pconfig['tld_allow']) === PfbToggle::On,
-	'on'
-))->setHelp('Enable the TLD Allow feature. This will block all TLDs that are not specifically selected. '
-		. pfb_list_section_help_note(['TLD Allow list'], TRUE));
-
-$form->add($section);
-
-$section = new Form_Section('DNSBL Webserver Configuration');
-$section->addInput(new Form_Select(
-	'dnsbl_interface',
-	gettext('Web Server Interface'),
-	$pconfig['dnsbl_interface'],
-	$options_dnsbl_interface_all
-))->setHelp('Select the interface which DNSBL Web Server will Listen on.<br />'
-	. 'Default: <strong>Localhost (ports 80/443)</strong> - Selected Interface should be a Local Interface only.');
-
-$section->addInput(new Form_Checkbox(
-	'pfb_dnsbl_nonat',
-	gettext('Auto NAT'),
-	gettext('Disable automatic NAT rule creation'),
-	(pfb_cfg_toggle_read($pconfig['pfb_dnsbl_nonat']) === PfbToggle::On),
-	'on'
-))->setHelp('When set, pfBlockerNG will not auto-create the DNSBL NAT port-forward rules (non-Localhost interface only); manage them manually.');
-
-// [ ADR-13 ] Compute the address(es) the package WOULD auto-create, for the currently
-// selected DNSBL Web Server interface, so the UI can pre-fill them and detect conflict
-// exhaustion. pfb_pick_free_dnsbl_vip() returns the first free candidate from
-// pfb_dnsbl_vip_candidates() (null when every candidate conflicts). A v6 VIP is only relevant when the
-// DNS Resolver listens on IPv6 (pfb_unbound_listens_v6()); otherwise v6 is not required.
-$pfb_auto_iface		= $pconfig['dnsbl_interface'] ?: 'lo0';
-$pfb_auto_v6_needed	= pfb_unbound_listens_v6();
-$pfb_auto_vip4		= pfb_pick_free_dnsbl_vip(AF_INET, $pfb_auto_iface);
-$pfb_auto_vip6		= $pfb_auto_v6_needed ? pfb_pick_free_dnsbl_vip(AF_INET6, $pfb_auto_iface) : null;
-
-// Conflict exhaustion: v4 is always required; v6 only when the resolver listens on it.
-// When no free candidate exists for a required family the checkbox is rendered disabled
-// with a warning, so auto-create can never be enabled into a known-conflicting state.
-$pfb_auto_exhausted	= ($pfb_auto_vip4 === null) || ($pfb_auto_v6_needed && $pfb_auto_vip6 === null);
-
-$vips = pfb_get_vips();
-
-// [ ADR-13 ] The "Create VIPs automatically" toggle on its OWN row, above the
-// manual VIP selects. Its explanation lives in the group help UNDER the fields,
-// not on the checkbox: a long inline checkbox help renders as a very tall, narrow
-// column that towers over the rest of the section.
-$pfb_auto_chk = new Form_Checkbox(
-	'pfb_dnsvip_auto',
-	gettext('Auto VIP'),
-	gettext('Create VIPs automatically'),
-	(!$pfb_auto_exhausted && pfb_cfg_toggle_read($pconfig['pfb_dnsvip_auto']) === PfbToggle::On),
-	'on'
-);
-if ($pfb_auto_exhausted) {
-	$pfb_auto_chk->setAttribute('disabled', 'disabled');
-}
-$section->addInput($pfb_auto_chk);
-
-$group = new Form_Group('DNSBL Virtual IP');
-$group->add(new Form_Select(
-	'pfb_dnsvip4',
-	gettext('IPv4 VIP'),
-	$pconfig['pfb_dnsvip4'],
-	pfb_get_vip_options(AF_INET)
-))->setWidth(4)->setHelp('IPv4 Virtual IP');
-$group->add(new Form_Select(
-	'pfb_dnsvip6',
-	gettext('IPv6 VIP'),
-	(!empty($pconfig['pfb_dnsvip6']) ? $pconfig['pfb_dnsvip6'] : 'none'),
-	pfb_get_vip_options(AF_INET6)
-))->setWidth(4)->setHelp('IPv6 Virtual IP (optional)');
-
-// Help under the side-by-side VIP fields: the original intro, a line break at the
-// SENTENCE boundary (never mid-sentence), then one concise line covering both
-// modes. "VIP"/"Virtual IP" used consistently (no "IP-Alias VIP" jargon); the
-// address/lifecycle detail belongs in the docs.
-$pfb_vip_help = 'Select the DNSBL VIP address — rejected DNS requests are forwarded here. '
-	. 'It should be in an isolated range not already used on the network.<br />'
-	. 'Enable <strong>Create VIPs automatically</strong> to have pfBlockerNG manage it, or select one '
-	. 'manually — create it first at '
-	. '<a target="_blank" rel="noopener noreferrer" href="/firewall_virtual_ip.php">Firewall &gt; Virtual IPs</a>.';
-if ($pfb_auto_exhausted) {
-	$pfb_vip_help .= '<br /><i class="fa fa-exclamation-triangle text-warning"></i> '
-		. '<span class="text-warning">No free auto-create address is available — free one of the '
-		. 'auto-create candidates, or select a VIP manually.</span>';
-}
-$group->setHelp($pfb_vip_help);
-$section->add($group);
-
-$section->addInput(new Form_Input(
-	'pfb_dnsport',
-	gettext('Port'),
-	'number',
-	$pconfig['pfb_dnsport'],
-	[ 'min' => 1, 'max' => 65535, 'placeholder' => 'Enter DNSBL Listening Port' ]
-))->setHelp('Example ( 8081 ) &mdash; a single PORT in the range 1 - 65535. '
-		. 'Applies when Web Server Interface is not Localhost.'
-		. '<div class="infoblock">This Port must not be in use by any other process.</div>'
-);
-
-$section->addInput(new Form_Input(
-	'pfb_dnsport_ssl',
-	gettext('SSL Port'),
-	'number',
-	$pconfig['pfb_dnsport_ssl'],
-	[ 'min' => 1, 'max' => 65535, 'placeholder' => 'Enter DNSBL SSL Listening Port' ]
-))->setHelp('Example ( 8443 ) &mdash; a single PORT in the range 1 - 65535. '
-		. 'Applies when Web Server Interface is not Localhost.'
-		. '<div class="infoblock">This Port must not be in use by any other process.</div>'
-);
-
-// Add option to disable DNSBL logging and utilize the DNSBL Webserver (excluding nullblocking events)
-$section->addInput(new Form_Checkbox(
-	'pfb_py_nolog',
-	gettext('DNSBL Event Logging'),
-	'Enable',
-	pfb_cfg_toggle_read($pconfig['pfb_py_nolog']) === PfbToggle::On,
-	'on'
-))->setHelp('Disable event logging in the DNS Resolver and utilize the DNSBL Webserver. Typically used when an upstream LAN DNS server is utilized.<br />'
-	. 'Null blocked events will still be logged.');
-
-
-$section->addInput(new Form_Checkbox(
-	'pfb_dnsbl_rule',
-	gettext('Permit Firewall Rules'),
-	gettext('Enable'),
-	pfb_cfg_toggle_read($pconfig['pfb_dnsbl_rule']) === PfbToggle::On,
-	'on'
-))->setHelp('Creates \'Floating\' Firewall permit rules allowing the selected interface(s) to reach the DNSBL Webserver (ICMP and Webserver ports only).'
-		. '<div class="infoblock">This option is not designed to bypass DNSBL for the non-selected LAN segments. '
-		. 'Only required for networks with multiple LAN Segments.</div>');
-
-$section->addInput(new Form_Select(
-	'dnsbl_allow_int',
-	gettext('Interface(s)'),
-	$pconfig['dnsbl_allow_int'],
-	$options_dnsbl_interface,
-	TRUE
-))->setAttribute('style', 'width: auto')
-  ->setAttribute('size', $options_dnsbl_interface_cnt)
-  ->setHelp('Interface(s) permitted to reach the DNSBL Webserver by the Permit Firewall Rules above.');
-
-$section->addInput(new Form_Select(
-	'dnsbl_webpage',
-	'Blocked Webpage',
-	$pconfig['dnsbl_webpage'],
-	$options_dnsbl_webpage
-))->sethelp('Default: <strong>dnsbl_default.php</strong><br />Select the DNSBL Blocked Webpage.<br /><br />'
-	. 'Custom block web pages can be added to: <strong>/usr/local/www/pfblockerng/www/</strong> folder.')
-  ->setAttribute('style', 'width: auto')
-  ->setAttribute('size', $options_dnsbl_webpage_cnt);
-$form->add($section);
+// TLD data. Defined before the GUI block so $tld_total is in scope for the
+// TLD Allow help text below -- the reorganisation moved that control above
+// where these arrays used to sit, which made the count unrenderable there.
 
 $tld_list = array();
 
@@ -2997,6 +2582,426 @@ $tld_info['iTLD']	= 'List of Internationalized (IDN) Top-Level-Domains (iTLD)';
 $tld_info['bgTLD']	= 'List of Branded Generic Top-Level-Domains (bgTLD)';
 
 $tld_total = array_sum(array_map('count', $tld_list));
+
+$pgtitle = array(gettext('Firewall'), gettext('pfBlockerNG'), gettext('DNSBL'));
+$pglinks = array('', '/pfblockerng/pfblockerng_dnsbl.php', '@self');
+$shortcut_section = 'pfblockerng';
+include_once('head.inc');
+
+if ($input_errors) {
+	print_input_errors($input_errors);
+}
+
+// Define default Alerts Tab href link (Top row)
+$get_req = pfb_alerts_default_page();
+
+$tab_array	= array();
+$tab_array[]	= array(gettext('General'),	FALSE,	'/pfblockerng/pfblockerng_general.php');
+$tab_array[]	= array(gettext('IP'),		FALSE,	'/pfblockerng/pfblockerng_ip.php');
+$tab_array[]	= array(gettext('DNSBL'),	TRUE,	'/pfblockerng/pfblockerng_dnsbl.php');
+$tab_array[]	= array(gettext('Update'),	FALSE,	'/pfblockerng/pfblockerng_update.php');
+$tab_array[]	= array(gettext('Reports'),	FALSE,	"/pfblockerng/pfblockerng_alerts.php{$get_req}");
+$tab_array[]	= array(gettext('Feeds'),	FALSE,	'/pfblockerng/pfblockerng_feeds.php');
+$tab_array[]	= array(gettext('Logs'),	FALSE,	'/pfblockerng/pfblockerng_log.php');
+$tab_array[]	= array(gettext('Sync'),	FALSE,	'/pfblockerng/pfblockerng_sync.php');
+pfb_software_add_tab($tab_array);
+display_top_tabs($tab_array, TRUE);
+
+$tab_array	= array();
+$tab_array[]	= array(gettext('DNSBL Groups'),	FALSE,		'/pfblockerng/pfblockerng_category.php?type=dnsbl');
+$tab_array[]	= array(gettext('DNSBL Category'),	FALSE,		'/pfblockerng/pfblockerng_blacklist.php');
+$tab_array[]	= array(gettext('DNSBL SafeSearch'),	FALSE,		'/pfblockerng/pfblockerng_safesearch.php');
+display_top_tabs($tab_array, TRUE);
+pfb_print_pending_changes_box();
+
+if (isset($_REQUEST['savemsg'])) {
+	$savemsg = htmlspecialchars($_REQUEST['savemsg']);
+	print_info_box($savemsg);
+}
+
+$form = new Form('Save DNSBL settings');
+
+$section = new Form_Section('DNSBL');
+$section->addInput(new Form_StaticText(
+	'Links',
+	'<small>'
+	. '<a href="/firewall_aliases.php" target="_blank" rel="noopener noreferrer">Firewall Aliases</a>&emsp;'
+	. '<a href="/firewall_rules.php" target="_blank" rel="noopener noreferrer">Firewall Rules</a>&emsp;'
+	. '<a href="/status_logs_filter.php" target="_blank" rel="noopener noreferrer">Firewall Logs</a></small>'
+));
+
+$dnsbl_text = '<div class="infoblock">'
+		. '<div id="dnsbl_eval_order">'
+		. '<strong>DNSBL evaluation order</strong> (first match wins):'
+		. '<ol>'
+		. '<li><strong>Feed lists, exact name</strong> — a listed domain is blocked (logged as DNSBL).</li>'
+		. '<li><strong>Feed lists, wildcard/zone</strong> — Wildcard Blocking classifies registrable domains (logged as TLD).</li>'
+		. '<li><strong>TLD Allow</strong> — when enabled, a name whose suffix is not selected is blocked here (logged as TLD_Allow).</li>'
+		. '<li><strong>IDN Blocking</strong> — Off / Confusable / Always. Confusable can raise a non-blocking alert instead of a block.</li>'
+		. '<li><strong>Regex Blocking</strong> — user regex and ABP feed block-regex.</li>'
+		. '</ol>'
+		. 'Feed exact and wildcard matching (1–2) run only while DNSBL blocking is enabled; TLD Allow, IDN, and Regex (3–5) still run.<br /><br />'
+		. 'If a block is found, a whitelist entry, an ABP allow rule (@@) or an allow-regex can override it. Once an ABP feed loads $important rules, block and allow are resolved by priority rather than allow-always-wins.<br /><br />'
+		. 'If the name is still blocked, the reply is shaped last: HSTS may use null-blocking to avoid browser certificate errors; NXDOMAIN replies (logged or silent) replace a VIP or null answer; a hit via a CNAME chain is tagged _CNAME. Null-blocking is not a property of which stage matched.<br /><br />'
+		. 'CNAME Validation and no-AAAA are separate features, not steps in this order. Feed-at-suffix (PSL) policies, the regex cap, and Download Schemes shape what is loaded, not the per-query order.'
+		. '</div><br /><br />'
+		. '<span class="text-danger">Note: </span>'
+		. 'DNSBL requires the DNS Resolver (Unbound) to be used as the DNS service.<br />'
+		. 'How a blocked name is answered depends on the <strong>Global Logging/Blocking Mode</strong> and on each DNSBL Group\'s own Logging/Blocking setting:<br />'
+		. '&#8226 <strong>DNSBL WebServer/VIP</strong> - the request is redirected to the DNSBL Virtual IP, where a Lighttpd instance records the hit and returns a \'1x1\' GIF. For a root domain the customizable Blocked Webpage is shown instead.<br />'
+		. '&#8226 <strong>Null Blocking</strong> - the name is answered with \'0.0.0.0\'. No Virtual IP, no web server and no block page are involved.<br />'
+		. '&#8226 <strong>NXDOMAIN</strong> - the name is answered NXDOMAIN and the block page is bypassed.<br /><br />'
+		. 'If browsing is slow <strong>in VIP mode</strong>, check for Firewall LAN Rules/Limiters that might be blocking access to the DNSBL VIP.<br /><br />'
+		. '<span class="text-danger">Note: </span>'
+		. 'DNSBL will block and <u>partially</u> log Alerts for HTTPS requests. '
+		. 'To debug issues with \'False Positives\', the following tools below can be used:<br />'
+		. '<ol>'
+		. '<li>Browser Developer tools, Console tab, for error messages.</li>'
+		. '<li>Execute the following from the pfSense Shell, substituting your LAN interface for \'re1\' and the DNSBL Virtual IP listed under <strong>DNSBL Webserver Configuration</strong> above:<br />'
+		. '&emsp;<strong>tcpdump -nnvli re1 port 53 | grep -B1 \'A &lt;VIP&gt;\'</strong></li>'
+		. '<li>Packet capture software such as Wireshark.</li>'
+		. '</ol>'
+		. '</div>';
+
+$section->addInput(new Form_Checkbox(
+	'pfb_dnsbl',
+	gettext('DNSBL'),
+	'Enable DNSBL',
+	pfb_cfg_toggle_read($pconfig['pfb_dnsbl']) === PfbToggle::On,
+	'on'
+))->setHelp('This will enable DNS Block List for Malicious and/or unwanted Adverts Domains<br />'
+		. 'To Utilize, <strong>Unbound DNS Resolver</strong> must be enabled. Also ensure that pfBlockerNG is enabled.'
+		. "{$dnsbl_text}"
+);
+
+$tld_wildcard_text = 'Block listed domains and their subdomains. '
+		. pfb_list_section_help_note(['TLD Exclusion List', 'TLD Blacklist'], TRUE)
+		. '<div id="dnsbl_tld_info" class="infoblock">
+
+		<strong>Definition: Public suffix</strong> -
+		&emsp;a domain suffix under which the public may register names, per the
+		<a href="https://publicsuffix.org/" target="_blank" rel="noopener noreferrer">Public Suffix List</a>. IE: <strong>com</strong>,
+		<strong>co.uk</strong>, <strong>github.io</strong><br /><br />
+
+		<strong>Definition: Registrable domain</strong> -
+		&emsp;a public suffix plus exactly one additional label. IE: example.com (suffix = com), example.co.uk (suffix = co.uk)<br /><br />
+
+		When enabled and after all downloads for DNSBL Feeds have completed; this process will classify the listed Domains.<br />
+		A Domain listed at its <strong>registrable domain</strong> is wildcard blocked (Block all sub-Domains).<br />
+		A Domain that is itself a <strong>public suffix</strong> is <strong>never</strong> wildcard blocked (blocking it would block every registrant under it).<br />
+		A Domain listed <strong>deeper</strong> than its registrable domain stays an exact block (only that specific name).<br />
+		The Public Suffix List authority can be found in &emsp;<u>/usr/local/pkg/pfblockerng/dnsbl_psl</u><br /><br />
+
+		To exclude a suffix/Domain from this process, add it to the <strong>TLD Exclusion</strong> custom list:<br />
+		&#8226&emsp;This only excludes the domain from the process, it doesn\'t whitelist the domain.<br />
+		&#8226&emsp;Only the specific Sub-Domains/Domains listed in the DNSBL Feeds will be blocked.<br />
+		&#8226&emsp;Changes to the TLD Exclusion take effect on the next DNSBL update.<br /><br />
+		<strong>Note:</strong>
+		&emsp;A specific sub-Domain added to the <strong>Custom Domain Whitelist</strong> is exempted from a
+		Wildcard Blocked domain (that exact name resolves).<br />
+		&emsp;&emsp;&emsp;&emsp;To exempt the whole domain (all sub-Domains), add it to the TLD Exclusion, or add a wildcard Whitelist entry for the domain.<br /><br />
+
+		<strong>TLD Blacklist</strong>, can be used to block whole TLDs. &emsp;IE: <strong>xyz</strong><br />
+
+		Enabling or disabling this option takes effect on the next DNSBL update.<br /><br />
+
+	</div>';
+
+$section->addInput(new Form_Checkbox(
+	'tld_wildcard',
+	gettext('Wildcard Blocking'),
+	'Enable',
+	pfb_cfg_toggle_read($pconfig['tld_wildcard']) === PfbToggle::On,
+	'on'
+))->setHelp($tld_wildcard_text);
+
+$section->addInput(new Form_Checkbox(
+	'pfb_py_reply',
+	gettext('DNS Reply Logging'),
+	'Enable',
+	pfb_dnsbl_toggle_enabled($pconfig['pfb_py_reply'] ?? NULL),
+	'on'
+))->setHelp('Enable the logging of all DNS Replies that were not blocked via DNSBL.');
+
+$section->addInput(new Form_Checkbox(
+	'pfb_hsts',
+	gettext('HSTS mode'),
+	'Enable',
+	pfb_dnsbl_toggle_enabled($pconfig['pfb_hsts'] ?? NULL),
+	'on'
+))->setHelp('Answer HSTS-preload domains with 0.0.0.0 instead of the DNSBL VIP, which may avoid browser certificate errors.'
+	. '<div class="infoblock">'
+	. 'Enable the DNSBL <strong title="Utilizes 0.0.0.0 instead of the DNSBL VIP">Null Blocking mode</strong> for HSTS domains.<br />'
+	. 'Blocked domains that are in the <a target=_"blank" href="https://hstspreload.org/">HSTS preload</a> browser'
+	. ' <a target=_"blank" href="https://raw.githubusercontent.com/chromium/chromium/master/net/http/transport_security_state_static.json">list</a>'
+	. ' will use the Null Blocking Mode which *may* prevent Browser Certificate Errors.<br />'
+	. '<span class="text-danger">Note:</span> This option will not block HSTS domains, unless those Domains are added via the Feeds/Customlists.'
+	. '</div>'
+);
+
+$section->addInput(new Form_Select(
+	'pfb_idn',
+	gettext('IDN Blocking'),
+	$pconfig['pfb_idn'],
+	array(
+		'off'		=> 'Off',
+		'confusable'	=> 'Confusable',
+		'on'		=> 'Always',
+	)
+))->setHelp('How IDN / xn-- names are handled (Off, Confusable, or Always). Not regex-based.'
+		. '<div class="infoblock">'
+		. 'IDN handling (not Regex based).<ul>'
+		. '<li><strong>Off</strong> - no IDN action.</li>'
+		. '<li><strong>Confusable</strong> - block only cross-script homoglyphs (Latin/Cyrillic/Greek mixes, '
+		. 'including Cyrillic+Greek).<br />Does not catch whole-script confusables or pure-ASCII typosquats.</li>'
+		. '<li><strong>Always</strong> - block every IDN/\'xn--\' domain (blunt).</li></ul>'
+		. '</div>');
+
+$section->addInput(new Form_Checkbox(
+	'pfb_idn_block_malicious',
+	gettext('Block clearly-malicious homoglyphs'),
+	'Enable',
+	pfb_dnsbl_toggle_enabled($pconfig['pfb_idn_block_malicious'] ?? NULL),
+	'on'
+))->setHelp('Confusable mode: block names that mix confusable scripts in one label (clearly malicious). Disable to alert only. '
+		. 'Applies in Confusable mode.');
+
+$section->addInput(new Form_Checkbox(
+	'pfb_idn_escalate_suspicious',
+	gettext('Block suspicious mixed-script'),
+	'Enable',
+	pfb_dnsbl_toggle_enabled($pconfig['pfb_idn_escalate_suspicious'] ?? NULL),
+	'on'
+))->setHelp('Confusable mode: escalate suspicious mixed-script names to a block. Default alerts only (no block). '
+		. 'Applies in Confusable mode.');
+
+$section->addInput(new Form_Checkbox(
+	'pfb_regex',
+	gettext('Regex Blocking'),
+	'Enable',
+	pfb_cfg_toggle_read($pconfig['pfb_regex']) === PfbToggle::On,
+	'on'
+))->setHelp('Enable the Regex blocking feature. '
+		. pfb_list_section_help_note(['Regex List'], TRUE));
+
+$section->addInput(new Form_Checkbox(
+	'pfb_regex_cap',
+	gettext('Limit long/complex regex'),
+	'Enable',
+	pfb_cfg_toggle_read($pconfig['pfb_regex_cap']) === PfbToggle::On,
+	'on'
+))->setHelp('Best-effort ReDoS safeguard (opt-in): over-long or catastrophic-backtracking regex patterns are dropped at load, before they run. '
+		. 'Applies when Regex Blocking is enabled.'
+		. '<div class="infoblock">From both feeds (ABP) and the Regex List below (each drop is logged). '
+		. 'An always-on runtime guard additionally warns on, then evicts, any pattern whose match runs too slow.</div>');
+
+$section->addInput(new Form_Checkbox(
+	'pfb_cname',
+	gettext('CNAME Validation'),
+	'Enable',
+	pfb_cfg_toggle_read($pconfig['pfb_cname']) === PfbToggle::On,
+	'on'
+))->setHelp('Also check CNAME targets against DNSBL.'
+		. '<div class="infoblock">'
+		. 'Enable the CNAME Validation feature. All CNAMES will be evaluated against DNSBL database and blocked.<br />'
+		. 'Events are logged with a "_CNAME" suffix in the DNSBL Log.'
+		. '</div>');
+
+$section->addInput(new Form_Checkbox(
+	'pfb_noaaaa',
+	gettext('no-AAAA'),
+	'Enable',
+	pfb_cfg_toggle_read($pconfig['pfb_noaaaa']) === PfbToggle::On,
+	'on'
+))->setHelp('Enable the no-AAAA feature. This will block all (IPv6) AAAA DNS requests for the defined domains. '
+		. pfb_list_section_help_note(['no-AAAA List'], TRUE));
+
+$section->addInput(new Form_Checkbox(
+	'pfb_gp',
+	gettext('DNSBL Group Policy'),
+	'Enable',
+	pfb_cfg_toggle_read($pconfig['pfb_gp']) === PfbToggle::On,
+	'on'
+))->setHelp('Enable the Group Policy functionality to allow certain Local LAN IPs to bypass DNSBL. '
+		. pfb_list_section_help_note(['DNSBL Group Policy'], TRUE));
+
+$section->addInput(new Form_Checkbox(
+	'pfb_dnsbl_lenient',
+	gettext('Download Schemes'),
+	'Enable',
+	pfb_cfg_toggle_read($pconfig['pfb_dnsbl_lenient']) === PfbToggle::On,
+	'on'
+))->setHelp('How feed lines are parsed: strip scheme:// and URL paths, or skip those lines.'
+		. '<div class="infoblock">'
+		. 'Parse DNSBL feed lines permissively: any <strong>scheme://</strong> is stripped and URL paths are removed.<br />'
+		. 'When disabled (strict), lines with an invalid scheme (e.g. <strong>123://</strong>) or a URL path are skipped and logged.<br />'
+		. 'New installs default to disabled (strict); upgraded installs keep the permissive behaviour.'
+		. '</div>');
+
+$section->addInput(new Form_Select(
+	'global_log',
+	'Global Logging/Blocking Mode',
+	$pconfig['global_log'],
+	$options_global_log
+))->setHelp($options_global_log_txt)
+  ->setAttribute('style', 'width: auto');
+
+$section->addInput(new Form_Checkbox(
+	'tld_allow',
+	gettext('Allow Only Selected Domain Suffixes'),
+	'Enable',
+	pfb_cfg_toggle_read($pconfig['tld_allow']) === PfbToggle::On,
+	'on'
+))->setHelp('Enable the TLD Allow feature (' . number_format($tld_total) . ' TLDs available). '
+		. 'This will block all TLDs that are not specifically selected. '
+		. pfb_list_section_help_note(['TLD Allow list'], TRUE));
+
+$form->add($section);
+
+$section = new Form_Section('DNSBL Webserver Configuration');
+$section->addInput(new Form_Select(
+	'dnsbl_interface',
+	gettext('Web Server Interface'),
+	$pconfig['dnsbl_interface'],
+	$options_dnsbl_interface_all
+))->setHelp('Select the interface which DNSBL Web Server will Listen on.<br />'
+	. 'Default: <strong>Localhost (ports 80/443)</strong> - Selected Interface should be a Local Interface only.');
+
+$section->addInput(new Form_Checkbox(
+	'pfb_dnsbl_nonat',
+	gettext('Auto NAT'),
+	gettext('Disable automatic NAT rule creation'),
+	(pfb_cfg_toggle_read($pconfig['pfb_dnsbl_nonat']) === PfbToggle::On),
+	'on'
+))->setHelp('When set, pfBlockerNG will not auto-create the DNSBL NAT port-forward rules (non-Localhost interface only); manage them manually.');
+
+// [ ADR-13 ] Compute the address(es) the package WOULD auto-create, for the currently
+// selected DNSBL Web Server interface, so the UI can pre-fill them and detect conflict
+// exhaustion. pfb_pick_free_dnsbl_vip() returns the first free candidate from
+// pfb_dnsbl_vip_candidates() (null when every candidate conflicts). A v6 VIP is only relevant when the
+// DNS Resolver listens on IPv6 (pfb_unbound_listens_v6()); otherwise v6 is not required.
+$pfb_auto_iface		= $pconfig['dnsbl_interface'] ?: 'lo0';
+$pfb_auto_v6_needed	= pfb_unbound_listens_v6();
+$pfb_auto_vip4		= pfb_pick_free_dnsbl_vip(AF_INET, $pfb_auto_iface);
+$pfb_auto_vip6		= $pfb_auto_v6_needed ? pfb_pick_free_dnsbl_vip(AF_INET6, $pfb_auto_iface) : null;
+
+// Conflict exhaustion: v4 is always required; v6 only when the resolver listens on it.
+// When no free candidate exists for a required family the checkbox is rendered disabled
+// with a warning, so auto-create can never be enabled into a known-conflicting state.
+$pfb_auto_exhausted	= ($pfb_auto_vip4 === null) || ($pfb_auto_v6_needed && $pfb_auto_vip6 === null);
+
+$vips = pfb_get_vips();
+
+// [ ADR-13 ] The "Create VIPs automatically" toggle on its OWN row, above the
+// manual VIP selects. Its explanation lives in the group help UNDER the fields,
+// not on the checkbox: a long inline checkbox help renders as a very tall, narrow
+// column that towers over the rest of the section.
+$pfb_auto_chk = new Form_Checkbox(
+	'pfb_dnsvip_auto',
+	gettext('Auto VIP'),
+	gettext('Create VIPs automatically'),
+	(!$pfb_auto_exhausted && pfb_cfg_toggle_read($pconfig['pfb_dnsvip_auto']) === PfbToggle::On),
+	'on'
+);
+if ($pfb_auto_exhausted) {
+	$pfb_auto_chk->setAttribute('disabled', 'disabled');
+}
+$section->addInput($pfb_auto_chk);
+
+$group = new Form_Group('DNSBL Virtual IP');
+$group->add(new Form_Select(
+	'pfb_dnsvip4',
+	gettext('IPv4 VIP'),
+	$pconfig['pfb_dnsvip4'],
+	pfb_get_vip_options(AF_INET)
+))->setWidth(4)->setHelp('IPv4 Virtual IP');
+$group->add(new Form_Select(
+	'pfb_dnsvip6',
+	gettext('IPv6 VIP'),
+	(!empty($pconfig['pfb_dnsvip6']) ? $pconfig['pfb_dnsvip6'] : 'none'),
+	pfb_get_vip_options(AF_INET6)
+))->setWidth(4)->setHelp('IPv6 Virtual IP (optional)');
+
+// Help under the side-by-side VIP fields: the original intro, a line break at the
+// SENTENCE boundary (never mid-sentence), then one concise line covering both
+// modes. "VIP"/"Virtual IP" used consistently (no "IP-Alias VIP" jargon); the
+// address/lifecycle detail belongs in the docs.
+$pfb_vip_help = 'Select the DNSBL VIP address — rejected DNS requests are forwarded here. '
+	. 'It should be in an isolated range not already used on the network.<br />'
+	. 'Enable <strong>Create VIPs automatically</strong> to have pfBlockerNG manage it, or select one '
+	. 'manually — create it first at '
+	. '<a target="_blank" rel="noopener noreferrer" href="/firewall_virtual_ip.php">Firewall &gt; Virtual IPs</a>.';
+if ($pfb_auto_exhausted) {
+	$pfb_vip_help .= '<br /><i class="fa fa-exclamation-triangle text-warning"></i> '
+		. '<span class="text-warning">No free auto-create address is available — free one of the '
+		. 'auto-create candidates, or select a VIP manually.</span>';
+}
+$group->setHelp($pfb_vip_help);
+$section->add($group);
+
+$section->addInput(new Form_Input(
+	'pfb_dnsport',
+	gettext('Port'),
+	'number',
+	$pconfig['pfb_dnsport'],
+	[ 'min' => 1, 'max' => 65535, 'placeholder' => 'Enter DNSBL Listening Port' ]
+))->setHelp('Example ( 8081 ) &mdash; a single PORT in the range 1 - 65535. '
+		. 'Applies when Web Server Interface is not Localhost.'
+		. '<div class="infoblock">This Port must not be in use by any other process.</div>'
+);
+
+$section->addInput(new Form_Input(
+	'pfb_dnsport_ssl',
+	gettext('SSL Port'),
+	'number',
+	$pconfig['pfb_dnsport_ssl'],
+	[ 'min' => 1, 'max' => 65535, 'placeholder' => 'Enter DNSBL SSL Listening Port' ]
+))->setHelp('Example ( 8443 ) &mdash; a single PORT in the range 1 - 65535. '
+		. 'Applies when Web Server Interface is not Localhost.'
+		. '<div class="infoblock">This Port must not be in use by any other process.</div>'
+);
+
+// Add option to disable DNSBL logging and utilize the DNSBL Webserver (excluding nullblocking events)
+$section->addInput(new Form_Checkbox(
+	'pfb_py_nolog',
+	gettext('DNSBL Event Logging'),
+	'Enable',
+	pfb_cfg_toggle_read($pconfig['pfb_py_nolog']) === PfbToggle::On,
+	'on'
+))->setHelp('Disable event logging in the DNS Resolver and utilize the DNSBL Webserver. Typically used when an upstream LAN DNS server is utilized.<br />'
+	. 'Null blocked events will still be logged.');
+
+
+$section->addInput(new Form_Checkbox(
+	'pfb_dnsbl_rule',
+	gettext('Permit Firewall Rules'),
+	gettext('Enable'),
+	pfb_cfg_toggle_read($pconfig['pfb_dnsbl_rule']) === PfbToggle::On,
+	'on'
+))->setHelp('Creates \'Floating\' Firewall permit rules allowing the selected interface(s) to reach the DNSBL Webserver (ICMP and Webserver ports only).'
+		. '<div class="infoblock">This option is not designed to bypass DNSBL for the non-selected LAN segments. '
+		. 'Only required for networks with multiple LAN Segments.</div>');
+
+$section->addInput(new Form_Select(
+	'dnsbl_allow_int',
+	gettext('Interface(s)'),
+	$pconfig['dnsbl_allow_int'],
+	$options_dnsbl_interface,
+	TRUE
+))->setAttribute('style', 'width: auto')
+  ->setAttribute('size', $options_dnsbl_interface_cnt)
+  ->setHelp('Interface(s) permitted to reach the DNSBL Webserver by the Permit Firewall Rules above.');
+
+$section->addInput(new Form_Select(
+	'dnsbl_webpage',
+	'Blocked Webpage',
+	$pconfig['dnsbl_webpage'],
+	$options_dnsbl_webpage
+))->sethelp('Default: <strong>dnsbl_default.php</strong><br />Select the DNSBL Blocked Webpage.<br /><br />'
+	. 'Custom block web pages can be added to: <strong>/usr/local/www/pfblockerng/www/</strong> folder.')
+  ->setAttribute('style', 'width: auto')
+  ->setAttribute('size', $options_dnsbl_webpage_cnt);
+$form->add($section);
 
 $section = new Form_Section('AdBlock suffix handling', 'dnsbl_suffix', COLLAPSIBLE|SEC_CLOSED);
 

--- a/tests/php/DnsblTldAllowCountTest.php
+++ b/tests/php/DnsblTldAllowCountTest.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The TLD Allow count renders because its data is in scope where the control is built.
+ *
+ * The DNSBL tab reorganisation moved the TLD Allow checkbox above the four $tld_list
+ * arrays, so number_format($tld_total) there read an undefined variable: the count
+ * collapsed to 0 and every page load logged a warning. The live-VM guard that catches
+ * the rendered value (test_dnsbl_page_renders_tld_pickers) only runs in the UI fan-out;
+ * this pins the ordering invariant behind it on every PHPUnit run.
+ */
+final class DnsblTldAllowCountTest extends TestCase
+{
+	private const PAGE = __DIR__ . '/../../src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php';
+
+	private const TYPES = ['gTLD', 'ccTLD', 'iTLD', 'bgTLD'];
+
+	private const DATA_START = '$tld_list = array();';
+
+	private const TOTAL = '$tld_total = array_sum(array_map(\'count\', $tld_list));';
+
+	private const HELP = "setHelp('Enable the TLD Allow feature (' . number_format(\$tld_total) . ' TLDs available). '";
+
+	private static function source(): string
+	{
+		$source = file_get_contents(self::PAGE);
+		self::assertIsString($source, 'the DNSBL page must be readable');
+		return $source;
+	}
+
+	/**
+	 * Scenario: the control's help text renders a figure derived from the TLD arrays.
+	 * Expected: those arrays are defined earlier in the file than the control that reads
+	 * them -- the single property whose loss produced "(0 TLDs available)".
+	 */
+	public function testTldDataIsDefinedBeforeTheControlThatRendersTheCount(): void
+	{
+		$source = self::source();
+		$data = strpos($source, self::DATA_START);
+		$total = strpos($source, self::TOTAL);
+		$help = strpos($source, self::HELP);
+
+		$this->assertNotFalse($data, 'the TLD data block must exist: ' . self::DATA_START);
+		$this->assertNotFalse($total, 'the derived total must exist: ' . self::TOTAL);
+		$this->assertNotFalse($help, 'the TLD Allow help must render the derived count');
+		$this->assertLessThan($help, $total,
+			"\$tld_total is assigned at offset {$total} but read at offset {$help}: the control is "
+			. 'built before its own data, so the count renders as 0 and the load warns');
+		$this->assertLessThan($total, $data, 'the arrays must precede the total derived from them');
+	}
+
+	/** The figure is derived from the arrays, never restated as a literal. */
+	public function testTldAllowCountIsDerivedAndNotHardcoded(): void
+	{
+		$source = self::source();
+
+		$this->assertStringContainsString(self::HELP, $source,
+			'the help text must render number_format($tld_total), not a literal count');
+		$this->assertStringNotContainsString('1,546 TLDs available', $source,
+			'the retired hardcoded total must not come back');
+	}
+
+	/**
+	 * Behaviour-preserving oracle for the move: the relocated block still computes the
+	 * same aggregate the four per-list "Total TLD Count: [N]" figures add up to.
+	 */
+	public function testTldTotalIsTheSumOfTheFourListsAndPlausible(): void
+	{
+		$data = $this->evaluateTldDataBlock();
+
+		$this->assertSame(self::TYPES, array_keys($data['list']),
+			'the four TLD lists must be present, in their rendered order');
+		$this->assertSame(self::TYPES, array_keys($data['info']),
+			'every list must carry the description its picker renders beside the count');
+
+		$per_list = array_map('count', $data['list']);
+		$this->assertSame(array_sum($per_list), $data['total'],
+			'the aggregate must equal the sum of the four per-list counts, which the page renders '
+			. 'separately: ' . var_export($per_list, TRUE));
+		$this->assertGreaterThanOrEqual(1000, $data['total'],
+			"a total of {$data['total']} is implausibly low -- an array was blanked or narrowed");
+		foreach ($per_list as $type => $count) {
+			$this->assertGreaterThan(0, $count, "the {$type} list must not be empty");
+		}
+	}
+
+	/**
+	 * The block sits outside form construction, so it must not reach for form state --
+	 * the property that made relocating it safe, and that a later edit could quietly lose.
+	 */
+	public function testTldDataBlockCarriesNoFormState(): void
+	{
+		$source = self::source();
+		$start = strpos($source, self::DATA_START);
+		$end = strpos($source, self::TOTAL);
+		$this->assertNotFalse($start);
+		$this->assertNotFalse($end);
+		$block = substr($source, $start, $end - $start);
+
+		foreach (['$pconfig', '$section', '$form', '$group'] as $symbol) {
+			$this->assertStringNotContainsString($symbol, $block,
+				"the TLD data block must stay pure data; it now references {$symbol}");
+		}
+	}
+
+	/** @return array{list: array<string, array<string, string>>, info: array<string, string>, total: int} */
+	private function evaluateTldDataBlock(): array
+	{
+		$source = self::source();
+		$start = strpos($source, self::DATA_START);
+		$end = strpos($source, self::TOTAL);
+		$this->assertNotFalse($start, 'the TLD data block must exist');
+		$this->assertNotFalse($end, 'the derived total must exist');
+		$block = substr($source, $start, ($end - $start) + strlen(self::TOTAL));
+
+		$path = tempnam(sys_get_temp_dir(), 'pfb_tld_');
+		$this->assertNotFalse($path);
+		try {
+			file_put_contents($path,
+				"<?php\n" . $block . "\nreturn ['list' => \$tld_list, 'info' => \$tld_info, 'total' => \$tld_total];\n");
+			$data = (static fn (string $file): mixed => include $file)($path);
+		} finally {
+			@unlink($path);
+		}
+		$this->assertIsArray($data, 'the TLD data block must evaluate to its three bindings alone');
+		return $data;
+	}
+}

--- a/tests/php/DnsblTldAllowCountTest.php
+++ b/tests/php/DnsblTldAllowCountTest.php
@@ -21,7 +21,8 @@ final class DnsblTldAllowCountTest extends TestCase
 
 	private const DATA_START = '$tld_list = array();';
 
-	private const TOTAL = '$tld_total = array_sum(array_map(\'count\', $tld_list));';
+	/** The derivation, as a pattern: a reformat of that line is not a defect. */
+	private const TOTAL = '/\$tld_total\s*=\s*array_sum\(\s*array_map\(\s*\'count\'\s*,\s*\$tld_list\s*\)\s*\)\s*;/';
 
 	private const HELP = "setHelp('Enable the TLD Allow feature (' . number_format(\$tld_total) . ' TLDs available). '";
 
@@ -41,11 +42,10 @@ final class DnsblTldAllowCountTest extends TestCase
 	{
 		$source = self::source();
 		$data = strpos($source, self::DATA_START);
-		$total = strpos($source, self::TOTAL);
+		$total = $this->derivationOffset($source);
 		$help = strpos($source, self::HELP);
 
 		$this->assertNotFalse($data, 'the TLD data block must exist: ' . self::DATA_START);
-		$this->assertNotFalse($total, 'the derived total must exist: ' . self::TOTAL);
 		$this->assertNotFalse($help,
 			'the TLD Allow help must render number_format($tld_total), not a literal count');
 		$this->assertLessThan($help, $total,
@@ -58,60 +58,78 @@ final class DnsblTldAllowCountTest extends TestCase
 
 	/**
 	 * Behaviour-preserving oracle for the move: the relocated block still defines the four
-	 * lists the pickers render, and the total is still derived from them.
+	 * lists the pickers render, with unique keys, and the total is still derived from them.
 	 *
 	 * Counted by tokenising, never by evaluating. Executing a slice of a page to measure it
 	 * put arbitrary code one edit away from running in this suite, and no allowlist of
-	 * tokens closes that -- `array_map` takes its callback as a string.
+	 * tokens closes that -- array_map takes its callback as a string.
 	 */
 	public function testTldTotalIsTheSumOfTheFourListsAndPlausible(): void
 	{
-		$lists = $this->entryCounts('$tld_list');
-		$info = $this->entryCounts('$tld_info');
+		$lists = $this->entryKeys('$tld_list');
+		$info = $this->entryKeys('$tld_info');
 
 		$this->assertSame(self::TYPES, array_keys($lists),
 			'the four TLD lists must be present, in their rendered order');
 		$this->assertSame(self::TYPES, array_keys($info),
 			'every list must carry the description its picker renders beside the count');
 
-		foreach ($lists as $type => $count) {
-			$this->assertGreaterThan(0, $count, "the {$type} list must not be empty");
+		$counts = [];
+		foreach ($lists as $type => $keys) {
+			$this->assertNotSame([], $keys, "the {$type} list must not be empty");
+			$duplicates = array_keys(array_filter(array_count_values($keys),
+				static fn (int $seen): bool => $seen > 1));
+			$this->assertSame([], $duplicates,
+				"the {$type} list must not repeat a TLD -- PHP keeps the last of a duplicate pair, so "
+				. 'the rendered count would silently drop one: ' . implode(', ', $duplicates));
+			$counts[$type] = count($keys);
 		}
-		$total = array_sum($lists);
+
+		$total = array_sum($counts);
 		$this->assertGreaterThanOrEqual(1000, $total,
 			"a total of {$total} is implausibly low -- an array was blanked or narrowed: "
-			. var_export($lists, TRUE));
+			. var_export($counts, TRUE));
 
 		// The page derives the aggregate with exactly this expression, so it IS the sum of
 		// these counts by construction; the ordering test pins that the expression is there.
-		$this->assertStringContainsString(self::TOTAL, self::source(),
+		$this->assertNotFalse($this->derivationOffset(self::source()),
 			'the total must stay derived from $tld_list, never restated');
 	}
 
+	/** Byte offset of the $tld_total derivation, or FALSE when it is absent. */
+	private function derivationOffset(string $source): int|false
+	{
+		return preg_match(self::TOTAL, $source, $match, PREG_OFFSET_CAPTURE) === 1
+			? $match[0][1] : FALSE;
+	}
+
 	/**
-	 * Entries per sub-array of $name in the TLD data block, keyed by sub-array name.
+	 * Entry keys per sub-array of $name in the TLD data block, keyed by sub-array name.
 	 *
-	 * @return array<string, int>
+	 * Keys rather than a tally: a repeated key is one entry at runtime but two arrows in
+	 * the source, so counting arrows would report a list larger than the page renders.
+	 *
+	 * @return array<string, list<string>>
 	 */
-	private function entryCounts(string $name): array
+	private function entryKeys(string $name): array
 	{
 		$tokens = token_get_all('<?php ' . $this->tldDataBlock());
-		$counts = [];
+		$keys = [];
 		$current = NULL;
 		$depth = 0;
 		foreach ($tokens as $index => $token) {
 			if (is_array($token) && $token[0] === T_VARIABLE && $token[1] === $name) {
-				$key = NULL;
+				$subscript = NULL;
 				for ($ahead = $index + 1; $ahead < $index + 6; $ahead++) {
 					$next = $tokens[$ahead] ?? NULL;
 					if (is_array($next) && $next[0] === T_CONSTANT_ENCAPSED_STRING) {
-						$key = trim($next[1], "'\"");
+						$subscript = trim($next[1], "'\"");
 						break;
 					}
 				}
-				if ($key !== NULL) {
-					$current = $key;
-					$counts[$key] = 0;
+				if ($subscript !== NULL) {
+					$current = $subscript;
+					$keys[$subscript] = [];
 					$depth = 0;
 				}
 			}
@@ -124,20 +142,36 @@ final class DnsblTldAllowCountTest extends TestCase
 				if (--$depth <= 0) {
 					$current = NULL;
 				}
-			} elseif (is_array($token) && $token[0] === T_DOUBLE_ARROW && $depth === 1) {
-				$counts[$current]++;
+			} elseif ($depth === 1 && is_array($token) && $token[0] === T_CONSTANT_ENCAPSED_STRING
+				&& $this->arrowFollows($tokens, $index)) {
+				$keys[$current][] = trim($token[1], "'\"");
 			}
 		}
-		return $counts;
+		return $keys;
+	}
+
+	/** @param array<int, array{0: int, 1: string}|string> $tokens */
+	private function arrowFollows(array $tokens, int $index): bool
+	{
+		for ($ahead = $index + 1; $ahead < $index + 4; $ahead++) {
+			$next = $tokens[$ahead] ?? NULL;
+			if (is_array($next) && $next[0] === T_DOUBLE_ARROW) {
+				return TRUE;
+			}
+			if (!is_array($next) || $next[0] !== T_WHITESPACE) {
+				return FALSE;
+			}
+		}
+		return FALSE;
 	}
 
 	private function tldDataBlock(): string
 	{
 		$source = self::source();
 		$start = strpos($source, self::DATA_START);
-		$end = strpos($source, self::TOTAL);
+		$end = $this->derivationOffset($source);
 		$this->assertNotFalse($start, 'the TLD data block must exist');
 		$this->assertNotFalse($end, 'the derived total must exist');
-		return substr($source, $start, ($end - $start) + strlen(self::TOTAL));
+		return substr($source, $start, $end - $start);
 	}
 }

--- a/tests/php/DnsblTldAllowCountTest.php
+++ b/tests/php/DnsblTldAllowCountTest.php
@@ -57,76 +57,78 @@ final class DnsblTldAllowCountTest extends TestCase
 	}
 
 	/**
-	 * Behaviour-preserving oracle for the move: the relocated block still computes the
-	 * same aggregate the four per-list "Total TLD Count: [N]" figures add up to.
+	 * Behaviour-preserving oracle for the move: the relocated block still defines the four
+	 * lists the pickers render, and the total is still derived from them.
+	 *
+	 * Counted by tokenising, never by evaluating. Executing a slice of a page to measure it
+	 * put arbitrary code one edit away from running in this suite, and no allowlist of
+	 * tokens closes that -- `array_map` takes its callback as a string.
 	 */
 	public function testTldTotalIsTheSumOfTheFourListsAndPlausible(): void
 	{
-		$data = $this->evaluateTldDataBlock();
+		$lists = $this->entryCounts('$tld_list');
+		$info = $this->entryCounts('$tld_info');
 
-		$this->assertSame(self::TYPES, array_keys($data['list']),
+		$this->assertSame(self::TYPES, array_keys($lists),
 			'the four TLD lists must be present, in their rendered order');
-		$this->assertSame(self::TYPES, array_keys($data['info']),
+		$this->assertSame(self::TYPES, array_keys($info),
 			'every list must carry the description its picker renders beside the count');
 
-		$per_list = array_map('count', $data['list']);
-		$this->assertSame(array_sum($per_list), $data['total'],
-			'the aggregate must equal the sum of the four per-list counts, which the page renders '
-			. 'separately: ' . var_export($per_list, TRUE));
-		$this->assertGreaterThanOrEqual(1000, $data['total'],
-			"a total of {$data['total']} is implausibly low -- an array was blanked or narrowed");
-		foreach ($per_list as $type => $count) {
+		foreach ($lists as $type => $count) {
 			$this->assertGreaterThan(0, $count, "the {$type} list must not be empty");
 		}
+		$total = array_sum($lists);
+		$this->assertGreaterThanOrEqual(1000, $total,
+			"a total of {$total} is implausibly low -- an array was blanked or narrowed: "
+			. var_export($lists, TRUE));
+
+		// The page derives the aggregate with exactly this expression, so it IS the sum of
+		// these counts by construction; the ordering test pins that the expression is there.
+		$this->assertStringContainsString(self::TOTAL, self::source(),
+			'the total must stay derived from $tld_list, never restated');
 	}
 
 	/**
-	 * The oracle below evaluates the block, so the block must stay inert data. Allowlist
-	 * rather than blocklist: a backtick shell-exec produces neither a variable binding nor
-	 * a name-followed-by-paren, so anything screening for known-bad constructs misses it.
+	 * Entries per sub-array of $name in the TLD data block, keyed by sub-array name.
+	 *
+	 * @return array<string, int>
 	 */
-	public function testTldDataBlockIsInertEnoughToEvaluate(): void
+	private function entryCounts(string $name): array
 	{
-		$this->assertTldDataBlockIsInert();
-	}
-
-	/** @return list<string> the disallowed tokens found, empty when the block is inert */
-	private function foreignTokens(string $block): array
-	{
-		// Every token the four literal arrays plus the array_sum(array_map(...)) need.
-		$types = ['T_OPEN_TAG', 'T_VARIABLE', 'T_WHITESPACE', 'T_ARRAY',
-			'T_CONSTANT_ENCAPSED_STRING', 'T_DOUBLE_ARROW', 'T_STRING'];
-		$chars = ['=', '(', ')', ';', '[', ']', ','];
-		$names = ['$tld_list', '$tld_info', '$tld_total'];
-		$callees = ['array', 'array_sum', 'array_map'];
-
-		$foreign = [];
-		foreach (token_get_all('<?php ' . $block) as $token) {
-			if (!is_array($token)) {
-				if (!in_array($token, $chars, TRUE)) {
-					$foreign[] = $token;
+		$tokens = token_get_all('<?php ' . $this->tldDataBlock());
+		$counts = [];
+		$current = NULL;
+		$depth = 0;
+		foreach ($tokens as $index => $token) {
+			if (is_array($token) && $token[0] === T_VARIABLE && $token[1] === $name) {
+				$key = NULL;
+				for ($ahead = $index + 1; $ahead < $index + 6; $ahead++) {
+					$next = $tokens[$ahead] ?? NULL;
+					if (is_array($next) && $next[0] === T_CONSTANT_ENCAPSED_STRING) {
+						$key = trim($next[1], "'\"");
+						break;
+					}
 				}
+				if ($key !== NULL) {
+					$current = $key;
+					$counts[$key] = 0;
+					$depth = 0;
+				}
+			}
+			if ($current === NULL) {
 				continue;
 			}
-			$name = token_name($token[0]);
-			if (!in_array($name, $types, TRUE)) {
-				$foreign[] = $name . ' ' . trim($token[1]);
-			} elseif ($name === 'T_VARIABLE' && !in_array($token[1], $names, TRUE)) {
-				$foreign[] = $token[1];
-			} elseif ($name === 'T_STRING' && !in_array($token[1], $callees, TRUE)) {
-				$foreign[] = $token[1] . '()';
+			if ($token === '(') {
+				$depth++;
+			} elseif ($token === ')') {
+				if (--$depth <= 0) {
+					$current = NULL;
+				}
+			} elseif (is_array($token) && $token[0] === T_DOUBLE_ARROW && $depth === 1) {
+				$counts[$current]++;
 			}
 		}
-		return array_values(array_unique($foreign));
-	}
-
-	private function assertTldDataBlockIsInert(): void
-	{
-		$foreign = $this->foreignTokens($this->tldDataBlock());
-
-		$this->assertSame([], $foreign,
-			'the TLD data block is evaluated by this suite, so it must stay literal arrays plus '
-			. 'the count it derives; it now carries: ' . implode(', ', $foreign));
+		return $counts;
 	}
 
 	private function tldDataBlock(): string
@@ -137,15 +139,5 @@ final class DnsblTldAllowCountTest extends TestCase
 		$this->assertNotFalse($start, 'the TLD data block must exist');
 		$this->assertNotFalse($end, 'the derived total must exist');
 		return substr($source, $start, ($end - $start) + strlen(self::TOTAL));
-	}
-
-	/** @return array{list: array<string, array<string, string>>, info: array<string, string>, total: int} */
-	private function evaluateTldDataBlock(): array
-	{
-		$this->assertTldDataBlockIsInert();
-		$data = eval($this->tldDataBlock()
-			. ' return [\'list\' => $tld_list, \'info\' => $tld_info, \'total\' => $tld_total];');
-		$this->assertIsArray($data, 'the TLD data block must evaluate to its three bindings alone');
-		return $data;
 	}
 }

--- a/tests/php/DnsblTldAllowCountTest.php
+++ b/tests/php/DnsblTldAllowCountTest.php
@@ -81,37 +81,52 @@ final class DnsblTldAllowCountTest extends TestCase
 	}
 
 	/**
-	 * The oracle above evaluates the block, so the block must stay inert data: it may bind
-	 * only its own three names and call only the array builders. Anything else would run
-	 * inside PHPUnit, in a scope where the page's own state does not exist.
+	 * The oracle below evaluates the block, so the block must stay inert data. Allowlist
+	 * rather than blocklist: a backtick shell-exec produces neither a variable binding nor
+	 * a name-followed-by-paren, so anything screening for known-bad constructs misses it.
 	 */
 	public function testTldDataBlockIsInertEnoughToEvaluate(): void
 	{
-		// Tokenised, not grepped: the TLD descriptions themselves contain parentheses
-		// ('List of Generic Top-Level-Domains (gTLD)'), which a regex reads as calls.
-		$tokens = token_get_all('<?php ' . $this->tldDataBlock());
-		$calls = [];
-		$names = [];
-		foreach ($tokens as $index => $token) {
+		$this->assertTldDataBlockIsInert();
+	}
+
+	/** @return list<string> the disallowed tokens found, empty when the block is inert */
+	private function foreignTokens(string $block): array
+	{
+		// Every token the four literal arrays plus the array_sum(array_map(...)) need.
+		$types = ['T_OPEN_TAG', 'T_VARIABLE', 'T_WHITESPACE', 'T_ARRAY',
+			'T_CONSTANT_ENCAPSED_STRING', 'T_DOUBLE_ARROW', 'T_STRING'];
+		$chars = ['=', '(', ')', ';', '[', ']', ','];
+		$names = ['$tld_list', '$tld_info', '$tld_total'];
+		$callees = ['array', 'array_sum', 'array_map'];
+
+		$foreign = [];
+		foreach (token_get_all('<?php ' . $block) as $token) {
 			if (!is_array($token)) {
+				if (!in_array($token, $chars, TRUE)) {
+					$foreign[] = $token;
+				}
 				continue;
 			}
-			if ($token[0] === T_VARIABLE
-				&& !in_array($token[1], ['$tld_list', '$tld_info', '$tld_total'], TRUE)) {
-				$names[$token[1]] = TRUE;
-			}
-			if (($tokens[$index + 1] ?? NULL) === '('
-				&& !in_array($token[1], ['array', 'array_sum', 'array_map'], TRUE)) {
-				$calls[$token[1]] = TRUE;
+			$name = token_name($token[0]);
+			if (!in_array($name, $types, TRUE)) {
+				$foreign[] = $name . ' ' . trim($token[1]);
+			} elseif ($name === 'T_VARIABLE' && !in_array($token[1], $names, TRUE)) {
+				$foreign[] = $token[1];
+			} elseif ($name === 'T_STRING' && !in_array($token[1], $callees, TRUE)) {
+				$foreign[] = $token[1] . '()';
 			}
 		}
+		return array_values(array_unique($foreign));
+	}
 
-		$this->assertSame([], array_keys($names),
-			'the TLD data block must bind only its own three names; it now reaches for: '
-			. implode(', ', array_keys($names)));
-		$this->assertSame([], array_keys($calls),
-			'the TLD data block must stay literal arrays plus the count it derives; evaluating it '
-			. 'would otherwise execute: ' . implode(', ', array_keys($calls)));
+	private function assertTldDataBlockIsInert(): void
+	{
+		$foreign = $this->foreignTokens($this->tldDataBlock());
+
+		$this->assertSame([], $foreign,
+			'the TLD data block is evaluated by this suite, so it must stay literal arrays plus '
+			. 'the count it derives; it now carries: ' . implode(', ', $foreign));
 	}
 
 	private function tldDataBlock(): string
@@ -127,6 +142,7 @@ final class DnsblTldAllowCountTest extends TestCase
 	/** @return array{list: array<string, array<string, string>>, info: array<string, string>, total: int} */
 	private function evaluateTldDataBlock(): array
 	{
+		$this->assertTldDataBlockIsInert();
 		$data = eval($this->tldDataBlock()
 			. ' return [\'list\' => $tld_list, \'info\' => $tld_info, \'total\' => $tld_total];');
 		$this->assertIsArray($data, 'the TLD data block must evaluate to its three bindings alone');

--- a/tests/php/DnsblTldAllowCountTest.php
+++ b/tests/php/DnsblTldAllowCountTest.php
@@ -8,10 +8,10 @@ use PHPUnit\Framework\TestCase;
  * The TLD Allow count renders because its data is in scope where the control is built.
  *
  * The DNSBL tab reorganisation moved the TLD Allow checkbox above the four $tld_list
- * arrays, so number_format($tld_total) there read an undefined variable: the count
- * collapsed to 0 and every page load logged a warning. The live-VM guard that catches
- * the rendered value (test_dnsbl_page_renders_tld_pickers) only runs in the UI fan-out;
- * this pins the ordering invariant behind it on every PHPUnit run.
+ * arrays and dropped the "(N TLDs available)" figure, because $tld_total was no longer
+ * in scope to render it there. The live-VM guard that catches the rendered value
+ * (test_dnsbl_page_renders_tld_pickers) only runs in the UI fan-out; this pins the
+ * ordering invariant behind it on every PHPUnit run.
  */
 final class DnsblTldAllowCountTest extends TestCase
 {
@@ -35,7 +35,7 @@ final class DnsblTldAllowCountTest extends TestCase
 	/**
 	 * Scenario: the control's help text renders a figure derived from the TLD arrays.
 	 * Expected: those arrays are defined earlier in the file than the control that reads
-	 * them -- the single property whose loss produced "(0 TLDs available)".
+	 * them, and the figure is derived rather than restated as a literal.
 	 */
 	public function testTldDataIsDefinedBeforeTheControlThatRendersTheCount(): void
 	{
@@ -46,20 +46,12 @@ final class DnsblTldAllowCountTest extends TestCase
 
 		$this->assertNotFalse($data, 'the TLD data block must exist: ' . self::DATA_START);
 		$this->assertNotFalse($total, 'the derived total must exist: ' . self::TOTAL);
-		$this->assertNotFalse($help, 'the TLD Allow help must render the derived count');
+		$this->assertNotFalse($help,
+			'the TLD Allow help must render number_format($tld_total), not a literal count');
 		$this->assertLessThan($help, $total,
 			"\$tld_total is assigned at offset {$total} but read at offset {$help}: the control is "
-			. 'built before its own data, so the count renders as 0 and the load warns');
+			. 'built before its own data, so the count cannot render there');
 		$this->assertLessThan($total, $data, 'the arrays must precede the total derived from them');
-	}
-
-	/** The figure is derived from the arrays, never restated as a literal. */
-	public function testTldAllowCountIsDerivedAndNotHardcoded(): void
-	{
-		$source = self::source();
-
-		$this->assertStringContainsString(self::HELP, $source,
-			'the help text must render number_format($tld_total), not a literal count');
 		$this->assertStringNotContainsString('1,546 TLDs available', $source,
 			'the retired hardcoded total must not come back');
 	}
@@ -89,43 +81,54 @@ final class DnsblTldAllowCountTest extends TestCase
 	}
 
 	/**
-	 * The block sits outside form construction, so it must not reach for form state --
-	 * the property that made relocating it safe, and that a later edit could quietly lose.
+	 * The oracle above evaluates the block, so the block must stay inert data: it may bind
+	 * only its own three names and call only the array builders. Anything else would run
+	 * inside PHPUnit, in a scope where the page's own state does not exist.
 	 */
-	public function testTldDataBlockCarriesNoFormState(): void
+	public function testTldDataBlockIsInertEnoughToEvaluate(): void
 	{
-		$source = self::source();
-		$start = strpos($source, self::DATA_START);
-		$end = strpos($source, self::TOTAL);
-		$this->assertNotFalse($start);
-		$this->assertNotFalse($end);
-		$block = substr($source, $start, $end - $start);
-
-		foreach (['$pconfig', '$section', '$form', '$group'] as $symbol) {
-			$this->assertStringNotContainsString($symbol, $block,
-				"the TLD data block must stay pure data; it now references {$symbol}");
+		// Tokenised, not grepped: the TLD descriptions themselves contain parentheses
+		// ('List of Generic Top-Level-Domains (gTLD)'), which a regex reads as calls.
+		$tokens = token_get_all('<?php ' . $this->tldDataBlock());
+		$calls = [];
+		$names = [];
+		foreach ($tokens as $index => $token) {
+			if (!is_array($token)) {
+				continue;
+			}
+			if ($token[0] === T_VARIABLE
+				&& !in_array($token[1], ['$tld_list', '$tld_info', '$tld_total'], TRUE)) {
+				$names[$token[1]] = TRUE;
+			}
+			if (($tokens[$index + 1] ?? NULL) === '('
+				&& !in_array($token[1], ['array', 'array_sum', 'array_map'], TRUE)) {
+				$calls[$token[1]] = TRUE;
+			}
 		}
+
+		$this->assertSame([], array_keys($names),
+			'the TLD data block must bind only its own three names; it now reaches for: '
+			. implode(', ', array_keys($names)));
+		$this->assertSame([], array_keys($calls),
+			'the TLD data block must stay literal arrays plus the count it derives; evaluating it '
+			. 'would otherwise execute: ' . implode(', ', array_keys($calls)));
 	}
 
-	/** @return array{list: array<string, array<string, string>>, info: array<string, string>, total: int} */
-	private function evaluateTldDataBlock(): array
+	private function tldDataBlock(): string
 	{
 		$source = self::source();
 		$start = strpos($source, self::DATA_START);
 		$end = strpos($source, self::TOTAL);
 		$this->assertNotFalse($start, 'the TLD data block must exist');
 		$this->assertNotFalse($end, 'the derived total must exist');
-		$block = substr($source, $start, ($end - $start) + strlen(self::TOTAL));
+		return substr($source, $start, ($end - $start) + strlen(self::TOTAL));
+	}
 
-		$path = tempnam(sys_get_temp_dir(), 'pfb_tld_');
-		$this->assertNotFalse($path);
-		try {
-			file_put_contents($path,
-				"<?php\n" . $block . "\nreturn ['list' => \$tld_list, 'info' => \$tld_info, 'total' => \$tld_total];\n");
-			$data = (static fn (string $file): mixed => include $file)($path);
-		} finally {
-			@unlink($path);
-		}
+	/** @return array{list: array<string, array<string, string>>, info: array<string, string>, total: int} */
+	private function evaluateTldDataBlock(): array
+	{
+		$data = eval($this->tldDataBlock()
+			. ' return [\'list\' => $tld_list, \'info\' => $tld_info, \'total\' => $tld_total];');
 		$this->assertIsArray($data, 'the TLD data block must evaluate to its three bindings alone');
 		return $data;
 	}

--- a/tests/smoke/ui/test_render_smoke.py
+++ b/tests/smoke/ui/test_render_smoke.py
@@ -1666,10 +1666,8 @@ def test_dnsbl_page_renders_tld_pickers(webui: WebUI, php_error_log_guard: PhpEr
     tld_count = int(count_match.group(1).replace(",", ""))
     assert tld_count >= 1000, f"TLD-Allow count {tld_count} is implausibly low (arrays blanked?)"
     assert count_match.group(1) != "1,546", "TLD-Allow count is still the stale hardcoded 1,546"
-    # The aggregate and the four per-list figures derive from the same $tld_list, so they
-    # must agree on the rendered page. A count that is plausible but no longer the sum means
-    # the aggregate was computed from different data than the pickers -- the failure mode a
-    # ">= 1000" floor cannot see.
+    # Aggregate and per-list figures derive from the same $tld_list, so they must agree on
+    # the rendered page -- a divergence the ">= 1000" floor cannot see.
     per_list = [int(n) for n in re.findall(r"Total TLD Count: \[(\d+)\]", body)]
     assert len(per_list) == len(_TLD_STABLE_OPTIONS), (
         f"expected {len(_TLD_STABLE_OPTIONS)} per-list TLD counts, found {len(per_list)}: {per_list}"

--- a/tests/smoke/ui/test_render_smoke.py
+++ b/tests/smoke/ui/test_render_smoke.py
@@ -1666,6 +1666,17 @@ def test_dnsbl_page_renders_tld_pickers(webui: WebUI, php_error_log_guard: PhpEr
     tld_count = int(count_match.group(1).replace(",", ""))
     assert tld_count >= 1000, f"TLD-Allow count {tld_count} is implausibly low (arrays blanked?)"
     assert count_match.group(1) != "1,546", "TLD-Allow count is still the stale hardcoded 1,546"
+    # The aggregate and the four per-list figures derive from the same $tld_list, so they
+    # must agree on the rendered page. A count that is plausible but no longer the sum means
+    # the aggregate was computed from different data than the pickers -- the failure mode a
+    # ">= 1000" floor cannot see.
+    per_list = [int(n) for n in re.findall(r"Total TLD Count: \[(\d+)\]", body)]
+    assert len(per_list) == len(_TLD_STABLE_OPTIONS), (
+        f"expected {len(_TLD_STABLE_OPTIONS)} per-list TLD counts, found {len(per_list)}: {per_list}"
+    )
+    assert sum(per_list) == tld_count, (
+        f"TLD-Allow aggregate {tld_count} != sum of the rendered per-list counts {per_list} = {sum(per_list)}"
+    )
 
 
 # The DNSBL master-enable toggle -- gates the 'dnsbl'/'upstream'/'reply' rows of the alerts


### PR DESCRIPTION
## The bug

The DNSBL tab reorganisation moved the **TLD Allow** checkbox to the top of the
page. The four `$tld_list` arrays and `$tld_total` sit ~1,500 lines further
down, wedged between two `Form_Section`s. So the control is now built **before**
its own data exists, and the help text's `(N TLDs available)` figure could no
longer be rendered there. It was dropped.

Dropping it was the right call at that position — but `$tld_total` was left
behind, computed and never read.

## Why the obvious fix is wrong

Putting the figure back on the checkbox does not work. `$tld_total` is not in
scope at that point, so PHP renders:

```
Enable the TLD Allow feature (0 TLDs available).
```

and logs, on **every page load**:

```
PHP Warning:   Undefined variable $tld_total in pfblockerng_dnsbl.php on line 1300
PHP Deprecated: number_format(): Passing null to parameter #1 ($num) of type float is deprecated
```

That is measured, not predicted: on a live VM it produced 22 diagnostics and
grew the PHP error log from 3.7 MB to 9.3 MB during a single render sweep.

## The fix

Move the **data**, not the text. `$tld_list`, `$tld_info` and `$tld_total` now
sit above the GUI block instead of inside form construction, so the count is in
scope where the control is built and renders where it always did.

The block is safe to move, verified before touching it:

- it is pure literals — **zero** references to `$pconfig`, `$section`, `$form`
  or `$group`
- nothing above it referenced `$tld_list`, `$tld_info` or `$tld_total`

`$tld_total` resolves before the control that uses it, data now precedes
presentation, and the previously-dead variable is read again.

> **Reviewer note on the diff.** It reports ~429 insertions / ~424 deletions
> rather than the ~1,550 lines actually relocated: git represents the change as
> moving the smaller block — the form-construction code — *downward*, because
> that is the cheaper edit. So the diff appears to move GUI code when what
> actually moved is the TLD data. `git diff --color-moved` or
> `-M --patience` makes it read correctly. **No form logic is rewritten.**

## Verification

Rendered on a live pfSense Plus VM after deploying the change:

```
Enable the TLD Allow feature (1,529 TLDs available).
Total TLD Count: [644]  [248]  [151]  [486]
```

- 644 + 248 + 151 + 486 = **1,529** — the aggregate is exactly the sum of the
  four per-list counts, which are unchanged by this PR
- no duplicate keys in any of the four arrays; nothing is hardcoded, both the
  per-list counts and the total derive from `$tld_list`, so they cannot drift
- `/tmp/PHP_errors.log` **0 bytes** after a clean render — versus 22
  diagnostics for the naive fix above

This makes `test_dnsbl_page_renders_tld_pickers` pass. That test is well built
and its guard is worth keeping: the regex alone would accept
`(0 TLDs available)`, but its `tld_count >= 1000` plausibility check — written
to catch a blanked `$tld_list` — is what rejects the broken value.

## Relationship to #2885

Independent; either can merge first. #2885 is test-only and fixes the separate
`ui_render` failure where the Support byline case still names a URL the page no
longer renders. Together the two take `ui_render` to fully green
(**220 passed, 0 failed**, measured on a branch carrying both).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed the DNSBL TLD Allow help text so it displays the current total number of available TLDs.
  - Ensured TLD data is initialized before the picker and count are rendered.

- **Tests**
  - Added coverage validating TLD list integrity, ordering, uniqueness, and totals.
  - Updated UI smoke tests to verify individual TLD counts match the aggregate total.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->