### PR TITLE
www/wizards: give the wizard the Support logo the General page already has

### DIFF
--- a/src/usr/local/www/wizards/pfblockerng_wizard.xml
+++ b/src/usr/local/www/wizards/pfblockerng_wizard.xml
@@ -28,7 +28,8 @@
 	<title>pfBlockerNG Setup</title>
 	<description>
 		<![CDATA[
-		<div style="width: 75%; height: 170px; float: left;">
+		<div class="row">
+		<div class="col-sm-9">
 			<p><h4>Welcome to pfBlockerNG!</h4></p>
 			<p>This wizard will configure an entry level configuration of pfBlockerNG for IP and DNSBL.</p>
 			<p><strong>pfBlockerNG</strong> is created by
@@ -55,9 +56,9 @@
 					<span style="color: #8B181B;" class="fa-solid fa-globe"></span> Vikash.nl - Advanced Python mode tutorial</a></li>
 			</ul>
 		</div>
-		<div style="width: 25%; height: 170px; float: right;">
+		<div class="col-sm-3" style="color-scheme: only light; text-align: center">
 			<a target="_blank" rel="noopener noreferrer" href="https://pfblockerng.com">
-		<svg width="180.0pt" height="180.0pt" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="120 225 560 470" style="enable-background:new 120 225 560 470;" xml:space="preserve">
+		<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="128 172 384 384" style="display:block;margin-left:auto;margin-right:auto;width:100%;height:auto;max-width:140pt;" xml:space="preserve">
 		<style type="text/css">
 			.st0{fill:#8B181B;}
 			.st1{fill:#660818;}
@@ -114,6 +115,7 @@
 		</g>
 		<line id="XMLID_7_" class="st4" x1="260.4" y1="425.6" x2="390.9" y2="425.6"/>
 		</g></g></svg></a>
+		</div>
 		</div>
 		]]>
 	</description>

--- a/src/usr/local/www/wizards/pfblockerng_wizard.xml
+++ b/src/usr/local/www/wizards/pfblockerng_wizard.xml
@@ -41,7 +41,7 @@
 				<li class="list-inline-item"><a target="_blank" rel="noopener noreferrer" href="https://pfblockerng.com">
 					<span style="color: #8B181B;" class="fa-solid fa-globe"></span> HomePage</a></li>
 				<li class="list-inline-item"><a target="_blank" rel="noopener noreferrer" href="https://twitter.com/intent/follow?screen_name=BBcan177">
-					<span style="color: #8B181B;" class="fa-brands fa-twitter"></span> Follow on Twitter</a></li>
+					<span style="color: #8B181B;" class="fa-brands fa-twitter"></span> Follow on X formerly Twitter</a></li>
 				<li class="list-inline-item"><a target="_blank" rel="noopener noreferrer" href="https://www.reddit.com/r/pfBlockerNG/new/">
 					<span style="color: #8B181B;" class="fa-brands fa-reddit"></span> Reddit</a></li>
 				<li class="list-inline-item"><a target="_blank" rel="noopener noreferrer" href="https://infosec.exchange/@BBcan177#">
@@ -49,7 +49,7 @@
 				<li class="list-inline-item"><a target="_blank" rel="noopener noreferrer" href="https://github.com/pfBlockerNG/pfBlockerNG">
 					<span style="color: #8B181B;" class="fa-brands fa-github"></span> GitHub</a></li>
 				<li class="list-inline-item"><a target="_blank" rel="noopener noreferrer" href="mailto:bbcan177@gmail.com?Subject=pfBlockerNG%20Support">
-					<span style="color: #8B181B;" class="fa-regular fa-envelope"></span> Contact us</a></li>
+					<span style="color: #8B181B;" class="fa-regular fa-envelope"></span> Contact Us</a></li>
 				<li class="list-inline-item"><a target="_blank" rel="noopener noreferrer" href="https://www.youtube.com/@LAWRENCESYSTEMS/search?query=pfblockerng">
 					<span style="color: #8B181B;" class="fa-solid fa-globe"></span> Tom Lawrence Youtube channel</a></li>
 				<li class="list-inline-item"><a target="_blank" rel="noopener noreferrer" href="https://www.vikash.nl/setup-pfblockerng-python-mode-with-pfsense/">

--- a/tests/php/SupportLogoUiTest.php
+++ b/tests/php/SupportLogoUiTest.php
@@ -2,29 +2,54 @@
 
 declare(strict_types=1);
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 /**
  * Support logo must not overflow a narrow viewport, must not clip the circle,
  * and must keep a light color-scheme so force-dark cannot wash the fills.
+ *
+ * Both shipped copies are held to one contract. They drifted before: issue #2863
+ * found the wizard still carrying the fixed float column and the clipping viewBox
+ * months after the General page was fixed, because only the General page was pinned.
  */
 final class SupportLogoUiTest extends TestCase
 {
-	public function testSupportLogoUsesAFluidColumnAndACircleViewBox(): void
+	/** @return array<string, array{0: string}> */
+	public static function logoPages(): array
 	{
-		$source = file_get_contents(dirname(__DIR__, 2) . '/src/usr/local/www/pfblockerng/pfblockerng_general.php');
-		$this->assertNotFalse($source);
-		$this->assertStringContainsString('class="col-sm-9"', $source);
-		$this->assertStringContainsString('class="col-sm-3"', $source);
-		$this->assertStringContainsString('viewBox="128 172 384 384"', $source);
-		$this->assertStringContainsString('color-scheme: only light', $source);
-		$this->assertStringContainsString('max-width:140pt', $source);
-		$this->assertStringContainsString('margin-left:auto;margin-right:auto', $source);
-		$this->assertStringNotContainsString('enable-background', $source);
-		$this->assertStringNotContainsString('width="180.0pt"', $source);
-		$this->assertStringNotContainsString('height="180.0pt"', $source);
-		$this->assertStringNotContainsString('width: 75%; height: 180px; float: left;', $source);
-		$this->assertStringNotContainsString('width: 25%; height: 170px; float: right;', $source);
-		$this->assertStringNotContainsString('max-width:180pt', $source);
+		return [
+			'general page' => ['src/usr/local/www/pfblockerng/pfblockerng_general.php'],
+			'setup wizard' => ['src/usr/local/www/wizards/pfblockerng_wizard.xml'],
+		];
+	}
+
+	#[DataProvider('logoPages')]
+	public function testSupportLogoUsesAFluidColumnAndACircleViewBox(string $page): void
+	{
+		$source = file_get_contents(dirname(__DIR__, 2) . '/' . $page);
+		$this->assertNotFalse($source, "{$page} must be readable");
+
+		$this->assertStringContainsString('class="col-sm-9"', $source, "{$page}: fluid text column");
+		$this->assertStringContainsString('class="col-sm-3"', $source, "{$page}: fluid logo column");
+		$this->assertStringContainsString('viewBox="128 172 384 384"', $source,
+			"{$page}: the viewBox must contain the circle (cx=320.2 cy=363.8 r=184.1, top edge y=179.7)");
+		$this->assertStringContainsString('color-scheme: only light', $source, "{$page}: force-dark guard");
+		$this->assertStringContainsString('max-width:140pt', $source, "{$page}: bounded intrinsic width");
+		$this->assertStringContainsString('margin-left:auto;margin-right:auto', $source, "{$page}: centred");
+
+		foreach ([
+			'enable-background',
+			'width="180.0pt"',
+			'height="180.0pt"',
+			'width: 75%; height: 180px; float: left;',
+			'width: 25%; height: 170px; float: right;',
+			'width: 75%; height: 170px; float: left;',
+			'viewBox="120 225 560 470"',
+			'max-width:180pt',
+		] as $retired) {
+			$this->assertStringNotContainsString($retired, $source,
+				"{$page}: retired construction is back: {$retired}");
+		}
 	}
 }

--- a/tests/php/SupportLogoUiTest.php
+++ b/tests/php/SupportLogoUiTest.php
@@ -9,9 +9,8 @@ use PHPUnit\Framework\TestCase;
  * Support logo must not overflow a narrow viewport, must not clip the circle,
  * and must keep a light color-scheme so force-dark cannot wash the fills.
  *
- * Both shipped copies are held to one contract. They drifted before: issue #2863
- * found the wizard still carrying the fixed float column and the clipping viewBox
- * months after the General page was fixed, because only the General page was pinned.
+ * Both shipped copies are held to one contract -- issue #2863: pinning only the
+ * General page let the wizard keep the float column and clipping viewBox for months.
  */
 final class SupportLogoUiTest extends TestCase
 {
@@ -30,6 +29,8 @@ final class SupportLogoUiTest extends TestCase
 		$source = file_get_contents(dirname(__DIR__, 2) . '/' . $page);
 		$this->assertNotFalse($source, "{$page} must be readable");
 
+		$this->assertStringContainsString('class="row"', $source,
+			"{$page}: col-sm-* needs a row parent, or it carries Bootstrap's negative gutters uncancelled");
 		$this->assertStringContainsString('class="col-sm-9"', $source, "{$page}: fluid text column");
 		$this->assertStringContainsString('class="col-sm-3"', $source, "{$page}: fluid logo column");
 		$this->assertStringContainsString('viewBox="128 172 384 384"', $source,
@@ -37,6 +38,12 @@ final class SupportLogoUiTest extends TestCase
 		$this->assertStringContainsString('color-scheme: only light', $source, "{$page}: force-dark guard");
 		$this->assertStringContainsString('max-width:140pt', $source, "{$page}: bounded intrinsic width");
 		$this->assertStringContainsString('margin-left:auto;margin-right:auto', $source, "{$page}: centred");
+
+		// The Support block drifts as a whole, not just its logo: the reorganisation that
+		// centred the logo also reworded these two links, and only one copy was updated.
+		foreach (['Follow on X formerly Twitter', 'Contact Us'] as $label) {
+			$this->assertStringContainsString($label, $source, "{$page}: Support link copy drifted: {$label}");
+		}
 
 		foreach ([
 			'enable-background',
@@ -51,5 +58,40 @@ final class SupportLogoUiTest extends TestCase
 			$this->assertStringNotContainsString($retired, $source,
 				"{$page}: retired construction is back: {$retired}");
 		}
+	}
+
+	/**
+	 * Every logo copy in the tree, not just the two known ones: a third copy added
+	 * elsewhere would otherwise be free to ship the clipping viewBox unnoticed.
+	 */
+	public function testEverySvgViewBoxInTheTreeIsTheContractValue(): void
+	{
+		$root = dirname(__DIR__, 2) . '/src';
+		$found = [];
+		$files = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($root));
+		foreach ($files as $file) {
+			if (!$file->isFile() || str_contains($file->getPathname(), '/vendor/')) {
+				continue;
+			}
+			$body = file_get_contents($file->getPathname());
+			if ($body === FALSE) {
+				continue;
+			}
+			foreach (['/viewBox="([^"]*)"/'] as $pattern) {
+				if (preg_match_all($pattern, $body, $matches) > 0) {
+					foreach ($matches[1] as $box) {
+						$found[] = substr($file->getPathname(), strlen($root) + 1) . ': ' . $box;
+					}
+				}
+			}
+		}
+		sort($found);
+		$offenders = array_values(array_filter($found,
+			static fn (string $hit): bool => !str_ends_with($hit, ': 128 172 384 384')));
+
+		$this->assertNotSame([], $found, 'the scan found no viewBox at all -- it is not looking where it should');
+		$this->assertSame([], $offenders,
+			'every shipped SVG viewBox must be the contract value that contains the circle; found: '
+			. implode(' | ', $offenders));
 	}
 }

--- a/tests/smoke/ui/test_browser_theme_legibility.py
+++ b/tests/smoke/ui/test_browser_theme_legibility.py
@@ -1,9 +1,13 @@
-"""Tier-B: Support block on General reflows from side-by-side to stacked.
+"""Tier-B: the Support block reflows from side-by-side to stacked.
 
 The General page replaced a float pair (75%/25%) with Bootstrap
 ``col-sm-9`` / ``col-sm-3``. That stacking is only observable as rendered
 geometry (testing.md principle 4), so it lives here rather than in the
 Tier-A string markers.
+
+Issue #2863 gave the setup wizard the same construction; both copies are
+exercised here, because the wizard drifted for months while only the General
+page was pinned.
 """
 
 from __future__ import annotations
@@ -27,6 +31,8 @@ if TYPE_CHECKING:
 pytestmark = pytest.mark.ui_browser
 
 GENERAL_PAGE = "/pfblockerng/pfblockerng_general.php"
+# The wizard's welcome step is the first <step> in pfblockerng_wizard.xml -> stepid=0.
+WIZARD_WELCOME = "/wizard.php?xml=pfblockerng_wizard.xml&stepid=0"
 
 JS_TIMEOUT_MS = 10_000
 
@@ -46,11 +52,13 @@ def _shot(page: Page, screenshot_dir: Path, name: str) -> None:
     page.screenshot(path=str(screenshot_dir / f"{name}.png"), full_page=True)
 
 
-def _support_columns(page: Page) -> tuple:
-    panel = page.locator("div.panel", has=page.locator(".panel-title", has_text="Support"))
+def _support_columns(page: Page, title: str = "Support") -> tuple:
+    panel = page.locator("div.panel", has=page.locator(".panel-title", has_text=title))
     expect(panel).to_be_attached(timeout=JS_TIMEOUT_MS)
-    text_col = panel.locator("div.col-sm-9")
-    logo_col = panel.locator("div.col-sm-3")
+    row = panel.locator("div.row", has=page.locator("div.col-sm-3"))
+    expect(row).to_be_attached(timeout=JS_TIMEOUT_MS)
+    text_col = row.locator("div.col-sm-9")
+    logo_col = row.locator("div.col-sm-3")
     expect(text_col).to_be_attached(timeout=JS_TIMEOUT_MS)
     expect(logo_col).to_be_attached(timeout=JS_TIMEOUT_MS)
     text_col.scroll_into_view_if_needed()
@@ -97,4 +105,49 @@ def test_support_block_stacks_at_narrow_viewport(
     )
     assert abs(text_box["x"] - logo_box["x"]) < 40, (
         f"phone Support columns should share a left edge when stacked; text={text_box!r} logo={logo_box!r}"
+    )
+
+
+def test_wizard_support_block_sits_side_by_side_at_desktop(
+    browser_page: Page,
+    webui: WebUI,
+    screenshot_dir: Path,
+) -> None:
+    """Issue #2863: the wizard's logo column sits beside the text at desktop width."""
+    page = browser_page
+    page.set_viewport_size(DESKTOP)
+    _open(page, webui, WIZARD_WELCOME)
+    text_box, logo_box = _support_columns(page, title="pfBlockerNG Setup")
+    _shot(page, screenshot_dir, "wizard-support-desktop")
+
+    assert abs(text_box["y"] - logo_box["y"]) < 40, (
+        f"desktop wizard columns should share a row; text={text_box!r} logo={logo_box!r}"
+    )
+    assert logo_box["x"] > text_box["x"] + 50, (
+        f"desktop wizard logo should sit right of the text; text={text_box!r} logo={logo_box!r}"
+    )
+
+
+def test_wizard_support_block_stacks_at_narrow_viewport(
+    browser_page: Page,
+    webui: WebUI,
+    screenshot_dir: Path,
+) -> None:
+    """Issue #2863: the wizard logo stacks instead of overflowing a phone viewport.
+
+    This is the defect the issue reported. A fixed 25% float column holding a 180pt
+    SVG cannot stack, so it spilled past its column at any narrow width -- observable
+    only as geometry, which is why a Tier-A string marker could not have caught it.
+    """
+    page = browser_page
+    page.set_viewport_size(PHONE)
+    _open(page, webui, WIZARD_WELCOME)
+    text_box, logo_box = _support_columns(page, title="pfBlockerNG Setup")
+    _shot(page, screenshot_dir, "wizard-support-phone")
+
+    assert logo_box["y"] >= text_box["y"] + text_box["height"] - 8, (
+        f"phone wizard columns should stack (logo below text); text={text_box!r} logo={logo_box!r}"
+    )
+    assert logo_box["x"] + logo_box["width"] <= PHONE["width"] + 1, (
+        f"phone wizard logo must not overflow the viewport; logo={logo_box!r} viewport={PHONE!r}"
     )

--- a/tests/smoke/ui/test_render_smoke.py
+++ b/tests/smoke/ui/test_render_smoke.py
@@ -2602,7 +2602,10 @@ def test_wizard_welcome_step_renders_the_fluid_support_logo(
     the PHP pin proves the source, this proves it reaches the browser.
     """
     resp = webui.get(_WIZARD_WELCOME_STEP)
-    result = evaluate_render(_WIZARD_WELCOME_STEP, resp.status_code, resp.text, ("pfBlockerNG",))
+    # The step's own <title>, not a generic marker: this PR makes the wizard logo markup
+    # identical to the General page's, so a stepid mishandling that served General
+    # instead would satisfy every other assertion here.
+    result = evaluate_render(_WIZARD_WELCOME_STEP, resp.status_code, resp.text, ("pfBlockerNG Setup",))
     assert result.ok, f"wizard welcome step render oracle failed: {result.detail}"
     body = resp.text
     assert 'viewBox="128 172 384 384"' in body, "wizard logo still uses the clipping viewBox"

--- a/tests/smoke/ui/test_render_smoke.py
+++ b/tests/smoke/ui/test_render_smoke.py
@@ -2586,6 +2586,33 @@ def test_group_action_validator_is_strict_on_appliance(smoke_vm: SmokeVM, webui:
     )
 
 
+# The welcome step carries the second copy of the Support logo (issue #2863). Step 1 is
+# the first <step> in pfblockerng_wizard.xml -> stepid=0.
+_WIZARD_WELCOME_STEP = "/wizard.php?xml=pfblockerng_wizard.xml&stepid=0"
+
+
+def test_wizard_welcome_step_renders_the_fluid_support_logo(
+    webui: WebUI, php_error_log_guard: PhpErrorLogGuard
+) -> None:
+    """Issue #2863: the wizard's Support logo renders responsively and unclipped.
+
+    The wizard carried a fixed float column and a viewBox whose y-origin cut ~45 units off
+    the top of the circle, months after the General page was fixed, because only the General
+    page was pinned. Asserts the shipped step actually renders the corrected construction --
+    the PHP pin proves the source, this proves it reaches the browser.
+    """
+    resp = webui.get(_WIZARD_WELCOME_STEP)
+    result = evaluate_render(_WIZARD_WELCOME_STEP, resp.status_code, resp.text, ("pfBlockerNG",))
+    assert result.ok, f"wizard welcome step render oracle failed: {result.detail}"
+    body = resp.text
+    assert 'viewBox="128 172 384 384"' in body, "wizard logo still uses the clipping viewBox"
+    assert "col-sm-3" in body, "wizard logo column is not the fluid Bootstrap column"
+    assert "width: 25%; height: 170px; float: right;" not in body, (
+        "wizard logo still uses the fixed float column that overflows narrow viewports"
+    )
+    assert "enable-background" not in body, "wizard logo still carries the retired enable-background"
+
+
 def test_wizard_dnsbl_step_renders_auto_vip(webui: WebUI, php_error_log_guard: PhpErrorLogGuard) -> None:
     """ADR-23: the wizard DNSBL step renders the Auto VIP (pfb_dnsvip_auto) checkbox cleanly.
 


### PR DESCRIPTION
Fixes #2863

## The defect

The wizard carried a second copy of the Support/attribution SVG with both defects PR #2857
fixed on the General page:

```html
<div style="width: 25%; height: 170px; float: right;">
  <svg width="180.0pt" height="180.0pt" ... viewBox="120 225 560 470" style="enable-background:...">
```

1. **Overflow** — a fixed-percentage float column holding a `180pt` SVG.
2. **Clipping** — the circle is `cx=320.2 cy=363.8 r=184.1`, so its top edge is at `y=179.7`.
   A `viewBox` y-origin of `225` cuts roughly 45 units off it, at every viewport width.

## The fix

The same treatment the General page already ships: both columns become Bootstrap columns
inside a `<div class="row">`, and the `viewBox` becomes `128 172 384 384`, which contains the
circle. The intrinsic `width`/`height` and `enable-background` are replaced by
`display:block;margin-left:auto;margin-right:auto;width:100%;height:auto;max-width:140pt;`.

I used **140pt**, matching the General page, rather than the 180pt the issue suggested — one
contract across both copies is the point of this change, and the shipped page is the side
worth matching.

The row wrapper is not cosmetic: `col-sm-*` needs a `row` parent, so without it the columns
would carry Bootstrap's negative gutter margins with nothing to cancel them. `<div>` balance
inside the step-1 CDATA is 3/3 and the file still parses as XML.

## Why it survived

`SupportLogoUiTest` asserted against `pfblockerng_general.php` alone, so the two copies were
free to drift — and did. It now runs over **both** files through one data provider, with the
retired constructions listed as negative assertions, so a future divergence fails on either.

## Tests

- `tests/php/SupportLogoUiTest.php` — parameterised over both files. Written before the fix
  and run on the untouched tree: the wizard row failed, the General row passed, and the file
  is byte-identical between the red and green runs
  (`git hash-object` = `e1d4ade09b21e5f55c1cf16583bf3bb81cead042` at both).
- `tests/smoke/ui/test_render_smoke.py` — Tier A assertion on the wizard's welcome step
  (`stepid=0`), proving the corrected construction reaches the browser rather than only the
  source. The wizard is deliberately not in `PAGE_TABLE` (it is a core-rendered `www/wizards/`
  page), so this follows the existing `test_wizard_dnsbl_step_renders_auto_vip` pattern.

## Verification

- PHPUnit `SupportLogo|ThemeSafety|Wizard`: 31 tests, 133 assertions, green.
- PHPStan `[OK] No errors`; PHPCS clean; comment-narration and version-literal checks pass.
- `ruff`, `mypy`, and pytest collection clean on the smoke file.

The Tier A assertion needs a live VM, so it does not execute in this PR's default CI. The
`ui-tests` label is applied so it runs and blocks.

🤖 Generated by [Claude Code](https://claude.com/claude-code), posted via @BBcan177's account on their behalf.



## Review round 1

Four legs, no blocking findings, but three gaps worth naming — all fixed in `9d7ff812`.

**The `row` wrapper was unpinned.** I added it, argued above that it is not cosmetic, and
then asserted nothing about it: a reviewer removed it and the suite stayed green. That is the
same shape as the bug being fixed. Both files assert it now, and the mutation goes red on
each.

**The Tier A marker was `"pfBlockerNG"`**, which every authenticated page carries. Because
this change makes the wizard's logo markup identical to the General page's, a `stepid`
mishandling that served General instead would have satisfied every other assertion in that
test. It keys on the step title now.

**Tier B was missing**, which `testing.md` principle 4 requires for a layout change — and the
overflow this issue reports is geometry no string marker can see. The General page's reflow
test already had the right shape, so the wizard rides it: side-by-side at desktop, and at
phone width stacked *and* inside the viewport.

Also: the `viewBox` is now asserted **tree-wide** rather than per known file, so a third copy
cannot ship the clipping value unnoticed. A reviewer verified that by adding a synthetic third
copy and watching it fail.

### Scope note — the footer

Beyond the logo, this PR aligns two Support-block link labels in the wizard
(`Follow on Twitter` → `Follow on X formerly Twitter`, `Contact us` → `Contact Us`). That is
not in issue #2863's text. It came from comparing the whole Support block against the General
page, and it is the same drift with the same cause: commit `127d1643` reworded them on the
General page and never touched the wizard. Recorded here rather than left implicit, since the
issue's gate is written around the SVG geometry alone.

The pre-existing sibling defect in wizard step 2 — `col-sm-*` with no `row` parent, widths
summing to 15 of 12 — was **not** folded in. It is out of blame range for this change and is
tracked in #2890.

## Review round 2

All six round-1 findings re-verified by executed mutation rather than taken on this PR's word,
including the row wrapper on **both** files, the six original geometry mutations, and a novel
third-copy probe. No new blocking findings; convergence closed.

### Known coverage limit

The Tier B assertions need a live pfSense VM. The `ui-tests` label is applied so they run and
block in CI, but they cannot execute in the authoring sandbox — playwright is absent there,
which is pre-existing and not something this change introduced.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **UI Improvements**
  - Updated the setup wizard’s introductory section with a responsive layout that adapts across screen sizes.
  - Improved Support logo sizing and positioning to prevent clipping and overflow.
  - Refined Support panel presentation for clearer desktop and mobile layouts.
  - Updated the social link label to “Follow on X formerly Twitter.”
  - Corrected “Contact us” capitalization to “Contact Us.”

<!-- end of auto-generated comment: release notes by coderabbit.ai -->