### PR TITLE
widgets: pair the jQuery-set backgrounds, and let the scanner see them

### DIFF
--- a/src/usr/local/www/pfblockerng/pfBlockerNG.js
+++ b/src/usr/local/www/pfblockerng/pfBlockerNG.js
@@ -126,14 +126,14 @@ function pfb_greyout(sel) {
 
 	$(sel).click(function() {
 		if ($(this).val() == 'Disabled') {
-			$(this).css('background-color', 'lightgrey');
+			$(this).css({'background-color': 'lightgrey', 'color': '#212121'});
 		} else {
-			$(this).css('background-color', '');
+			$(this).css({'background-color': '', 'color': ''});
 		}
 	});
 	$(sel).each(function() {
 		if ($(this).val() == 'Disabled') {
-			$(this).css('background-color', 'lightgrey');
+			$(this).css({'background-color': 'lightgrey', 'color': '#212121'});
 		}
 	});
 }

--- a/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
@@ -5482,7 +5482,7 @@ function add_description(mode) {
 				$(this).dialog('close');
 			}
 		}
-	}).css('background-color','#ffd700');
+	}).css({'background-color': '#ffd700', 'color': '#000000'});
 	$("div[role=dialog]").find('button').addClass('btn-info btn-xs');
 }
 
@@ -5527,7 +5527,7 @@ function select_whitelist(mode, permit_list) {
 		position: { my: 'top', at: 'top' },
 		width: 750,
 		buttons: buttons
-	}).css('background-color','#ffd700');
+	}).css({'background-color': '#ffd700', 'color': '#000000'});
 	$("div[role=dialog]").find('button').addClass('btn-info btn-xs');
 }
 
@@ -5753,7 +5753,7 @@ events.push(function() {
 				title: 'Domain ' + button_text + 'ing:',
 				position: { my: 'top', at: 'top' },
 				buttons: buttons
-			}).css('background-color','#ffd700');
+			}).css({'background-color': '#ffd700', 'color': '#000000'});
 			$("div[role=dialog]").find('button').addClass('btn-info btn-xs');
 		}
 	});
@@ -5791,7 +5791,7 @@ events.push(function() {
 							$(this).dialog('close');
 						}
 					}
-				}).css('background-color','#ffd700');
+				}).css({'background-color': '#ffd700', 'color': '#000000'});
 				$("div[role=dialog]").find('button').addClass('btn-info btn-xs');
 			}
 			else {

--- a/src/usr/local/www/widgets/javascript/pfblockerng.js
+++ b/src/usr/local/www/widgets/javascript/pfblockerng.js
@@ -223,7 +223,7 @@ if (typeof window !== 'undefined') {
 						$(this).dialog("close");
 					}
 				}
-			}).css('background-color','#ffd700');
+			}).css({'background-color': '#ffd700', 'color': '#000000'});
 			$("div[role=dialog]").find('button').addClass('btn-info btn-xs');
 		});
 	});

--- a/tests/php/ThemeSafetyUiTest.php
+++ b/tests/php/ThemeSafetyUiTest.php
@@ -122,8 +122,17 @@ final class ThemeSafetyUiTest extends TestCase
 	public static function scan(string $source): array
 	{
 		$hits = [];
+		// Four shapes reach a background: a CSS declaration, a JS object property with a
+		// bare key or a quoted one, and jQuery's setter -- issue #2864: only the first two
+		// were matched, so every .css('background-color', ...) call was invisible here.
+		// Named groups, because an alternation numbers its groups globally and a
+		// backreference written by hand silently points at the wrong branch.
 		if (preg_match_all(
-			'/background(?:-color)?\s*:\s*([^;}\n]+)|backgroundColor\s*:\s*(["\'])([^"\']+)\2/i',
+			'/background(?:-color)?\s*:\s*(?<css>[^;}\n]+)'
+			. '|backgroundColor\s*:\s*(?<jsq>["\'])(?<js>[^"\']+)\k<jsq>'
+			. '|(?<objq>["\'])background(?:-color)?\k<objq>\s*:\s*(?<objvq>["\'])(?<obj>[^"\']*)\k<objvq>'
+			. '|\.css\(\s*(?<setq>["\'])background(?:-color)?\k<setq>\s*,\s*'
+			. '(?<setvq>["\'])(?<set>[^"\']*)\k<setvq>/i',
 			$source,
 			$matches,
 			PREG_OFFSET_CAPTURE
@@ -132,9 +141,13 @@ final class ThemeSafetyUiTest extends TestCase
 			for ($i = 0; $i < $count; $i++) {
 				$full = $matches[0][$i][0];
 				$offset = $matches[0][$i][1];
-				$cssVal = self::firstColorToken($matches[1][$i][0] ?? '');
-				$jsVal = trim($matches[3][$i][0] ?? '');
-				$value = $cssVal !== '' ? $cssVal : $jsVal;
+				$value = self::firstColorToken($matches['css'][$i][0] ?? '');
+				foreach (['js', 'obj', 'set'] as $group) {
+					if ($value !== '') {
+						break;
+					}
+					$value = trim($matches[$group][$i][0] ?? '');
+				}
 				if ($value === '' || self::isInterpolated($value) || self::isTranslucent($value)) {
 					continue;
 				}
@@ -226,7 +239,9 @@ final class ThemeSafetyUiTest extends TestCase
 
 	private static function contextHasForeground(string $ctx): bool
 	{
-		return (bool)preg_match('/(?<![A-Za-z-])color\s*:/i', $ctx);
+		// The optional quote matches an object property ("color": "white") as well as a
+		// declaration; the lookbehind still excludes background-color in either form.
+		return (bool)preg_match('/(?<![A-Za-z-])color["\']?\s*:/i', $ctx);
 	}
 
 	private static function themeRootPinsForeground(string $source, int $offset): bool

--- a/tests/php/ThemeSafetyUiTest.php
+++ b/tests/php/ThemeSafetyUiTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -79,6 +80,42 @@ final class ThemeSafetyUiTest extends TestCase
 		}
 	}
 
+	/**
+	 * Every syntax scan() detects, in its unpaired and paired form.
+	 *
+	 * @return array<string, array{0: string, 1: string}>
+	 */
+	public static function backgroundSyntaxes(): array
+	{
+		return [
+			'css declaration'   => ['a { background-color: #fff; }', 'a { background-color: #fff; color: #000; }'],
+			'css shorthand'     => ['a { background: #fff; }', 'a { background: #fff; color: #000; }'],
+			'js bare key'       => ['{ backgroundColor: "#fff" }', '{ backgroundColor: "#fff", color: "#000" }'],
+			'js quoted key'     => ['{ "background-color": "#fff" }', '{ "background-color": "#fff", "color": "#000" }'],
+			'js quoted camel'   => ['{ "backgroundColor": "#fff" }', '{ "backgroundColor": "#fff", "color": "#000" }'],
+			'jquery setter'     => ["\$(x).css('background-color', '#fff');", "\$(x).css({'background-color': '#fff', 'color': '#000'});"],
+			'jquery camel'      => ["\$(x).css('backgroundColor', '#fff');", "\$(x).css({'backgroundColor': '#fff', 'color': '#000'});"],
+			'setProperty'       => ["e.style.setProperty('background-color', '#fff');", "e.style.setProperty('background-color', '#fff'); e.style.setProperty('color', '#000');"],
+			'style assignment'  => ["e.style.backgroundColor = '#fff';", "e.style.backgroundColor = '#fff'; e.style.color = '#000';"],
+		];
+	}
+
+	/**
+	 * scan()'s background vocabulary and contextHasForeground()'s foreground vocabulary are
+	 * separate patterns that must agree. They have drifted apart twice (issue #2864): once
+	 * leaving a form undetected, once rejecting a form that was correctly paired. Every
+	 * detected syntax is exercised BOTH ways here, so a future addition to one pattern that
+	 * is not mirrored in the other fails instead of shipping.
+	 */
+	#[DataProvider('backgroundSyntaxes')]
+	public function testEveryDetectedFormIsAlsoRecognisedWhenPaired(string $unpaired, string $paired): void
+	{
+		$this->assertNotSame([], self::scan($unpaired),
+			'scan() must detect this background syntax: ' . $unpaired);
+		$this->assertSame([], self::scan($paired),
+			'contextHasForeground() must accept the pairing idiom native to this syntax: ' . $paired);
+	}
+
 	public function testCurrentTreeInventoryMatchesTheDatedTodo(): void
 	{
 		$root = dirname(__DIR__, 2);
@@ -142,10 +179,10 @@ final class ThemeSafetyUiTest extends TestCase
 		if (preg_match_all(
 			'/background(?:-color)?\s*:\s*(?<css>[^;}\n]+)'
 			. '|backgroundColor\s*:\s*(?<jsq>["\'])(?<js>[^"\']+)\k<jsq>'
-			. '|(?<objq>["\'])background(?:-color|Color)?\k<objq>\s*:\s*(?<objvq>["\'])(?<obj>[^"\']*)\k<objvq>'
-			. '|(?:\.css|setProperty)\(\s*(?<setq>["\'])background(?:-color|Color)?\k<setq>\s*,\s*'
-			. '(?<setvq>["\'])(?<set>[^"\']*)\k<setvq>'
-			. '|\.style\.backgroundColor\s*=\s*(?<domq>["\'])(?<dom>[^"\']*)\k<domq>/i',
+			. '|(?<objq>["\'])background(?:-color|Color)?\k<objq>\s*:\s*(?<objvq>["\'])(?<obj>[^"\']*+)\k<objvq>'
+			. '|(?<![A-Za-z0-9_])(?:\.css|setProperty)\(\s*(?<setq>["\'])background(?:-color|Color)?\k<setq>\s*,\s*'
+			. '(?<setvq>["\'])(?<set>[^"\']*+)\k<setvq>'
+			. '|\.style\.backgroundColor\s*=\s*(?<domq>["\'])(?<dom>[^"\']*+)\k<domq>/i',
 			$source,
 			$matches,
 			PREG_OFFSET_CAPTURE
@@ -250,9 +287,15 @@ final class ThemeSafetyUiTest extends TestCase
 
 	private static function contextHasForeground(string $ctx): bool
 	{
-		// The optional quote matches an object property ("color": "white") as well as a
-		// declaration; the lookbehind still excludes background-color in either form.
-		return (bool)preg_match('/(?<![A-Za-z-])color["\']?\s*:/i', $ctx);
+		// Every way a foreground can be set must be recognised here, or code paired through
+		// a form scan() detects but this does not reports as a violation. The two
+		// vocabularies are kept in lockstep by testEveryDetectedFormIsAlsoRecognisedWhenPaired.
+		return (bool)preg_match(
+			'/(?<![A-Za-z-])color["\']?\s*:'
+			. '|(?<![A-Za-z-])color\s*='
+			. '|setProperty\(\s*["\']color["\']/i',
+			$ctx
+		);
 	}
 
 	private static function themeRootPinsForeground(string $source, int $offset): bool

--- a/tests/php/ThemeSafetyUiTest.php
+++ b/tests/php/ThemeSafetyUiTest.php
@@ -94,26 +94,40 @@ final class ThemeSafetyUiTest extends TestCase
 		}
 
 		$todo = self::TODO_OPAQUE_WITHOUT_FOREGROUND_20260829;
-		$extra = array_diff_key($found, $todo);
-		$stale = array_diff_key($todo, $found);
-		$this->assertSame([], $extra, 'new opaque-without-foreground site — do not allowlist it, fix it or get an owner ruling');
-		$this->assertSame([], $stale, 'TODO entry is fixed; remove it from TODO_OPAQUE_WITHOUT_FOREGROUND_20260829');
 
-		foreach ($todo as $rel => $needles) {
-			$joined = implode("\n", $found[$rel]);
-			foreach ($needles as $needle) {
-				$this->assertTrue(
-					self::listContainsNeedle($found[$rel], $needle),
-					$rel . ' TODO needle missing: ' . $needle . ' (have: ' . $joined . ')'
-				);
+		// Collected, not asserted one at a time: a new hit inside a file the TODO already
+		// lists is invisible to a key-wise diff, and an early assert would abort before the
+		// per-needle loop that does see it. One verdict reports every violation at once.
+		$problems = [];
+		foreach (array_keys($found + $todo) as $rel) {
+			$have = $found[$rel] ?? [];
+			$needles = $todo[$rel] ?? [];
+			if (!array_key_exists($rel, $todo)) {
+				$problems[] = $rel . ': new opaque-without-foreground site -- do not allowlist it, '
+					. 'fix it or get an owner ruling: ' . implode(', ', $have);
+				continue;
 			}
-			foreach ($found[$rel] as $have) {
-				$this->assertTrue(
-					self::listContainsNeedle($needles, $have),
-					$rel . ' extra opaque-without-foreground hit: ' . $have
-				);
+			if ($have === []) {
+				$problems[] = $rel . ': TODO entry is fixed; remove it from '
+					. 'TODO_OPAQUE_WITHOUT_FOREGROUND_20260829';
+				continue;
+			}
+			foreach ($needles as $needle) {
+				if (!self::listContainsNeedle($have, $needle)) {
+					$problems[] = $rel . ': TODO needle missing: ' . $needle
+						. ' (have: ' . implode(' | ', $have) . ')';
+				}
+			}
+			foreach ($have as $hit) {
+				if (!self::listContainsNeedle($needles, $hit)) {
+					$problems[] = $rel . ': extra opaque-without-foreground hit: ' . $hit;
+				}
 			}
 		}
+
+		$this->assertSame([], $problems,
+			"the tree's opaque-without-foreground inventory no longer matches the dated TODO:\n  "
+			. implode("\n  ", $problems));
 	}
 
 	/**
@@ -122,17 +136,16 @@ final class ThemeSafetyUiTest extends TestCase
 	public static function scan(string $source): array
 	{
 		$hits = [];
-		// Four shapes reach a background: a CSS declaration, a JS object property with a
-		// bare key or a quoted one, and jQuery's setter -- issue #2864: only the first two
-		// were matched, so every .css('background-color', ...) call was invisible here.
-		// Named groups, because an alternation numbers its groups globally and a
-		// backreference written by hand silently points at the wrong branch.
+		// issue #2864: every shape that can set a background, not just the declaration and
+		// the bare object key. Named groups, because an alternation numbers groups globally
+		// and a hand-written backreference silently points at the wrong branch.
 		if (preg_match_all(
 			'/background(?:-color)?\s*:\s*(?<css>[^;}\n]+)'
 			. '|backgroundColor\s*:\s*(?<jsq>["\'])(?<js>[^"\']+)\k<jsq>'
-			. '|(?<objq>["\'])background(?:-color)?\k<objq>\s*:\s*(?<objvq>["\'])(?<obj>[^"\']*)\k<objvq>'
-			. '|\.css\(\s*(?<setq>["\'])background(?:-color)?\k<setq>\s*,\s*'
-			. '(?<setvq>["\'])(?<set>[^"\']*)\k<setvq>/i',
+			. '|(?<objq>["\'])background(?:-color|Color)?\k<objq>\s*:\s*(?<objvq>["\'])(?<obj>[^"\']*)\k<objvq>'
+			. '|(?:\.css|setProperty)\(\s*(?<setq>["\'])background(?:-color|Color)?\k<setq>\s*,\s*'
+			. '(?<setvq>["\'])(?<set>[^"\']*)\k<setvq>'
+			. '|\.style\.backgroundColor\s*=\s*(?<domq>["\'])(?<dom>[^"\']*)\k<domq>/i',
 			$source,
 			$matches,
 			PREG_OFFSET_CAPTURE
@@ -142,12 +155,10 @@ final class ThemeSafetyUiTest extends TestCase
 				$full = $matches[0][$i][0];
 				$offset = $matches[0][$i][1];
 				$value = self::firstColorToken($matches['css'][$i][0] ?? '');
-				foreach (['js', 'obj', 'set'] as $group) {
-					if ($value !== '') {
-						break;
-					}
-					$value = trim($matches[$group][$i][0] ?? '');
-				}
+				$value = $value !== '' ? $value : trim($matches['js'][$i][0] ?? '');
+				$value = $value !== '' ? $value : trim($matches['obj'][$i][0] ?? '');
+				$value = $value !== '' ? $value : trim($matches['set'][$i][0] ?? '');
+				$value = $value !== '' ? $value : trim($matches['dom'][$i][0] ?? '');
 				if ($value === '' || self::isInterpolated($value) || self::isTranslucent($value)) {
 					continue;
 				}

--- a/tests/php/ThemeSafetyUiTest.php
+++ b/tests/php/ThemeSafetyUiTest.php
@@ -97,7 +97,9 @@ final class ThemeSafetyUiTest extends TestCase
 			'jquery on a var'   => ["\$el.css('background-color', '#fff');", "\$el.css({'background-color': '#fff', 'color': '#000'});"],
 			'jquery on this'    => ["this.css('background-color', '#fff');", "this.css({'background-color': '#fff', 'color': '#000'});"],
 			'jquery camel'      => ["\$(x).css('backgroundColor', '#fff');", "\$(x).css({'backgroundColor': '#fff', 'color': '#000'});"],
+			'jquery double-q'   => ['$(x).css("background-color", "#fff");', '$(x).css({"background-color": "#fff", "color": "#000"});'],
 			'setProperty'       => ["e.style.setProperty('background-color', '#fff');", "e.style.setProperty('background-color', '#fff'); e.style.setProperty('color', '#000');"],
+			'setProperty dbl-q' => ['e.style.setProperty("background-color", "#fff");', 'e.style.setProperty("background-color", "#fff"); e.style.setProperty("color", "#000");'],
 			'style assignment'  => ["e.style.backgroundColor = '#fff';", "e.style.backgroundColor = '#fff'; e.style.color = '#000';"],
 		];
 	}
@@ -293,8 +295,8 @@ final class ThemeSafetyUiTest extends TestCase
 		// a form scan() detects but this does not reports as a violation. The two
 		// vocabularies are kept in lockstep by testEveryDetectedFormIsAlsoRecognisedWhenPaired.
 		return (bool)preg_match(
-			'/(?<![A-Za-z-])color["\']?\s*:'
-			. '|(?<![A-Za-z-])color\s*='
+			'/(?<![A-Za-z0-9_-])color["\']?\s*:'
+			. '|(?<![A-Za-z0-9_-])color\s*='
 			. '|setProperty\(\s*["\']color["\']/i',
 			$ctx
 		);

--- a/tests/php/ThemeSafetyUiTest.php
+++ b/tests/php/ThemeSafetyUiTest.php
@@ -94,6 +94,8 @@ final class ThemeSafetyUiTest extends TestCase
 			'js quoted key'     => ['{ "background-color": "#fff" }', '{ "background-color": "#fff", "color": "#000" }'],
 			'js quoted camel'   => ['{ "backgroundColor": "#fff" }', '{ "backgroundColor": "#fff", "color": "#000" }'],
 			'jquery setter'     => ["\$(x).css('background-color', '#fff');", "\$(x).css({'background-color': '#fff', 'color': '#000'});"],
+			'jquery on a var'   => ["\$el.css('background-color', '#fff');", "\$el.css({'background-color': '#fff', 'color': '#000'});"],
+			'jquery on this'    => ["this.css('background-color', '#fff');", "this.css({'background-color': '#fff', 'color': '#000'});"],
 			'jquery camel'      => ["\$(x).css('backgroundColor', '#fff');", "\$(x).css({'backgroundColor': '#fff', 'color': '#000'});"],
 			'setProperty'       => ["e.style.setProperty('background-color', '#fff');", "e.style.setProperty('background-color', '#fff'); e.style.setProperty('color', '#000');"],
 			'style assignment'  => ["e.style.backgroundColor = '#fff';", "e.style.backgroundColor = '#fff'; e.style.color = '#000';"],
@@ -180,7 +182,7 @@ final class ThemeSafetyUiTest extends TestCase
 			'/background(?:-color)?\s*:\s*(?<css>[^;}\n]+)'
 			. '|backgroundColor\s*:\s*(?<jsq>["\'])(?<js>[^"\']+)\k<jsq>'
 			. '|(?<objq>["\'])background(?:-color|Color)?\k<objq>\s*:\s*(?<objvq>["\'])(?<obj>[^"\']*+)\k<objvq>'
-			. '|(?<![A-Za-z0-9_])(?:\.css|setProperty)\(\s*(?<setq>["\'])background(?:-color|Color)?\k<setq>\s*,\s*'
+			. '|(?:\.css\(|(?<![A-Za-z0-9_])setProperty\()\s*(?<setq>["\'])background(?:-color|Color)?\k<setq>\s*,\s*'
 			. '(?<setvq>["\'])(?<set>[^"\']*+)\k<setvq>'
 			. '|\.style\.backgroundColor\s*=\s*(?<domq>["\'])(?<dom>[^"\']*+)\k<domq>/i',
 			$source,

--- a/tests/smoke/ui/test_browser.py
+++ b/tests/smoke/ui/test_browser.py
@@ -243,6 +243,14 @@ def test_state_select_greyed_when_disabled(
 
     expect(state).to_have_css("background-color", "rgb(211, 211, 211)", timeout=JS_TIMEOUT_MS)
     assert "grey" in bg().lower() or bg() == "lightgrey", f"expected lightgrey inline bg, got {bg()!r}"
+
+    # issue #2864: the grey must arrive with a foreground. Unpaired, the text kept the
+    # page colour, which is near-white on the dark themes -- unreadable on lightgrey.
+    def fg() -> str:
+        return page.evaluate("document.getElementById('state-0').style.color")
+
+    assert fg() != "", "greyed select has no inline color: its text inherits the page colour"
+    expect(state).to_have_css("color", "rgb(33, 33, 33)", timeout=JS_TIMEOUT_MS)
     _shot(page, screenshot_dir, "state_disabled_grey")
 
     # AFTER: switch to Enabled and fire the bound click handler -> grey cleared.
@@ -250,6 +258,9 @@ def test_state_select_greyed_when_disabled(
     state.dispatch_event("click")
     expect(state).not_to_have_css("background-color", "rgb(211, 211, 211)", timeout=JS_TIMEOUT_MS)
     assert bg() in ("", "rgba(0, 0, 0, 0)"), f"expected cleared inline bg after Enabled, got {bg()!r}"
+    # The foreground clears with it: a pinned colour that outlived its background would
+    # fight whatever theme the row reverts to.
+    assert fg() == "", f"expected cleared inline color after Enabled, got {fg()!r}"
 
 
 def test_dashboard_widget_renders(


### PR DESCRIPTION
Fixes #2864

## The scanner could not see the defect class

`ThemeSafetyUiTest::scan()` matched a CSS declaration and the `backgroundColor:` JS object
property, but **not jQuery's setter**. So every `.css('background-color', ...)` call in the tree
was invisible to a guard whose own docblock promises that a new unpaired background fails the
suite.

Widening it turned up **seven** unpaired sites, not the one the issue names:

| Site | Value |
| --- | --- |
| `pfblockerng_alerts.php:5485, 5530, 5756, 5794` | `#ffd700` — four jQuery-UI dialogs |
| `widgets/javascript/pfblockerng.js:226` | `#ffd700` — the site the issue names |
| `pfBlockerNG.js:129, 136` | `lightgrey` — the disabled-select greyout |

Per `landing.md`, a finding that names a class is fixed by re-enumerating the class tree-wide
rather than at the one site it was spotted at. All seven now set a foreground with the
background.

## The guard had the mirror-image blind spot too

`contextHasForeground()` read `color:` as a declaration but not as a **quoted object key**, so
the one site that was already correct —

```js
$(this).css({"background-color": "#1976D2", "color": "white"});
```

— reported as unpaired the moment the scanner could see it. Fixing only the matching half
would have produced a false positive on correct code. It now reads both forms, and still
excludes `background-color` in either.

## The greyout's reset path

```js
if ($(this).val() == 'Disabled') {
    $(this).css({'background-color': 'lightgrey', 'color': '#212121'});
} else {
    $(this).css({'background-color': '', 'color': ''});
}
```

Both clear together. A pinned foreground outliving its background would fight whatever theme
the row reverts to.

## A note on the pattern itself

The first version numbered its backreferences by hand across a four-branch alternation. Groups
number **globally**, so `\6` and `\7` in the last branch pointed at the previous branch's
groups: it compiled, ran, matched nothing, and the suite went green. It uses named groups now,
which makes that class of error impossible — and a green run on a widened scanner is exactly
the result that should have been suspicious.

## Tests

Red-first. Widening the scanner is what makes the defects visible, so that change went in
first and the suite went red with the seven hits; the fixes then took it green. The scanner
file is byte-identical between the two runs (`git hash-object` =
`5c5d56cb69e6ae8f765227fc355236ba2b5bbd92`).

`tests/smoke/ui/test_browser.py` — the existing greyout browser test now asserts the paired
foreground on **both** branches: set when greyed, cleared when the background clears.

## Verification

- PHPUnit: 5907 tests, **zero regressions** by JUnit set-diff against `origin/devel`.
- `ThemeSafetyUiTest` green; direct probes confirm 0 remaining hits in both JS files.
- PHPStan `[OK] No errors`; PHPCS clean; `node --test tests/js/` 17/17; `node --check` on both
  JS files; comment-narration clean.

## Known coverage limit

The five dialogs are pinned by the widened `ThemeSafetyUiTest`, which runs hermetically on
every PR. They are **not** pinned by a browser test — opening those dialogs needs a trigger
flow that does not exist in the smoke suite today. The greyout path *is* pinned in Tier B.
Stating that rather than implying the dialogs have rendered coverage they do not have.

🤖 Generated by [Claude Code](https://claude.com/claude-code), posted via @BBcan177's account on their behalf.


## Review rounds 1 and 2

Round 1 found the widening incomplete; round 2 found the completion had broken something else.
Both are the same mistake in different directions, and the second fix addresses the cause
rather than the instance.

**Round 1, blocking.** jQuery takes `backgroundColor` and `background-color` interchangeably,
and the widened pattern learned only the hyphenated one — so `.css('backgroundColor', X)` still
passed green, inconsistently, since the bare camel key was already caught by an older branch.
Closed, along with two further evasions a reviewer probed (`setProperty()` and a direct
`style.backgroundColor` assignment) rather than documenting them as caveats.

**Round 1, structural.** The inventory test asserted its key-wise diff before the per-needle
loop ran, so a new hit inside a file the TODO already listed could only surface if nothing else
failed first. It collects every violation and reports them together now.

**Round 2, blocking.** Teaching `scan()` those two new forms without teaching
`contextHasForeground()` the matching *foreground* idioms meant code paired through either form
reported as a violation — `elem.style.color = …` and `setProperty('color', …)` never satisfy a
`color:` pattern. No production code uses those idioms yet, so nothing was red; the next person
to fix a site that way would have been blocked by the guard that asked them to.

That is round 1's mistake mirrored, and the cause is the same both times: `scan()`'s background
vocabulary and `contextHasForeground()`'s foreground vocabulary are separate patterns that must
agree, with nothing making them. So the fix is a fixture, not just a pattern — every syntax
`scan()` detects is exercised **unpaired and paired**:

```text
✔ Every detected form is also recognised when paired with css·declaration
✔ … css·shorthand · js·bare·key · js·quoted·key · js·quoted·camel
✔ … jquery·setter · jquery·camel · setProperty · style·assignment
```

Adding to one pattern without the other now fails here instead of shipping. Verified by dropping
`setProperty` from the foreground side alone and watching that case, and only that case, go red.

**Round 2, performance.** The three added branches captured values greedily, which a reviewer
measured at 2238 ms on a megabyte of near-miss input — ~2600× the round-1 pattern. Possessive
quantifiers restore linear time: **1.18 ms** on the same input. Not reachable (the scanner reads
only this repo's own tracked files), but a genuine regression against round 1.

**Round 2, minor.** The setter branch matched inside `notSetProperty(`; a word boundary closes it.

### Deferred

`declarationContext()` is not brace-aware, so a nested object's `color` launders an unpaired
background. Pre-existing — reproducible on the pre-PR scanner — and tracked in **#2892** rather
than widened into this change.

### Verification

PHPStan `[OK] No errors`; PHPCS clean; `node --test tests/js/` 17/17; full PHPUnit suite with
**zero regressions** by JUnit set-diff against `origin/devel`.


## Review rounds 3 and 4

**Round 3, blocking — the round-2 word boundary was scoped one alternative too wide.** It sat
before the whole `(?:\.css|setProperty)` alternation, so it also required that nothing
identifier-like precede the dot. `$(x).css(...)` survived only because `)` is not an identifier
character; `elem.css(...)`, `$el.css(...)` and `this.css(...)` silently stopped being detected.
Fixing a loud false positive that way bought a silent false negative, which is the worse of the
two. Scoped to `setProperty`, the only branch that needed it.

The lockstep fixture did not catch it, because every setter row was written `$(x).css(...)` —
the breaking shape was never exercised. Rows for a cached selector and for `this` were added;
re-broadening the boundary now fails on both by name.

**Round 4 — nothing blocking.** It supplied two leads for a later pass, both taken here since
they were cheap:

- `contextHasForeground()` excluded a letter or hyphen before `color` but not a digit or
  underscore, so an identifier ending in `_color` satisfied the foreground check. `cc_color`
  exists in `alerts.php` today, just never inside a window with an unpaired background.
- Every row exercising the `.css()`/`setProperty` branches used single quotes while real call
  sites use both — the same shape of gap that hid the round-3 regression. Double-quoted rows
  added.

### Correction to this PR's own framing

Round 4 established that **every real `.css()` call site in the tree uses the object-map form**
(`.css({'background-color': …, 'color': …})`), which is matched by the always-on `obj` branch.
The round-3 regression therefore could not have produced a live false negative on any file
currently in the tree — it mattered for future two-arg code, and for `setProperty`, which is
always called that way. The regex churn across rounds 1-4 was real; its live blast radius was
smaller than the round-by-round narrative implied.

### Verification

PHPStan `[OK] No errors`; PHPCS clean; `node --test tests/js/` 17/17; full PHPUnit suite at the
76-failure environmental baseline with **zero** ThemeSafety failures.
