### PR TITLE
test: allow expected default smoke skips

### DIFF
--- a/tests/skip-allowlist.txt
+++ b/tests/skip-allowlist.txt
@@ -63,5 +63,12 @@ pytest:tests.test_cross_agent_tooling::test_semgrep_scans_a_php_inc_file_only_wi
 # none render; the `ui-tests` label gates that fan-out, so the gate had not observed it.
 ui:tests.smoke.ui.test_browser_misc::test_feeds_alt_radio_submit_wiring  # no pre-defined feed exposes an Alternate-URL radio on this box
 
+# smoke -- expected default-scope outcomes recorded from the live fan-out (issue #2629).
+smoke:tests.smoke.test_smoke_714_asn_geoip::test_714_c1_asn_table_logs_not_stray_file  # licensed IPinfo token is intentionally absent from CI; dispatch-only live proof (ADR-04 §7)
+smoke:tests.smoke.test_smoke_714_asn_geoip::test_714_c8_geoip_single_ip_preserved  # licensed MaxMind credentials are intentionally absent from CI; dispatch-only live proof (ADR-04 §7)
+smoke:tests.smoke.test_smoke_boot::test_control_name_resolves  # baked control name is optional; matrix cases inject their own control records
+smoke:tests.smoke.test_smoke_helpers::test_reset_returns_to_baseline  # baked control name is optional; the reset executes before this scaffold assertion skips
+smoke:tests.smoke.test_smoke_matrix::test_false_green_guard_vm  # strict xfail is the guard's expected outcome and pytest records it as a JUnit skip
+
 # phpunit -- only on a host that carries the pkg(8) port binary (a FreeBSD/pfSense dev box).
 phpunit:SoftwareFailedCheckStateTest::testPkgLatestReportsAFailedAttemptToItsCaller  # drives the real pkg shellout; its outcome is host repository state where /usr/local/sbin/pkg exists

--- a/tests/test_check_skip_allowlist.py
+++ b/tests/test_check_skip_allowlist.py
@@ -633,8 +633,8 @@ def test_canary_fixture_is_never_on_the_real_allowlist(suite: str, capsys: pytes
 
 
 # Suite prefixes the allowlist may legitimately carry, one per --suite value the gates pass:
-# run-gates.sh uses pytest/phpunit/shellspec and ui-tests.yml uses ui.
-_ALLOWLIST_SUITES = ("pytest", "phpunit", "shellspec", "ui")
+# run-gates.sh uses pytest/phpunit/shellspec; the live workflows use ui/smoke.
+_ALLOWLIST_SUITES = ("pytest", "phpunit", "shellspec", "ui", "smoke")
 
 
 def test_real_allowlist_file_parses_cleanly() -> None:
@@ -644,3 +644,28 @@ def test_real_allowlist_file_parses_cleanly() -> None:
     assert entries, "tests/skip-allowlist.txt must seed at least the known PHPUnit/pytest skips"
     for entry_id in entries:
         assert entry_id.split(":", 1)[0] in _ALLOWLIST_SUITES, entry_id
+
+
+def test_default_smoke_skips_are_allowlisted(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    root = Path(__file__).resolve().parents[1]
+    testcases = "".join(
+        f'<testcase classname="{classname}" name="{name}"><skipped message="expected"/></testcase>'
+        for classname, name in (
+            ("tests.smoke.test_smoke_714_asn_geoip", "test_714_c1_asn_table_logs_not_stray_file"),
+            ("tests.smoke.test_smoke_714_asn_geoip", "test_714_c8_geoip_single_ip_preserved"),
+            ("tests.smoke.test_smoke_boot", "test_control_name_resolves"),
+            ("tests.smoke.test_smoke_helpers", "test_reset_returns_to_baseline"),
+            ("tests.smoke.test_smoke_matrix", "test_false_green_guard_vm"),
+        )
+    )
+    report = _report(tmp_path, "smoke.xml", testcases)
+    rc = csa.main(
+        [
+            "--suite",
+            "smoke",
+            "--allowlist",
+            str(root / "tests/skip-allowlist.txt"),
+            str(report),
+        ]
+    )
+    assert rc == 0, capsys.readouterr().err


### PR DESCRIPTION
Part of #2629; fixes only the missing default-smoke skip baseline. #2629 remains open for a green current default fan-out after the independent shard-3 root in #2900 is resolved.

## Root cause

PR #2718 wired the canonical skip-set gate into every smoke shard, but `tests/skip-allowlist.txt` carried no `smoke:` baseline entries. The default live environment intentionally produces five non-running outcomes:

- two licensed-data cases skip because CI has no IPinfo/MaxMind credentials;
- two scaffold checks skip when the optional baked control name is absent;
- the strict false-green guard xfails, which pytest serializes as a JUnit `<skipped type="pytest.xfail">`.

The suite itself is green on the affected shards, then the new gate turns those expected outcomes into exit 1. Current-develop default-scope run [33291279634](https://github.com/pfBlockerNG/pfBlockerNG/actions/runs/33291279634) proves that exact split: shard 1/3 reports 118 tests, zero failures/errors, two expected skips; shard 2/3 reports 119 tests, zero failures/errors, two expected skips plus the strict xfail. Replaying both JUnit reports against this branch's allowlist returns rc 0.

Shard 3/3 still has one independent failure in `test_persisted_schedule_runs_once_in_locked_runtime_order`; it is routed to #2900 rather than combined here. Exact-current-head isolated run [33291997019](https://github.com/pfBlockerNG/pfBlockerNG/actions/runs/33291997019) passes 1/1, proving the full-shard red is the test's shared-session baseline dependency, not a product migration failure.

## Change

- Record the five exact `smoke:` JUnit IDs, each with its own reason.
- Add a regression that feeds those exact live-report IDs through the real checker and canonical allowlist.

No product code, fixture skip condition, marker, or checker semantics change.

## Executed proof

Frozen regression: `tests/test_check_skip_allowlist.py`, `git hash-object` `f59b44166e3da01557ae8dc8969a4a64aeb5c092` at RED and GREEN.

- RED on untouched allowlist: `1 failed`; checker named all five missing IDs.
- GREEN unchanged test: `1 passed`.
- Mutation: removed one production allowlist row; the regression failed naming that exact ID; restored row: `1 passed`.
- Focused file: `57 passed`.
- Replayed the real JUnit diagnostics from all 12 legs of scheduled run [33254160363](https://github.com/pfBlockerNG/pfBlockerNG/actions/runs/33254160363): before, shard 1/3 and 2/3 reports returned checker rc 1; after, all 12 reports return rc 0 for the skip gate.
- Canonical `scripts/agent/run-gates.sh --diff origin/devel`: `GATES: PASS` (pytest, Ruff check/format, mypy, coverage pairing).
- Exact-head CI [33291854526](https://github.com/pfBlockerNG/pfBlockerNG/actions/runs/33291854526): success at `89616eec`.
- Independent verifier: PASS at exact `89616eec`; five-entry RED, restored GREEN, frozen hash matched, clean tree.
- Four adversarial legs: clean after removing the premature `Fixes #2629` lifecycle claim; CodeRabbit: no actionable comments.

🤖 Generated by Oh My Pi and posted on behalf of @andrebrait.