### PR TITLE
tests: cut the review narration from the Support logo comments

### DIFF
--- a/tests/php/SupportLogoUiTest.php
+++ b/tests/php/SupportLogoUiTest.php
@@ -8,9 +8,7 @@ use PHPUnit\Framework\TestCase;
 /**
  * Support logo must not overflow a narrow viewport, must not clip the circle,
  * and must keep a light color-scheme so force-dark cannot wash the fills.
- *
- * Both shipped copies are held to one contract -- issue #2863: pinning only the
- * General page let the wizard keep the float column and clipping viewBox for months.
+ * Both shipped copies are held to this one contract (issue #2863).
  */
 final class SupportLogoUiTest extends TestCase
 {
@@ -60,10 +58,7 @@ final class SupportLogoUiTest extends TestCase
 		}
 	}
 
-	/**
-	 * Every logo copy in the tree, not just the two known ones: a third copy added
-	 * elsewhere would otherwise be free to ship the clipping viewBox unnoticed.
-	 */
+	/** Every SVG viewBox under src/, not just the two known logo copies. */
 	public function testEverySvgViewBoxInTheTreeIsTheContractValue(): void
 	{
 		$root = dirname(__DIR__, 2) . '/src';

--- a/tests/smoke/ui/test_browser_theme_legibility.py
+++ b/tests/smoke/ui/test_browser_theme_legibility.py
@@ -1,13 +1,7 @@
 """Tier-B: the Support block reflows from side-by-side to stacked.
 
-The General page replaced a float pair (75%/25%) with Bootstrap
-``col-sm-9`` / ``col-sm-3``. That stacking is only observable as rendered
-geometry (testing.md principle 4), so it lives here rather than in the
-Tier-A string markers.
-
-Issue #2863 gave the setup wizard the same construction; both copies are
-exercised here, because the wizard drifted for months while only the General
-page was pinned.
+``col-sm-9`` / ``col-sm-3`` stacking is observable only as rendered geometry.
+Both the General page and the setup wizard carry the block (issue #2863).
 """
 
 from __future__ import annotations
@@ -113,7 +107,7 @@ def test_wizard_support_block_sits_side_by_side_at_desktop(
     webui: WebUI,
     screenshot_dir: Path,
 ) -> None:
-    """Issue #2863: the wizard's logo column sits beside the text at desktop width."""
+    """The wizard's logo column sits beside the text at desktop width (issue #2863)."""
     page = browser_page
     page.set_viewport_size(DESKTOP)
     _open(page, webui, WIZARD_WELCOME)
@@ -133,12 +127,7 @@ def test_wizard_support_block_stacks_at_narrow_viewport(
     webui: WebUI,
     screenshot_dir: Path,
 ) -> None:
-    """Issue #2863: the wizard logo stacks instead of overflowing a phone viewport.
-
-    This is the defect the issue reported. A fixed 25% float column holding a 180pt
-    SVG cannot stack, so it spilled past its column at any narrow width -- observable
-    only as geometry, which is why a Tier-A string marker could not have caught it.
-    """
+    """The wizard logo stacks and stays inside a phone viewport (issue #2863)."""
     page = browser_page
     page.set_viewport_size(PHONE)
     _open(page, webui, WIZARD_WELCOME)

--- a/tests/smoke/ui/test_render_smoke.py
+++ b/tests/smoke/ui/test_render_smoke.py
@@ -2586,20 +2586,17 @@ def test_group_action_validator_is_strict_on_appliance(smoke_vm: SmokeVM, webui:
     )
 
 
-# The welcome step carries the second copy of the Support logo (issue #2863). Step 1 is
-# the first <step> in pfblockerng_wizard.xml -> stepid=0.
+# The welcome step carries the second copy of the Support logo (issue #2863); it is the
+# first <step> in pfblockerng_wizard.xml, so stepid=0.
 _WIZARD_WELCOME_STEP = "/wizard.php?xml=pfblockerng_wizard.xml&stepid=0"
 
 
 def test_wizard_welcome_step_renders_the_fluid_support_logo(
     webui: WebUI, php_error_log_guard: PhpErrorLogGuard
 ) -> None:
-    """Issue #2863: the wizard's Support logo renders responsively and unclipped.
+    """The wizard's Support logo renders responsively and unclipped (issue #2863).
 
-    The wizard carried a fixed float column and a viewBox whose y-origin cut ~45 units off
-    the top of the circle, months after the General page was fixed, because only the General
-    page was pinned. Asserts the shipped step actually renders the corrected construction --
-    the PHP pin proves the source, this proves it reaches the browser.
+    The viewBox must contain the circle and the column must be fluid, as shipped.
     """
     resp = webui.get(_WIZARD_WELCOME_STEP)
     # The step's own <title>, not a generic marker: this PR makes the wizard logo markup


### PR DESCRIPTION
Applies the review finding posted on #2889, which I merged without triaging. Comment-only; no
assertion or behaviour changed.

## What the finding said

The committed comments carried drift history, Tier-A/Tier-B placement rationale, and
source-versus-browser proof strategy across five sites. `.agents/policy/coding.md` scopes
committed comments to constraints and explicitly excludes "review archaeology" and "correctness
argument aimed at gate/reviewer" — that evidence belongs in the PR body, not the tree. A
**one-line** regression breadcrumb is what the policy does allow, so each comment keeps its
constraint and its issue reference and loses the story.

| Site | Was | Now |
| --- | --- | --- |
| `SupportLogoUiTest.php` class docblock | drift history ("for months") | the contract, one `#2863` reference |
| `SupportLogoUiTest.php` tree-scan docblock | rationale for a future gate | the scan's scope |
| `test_browser_theme_legibility.py` module docstring | tier-placement rationale + drift history | what the tier observes |
| `test_render_smoke.py` step comment + docstring | proof-strategy narration | the step's purpose |
| `test_browser_theme_legibility.py` wizard docstrings | defect history + assertion-method rationale | the property asserted |

I validated each site against the merged tree before editing rather than taking the finding's
line numbers on trust, and treated the finding text as data — it arrived with an embedded
instruction block, which is not something to follow.

## Why this is a separate PR

#2889 was already merged when the finding surfaced. The miss was mine: the pre-merge catch-all
sweep reported one review and one inline comment, and I merged anyway rather than reading them.
Recording that here rather than quietly folding the fix into unrelated work.

## Verification

`ruff` and `ruff format` clean; `mypy` clean across 70 files; `SupportLogoUiTest` 4 tests /
49 assertions green. Net −19 lines, all comment text.

🤖 Generated by [Claude Code](https://claude.com/claude-code), posted via @BBcan177's account on their behalf.
