### PR TITLE
tests: seed the fresh install the persisted schedule case asserts

### DIFF
--- a/tests/smoke/test_schedule_runtime.py
+++ b/tests/smoke/test_schedule_runtime.py
@@ -117,7 +117,7 @@ echo '<<<SCHEDULE>>>' . json_encode($out) . '<<<END>>>';
 
 
 def test_persisted_schedule_runs_once_in_locked_runtime_order(deployed_vm: SmokeVM) -> None:
-    """Persist migration/runtime inputs, run the real tick, and prove once-only ordering."""
+    """Seed a fresh install, persist migration/runtime inputs, run the real tick, prove once-only ordering."""
     snippet = r"""
 require_once('/usr/local/pkg/pfblockerng/pfblockerng.inc');
 pfb_global();
@@ -137,6 +137,15 @@ $state_before = is_file($state_path) ? file_get_contents($state_path) : NULL;
 $cache_before = is_file($cache_path) ? file_get_contents($cache_path) : NULL;
 $out = array();
 try {
+    // Cause the virgin-install image instead of inheriting it (issue #2900): the
+    // cross-module baseline (conftest.py::_pfb_module_baseline) unsets these very
+    // keys, and pfb_schedule_migrate() reads General's operator view for freshness.
+    config_set_path($paths[0], array());
+    config_set_path($paths[1], array());
+    config_set_path($paths[2], array());
+    config_set_path($paths[3], array());
+    write_config('pfBlockerNG smoke #2308: fresh-install scheduler image');
+    pfb_run_migrations();
     $fresh = config_get_path($paths[0], array());
     $out['fresh'] = array(
         'master' => $fresh['pfb_scheduled_feed_updates'] ?? NULL,


### PR DESCRIPTION
Fixes #2900. Independent shard-3 root split from #2629; deliberately not combined with the merged skip-allowlist fix (PR #2899) or the reboot-marker tickets #2487/#2596.

## Root cause

`test_persisted_schedule_runs_once_in_locked_runtime_order` snapshotted the **live** General section and asserted install-time schedule defaults before it wrote any input of its own, so it only passed as the first module on a fresh box. The documented cross-module contract is the opposite: `tests/smoke/conftest.py::_pfb_module_baseline` calls `helpers.reset_pfb_baseline()` after every module, and `helpers._BASELINE_GLOBAL_KEYS` deliberately unsets `pfb_scheduled_feed_updates`, `pfb_schedule_weekday`, `pfb_schedule_hour`, `pfb_schedule_minute` and `skipfeed`. In the default shard order the case therefore read three `NULL`s and failed its own precondition, while the real subject — everything after it writes the legacy/runtime image — was never reached.

Both competing hypotheses were falsified on the exact base `3c54bd2e`, not reasoned away:

- **Product/install regression (the migration stopped seeding fresh defaults):** falsified. Module-only run [33292504795](https://github.com/pfBlockerNG/pfBlockerNG/actions/runs/33292504795) reports `2 passed, 1044 deselected in 67.12s`.
- **The sibling pure-migration case corrupts the baseline:** falsified by that same run — the sibling runs immediately before the persisted case there and both pass. Only a *preceding module* reddens it.

## Change

Test-only, one file. The case now **causes** the virgin-install image instead of inheriting it: empty General plus empty dynamic groups, then the installer's own migration driver (`pfb_run_migrations()`, the default `$migrations` callable of `pfb_install_settings_family_finalize()`). `pfb_schedule_migrate()` decides freshness from General's own operator view (`pfblockerng_extra.inc:2961`), and no registry entry ahead of `issue2308-quarter-hour-schedule` writes General (`pfb_migration_registry()`, entries 0–3 are all DNSBL sections), so this is exactly the state a new box presents.

No production code, fixture, marker or checker semantics change. Every assertion is retained byte-identical, including the `fresh` triple `{"master": "on", "skipfeed": "3", "weekday": "7"}` — `skipfeed` is `'3'` only on the fresh branch (`'0'` otherwise), so the retained assertion still pins live fresh-install detection, and the legacy migration, cache regeneration, once-only order, completion set, next-due, quiet-hours and manual-apply assertions are untouched.

## Executed proof

Base `3c54bd2e` (contains merged PR #2899). Head `0129f430`.

- **RED, default shard order, unmodified test** — [33292510234](https://github.com/pfBlockerNG/pfBlockerNG/actions/runs/33292510234) at exact base `3c54bd2e`, `-k "test_log_age_retention or test_schedule_runtime"` (both modules live in shard 3/3, in that path order):

  ```text
  >       assert data["fresh"] == {"master": "on", "skipfeed": "3", "weekday": "7"}
  E       AssertionError: assert {'master': No...eekday': None} == {'master': 'o...weekday': '7'}
  FAILED tests/smoke/test_schedule_runtime.py::test_persisted_schedule_runs_once_in_locked_runtime_order
  1 failed, 4 passed, 1041 deselected in 72.11s
  ```

  Byte-identical failure to the default-scope fan-out [33291279634](https://github.com/pfBlockerNG/pfBlockerNG/actions/runs/33291279634) this ticket was split from.

- **Module-only discriminator (base)** — [33292504795](https://github.com/pfBlockerNG/pfBlockerNG/actions/runs/33292504795): `2 passed, 1044 deselected`.
- **Test file `git hash-object`:** `6521a417b5fb318f665c46bcc1ea5a781118e775` at RED (the base file the RED run executed) → `8e33c04d27e2b5b134ab79f4fba95db7b589d3d8` committed. The change *is* the fix, so the frozen artifact is the RED-time base blob; the retained assertion lines are unchanged between them.
- **Mutation evidence — the retained `fresh` assertion still bites.** The assertion's values are production-derived, and the precondition mechanism is unit-pinned by `QuarterHourMigrationTest::testFreshMigrationPersistsSundayUniformSlotAndSkipfeed` (empty General → `pfb_run_migrations()` → `on` / `7` / `3`). Mutating the production seeds off-appliance:

  ```text
  $gen['skipfeed'] = $is_fresh ? '3' : '0';  ->  '0'   =>  1) ...SundayUniformSlotAndSkipfeed  -'3' +'0'   FAILURES! Tests: 1
  $gen['pfb_schedule_weekday'] = '7';        ->  '1'   =>  1) ...SundayUniformSlotAndSkipfeed  -'7' +'1'   FAILURES! Tests: 1
  restored                                          =>  OK (1 test, 11 assertions)
  ```

  The live RED above is the same evidence at appliance level: with the seeds absent the assertion fails and names the exact diff.
- **Embedded PHP parses:** both snippets in the module extracted and linted, `php -l` → `No syntax errors detected` (PHP 8.5.10, host).
- **Canonical gates** (`scripts/agent/run-gates.sh --diff origin/devel`):

  ```text
  GATE PASS: python3 scripts/check_coverage_pairing.py --name-status-z
  GATE PASS: uv run --locked pytest
  GATE PASS: uv run --locked ruff check .
  GATE PASS: uv run --locked ruff format --check .
  GATE PASS: uv run --locked mypy tests/
  GATES: PASS
  ```

- **GREEN at head `0129f430`, same shape as the RED** — [33292739264](https://github.com/pfBlockerNG/pfBlockerNG/actions/runs/33292739264): `5 passed, 1041 deselected in 71.48s` (was `1 failed, 4 passed`).
- **GREEN, focused isolated** — [33292743935](https://github.com/pfBlockerNG/pfBlockerNG/actions/runs/33292743935): `1 passed, 1045 deselected in 61.48s`.
- **Off-appliance three-arm probe of the inserted sequence** (real `pfblockerng_extra.inc` through the PHPUnit harness, `$GLOBALS['config']` seeded to the cross-module baseline shape): no precondition → `{"master":null,"skipfeed":null,"weekday":null}` (the live RED, reproduced); migrations without emptying General → `{"master":"on","skipfeed":"0","weekday":"7"}`; the committed insert → `{"master":"on","skipfeed":"3","weekday":"7"}`. Both halves of the insert are load-bearing; details in the audit comment.

Four-lens review, per-file verdicts and the measured blast radius are in the audit comment below.

🤖 Generated by Oh My Pi and posted on behalf of @andrebrait.
