### PR TITLE
tests: require redirect fixture readiness event

### DIFF
--- a/tests/php/DownloadRedirectCredentialScopeTest.php
+++ b/tests/php/DownloadRedirectCredentialScopeTest.php
@@ -129,8 +129,10 @@ file_put_contents(getenv('EVENT_LOG'), json_encode([
 	(int) $_SERVER['SERVER_PORT'],
 	$uri,
 ]) . PHP_EOL, FILE_APPEND);
-if ($uri === '/__pfb_ready/' . getenv('READY_TOKEN')) {
-	echo getenv('READY_TOKEN');
+if (str_starts_with($uri, '/__pfb_ready/')) {
+	if ($uri === '/__pfb_ready/' . getenv('READY_TOKEN')) {
+		echo getenv('READY_TOKEN');
+	}
 	return;
 }
 file_put_contents(getenv('AUTH_LOG'), json_encode([

--- a/tests/php/DownloadRedirectCredentialScopeTest.php
+++ b/tests/php/DownloadRedirectCredentialScopeTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 use PHPUnit\Framework\Attributes\CoversFunction;
 use PHPUnit\Framework\TestCase;
 
+require_once __DIR__ . '/support/HttpFixtureReadiness.php';
+
 /**
  * pfb_download() Basic-credential scope across manual redirect hops (issue #1919).
  *
@@ -105,7 +107,8 @@ final class DownloadRedirectCredentialScopeTest extends TestCase
 
 	/**
 	 * One shared router serves both servers (URIs are disjoint). Every request
-	 * appends [server-port, uri, PHP_AUTH_USER, PHP_AUTH_PW, HTTP_AUTHORIZATION,
+	 * appends [server-port, uri] to EVENT_LOG. Non-readiness requests append
+	 * [server-port, uri, PHP_AUTH_USER, PHP_AUTH_PW, HTTP_AUTHORIZATION,
 	 * HTTP_X_FEED_PROBE] to AUTH_LOG (the raw Authorization header covers
 	 * non-Basic credentials — the issue #1953 Bearer-token axis; X-Feed-Probe
 	 * stands in for a non-credential extra header that must ride every hop).
@@ -121,6 +124,15 @@ final class DownloadRedirectCredentialScopeTest extends TestCase
 		$router    = "{$this->workdir}/router.php";
 		$routerSrc = <<<'PHP'
 <?php
+$uri = $_SERVER['REQUEST_URI'] ?? '';
+file_put_contents(getenv('EVENT_LOG'), json_encode([
+	(int) $_SERVER['SERVER_PORT'],
+	$uri,
+]) . PHP_EOL, FILE_APPEND);
+if ($uri === '/__pfb_ready/' . getenv('READY_TOKEN')) {
+	echo getenv('READY_TOKEN');
+	return;
+}
 file_put_contents(getenv('AUTH_LOG'), json_encode([
 	(int) $_SERVER['SERVER_PORT'],
 	$_SERVER['REQUEST_URI'] ?? '',
@@ -129,7 +141,6 @@ file_put_contents(getenv('AUTH_LOG'), json_encode([
 	$_SERVER['HTTP_AUTHORIZATION'] ?? null,
 	$_SERVER['HTTP_X_FEED_PROBE'] ?? null,
 ]) . PHP_EOL, FILE_APPEND);
-$uri = $_SERVER['REQUEST_URI'] ?? '';
 // Both bases come from a ports file written AFTER both servers are up (the
 // second server's port is unknown when the first is spawned).
 $bases = json_decode((string) file_get_contents(getenv('PORTS_FILE')), true);
@@ -167,37 +178,52 @@ PHP;
 	/** Start one php -S fixture on a free port; return the port. */
 	private function startOneServer(string $router, string $label): int
 	{
-		$descriptors = [1 => ['file', '/dev/null', 'w'], 2 => ['file', '/dev/null', 'w']];
+		$failures = [];
 		for ($try = 0; $try < 10; $try++) {
-			$port = random_int(20000, 60000);
-			$proc = proc_open(
+			$port   = random_int(20000, 60000);
+			$nonce  = bin2hex(random_bytes(16));
+			$stderr = "{$this->workdir}/server-{$port}-{$try}.stderr";
+			$proc   = proc_open(
 				['php', '-S', "127.0.0.1:{$port}", $router],
-				$descriptors,
+				[1 => ['file', '/dev/null', 'w'], 2 => ['file', $stderr, 'w']],
 				$pipes,
 				$this->workdir,
 				[
 					'AUTH_LOG'   => "{$this->workdir}/auth.log",
+					'EVENT_LOG'  => "{$this->workdir}/events.log",
 					'PORTS_FILE' => "{$this->workdir}/ports.json",
+					'READY_TOKEN' => $nonce,
 					'PATH'       => (string) getenv('PATH'),
 				]
 			);
 			if (!is_resource($proc)) {
+				$failures[] = "port {$port}: process=proc_open failed stderr=(unavailable)";
 				continue;
 			}
-			// Poll readiness instead of a fixed wait (up to ~2s).
 			for ($i = 0; $i < 40; $i++) {
-				$sock = @fsockopen('127.0.0.1', $port, $errno, $errstr, 0.05);
-				if ($sock !== FALSE) {
-					fclose($sock);
-					$this->servers[] = $proc;
+				if (pfb_test_http_fixture_event_received($port, $nonce)) {
+					$this->servers[$port] = $proc;
 					return $port;
 				}
 				usleep(50000);
 			}
-			proc_terminate($proc);
-			proc_close($proc);
+
+			$status = proc_get_status($proc);
+			if ($status['running']) {
+				proc_terminate($proc);
+			}
+			$closeExit = proc_close($proc);
+			$stderrText = trim((string) @file_get_contents($stderr));
+			$failures[] = sprintf(
+				'port %d: process[running=%s exit=%d close=%d] stderr=%s',
+				$port,
+				$status['running'] ? 'true' : 'false',
+				$status['exitcode'],
+				$closeExit,
+				$stderrText === '' ? '(empty)' : $stderrText
+			);
 		}
-		$this->fail("could not start the {$label} php -S fixture server");
+		$this->fail("could not start the {$label} php -S fixture server; " . implode(' | ', $failures));
 	}
 
 	/** Run one credentialed change_detect probe against $path on the origin server. */
@@ -219,6 +245,49 @@ PHP;
 			password: $password,
 			extraHeaders: $extraHeaders,
 		));
+	}
+
+	private function redirectFailureMessage(PfbDownloadResult $result): string
+	{
+		$events = @file_get_contents("{$this->workdir}/events.log");
+		$events = is_string($events) ? trim($events) : '(missing)';
+		if ($events === '') {
+			$events = '(empty)';
+		}
+
+		$testLog = @file_get_contents("{$this->workdir}/pfblockerng.log");
+		$testLog = is_string($testLog) ? trim($testLog) : '(missing)';
+		if ($testLog === '') {
+			$testLog = '(empty)';
+		}
+
+		$processes = [];
+		foreach ($this->servers as $port => $server) {
+			if (!is_resource($server)) {
+				$processes[] = "port {$port} closed";
+				continue;
+			}
+			$status = proc_get_status($server);
+			$processes[] = sprintf(
+				'port %d running=%s exit=%d',
+				$port,
+				$status['running'] ? 'true' : 'false',
+				$status['exitcode']
+			);
+		}
+
+		$metadata = json_encode($result->responseMeta, JSON_UNESCAPED_SLASHES);
+		return sprintf(
+			'redirected download must succeed; response status=%s metadata=%s; events=%s; ports=origin:%d target:%d alt:%d; processes=%s; pfBlockerNG log=%s',
+			(string) ($result->responseMeta['status'] ?? '(missing)'),
+			is_string($metadata) ? $metadata : '(unavailable)',
+			$events,
+			$this->originPort,
+			$this->targetPort,
+			$this->altPort,
+			$processes === [] ? '(none)' : implode(', ', $processes),
+			$testLog
+		);
 	}
 
 	/** The Authorization header value cURL derives from the Basic credentials. */
@@ -248,7 +317,7 @@ PHP;
 	public function testCrossHostRedirectHopReceivesNoCredentials(): void
 	{
 		$result = $this->downloadFrom('/cross');
-		$this->assertTrue($result->success, 'redirected download must succeed');
+		$this->assertTrue($result->success, $this->redirectFailureMessage($result));
 		$this->assertSame('200', $result->responseMeta['status'] ?? '', 'probe metadata must carry the final 200');
 
 		$this->assertSame(
@@ -274,7 +343,7 @@ PHP;
 	public function testCrossHostRedirectHopReceivesNoAuthorizationHeader(): void
 	{
 		$result = $this->downloadFrom('/cross', '', '', ['Authorization: Bearer SECRET-TOKEN']);
-		$this->assertTrue($result->success, 'redirected download must succeed');
+		$this->assertTrue($result->success, $this->redirectFailureMessage($result));
 		$this->assertSame('200', $result->responseMeta['status'] ?? '', 'probe metadata must carry the final 200');
 
 		$this->assertSame(
@@ -303,7 +372,7 @@ PHP;
 			'Authorization: Bearer SECRET-TOKEN',
 			'X-Feed-Probe: keep',
 		]);
-		$this->assertTrue($result->success, 'redirected download must succeed');
+		$this->assertTrue($result->success, $this->redirectFailureMessage($result));
 		$this->assertSame('200', $result->responseMeta['status'] ?? '', 'probe metadata must carry the final 200');
 
 		$this->assertSame(
@@ -328,7 +397,7 @@ PHP;
 	public function testSameHostDifferentPortHopReceivesNoCredentials(): void
 	{
 		$result = $this->downloadFrom('/portjump');
-		$this->assertTrue($result->success, 'redirected download must succeed');
+		$this->assertTrue($result->success, $this->redirectFailureMessage($result));
 		$this->assertSame('200', $result->responseMeta['status'] ?? '', 'probe metadata must carry the final 200');
 
 		$this->assertSame(
@@ -350,7 +419,7 @@ PHP;
 	public function testSameHostRedirectKeepsCredentials(): void
 	{
 		$result = $this->downloadFrom('/same');
-		$this->assertTrue($result->success, 'redirected download must succeed');
+		$this->assertTrue($result->success, $this->redirectFailureMessage($result));
 		$this->assertSame('200', $result->responseMeta['status'] ?? '', 'probe metadata must carry the final 200');
 
 		$this->assertSame(

--- a/tests/php/DownloadRedirectFixtureReadinessHygieneTest.php
+++ b/tests/php/DownloadRedirectFixtureReadinessHygieneTest.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/DownloadRedirectCredentialScopeTest.php';
+require_once __DIR__ . '/HttpFixtureReadinessTest.php';
+
+/** Issue #2065: fixture diagnostics and readiness traffic stay distinct from credential hops. */
+final class DownloadRedirectFixtureReadinessHygieneTest extends TestCase
+{
+	public function testForeignReadinessNonceDoesNotPolluteCredentialLog(): void
+	{
+		$this->withFixture(function (DownloadRedirectCredentialScopeTest $suite, ReflectionClass $ref): void {
+			$port = $ref->getProperty('originPort');
+			$workdir = $ref->getProperty('workdir');
+			$this->assertFalse(
+				pfb_test_http_fixture_event_received((int) $port->getValue($suite), bin2hex(random_bytes(16))),
+				'a nonce for another fixture must not satisfy this router readiness event'
+			);
+			$authLines = @file(
+				(string) $workdir->getValue($suite) . '/auth.log',
+				FILE_IGNORE_NEW_LINES
+			);
+			$this->assertSame(
+				[],
+				$authLines ?: [],
+				'a foreign readiness nonce must not appear as a credential-bearing redirect hop'
+			);
+		});
+	}
+
+	public function testFailureDiagnosticsNameResponseHopsPortsAndProcesses(): void
+	{
+		$this->withFixture(function (DownloadRedirectCredentialScopeTest $suite, ReflectionClass $ref): void {
+			$message = $ref->getMethod('redirectFailureMessage')->invoke(
+				$suite,
+				PfbDownloadResult::failure(['status' => '599'])
+			);
+			$origin = $ref->getProperty('originPort')->getValue($suite);
+			$target = $ref->getProperty('targetPort')->getValue($suite);
+			$alt = $ref->getProperty('altPort')->getValue($suite);
+
+			$this->assertStringContainsString('response status=599', $message);
+			$this->assertStringContainsString('events=', $message);
+			$this->assertStringContainsString('__pfb_ready', $message);
+			$this->assertStringContainsString(
+				"ports=origin:{$origin} target:{$target} alt:{$alt}",
+				$message
+			);
+			$this->assertStringContainsString('processes=port ', $message);
+			$this->assertStringContainsString('pfBlockerNG log=', $message);
+		});
+	}
+
+	public function testReadinessTearDownGuardsWorkdirBeforeGlob(): void
+	{
+		$root = tempnam(sys_get_temp_dir(), 'pfbreadyguard');
+		$this->assertNotFalse($root);
+		$this->assertTrue(unlink($root) && mkdir($root, 0700) && mkdir("{$root}/match", 0700));
+		$sentinel = "{$root}/match/sentinel";
+		$this->assertNotFalse(file_put_contents($sentinel, 'keep'));
+
+		$suite = new HttpFixtureReadinessTest('testProbeRejectsReachableForeignListener');
+		$ref = new ReflectionClass($suite);
+		$ref->getProperty('workdir')->setValue($suite, "{$root}/*");
+
+		try {
+			$ref->getMethod('tearDown')->invoke($suite);
+			$this->assertFileExists(
+				$sentinel,
+				'tearDown must validate workdir before expanding its cleanup glob'
+			);
+		} finally {
+			@unlink($sentinel);
+			@rmdir("{$root}/match");
+			@rmdir($root);
+		}
+	}
+
+	private function withFixture(callable $test): void
+	{
+		$savedGlobals = [];
+		foreach (['config', 'pfb_test_resolve_map', 'pfb_test_configured_ips'] as $name) {
+			$savedGlobals[$name] = [
+				'had' => array_key_exists($name, $GLOBALS),
+				'value' => $GLOBALS[$name] ?? NULL,
+			];
+		}
+
+		$suite = new DownloadRedirectCredentialScopeTest('testCrossHostRedirectKeepsNonCredentialExtraHeaders');
+		$ref   = new ReflectionClass($suite);
+		$setUp = $ref->getMethod('setUp');
+		$tear  = $ref->getMethod('tearDown');
+
+		try {
+			$setUp->invoke($suite);
+			$test($suite, $ref);
+		} finally {
+			$tear->invoke($suite);
+			foreach ($savedGlobals as $name => $saved) {
+				if ($saved['had']) {
+					$GLOBALS[$name] = $saved['value'];
+				} else {
+					unset($GLOBALS[$name]);
+				}
+			}
+		}
+	}
+}

--- a/tests/php/HttpFixtureReadinessTest.php
+++ b/tests/php/HttpFixtureReadinessTest.php
@@ -27,10 +27,10 @@ final class HttpFixtureReadinessTest extends TestCase
 				proc_close($server);
 			}
 		}
-		foreach ((array) glob("{$this->workdir}/*") as $path) {
-			@unlink((string) $path);
-		}
 		if ($this->workdir !== '' && is_dir($this->workdir)) {
+			foreach ((array) glob("{$this->workdir}/*") as $path) {
+				@unlink((string) $path);
+			}
 			rmdir($this->workdir);
 		}
 	}
@@ -64,13 +64,13 @@ final class HttpFixtureReadinessTest extends TestCase
 				echo 'READY';
 				return;
 			}
-			$prefix = '/__pfb_ready/';
-			if (str_starts_with($uri, $prefix)) {
-				echo substr($uri, strlen($prefix));
+			$token = getenv('READY_TOKEN');
+			if ($uri === '/__pfb_ready/' . $token) {
+				echo $token;
 				return;
 			}
 			http_response_code(404);
-			PHP, 'READY');
+			PHP, 'READY', ['READY_TOKEN' => $token]);
 
 		$this->assertTrue(
 			pfb_test_http_fixture_event_received($port, $token),
@@ -88,7 +88,7 @@ final class HttpFixtureReadinessTest extends TestCase
 		require_once $helper;
 	}
 
-	private function startServer(string $routerSource, string $setupResponse): int
+	private function startServer(string $routerSource, string $setupResponse, array $environment = []): int
 	{
 		$router = "{$this->workdir}/router-" . count($this->servers) . '.php';
 		$this->assertNotFalse(file_put_contents($router, $routerSource));
@@ -103,7 +103,7 @@ final class HttpFixtureReadinessTest extends TestCase
 				[1 => ['file', '/dev/null', 'w'], 2 => ['file', $stderr, 'w']],
 				$pipes,
 				$this->workdir,
-				['PATH' => (string) getenv('PATH')]
+				$environment + ['PATH' => (string) getenv('PATH')]
 			);
 			if (!is_resource($server)) {
 				$failures[] = "port {$port}: proc_open failed";

--- a/tests/php/HttpFixtureReadinessTest.php
+++ b/tests/php/HttpFixtureReadinessTest.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/** Issue #2065: HTTP fixture readiness proves which process owns the selected port. */
+final class HttpFixtureReadinessTest extends TestCase
+{
+	/** @var array<int,resource> */
+	private array $servers = [];
+	private string $workdir = '';
+
+	protected function setUp(): void
+	{
+		$workdir = tempnam(sys_get_temp_dir(), 'pfbready');
+		$this->assertNotFalse($workdir);
+		$this->assertTrue(unlink($workdir) && mkdir($workdir, 0700));
+		$this->workdir = $workdir;
+	}
+
+	protected function tearDown(): void
+	{
+		foreach ($this->servers as $server) {
+			if (is_resource($server)) {
+				proc_terminate($server);
+				proc_close($server);
+			}
+		}
+		foreach ((array) glob("{$this->workdir}/*") as $path) {
+			@unlink((string) $path);
+		}
+		if ($this->workdir !== '' && is_dir($this->workdir)) {
+			rmdir($this->workdir);
+		}
+	}
+
+	public function testProbeRejectsReachableForeignListener(): void
+	{
+		$this->requireReadinessHelper();
+		$port = $this->startServer(<<<'PHP'
+			<?php
+			if (($_SERVER['REQUEST_URI'] ?? '') === '/setup') {
+				echo 'FOREIGN';
+				return;
+			}
+			echo 'not-the-readiness-token';
+			PHP, 'FOREIGN');
+
+		$this->assertFalse(
+			pfb_test_http_fixture_event_received($port, 'expected-readiness-token'),
+			'a reachable listener that did not handle the nonce-bearing fixture event must not count as ready'
+		);
+	}
+
+	public function testProbeAcceptsMatchingFixtureEvent(): void
+	{
+		$this->requireReadinessHelper();
+		$token = bin2hex(random_bytes(12));
+		$port = $this->startServer(<<<'PHP'
+			<?php
+			$uri = $_SERVER['REQUEST_URI'] ?? '';
+			if ($uri === '/setup') {
+				echo 'READY';
+				return;
+			}
+			$prefix = '/__pfb_ready/';
+			if (str_starts_with($uri, $prefix)) {
+				echo substr($uri, strlen($prefix));
+				return;
+			}
+			http_response_code(404);
+			PHP, 'READY');
+
+		$this->assertTrue(
+			pfb_test_http_fixture_event_received($port, $token),
+			'the fixture router must count as ready after it echoes the exact request nonce'
+		);
+	}
+
+	private function requireReadinessHelper(): void
+	{
+		$helper = __DIR__ . '/support/HttpFixtureReadiness.php';
+		$this->assertFileExists(
+			$helper,
+			'fixture readiness must use a nonce-bearing HTTP event instead of accepting raw port connectivity'
+		);
+		require_once $helper;
+	}
+
+	private function startServer(string $routerSource, string $setupResponse): int
+	{
+		$router = "{$this->workdir}/router-" . count($this->servers) . '.php';
+		$this->assertNotFalse(file_put_contents($router, $routerSource));
+		$context = stream_context_create(['http' => ['timeout' => 0.05, 'ignore_errors' => TRUE]]);
+		$failures = [];
+
+		for ($try = 0; $try < 10; $try++) {
+			$port = random_int(20000, 60000);
+			$stderr = "{$this->workdir}/server-{$port}.stderr";
+			$server = proc_open(
+				['php', '-S', "127.0.0.1:{$port}", $router],
+				[1 => ['file', '/dev/null', 'w'], 2 => ['file', $stderr, 'w']],
+				$pipes,
+				$this->workdir,
+				['PATH' => (string) getenv('PATH')]
+			);
+			if (!is_resource($server)) {
+				$failures[] = "port {$port}: proc_open failed";
+				continue;
+			}
+			for ($attempt = 0; $attempt < 40; $attempt++) {
+				$body = @file_get_contents("http://127.0.0.1:{$port}/setup", FALSE, $context);
+				if ($body === $setupResponse) {
+					$this->servers[] = $server;
+					return $port;
+				}
+				usleep(50000);
+			}
+			proc_terminate($server);
+			proc_close($server);
+			$failures[] = "port {$port}: " . trim((string) @file_get_contents($stderr));
+		}
+
+		$this->fail('could not start readiness-test HTTP fixture; ' . implode(' | ', $failures));
+	}
+}

--- a/tests/php/support/HttpFixtureReadiness.php
+++ b/tests/php/support/HttpFixtureReadiness.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+function pfb_test_http_fixture_event_received(int $port, string $nonce): bool
+{
+	$context = stream_context_create([
+		'http' => ['timeout' => 0.05, 'ignore_errors' => TRUE],
+	]);
+	$body = @file_get_contents("http://127.0.0.1:{$port}/__pfb_ready/{$nonce}", FALSE, $context);
+
+	return is_string($body) && hash_equals($nonce, $body);
+}


### PR DESCRIPTION
Fixes #2065

## Root cause

The fixture's readiness check proved only that *something* accepted a TCP connection on the randomly selected port. A forced occupied-port probe reproduced the intermittent failure shape: the new `php -S` child failed its bind, raw `fsockopen()` connected to the foreign listener, setup accepted the wrong owner, and the redirect download returned `false` with status 503 and no fixture requests.

Changing only the probe to a nonce-bearing router request rejected the foreign listener. The same mechanism reproduced under PHP 8.3 and 8.5.

## Change

- require the spawned router to echo a per-attempt nonce before accepting it as ready;
- reserve every readiness URI outside the credential log, including a foreign nonce that reaches an already-running sibling fixture;
- retain the existing 10-port / 40-poll / 0.05-second / 50ms salvage bounds;
- record readiness and redirect-hop events separately from credential assertions;
- report per-attempt bind stderr/process state when startup exhausts, and response/hop/port/process/fixture-log state when a redirect download fails;
- add real-server regressions for wrong-owner readiness, auth-log isolation, diagnostic fields, and cleanup guard ordering.

No downloader production code or arbitrary timeout changed. The same raw-readiness class in sibling fixtures is tracked separately by #2904.

## Evidence

- Initial frozen RED: 2 failures, exact missing event-readiness message; test hash `dfe47c2227ebc12be43971b12dadd10927b8ff95` stayed byte-identical through the first GREEN.
- Mutation: replacing the nonce probe with raw `fsockopen()` failed `testProbeRejectsReachableForeignListener` (`true` was accepted for the foreign service).
- Review RED: a foreign nonce wrote a `__pfb_ready` row into `auth.log`; after prefix reservation it stays empty. Reverting cleanup guard ordering deleted a controlled temp sentinel and failed its regression.
- Final review regression hashes: `HttpFixtureReadinessTest.php` `65a8e27c928fd204cc7461a83bc1d883a9d51b0c`; `DownloadRedirectFixtureReadinessHygieneTest.php` `856cdab3c920ffdac7913a3599067fde9250b336`.
- Focused target: 100/100 on PHP 8.3 and 100/100 on PHP 8.5 before review hardening; 8 assertions each.
- Final focused files: 10 tests / 70 assertions on PHP 8.3 and PHP 8.5; post-rebase PHP 8.3 repeated the same result.
- Independent verifier: PASS for scope, RED replay, mutation, bounds, diagnostics, auth/event separation, cleanup, and both runtimes.
- Canonical local gates: coverage pairing, Composer/vendor registry checks, PHP syntax, PHPStan, and PHPCS passed. The full local PHPUnit run exercised the new tests but hit the already-tracked macOS order/timing flake #1951 in `Top1mDccDetectorTest`; that exact test then passed focused, including immediately after the changed redirect test. Exact-head Linux CI remains authoritative for the full PHP 8.3/8.5 suites.

🤖 Generated by Oh My Pi and posted on behalf of @andrebrait.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved redirect test reliability by verifying fixture-server readiness with authenticated, per-process checks.
  * Added coverage to prevent false readiness signals from unrelated listeners.
  * Enhanced failure diagnostics with event logs, process status, ports, and server logs.
  * Strengthened cleanup checks to protect unrelated files during test teardown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->