### PR TITLE
tests: consume the dispatch and lookup events instead of a wall clock

### DIFF
--- a/tests/php/AlertsCnameLookupTimeoutTest.php
+++ b/tests/php/AlertsCnameLookupTimeoutTest.php
@@ -122,11 +122,14 @@ final class AlertsCnameLookupTimeoutTest extends TestCase
 		$timeout_flag = "{$this->tmp}/timeout fired";
 		$result = "{$this->tmp}/lookup result.json";
 		$child_log = "{$this->tmp}/child output.log";
-		// Two signals carry the events this harness used to poll a clock for: the drill
-		// announcing its partial output, and the worker reaching end of run.
+		// The events this harness used to poll a clock for. The end-of-run signal is
+		// always needed; the partial-output one exists only in stall mode, which is the
+		// only mode that consumes it, so the wiring shows where the event is read.
 		$partial_signal = "{$this->tmp}/partial signal";
 		$done_signal = "{$this->tmp}/done signal";
-		$this->assertTrue(posix_mkfifo($partial_signal, 0600), 'could not create the partial-output signal');
+		if ($stall) {
+			$this->assertTrue(posix_mkfifo($partial_signal, 0600), 'could not create the partial-output signal');
+		}
 		$this->assertTrue(posix_mkfifo($done_signal, 0600), 'could not create the end-of-run signal');
 
 		$drill = $this->fixture('drill fixture.sh',
@@ -134,8 +137,8 @@ final class AlertsCnameLookupTimeoutTest extends TestCase
 			. "printf '%b\\n' 'partial.example.com.\\t300\\tIN\\tCNAME\\talias.example.com.'\n"
 			. "printf '%s\\n' --PARTIAL-WRITTEN-- >> " . escapeshellarg($marker) . "\n"
 			// '1<>' opens read-write, so announcing partial output can never block the
-			// drill on a reader, in the runs where nobody is listening for it.
-			. "printf 'partial\\n' 1<> " . escapeshellarg($partial_signal) . "\n"
+			// drill on the shim that reads it.
+			. ($stall ? "printf 'partial\\n' 1<> " . escapeshellarg($partial_signal) . "\n" : '')
 			. ($drillFails ? "exit 7\n" : '')
 			. ($stall ? "while true; do sleep 1; done\n" : '')
 		);

--- a/tests/php/AlertsCnameLookupTimeoutTest.php
+++ b/tests/php/AlertsCnameLookupTimeoutTest.php
@@ -9,6 +9,12 @@ final class AlertsCnameLookupTimeoutTest extends TestCase
 {
 	private const ALERTS_PHP = __DIR__ . '/../../src/usr/local/www/pfblockerng/pfblockerng_alerts.php';
 
+	/**
+	 * Salvage cap for the worker's end-of-run signal. It exists only to reap a stuck
+	 * run; whether the lookup completed is decided by the worker's own result file.
+	 */
+	private const LOOKUP_SALVAGE_SECONDS = 60;
+
 	private string $tmp;
 
 	protected function setUp(): void
@@ -24,7 +30,7 @@ final class AlertsCnameLookupTimeoutTest extends TestCase
 
 	public function testSuccessfulCnameOutputIsReadFromFile(): void
 	{
-		$run = $this->runLookup(FALSE, FALSE);
+		$run = $this->runLookup(stall: FALSE);
 
 		$this->assertTrue($run['completed'], 'lookup worker must complete; child output: ' . $run['child_log']);
 		$this->assertSame(['alias.example.com'], $run['cname_list'], 'completed CNAME output must be read from the regular file');
@@ -35,7 +41,7 @@ final class AlertsCnameLookupTimeoutTest extends TestCase
 
 	public function testTimeoutDiscardsPartialOutputAndLogsExpiry(): void
 	{
-		$run = $this->runLookup(TRUE, TRUE);
+		$run = $this->runLookup(stall: TRUE);
 
 		$this->assertTrue($run['completed'], 'bounded lookup must return after the fixture stalls; child output: ' . $run['child_log']);
 		$this->assertTrue($run['partial_seen'], 'drill must emit partial output before the timeout fires');
@@ -58,7 +64,7 @@ final class AlertsCnameLookupTimeoutTest extends TestCase
 
 	public function testDrillFailureDiscardsPartialOutput(): void
 	{
-		$run = $this->runLookup(FALSE, FALSE, TRUE, FALSE, TRUE);
+		$run = $this->runLookup(stall: FALSE, drillFails: TRUE);
 
 		$this->assertTrue($run['completed'], 'failed drill must not abort the request; child output: ' . $run['child_log']);
 		$this->assertTrue($run['partial_seen'], 'drill must emit partial output before failing');
@@ -70,7 +76,7 @@ final class AlertsCnameLookupTimeoutTest extends TestCase
 
 	public function testCaptureFailureIsLoggedWithoutReadingMissingFile(): void
 	{
-		$run = $this->runLookup(FALSE, FALSE, FALSE);
+		$run = $this->runLookup(stall: FALSE, captureAvailable: FALSE);
 
 		$this->assertTrue($run['completed'], 'capture failure must not abort the request; child output: ' . $run['child_log']);
 		$this->assertSame([], $run['cname_list'], 'capture failure must not produce CNAME data');
@@ -81,7 +87,7 @@ final class AlertsCnameLookupTimeoutTest extends TestCase
 
 	public function testMissingCaptureAfterSuccessfulLookupIsLogged(): void
 	{
-		$run = $this->runLookup(FALSE, FALSE, TRUE, TRUE);
+		$run = $this->runLookup(stall: FALSE, removeCapture: TRUE);
 
 		$this->assertTrue($run['completed'], 'missing capture must not abort the request; child output: ' . $run['child_log']);
 		$this->assertSame([], $run['cname_list'], 'missing capture must not produce CNAME data');
@@ -109,18 +115,27 @@ final class AlertsCnameLookupTimeoutTest extends TestCase
 	/**
 	 * @return array{completed:bool,cname_list:list<string>,timeout_calls:list<list<string>>,log:string,capture_files:list<string>,child_log:string,drill_path:string,partial_seen:bool}
 	 */
-	private function runLookup(bool $stall, bool $expectTimeout, bool $captureAvailable = TRUE, bool $removeCapture = FALSE, bool $drillFails = FALSE): array
+	private function runLookup(bool $stall, bool $captureAvailable = TRUE, bool $removeCapture = FALSE, bool $drillFails = FALSE): array
 	{
 		$marker = "{$this->tmp}/stall marker.log";
 		$timeout_log = "{$this->tmp}/timeout args.log";
 		$timeout_flag = "{$this->tmp}/timeout fired";
 		$result = "{$this->tmp}/lookup result.json";
 		$child_log = "{$this->tmp}/child output.log";
+		// Two signals carry the events this harness used to poll a clock for: the drill
+		// announcing its partial output, and the worker reaching end of run.
+		$partial_signal = "{$this->tmp}/partial signal";
+		$done_signal = "{$this->tmp}/done signal";
+		$this->assertTrue(posix_mkfifo($partial_signal, 0600), 'could not create the partial-output signal');
+		$this->assertTrue(posix_mkfifo($done_signal, 0600), 'could not create the end-of-run signal');
 
 		$drill = $this->fixture('drill fixture.sh',
 			"printf '%s\\n' --START-- \"\$\$\" >> " . escapeshellarg($marker) . "\n"
 			. "printf '%b\\n' 'partial.example.com.\\t300\\tIN\\tCNAME\\talias.example.com.'\n"
 			. "printf '%s\\n' --PARTIAL-WRITTEN-- >> " . escapeshellarg($marker) . "\n"
+			// '1<>' opens read-write, so announcing partial output can never block the
+			// drill on a reader, in the runs where nobody is listening for it.
+			. "printf 'partial\\n' 1<> " . escapeshellarg($partial_signal) . "\n"
 			. ($drillFails ? "exit 7\n" : '')
 			. ($stall ? "while true; do sleep 1; done\n" : '')
 		);
@@ -128,11 +143,15 @@ final class AlertsCnameLookupTimeoutTest extends TestCase
 			"printf '%s\\n' --CALL-- >> " . escapeshellarg($timeout_log) . "\n"
 			. "printf '%s\\n' \"\$@\" >> " . escapeshellarg($timeout_log) . "\n"
 			. "shift 5\n"
+			// Hold the signal open BEFORE the drill starts, so its announcement cannot be
+			// written into a pipe this shim has not attached to yet.
+			. ($stall ? "exec 9<> " . escapeshellarg($partial_signal) . "\n" : '')
 			. "\"\$@\" & child=\$!\n"
 			. ($stall
-				? "tries=0\nwhile ! grep -q -- --PARTIAL-WRITTEN-- " . escapeshellarg($marker) . "; do\n"
-					. "tries=\$((tries + 1)); [ \"\$tries\" -ge 200 ] && { kill -TERM \$child 2>/dev/null; wait \$child 2>/dev/null; exit 125; }; sleep 0.01\n"
-					. "done\ntouch " . escapeshellarg($timeout_flag) . "; kill -TERM \$child 2>/dev/null\n"
+				// Block on the drill's announcement instead of budgeting poll attempts:
+				// a starved drill now delays this shim rather than being declared silent.
+				? "read -r _ <&9\n"
+					. "touch " . escapeshellarg($timeout_flag) . "; kill -TERM \$child 2>/dev/null\n"
 				: '')
 			. "wait \$child; rc=\$?\n"
 			. ($removeCapture ? "rm -f " . escapeshellarg($this->tmp) . "/pfb_alerts_cname_*\n" : '')
@@ -148,6 +167,11 @@ final class AlertsCnameLookupTimeoutTest extends TestCase
 		$worker_code = "<?php\n"
 			. 'require_once ' . var_export($bootstrap, TRUE) . ";\n"
 			. "if (function_exists('posix_setsid')) { posix_setsid(); }\n"
+			// Announce end of run from a shutdown handler, so a worker that dies before
+			// writing its result still reports in and is graded as a failed lookup rather
+			// than as a stuck host.
+			. 'register_shutdown_function(static function (): void { $signal = fopen('
+				. var_export($done_signal, TRUE) . ", 'r+'); fwrite(\$signal, \"done\\n\"); fclose(\$signal); });\n"
 			. 'eval(' . var_export($function, TRUE) . ");\n"
 			. '$GLOBALS[\'pfb\'][\'extdns\'] = \'127.0.0.1\';' . "\n"
 			. '$GLOBALS[\'pfb\'][\'drill\'] = ' . var_export($drill, TRUE) . ";\n"
@@ -166,6 +190,10 @@ final class AlertsCnameLookupTimeoutTest extends TestCase
 			1 => ['file', $child_log, 'ab'],
 			2 => ['file', $child_log, 'ab'],
 		];
+		// Hold the signal open BEFORE the worker starts: a worker that finishes at once
+		// must not be able to report into a pipe this side has not attached to yet.
+		$done = fopen($done_signal, 'r+');
+		$this->assertIsResource($done, 'could not open the end-of-run signal');
 		$process = proc_open([PHP_BINARY, $worker], $descriptors, $pipes);
 		if (!is_resource($process)) {
 			throw new RuntimeException('could not start lookup worker');
@@ -173,41 +201,41 @@ final class AlertsCnameLookupTimeoutTest extends TestCase
 		$worker_status = proc_get_status($process);
 		$worker_pid = (int) ($worker_status['pid'] ?? 0);
 
-		$completed = FALSE;
-		$marker_seen = FALSE;
-		$failure = NULL;
+		$reported = FALSE;
 		try {
-			$deadline = microtime(TRUE) + 8.0;
-			while (microtime(TRUE) < $deadline) {
-				if (is_file($marker)) {
-					$marker_seen = TRUE;
-				}
-				if (is_file($result)) {
-					break;
-				}
-				usleep(10_000);
-			}
-
-			$completed = is_file($result);
-			$failure = !$completed && $expectTimeout
-				? 'STUCK/ENVIRONMENT: bounded lookup did not return; marker=' . ($marker_seen ? 'seen' : 'missing')
-				: NULL;
+			// Consume the worker's own end-of-run event. The cap is a salvage bound whose
+			// only job is reaping a stuck run -- it never decides whether the lookup
+			// completed, which is what the result file below says.
+			$read = [$done];
+			$write = NULL;
+			$except = NULL;
+			$reported = stream_select($read, $write, $except, self::LOOKUP_SALVAGE_SECONDS) === 1
+				&& fgets($done) === "done\n";
 		} finally {
-			if (!$completed) {
+			if (!$reported) {
 				$group_killed = $worker_pid > 0 && function_exists('posix_kill') && @posix_kill(-$worker_pid, 9);
 				if (!$group_killed) {
 					proc_terminate($process, 9);
 				}
 			}
 			proc_close($process);
+			fclose($done);
 		}
 		$drill_pid = $this->fixturePid($marker);
 		if ($drill_pid !== NULL && function_exists('posix_kill')) {
 			@posix_kill($drill_pid, 9);
 		}
-		if ($failure !== NULL) {
-			$this->fail($failure);
+		if (!$reported) {
+			$this->fail(sprintf(
+				'STUCK/ENVIRONMENT: the lookup worker never reached its end-of-run signal within %ds, '
+				. 'so this run is stuck or its host starved the worker -- not a CNAME lookup verdict '
+				. '(drill marker %s, child output: %s)',
+				self::LOOKUP_SALVAGE_SECONDS,
+				is_file($marker) ? 'seen' : 'missing',
+				is_file($child_log) ? (string) file_get_contents($child_log) : '(none)'
+			));
 		}
+		$completed = is_file($result);
 
 		$payload = is_file($result) ? json_decode((string) file_get_contents($result), TRUE) : [];
 		$timeout_calls = $this->timeoutCalls($timeout_log);

--- a/tests/php/SourceScanningWiringPolicyTest.php
+++ b/tests/php/SourceScanningWiringPolicyTest.php
@@ -257,7 +257,14 @@ final class SourceScanningWiringPolicyTest extends TestCase
 			fclose($pipes[1]);
 			fclose($pipes[2]);
 			$status = proc_close($process);
-			$this->assertSame(0, $status, "{$stdout}\n{$stderr}");
+			$this->assertSame(0, $status, sprintf(
+				"nested source-execution suite FAILED inside this wrapper's comment-reworded copy of "
+				. "the tree (%s, removed on teardown). Every test name and message below belongs to "
+				. "that NESTED run, not to this wrapper:\n%s\n%s",
+				$temp,
+				$stdout,
+				$stderr
+			));
 		} finally {
 			$this->removeTree($temp);
 		}

--- a/tests/php/Top1mDccDetectorTest.php
+++ b/tests/php/Top1mDccDetectorTest.php
@@ -22,6 +22,12 @@ use PHPUnit\Framework\TestCase;
 #[CoversFunction('pfb_validator_write')]
 final class Top1mDccDetectorTest extends TestCase
 {
+	/**
+	 * Salvage cap for the dispatch signal below. It exists only to reap a stuck
+	 * run; the dispatch verdict is the fixture's own poke, never this number.
+	 */
+	private const DISPATCH_SALVAGE_SECONDS = 30;
+
 	private string $dir;
 
 	/** @var resource|null */
@@ -33,6 +39,9 @@ final class Top1mDccDetectorTest extends TestCase
 	private array $saved_pfb = [];
 	/** @var array<string,bool> */
 	private array $saved_pfb_exists = [];
+
+	/** @var list<resource> */
+	private array $signals = [];
 
 	protected function setUp(): void
 	{
@@ -54,6 +63,12 @@ final class Top1mDccDetectorTest extends TestCase
 	protected function tearDown(): void
 	{
 		$this->stopServer();
+		foreach ($this->signals as $signal) {
+			if (is_resource($signal)) {
+				fclose($signal);
+			}
+		}
+		$this->signals = [];
 		foreach ($this->saved_pfb as $key => $value) {
 			if (!$this->saved_pfb_exists[$key]) {
 				unset($GLOBALS['pfb'][$key]);
@@ -512,10 +527,9 @@ final class Top1mDccDetectorTest extends TestCase
 	public function testExtractedDispatchSeamRunsExistingCronCommand(): void
 	{
 		$dispatch_log = "{$this->dir}/dispatch.log";
-		$fake_php = "{$this->dir}/fake-php";
-		$script = "#!/bin/sh\nprintf '%s\\n' \"\$*\" >> " . escapeshellarg($dispatch_log) . "\n";
-		$this->assertNotFalse(file_put_contents($fake_php, $script));
-		$this->assertTrue(chmod($fake_php, 0755));
+		$dispatch_fifo = "{$this->dir}/dispatch.fifo";
+		$signal = $this->openDispatchSignal($dispatch_fifo);
+		$fake_php = $this->dispatchFixture('fake-php', $dispatch_log, $dispatch_fifo);
 
 		$saved_argv = $GLOBALS['argv'];
 		$had_php = array_key_exists('php', $GLOBALS['pfb']);
@@ -534,9 +548,7 @@ final class Top1mDccDetectorTest extends TestCase
 			unset($GLOBALS['pfb']['top1m_dispatch_done']);
 
 			$this->assertTrue(pfb_top1m_dispatch_if_changed(TRUE));
-			$this->assertEventually(static function () use ($dispatch_log): bool {
-				return is_file($dispatch_log);
-			}, 'TOP1M dispatch command did not run');
+			$this->awaitDispatch($signal);
 			$lines = file($dispatch_log, FILE_IGNORE_NEW_LINES);
 			$this->assertIsArray($lines);
 			$this->assertCount(1, $lines);
@@ -569,10 +581,9 @@ final class Top1mDccDetectorTest extends TestCase
 	public function testDispatchSuppressesFailedAndUnchangedButRunsChangedOnce(): void
 	{
 		$dispatch_log = "{$this->dir}/dispatch-matrix.log";
-		$fake_php = "{$this->dir}/fake-php-matrix";
-		$script = "#!/bin/sh\nprintf '%s\\n' \"\$*\" >> " . escapeshellarg($dispatch_log) . "\n";
-		$this->assertNotFalse(file_put_contents($fake_php, $script));
-		$this->assertTrue(chmod($fake_php, 0755));
+		$dispatch_fifo = "{$this->dir}/dispatch-matrix.fifo";
+		$signal = $this->openDispatchSignal($dispatch_fifo);
+		$fake_php = $this->dispatchFixture('fake-php-matrix', $dispatch_log, $dispatch_fifo);
 
 		$saved_argv = $GLOBALS['argv'];
 		$had_php = array_key_exists('php', $GLOBALS['pfb']);
@@ -597,9 +608,7 @@ final class Top1mDccDetectorTest extends TestCase
 			$GLOBALS['pfb']['top1m_changed'] = TRUE;
 			$this->assertTrue(pfb_top1m_dispatch_if_changed(FALSE), 'TOP1M change must dispatch despite unrelated extras failure');
 			$this->assertFalse(pfb_top1m_dispatch_if_changed(FALSE), 'the same TOP1M change must not dispatch twice');
-			$this->assertEventually(static function () use ($dispatch_log): bool {
-				return is_file($dispatch_log);
-			}, 'TOP1M dispatch command did not run');
+			$this->awaitDispatch($signal);
 			$lines = file($dispatch_log, FILE_IGNORE_NEW_LINES);
 			$this->assertIsArray($lines);
 			$this->assertCount(1, $lines, 'changed TOP1M must dispatch exactly once');
@@ -631,12 +640,9 @@ final class Top1mDccDetectorTest extends TestCase
 	public function testScheduledDccReportsChangeWithoutBackgroundDispatch(): void
 	{
 		$dispatch_log = "{$this->dir}/scheduled-dispatch.log";
-		$fake_php = "{$this->dir}/fake-php-scheduled";
-		$this->assertNotFalse(file_put_contents(
-			$fake_php,
-			"#!/bin/sh\nprintf '%s\\n' \"\$*\" >> " . escapeshellarg($dispatch_log) . "\n"
-		));
-		$this->assertTrue(chmod($fake_php, 0755));
+		$dispatch_fifo = "{$this->dir}/scheduled-dispatch.fifo";
+		$this->openDispatchSignal($dispatch_fifo);
+		$fake_php = $this->dispatchFixture('fake-php-scheduled', $dispatch_log, $dispatch_fifo);
 		$saved_argv = $GLOBALS['argv'];
 		$saved = $GLOBALS['pfb'];
 		try {
@@ -647,11 +653,22 @@ final class Top1mDccDetectorTest extends TestCase
 			unset($GLOBALS['pfb']['top1m_dispatch_done']);
 
 			$this->assertTrue(pfb_top1m_dispatch_if_changed(TRUE, FALSE));
-			$deadline = microtime(TRUE) + 2.0;
-			while (!is_file($dispatch_log) && microtime(TRUE) < $deadline) {
-				usleep(10_000);
-			}
+			// Scheduled mode returns before the seam's exec(), so no child exists and
+			// nothing can create the log after this point -- there is no event to wait
+			// for, and the wall-clock spin this replaced only slowed the suite down.
 			$this->assertFileDoesNotExist($dispatch_log);
+
+			// Vacuity guard: the SAME fixture does record a dispatch when it is run, so
+			// the absence above is the seam's decision and not an inert fixture.
+			$probe_output = [];
+			$probe_status = -1;
+			exec(escapeshellarg($fake_php) . ' scheduled-vacuity-probe', $probe_output, $probe_status);
+			$this->assertSame(0, $probe_status, 'the dispatch fixture must be runnable: ' . implode("\n", $probe_output));
+			$this->assertStringContainsString(
+				'scheduled-vacuity-probe',
+				(string) file_get_contents($dispatch_log),
+				'the fixture must be able to create the log this test asserts absent'
+			);
 		} finally {
 			$GLOBALS['argv'] = $saved_argv;
 			$GLOBALS['pfb'] = $saved;
@@ -706,15 +723,63 @@ final class Top1mDccDetectorTest extends TestCase
 		eval("\n" . substr($source, $start + 1, $end - $start - 1));
 	}
 
-	private static function assertEventually(callable $condition, string $message): void
+	/**
+	 * Create the dispatch signal and hold its read end. Called BEFORE the seam runs,
+	 * so a fixture that dispatches instantly cannot poke into a pipe nobody holds.
+	 *
+	 * The FIFO is opened 'r+' because a plain 'r' open blocks until a writer arrives,
+	 * which would be the very wall-clock race this signal exists to remove.
+	 *
+	 * @return resource
+	 */
+	private function openDispatchSignal(string $fifo)
 	{
-		$deadline = microtime(TRUE) + 2.0;
-		do {
-			if ($condition()) {
-				return;
-			}
-			usleep(10000);
-		} while (microtime(TRUE) < $deadline);
-		self::fail($message);
+		$this->assertTrue(posix_mkfifo($fifo, 0600), "could not create dispatch signal {$fifo}");
+		$handle = fopen($fifo, 'r+');
+		$this->assertIsResource($handle, "could not open dispatch signal {$fifo}");
+		$this->signals[] = $handle;
+		return $handle;
+	}
+
+	/**
+	 * The fake $pfb['php'] the dispatch seam execs: it records the argv it was handed,
+	 * then pokes the signal so the caller can consume the dispatch as an event.
+	 *
+	 * The poke redirects with '1<>' (open read-write), so it never blocks waiting for a
+	 * reader and can never strand the backgrounded child the seam orphans.
+	 */
+	private function dispatchFixture(string $name, string $log, string $fifo): string
+	{
+		$path = "{$this->dir}/{$name}";
+		$this->assertNotFalse(file_put_contents(
+			$path,
+			"#!/bin/sh\n"
+			. "printf '%s\\n' \"\$*\" >> " . escapeshellarg($log) . "\n"
+			. "printf 'dispatched\\n' 1<> " . escapeshellarg($fifo) . "\n"
+		));
+		$this->assertTrue(chmod($path, 0755));
+		return $path;
+	}
+
+	/**
+	 * Consume the dispatch event itself. The seam backgrounds its child, so the only
+	 * honest wait is one that blocks on the child reporting in; the salvage cap below
+	 * exists solely to reap a stuck run and says so, and never decides whether the
+	 * seam dispatched.
+	 *
+	 * @param resource $signal
+	 */
+	private function awaitDispatch($signal): void
+	{
+		$read = [$signal];
+		$write = NULL;
+		$except = NULL;
+		$ready = stream_select($read, $write, $except, self::DISPATCH_SALVAGE_SECONDS);
+		$this->assertSame(1, $ready, sprintf(
+			'STUCK/ENVIRONMENT: the dispatched fixture never reported in within %ds, so this '
+			. 'run is stuck or its host starved the child -- not a TOP1M dispatch verdict',
+			self::DISPATCH_SALVAGE_SECONDS
+		));
+		$this->assertSame("dispatched\n", fgets($signal), 'the dispatch signal must carry the fixture poke');
 	}
 }

--- a/tests/php/Top1mDccDetectorTest.php
+++ b/tests/php/Top1mDccDetectorTest.php
@@ -640,36 +640,40 @@ final class Top1mDccDetectorTest extends TestCase
 	public function testScheduledDccReportsChangeWithoutBackgroundDispatch(): void
 	{
 		$dispatch_log = "{$this->dir}/scheduled-dispatch.log";
+		$dispatch_started = "{$this->dir}/scheduled-dispatch.started";
 		$dispatch_fifo = "{$this->dir}/scheduled-dispatch.fifo";
 		$this->openDispatchSignal($dispatch_fifo);
 		$fake_php = $this->dispatchFixture('fake-php-scheduled', $dispatch_log, $dispatch_fifo);
+		// The foreground marker closes the negative race: the command shell must write
+		// it before starting the background fixture, and exec() waits for that shell.
+		$dispatch_command = "printf 'dispatch-started\\n' >> " . escapeshellarg($dispatch_started)
+			. ' || exit $?; ' . escapeshellarg($fake_php);
 		$saved_argv = $GLOBALS['argv'];
 		$saved = $GLOBALS['pfb'];
 		try {
 			$GLOBALS['argv'] = ['pfblockerng.php', 'dcc', 'scheduled'];
-			$GLOBALS['pfb']['php'] = $fake_php;
+			$GLOBALS['pfb']['php'] = $dispatch_command;
 			$GLOBALS['pfb']['runlog'] = '/dev/null';
 			$GLOBALS['pfb']['top1m_changed'] = TRUE;
 			unset($GLOBALS['pfb']['top1m_dispatch_done']);
 
 			$this->assertTrue(pfb_top1m_dispatch_if_changed(TRUE, FALSE));
-			// Scheduled mode returns before the seam's exec(), so there is no child and no
-			// event to wait for -- the wall-clock spin this replaced only slowed the suite.
-			$this->assertFileDoesNotExist($dispatch_log);
+			$this->assertFileDoesNotExist(
+				$dispatch_started,
+				'scheduled mode must not enter the background dispatch command'
+			);
 
-			// The probe below runs the SAME fixture synchronously, which makes it both the
-			// vacuity guard (the absence above is the seam's decision, not an inert fixture)
-			// and a barrier: anything the seam had dispatched would already be in the log
-			// beside it, so the exact line count is what pins "scheduled mode does not
-			// dispatch" -- with more margin than the deleted spin ever had.
+			// Run the same command synchronously as a vacuity check for both observables.
 			$probe_output = [];
 			$probe_status = -1;
-			exec(escapeshellarg($fake_php) . ' scheduled-vacuity-probe', $probe_output, $probe_status);
+			exec($dispatch_command . ' scheduled-vacuity-probe', $probe_output, $probe_status);
 			$this->assertSame(0, $probe_status, 'the dispatch fixture must be runnable: ' . implode("\n", $probe_output));
+			$started = file($dispatch_started, FILE_IGNORE_NEW_LINES);
+			$this->assertIsArray($started, 'the command marker must be writable');
+			$this->assertSame(['dispatch-started'], $started, 'the vacuity probe must be the only command launch');
 			$lines = file($dispatch_log, FILE_IGNORE_NEW_LINES);
-			$this->assertIsArray($lines, 'the fixture must be able to create the log this test asserts absent');
-			$this->assertCount(1, $lines, 'scheduled mode must not have dispatched: ' . implode(' | ', $lines ?: []));
-			$this->assertStringContainsString('scheduled-vacuity-probe', $lines[0]);
+			$this->assertIsArray($lines, 'the fixture must be able to create its behavior log');
+			$this->assertSame(['scheduled-vacuity-probe'], $lines, 'scheduled mode must not have dispatched');
 		} finally {
 			$GLOBALS['argv'] = $saved_argv;
 			$GLOBALS['pfb'] = $saved;
@@ -777,8 +781,8 @@ final class Top1mDccDetectorTest extends TestCase
 		$except = NULL;
 		$ready = stream_select($read, $write, $except, self::DISPATCH_SALVAGE_SECONDS);
 		$this->assertSame(1, $ready, sprintf(
-			'STUCK/ENVIRONMENT: the dispatched fixture never reported in within %ds, so this '
-			. 'run is stuck or its host starved the child -- not a TOP1M dispatch verdict',
+			'STUCK/ENVIRONMENT: the dispatch fixture never reported in within %ds; this run '
+			. 'is stuck, its host starved the child, or the seam never launched its dispatch',
 			self::DISPATCH_SALVAGE_SECONDS
 		));
 		$this->assertSame("dispatched\n", fgets($signal), 'the dispatch signal must carry the fixture poke');

--- a/tests/php/Top1mDccDetectorTest.php
+++ b/tests/php/Top1mDccDetectorTest.php
@@ -653,22 +653,23 @@ final class Top1mDccDetectorTest extends TestCase
 			unset($GLOBALS['pfb']['top1m_dispatch_done']);
 
 			$this->assertTrue(pfb_top1m_dispatch_if_changed(TRUE, FALSE));
-			// Scheduled mode returns before the seam's exec(), so no child exists and
-			// nothing can create the log after this point -- there is no event to wait
-			// for, and the wall-clock spin this replaced only slowed the suite down.
+			// Scheduled mode returns before the seam's exec(), so there is no child and no
+			// event to wait for -- the wall-clock spin this replaced only slowed the suite.
 			$this->assertFileDoesNotExist($dispatch_log);
 
-			// Vacuity guard: the SAME fixture does record a dispatch when it is run, so
-			// the absence above is the seam's decision and not an inert fixture.
+			// The probe below runs the SAME fixture synchronously, which makes it both the
+			// vacuity guard (the absence above is the seam's decision, not an inert fixture)
+			// and a barrier: anything the seam had dispatched would already be in the log
+			// beside it, so the exact line count is what pins "scheduled mode does not
+			// dispatch" -- with more margin than the deleted spin ever had.
 			$probe_output = [];
 			$probe_status = -1;
 			exec(escapeshellarg($fake_php) . ' scheduled-vacuity-probe', $probe_output, $probe_status);
 			$this->assertSame(0, $probe_status, 'the dispatch fixture must be runnable: ' . implode("\n", $probe_output));
-			$this->assertStringContainsString(
-				'scheduled-vacuity-probe',
-				(string) file_get_contents($dispatch_log),
-				'the fixture must be able to create the log this test asserts absent'
-			);
+			$lines = file($dispatch_log, FILE_IGNORE_NEW_LINES);
+			$this->assertIsArray($lines, 'the fixture must be able to create the log this test asserts absent');
+			$this->assertCount(1, $lines, 'scheduled mode must not have dispatched: ' . implode(' | ', $lines ?: []));
+			$this->assertStringContainsString('scheduled-vacuity-probe', $lines[0]);
 		} finally {
 			$GLOBALS['argv'] = $saved_argv;
 			$GLOBALS['pfb'] = $saved;


### PR DESCRIPTION
## What this changes

Three PHPUnit rows named in #1951 decided their verdict with a **wall-clock budget** instead
of the event they were waiting for. On a loaded macOS host a starved child misses the budget
and the suite reports a product failure. This replaces each budget with a wait that consumes
the event itself, and leaves behind only a salvage cap that says "stuck/environment" and
never grades the behaviour — the shape `testing.md` mandates ("Synchronize — duration never
an assertion") and the same contract #2065's acceptance criteria already state.

No production code changes. `git diff origin/devel --stat`:

```text
 tests/php/AlertsCnameLookupTimeoutTest.php   |  91 +++++++++++------
 tests/php/SourceScanningWiringPolicyTest.php |   9 +-
 tests/php/Top1mDccDetectorTest.php           | 142 ++++++++++++++++++++-------
 3 files changed, 175 insertions(+), 67 deletions(-)
```

## Root A — `Top1mDccDetectorTest`, the backgrounded dispatch seam

`pfb_top1m_dispatch_if_changed()` ends in `exec("… &")`, so the child is orphaned and there
is no handle to join. The test polled `is_file($dispatch_log)` for 2.0s and failed with
`TOP1M dispatch command did not run` — the deadline, not the seam, produced that sentence.

The fake `$pfb['php']` now pokes a FIFO after recording the command, and the test holds the
FIFO's read end **before** the seam runs, so an instant dispatch cannot poke into a pipe
nobody holds. The poke redirects with `1<>` (open read-write) so it can never block on a
reader and can never strand the orphan.

`testScheduledDccReportsChangeWithoutBackgroundDispatch` spun a full 2.0s waiting for a child
that mode never spawns (`$dispatch = FALSE` returns before the `exec()`). Its fake command now
writes a separate launch marker in the foreground before the shell starts the background
fixture. `exec()` cannot return until that marker command finishes, so marker absence after
the seam returns closes the dispatch opportunity without elapsed time. The same complete
command runs synchronously afterward as a fixture-capability check.

## Root B — `AlertsCnameLookupTimeoutTest`, two budgets

1. The timeout shim gave the drill **200 poll attempts** to announce its partial output before
   killing it and exiting 125. That is what produces
   `drill must emit partial output before the timeout fires`. It now blocks on the drill's
   announcement over a FIFO it opens before starting the child.
2. The harness gave the worker **8.0s** to write its result, and only labelled the expiry
   `STUCK/ENVIRONMENT` when the caller happened to pass `$expectTimeout` — every other row got
   a behavioural message for an environment condition. The worker now announces end of run
   from a `register_shutdown_function()`, so a worker that dies *without* writing a result
   still reports in and is graded as a failed lookup, and the salvage message is unconditional.

The now-dead `$expectTimeout` parameter is removed and all five call sites converted to named
arguments (they had grown to five positional booleans).

## Root C — the wrapper that misattributes

`SourceScanningWiringPolicyTest::testRewordingEveryProductionPhpCommentDoesNotBreakSourceExecutionTests`
runs a nested suite over 53 files (including `Top1mDccDetectorTest`) in a comment-reworded copy
of the tree, and reported the nested failure under its own name. Its message now states that
the test names it prints belong to the nested run. That misreading is exactly how #1951's
Top1M occurrence was attributed to the wrapper.

## Red → green (executed, same injected stimulus on both sides)

The flake is load-triggered, so the proof injects the delay deterministically instead of
waiting for a loaded host: a scratch copy of each file with a fixed child delay longer than
the shipped budget, run against the **committed** file before and after the change. Only the
wait mechanism differs between the two columns.

**Root A — 3s child delay, `HEAD` (before) vs this branch (after):**

```text
===== RED (3s child delay injected) rc=1 =====
FF                                                                  2 / 2 (100%)
1) Top1mDccDetectorTest::testExtractedDispatchSeamRunsExistingCronCommand
TOP1M dispatch command did not run
2) Top1mDccDetectorTest::testDispatchSuppressesFailedAndUnchangedButRunsChangedOnce
TOP1M dispatch command did not run
Tests: 2, Assertions: 14, Failures: 2.

===== GREEN (3s child delay injected) rc=0 =====
..                                                                  2 / 2 (100%)
OK (2 tests, 25 assertions)
```

**Root B — 6s drill delay, `HEAD` (before) vs this branch (after):**

```text
===== RED (6s drill delay injected) rc=1 =====
.F....                                                              6 / 6 (100%)
1) AlertsCnameLookupTimeoutTest::testTimeoutDiscardsPartialOutputAndLogsExpiry
drill must emit partial output before the timeout fires
Tests: 6, Assertions: 31, Failures: 1.

===== GREEN (6s drill delay injected) rc=0 =====
......                                                              6 / 6 (100%)
OK (6 tests, 59 assertions)
```

**Round-1 correctness repair — scheduled-negative dispatch mutation:**

```text
Frozen test blob: e3bc804f16bd6f953df457ee31a0fd0388ee8983
Mutation: if ($dispatch) -> if (TRUE)
Controlled load: four owned `yes` workers

122c3a9a test: mutant survived run 6
OK (1 test, 11 assertions)

6a5ac08e test: mutant killed on first run and 10/10 repeats
scheduled mode must not enter the background dispatch command
FAILURES! Tests: 1, Assertions: 7, Failures: 1.

Unmutated 6a5ac08e:
OK (1 test, 12 assertions)
```

The frozen blob is identical at mutant RED, unmutated GREEN, and committed head. At current
head without injected delays both affected files are green: `OK (28 tests, 284 assertions)`.

## Hypotheses that were refuted, with the probe that killed them

- **PHP stat cache hides the child's file.** `is_file()` was suspected of caching the negative
  result. Probed directly: after an external `touch`, `is_file()` returns `true` with no
  `clearstatcache()`. PHP 8.5.10 does not cache negative stats. Refuted.
- **The product genuinely fails to dispatch under load.** In the Root A red run the file
  arrived **+1.34s after the 2.0s budget expired** — the same child, same run, same host,
  delivered. Refuted.
- **The `php -S` port-collision class (#2904) is behind these rows.** The two Top1M rows
  reproduce under a `--filter` selection that never calls `downloadTop1m()`, so no fixture
  server exists on their failure path. Not the root here; filed separately as #2904 because it
  is a real defect in nine other files.

## Family rows

| #1951 row | Outcome |
| --- | --- |
| `Top1mDccDetectorTest::testDispatchSuppressesFailedAndUnchangedButRunsChangedOnce` | fixed here (Root A) |
| `Top1mDccDetectorTest::testExtractedDispatchSeamRunsExistingCronCommand` | fixed here (Root A) |
| `AlertsCnameLookupTimeoutTest` (3 rows) | fixed here (Root B) |
| wrapper misattribution via `SourceScanningWiringPolicyTest` | fixed here (Root C) |
| `Issue1840SuppUpdateNullPostinstallTest` | **not reproduced** — #1951 stays open owning this row |

This PR therefore says `Refs #1951`, not `Fixes`: the parent keeps the one row still
unaccounted for. `Issue1840SuppUpdateNullPostinstallTest` passed in all four full-suite runs
taken here (default order, pinned random seeds 1951 and 20260830, and a base-equivalent
revert run), and it contains none of the mechanisms fixed above — no deadline, no poll
budget, no asynchronous child. What was excluded is recorded in the issue thread.

Three adjacent roots were found while working this and filed rather than folded in:

- #2904 — every `php -S` fixture adopts a foreign listener because readiness is a bare
  `fsockopen` connect: nine sites across eight files, per that issue's own post-#2903
  recount (the tenth self-resolved when #2903 migrated `DownloadRedirectCredentialScopeTest`
  onto the nonce-bearing readiness helper). Raised from PR #2903's contract-review leg;
  #2065's owner scoped that ticket to one file and declined the siblings.
- #2905 — `DownloadSizeCeilingTest` grades `RLIMIT_FSIZE` by the inherited SIGXFSZ
  disposition, so it fails on every macOS shell run. Pre-existing and untouched by this diff
  (`git diff origin/devel -- tests/php/DownloadSizeCeilingTest.php` is empty).
- #2906 — four suites `unset($pfb['mime_types'])` in `tearDown()` instead of restoring it, so
  `DownloadSizeRefusalTest` TypeErrors under random order. A genuine member of #1951's
  declared order/state class, surfaced by the pinned-seed probe that issue asks for, but a
  different root and not one of its named rows.

## Gates

Final exact-head local gate at `6a5ac08e`:

```text
GATE PASS: python3 scripts/check_coverage_pairing.py --name-status-z
GATE PASS: uv run --locked python scripts/check_composer_vendor.py
GATE PASS: uv run --locked python scripts/check_toggle_registry.py --self-test && …
GATE PASS: uv run --locked python scripts/check_reentry_bounds.py --self-test && …
GATE PASS: php -l tests/php/AlertsCnameLookupTimeoutTest.php
GATE PASS: php -l tests/php/SourceScanningWiringPolicyTest.php
GATE PASS: php -l tests/php/Top1mDccDetectorTest.php
GATE FAIL: vendor/bin/phpunit
GATE PASS: composer phpstan
GATE PASS: composer phpcs -- --standard=phpcs.xml.dist src/
```

`Tests: 5914, Assertions: 33985, Failures: 1` — the only failure is the deterministic,
unmodified-base macOS SIGXFSZ row owned by #2905. All #2907 rows are green.

The exact-head CI wait for `6a5ac08e12db5792995799d85b3eb01f0fac5559` passed every required
check, including PHPUnit, PHPStan, PHPCS, and PHP syntax on PHP 8.3 and PHP 8.5, plus pytest,
Ruff, mypy, ShellCheck, shellspec, actionlint, coverage pairing, and the remaining required
checks. Advisory/skipped benchmark and live-VM fan-out legs were not treated as required.

Order coverage, since the issue asks for pinned seeds:

```text
--order-by=random --random-order-seed=1951      Tests: 5909, Errors: 1, Failures: 1
--order-by=random --random-order-seed=20260830  Tests: 5909, Errors: 1, Failures: 1
```

Both carry only #2905 and #2906, and both reproduce identically with this branch's three
files reverted to `origin/devel` — so neither is introduced here. The rows this PR touches
are green in every order tried.

🤖 Generated by Oh My Pi and posted on behalf of @andrebrait.
