### PR TITLE
tests: accept Darwin SIGXFSZ ceiling refusal

### DIFF
--- a/tests/php/DownloadSizeCeilingTest.php
+++ b/tests/php/DownloadSizeCeilingTest.php
@@ -95,8 +95,8 @@ final class DownloadSizeCeilingTest extends TestCase
 	 * Given  a wrapped command whose ceiling is two blocks and whose child
 	 *        writes one MiB
 	 * When   the command runs through the same exec() the extraction sites use
-	 * Then   Linux reports SIGXFSZ, Darwin reports dd's EFBIG exit, the
-	 *        extraction gates reject either, and output stays within the ceiling.
+	 * Then   Darwin refuses the write as either diagnosed EFBIG or SIGXFSZ;
+	 *        Linux reports SIGXFSZ, extraction gates reject either, and output stays within the ceiling.
 	 */
 	public function test_extract_cmd_ceiling_stops_a_child_that_writes_past_it(): void
 	{
@@ -117,9 +117,13 @@ final class DownloadSizeCeilingTest extends TestCase
 		);
 
 		if (PHP_OS_FAMILY === 'Darwin') {
-			$this->assertSame(1, $retval, 'Darwin dd must surface RLIMIT_FSIZE as its EFBIG exit');
-			$this->assertStringStartsWith("dd: {$target}: File too large\n", (string) file_get_contents($stderr),
-				'Darwin exit 1 must be the diagnosed EFBIG refusal, not an arbitrary failure');
+			if ($retval === 1) {
+				$this->assertStringStartsWith("dd: {$target}: File too large\n", (string) file_get_contents($stderr),
+					'Darwin exit 1 must be the diagnosed EFBIG refusal, not an arbitrary failure');
+			} else {
+				$this->assertSame(PFB_EXTRACT_SIGXFSZ_EXIT, $retval,
+					'Darwin must refuse a write past the ceiling with EFBIG or SIGXFSZ');
+			}
 		} else {
 			$this->assertSame(PFB_EXTRACT_SIGXFSZ_EXIT, $retval,
 				'a write past the ceiling must surface as the SIGXFSZ exit status');


### PR DESCRIPTION
## Summary

- accept Darwin's two exact `RLIMIT_FSIZE` refusal outcomes: diagnosed `EFBIG` exit 1 or `SIGXFSZ` exit 153
- keep Linux's required `SIGXFSZ` expectation unchanged
- keep real-command assertions for extraction-gate rejection and output bounded to the configured ceiling

## Verification

- reproduced the same command as rc 153 with parent `SIGXFSZ=SIG_DFL` and rc 1 with diagnosed `EFBIG` under `SIGXFSZ=SIG_IGN`
- PHP 8.3.33 and 8.5.10: `DownloadSizeCeilingTest.php` passes under both inherited dispositions (4/4 cells, 17 tests and 90 assertions each)
- frozen test hash `7d34e32d635913a0c9304089dee1ead6547ef39d`; mutations forcing rc 2, removing the ceiling, accepting failed extraction, or suppressing the rc-1 diagnostic each fail at the intended assertion
- `sh scripts/agent/run-gates.sh --diff origin/devel` (`GATES: PASS`)

Fixes #2905

🤖 Generated by Oh My Pi and posted on behalf of @andrebrait.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated download-size ceiling coverage to accept either supported Darwin outcome when a child process exceeds the write limit.
  * Clarified the test documentation for platform-specific error behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->