### PR TITLE
tests: align reboot ledger persistence with ADR-43 (#2596)

### DIFF
--- a/tests/smoke/test_smoke_tick.py
+++ b/tests/smoke/test_smoke_tick.py
@@ -770,6 +770,7 @@ def test_tick_reboot_persists_ledger(mfs_var: SmokeVM) -> None:
         f"ledger persistence probe missing after reboot; expected={persistence_probe} ledger={restored}"
     )
 
+    before_tick = int(vm.ssh("date +%s").stdout.strip())
     tick_result = _run_tick(vm)
     assert tick_result.returncode == 0, (
         f"post-reboot tick failed: rc={tick_result.returncode} stderr={tick_result.stderr!r}"
@@ -785,8 +786,9 @@ def test_tick_reboot_persists_ledger(mfs_var: SmokeVM) -> None:
     assert cron.get("next_due") != stale_next_due, (
         f"derived cron row was not regenerated; stale_next_due={stale_next_due} cron={cron}"
     )
-    assert isinstance(cron.get("next_due"), int) and after_now < cron["next_due"] <= after_now + 90000, (
-        f"regenerated cron next_due must be within the daily cadence; now={after_now} cron={cron}"
+    assert isinstance(cron.get("next_due"), int) and before_tick <= cron["next_due"] <= after_now + 90000, (
+        f"regenerated cron next_due must be due now or within the daily cadence; "
+        f"before_tick={before_tick} after_now={after_now} cron={cron}"
     )
     assert isinstance(cron.get("last_run"), int) and cron.get("jitter") == 0, (
         f"regenerated cron row has an invalid shape; cron={cron}"

--- a/tests/smoke/test_smoke_tick.py
+++ b/tests/smoke/test_smoke_tick.py
@@ -104,6 +104,7 @@ _PFB_INC = "/usr/local/pkg/pfblockerng/pfblockerng.inc"
 # came up as a memory filesystem (MFS wipes /var on every boot); if it survived, use_mfs_tmpvar
 # never engaged and the whole scenario would be a false positive.
 _VAR_WIPE_SENTINEL = "/var/PFB_SMOKE_TICK_WIPE_SENTINEL"
+_REBOOT_LEDGER_PROBE = "reboot_persistence_probe"
 
 # issue #2506: the model id pin_cron_due()/pfb_schedule_runtime_config() derive for the
 # module's IpCase feed group ("ipv4:<header>_v4" — helpers._ip_inject_snippet's config
@@ -702,40 +703,34 @@ def mfs_var(deployed_vm: SmokeVM, request: pytest.FixtureRequest) -> Iterator[Sm
 # same as boot_reload's fixture reboots — so the body still contains exactly ONE reboot.
 @pytest.mark.timeout(300)
 def test_tick_reboot_persists_ledger(mfs_var: SmokeVM) -> None:
-    """A clean reboot with MFS /var keeps the due-ledger (restored via #468 earlyshellcmd).
+    """MFS /var restores the ledger file while a later tick may rebuild its derived rows.
 
     Scenario:
-        Background: pfBlockerNG installed with MFS /var engaged (the ``mfs_var`` fixture;
-            issue #762 — previously only claimed in this docstring, never arranged, so the
-            test silently rode whatever /var state a sibling module happened to leave behind).
-            Given the ledger has a future cron next_due, and the aliastables archive has been
-            refreshed to include it (the archiver is called directly: ``pfb_aliastables('update')``
-            is reached only on the rule-change or alias-content-change paths, and this module's
-            one static smoketick feed (#2506) never changes between passes, so a quiescent
-            update pass would never archive the ledger).
+        Background: pfBlockerNG installed with MFS /var engaged (the ``mfs_var`` fixture).
+            Given the ledger contains a unique persistence probe and a deliberately stale
+            ``cron`` row, and the aliastables archive has been refreshed to include them.
         When the VM reboots cleanly.
         Then the /var sentinel is gone (MFS actually engaged this reboot),
-        And  the ledger is restored,
-        And  the cron next_due is still the value written before the reboot (no spurious dispatch).
+        And  the persistence probe is restored from the archive.
+        When a real post-reboot tick refreshes the derived cache.
+        Then the persistence probe remains and ``cron`` becomes a current derived schedule.
     """
     vm = mfs_var
 
     now_ts = int(vm.ssh("date +%s").stdout.strip())
-    future = now_ts + 7200  # 2 hours out
+    stale_next_due = now_ts + (10 * 366 * 86400)
+    persistence_probe = {"last_run": now_ts, "next_due": stale_next_due, "jitter": 0}
 
-    _write_ledger_entry(vm, "cron", now_ts, future)
+    _write_ledger_entry(vm, _REBOOT_LEDGER_PROBE, **persistence_probe)
+    _write_ledger_entry(vm, "cron", now_ts, stale_next_due)
 
-    # Wipe any stale archive a sibling module left behind (boot_reload's ramdisk legs write
-    # the same unscoped file), so archive_exists() below can only be true if THIS refresh
-    # wrote it — the archiver's exec() discards its output, so a silently-failed refresh
-    # would otherwise pass the precondition against the leftover.
+    # Wipe any stale archive a sibling module left behind, so archive_exists() below can
+    # only be true if this refresh wrote it.
     vm.ssh("rm", "-f", f"{h.ALIASARCHIVE}.zst", f"{h.ALIASARCHIVE}.bz2")
     assert not h.archive_exists(vm, h.ALIASARCHIVE), (
         f"precondition: stale {h.ALIASARCHIVE}.{{zst,bz2}} survived the wipe"
     )
 
-    # Refresh the archive directly (see docstring: 'update' mode is change-gated and the
-    # module's static smoketick feed trips neither gate on a quiescent pass).
     snippet = f"require_once('{_PFB_INC}');pfb_global();pfb_aliastables('update');echo 'OK';"
     result = h.php_eval(vm, snippet)
     if result.returncode != 0 or "OK" not in result.stdout:
@@ -744,27 +739,24 @@ def test_tick_reboot_persists_ledger(mfs_var: SmokeVM) -> None:
             f"rc={result.returncode} stdout={result.stdout!r} stderr={result.stderr!r}"
         )
 
-    # --- Given (before reboot): archive refreshed, ledger holds the just-written entry ---
     assert h.archive_exists(vm, h.ALIASARCHIVE), (
         f"precondition: {h.ALIASARCHIVE}.{{zst,bz2}} must exist after the archive refresh"
     )
     before = _read_ledger(vm)
-    assert before.get("cron", {}).get("next_due") == future, (
-        f"precondition: cron next_due should be {future} before reboot; ledger={before}"
+    assert before.get(_REBOOT_LEDGER_PROBE) == persistence_probe, (
+        f"precondition: persistence probe was not written; ledger={before}"
+    )
+    assert before.get("cron", {}).get("next_due") == stale_next_due, (
+        f"precondition: stale cron next_due should be {stale_next_due}; ledger={before}"
     )
 
-    # Drop a /var sentinel so the post-reboot check can PROVE /var came up as a memory
-    # filesystem this reboot (the sentinel is wiped), not merely re-use a prior MFS mount.
     vm.ssh("/usr/bin/touch", _VAR_WIPE_SENTINEL)
     assert vm.ssh("test", "-e", _VAR_WIPE_SENTINEL).returncode == 0, (
         f"precondition: {_VAR_WIPE_SENTINEL} must exist before reboot"
     )
 
-    # When: reboot.
     h.reboot_vm(vm)
 
-    # Then: the sentinel is gone -- print the /var mount line so a not-engaged MFS is
-    # diagnosable rather than a bare boolean (the test-coverage mandate's expected-vs-actual rule).
     var_mount = next(
         (ln for ln in vm.ssh("/sbin/mount").stdout.splitlines() if " on /var " in ln),
         "",
@@ -773,8 +765,29 @@ def test_tick_reboot_persists_ledger(mfs_var: SmokeVM) -> None:
         f"/var sentinel survived the reboot -- MFS did not engage; /var mount line: {var_mount!r}"
     )
 
+    restored = _read_ledger(vm)
+    assert restored.get(_REBOOT_LEDGER_PROBE) == persistence_probe, (
+        f"ledger persistence probe missing after reboot; expected={persistence_probe} ledger={restored}"
+    )
+
+    tick_result = _run_tick(vm)
+    assert tick_result.returncode == 0, (
+        f"post-reboot tick failed: rc={tick_result.returncode} stderr={tick_result.stderr!r}"
+    )
+
+    after_now = int(vm.ssh("date +%s").stdout.strip())
     after = _read_ledger(vm)
-    assert "cron" in after, f"cron ledger entry missing after reboot; ledger={after}"
-    assert after["cron"]["next_due"] == future, (
-        f"cron next_due changed across reboot; expected={future} actual={after['cron']['next_due']}; ledger={after}"
+    assert after.get(_REBOOT_LEDGER_PROBE) == persistence_probe, (
+        f"persistence probe changed during derived-cache regeneration; expected={persistence_probe} ledger={after}"
+    )
+    cron = after.get("cron")
+    assert isinstance(cron, dict), f"derived cron row missing after post-reboot tick; ledger={after}"
+    assert cron.get("next_due") != stale_next_due, (
+        f"derived cron row was not regenerated; stale_next_due={stale_next_due} cron={cron}"
+    )
+    assert isinstance(cron.get("next_due"), int) and after_now < cron["next_due"] <= after_now + 90000, (
+        f"regenerated cron next_due must be within the daily cadence; now={after_now} cron={cron}"
+    )
+    assert isinstance(cron.get("last_run"), int) and cron.get("jitter") == 0, (
+        f"regenerated cron row has an invalid shape; cron={cron}"
     )

--- a/tests/test_smoke_tick_marker_baseline.py
+++ b/tests/test_smoke_tick_marker_baseline.py
@@ -93,7 +93,7 @@ def _reboot_ledger_fixture(
             if args == (tick._PHP, tick._PFB_PHP, "tick"):
                 state["tick_calls"] += 1
                 if regenerate_cron:
-                    state["ledger"]["cron"] = {"last_run": 100, "next_due": 200, "jitter": 0}
+                    state["ledger"]["cron"] = {"last_run": 100, "next_due": 100, "jitter": 0}
                 return SimpleNamespace(returncode=0, stdout="", stderr="")
             raise AssertionError(args)
 

--- a/tests/test_smoke_tick_marker_baseline.py
+++ b/tests/test_smoke_tick_marker_baseline.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from copy import deepcopy
 from types import SimpleNamespace
 from typing import Any
 
@@ -60,3 +61,84 @@ def test_due_marker_after_baseline_is_accepted(monkeypatch: pytest.MonkeyPatch) 
     tick.test_tick_dispatches_due_feed(vm)
 
     assert state == {"drains": 2, "marker": 2, "next_due": 101, "pins": 1}
+
+
+def _reboot_ledger_fixture(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    preserve_probe: bool = True,
+    regenerate_cron: bool = True,
+) -> tuple[dict[str, Any], tick.SmokeVM]:
+    state: dict[str, Any] = {
+        "archive": None,
+        "ledger": {},
+        "sentinel": False,
+        "tick_calls": 0,
+    }
+
+    class VM(tick.SmokeVM):
+        def ssh(self, *args: str, timeout: float = 60.0) -> Any:
+            if args == ("date +%s",):
+                return SimpleNamespace(returncode=0, stdout="100\n", stderr="")
+            if args[:3] == ("rm", "-f", tick.h.ALIASARCHIVE + ".zst"):
+                state["archive"] = None
+                return SimpleNamespace(returncode=0, stdout="", stderr="")
+            if args == ("/usr/bin/touch", tick._VAR_WIPE_SENTINEL):
+                state["sentinel"] = True
+                return SimpleNamespace(returncode=0, stdout="", stderr="")
+            if args == ("test", "-e", tick._VAR_WIPE_SENTINEL):
+                return SimpleNamespace(returncode=0 if state["sentinel"] else 1, stdout="", stderr="")
+            if args == ("/sbin/mount",):
+                return SimpleNamespace(returncode=0, stdout="tmpfs on /var (rw)\n", stderr="")
+            if args == (tick._PHP, tick._PFB_PHP, "tick"):
+                state["tick_calls"] += 1
+                if regenerate_cron:
+                    state["ledger"]["cron"] = {"last_run": 100, "next_due": 200, "jitter": 0}
+                return SimpleNamespace(returncode=0, stdout="", stderr="")
+            raise AssertionError(args)
+
+    def write_entry(_vm: Any, job_key: str, last_run: int, next_due: int, jitter: int = 0) -> None:
+        state["ledger"][job_key] = {"last_run": last_run, "next_due": next_due, "jitter": jitter}
+
+    def php_eval(_vm: Any, _snippet: str) -> Any:
+        state["archive"] = deepcopy(state["ledger"])
+        return SimpleNamespace(returncode=0, stdout="OK", stderr="")
+
+    def reboot(_vm: Any) -> None:
+        state["ledger"] = deepcopy(state["archive"])
+        state["sentinel"] = False
+        if not preserve_probe:
+            state["ledger"].pop(tick._REBOOT_LEDGER_PROBE, None)
+
+    monkeypatch.setattr(tick, "_read_ledger", lambda _vm: deepcopy(state["ledger"]))
+    monkeypatch.setattr(tick, "_write_ledger_entry", write_entry)
+    monkeypatch.setattr(tick.h, "archive_exists", lambda *_args: state["archive"] is not None)
+    monkeypatch.setattr(tick.h, "php_eval", php_eval)
+    monkeypatch.setattr(tick.h, "reboot_vm", reboot)
+    monkeypatch.setattr(tick.h, "wait_no_active_pfb_task", lambda _vm: None)
+    return state, VM("")
+
+
+def test_reboot_ledger_oracle_accepts_file_persistence_with_cron_regeneration(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    state, vm = _reboot_ledger_fixture(monkeypatch)
+
+    tick.test_tick_reboot_persists_ledger(vm)
+
+    assert state["tick_calls"] == 1
+    assert tick._REBOOT_LEDGER_PROBE in state["ledger"]
+
+
+def test_reboot_ledger_oracle_rejects_lost_persistence_probe(monkeypatch: pytest.MonkeyPatch) -> None:
+    _state, vm = _reboot_ledger_fixture(monkeypatch, preserve_probe=False)
+
+    with pytest.raises(AssertionError, match="persistence probe missing after reboot"):
+        tick.test_tick_reboot_persists_ledger(vm)
+
+
+def test_reboot_ledger_oracle_rejects_byte_stable_derived_cron(monkeypatch: pytest.MonkeyPatch) -> None:
+    _state, vm = _reboot_ledger_fixture(monkeypatch, regenerate_cron=False)
+
+    with pytest.raises(AssertionError, match="derived cron row was not regenerated"):
+        tick.test_tick_reboot_persists_ledger(vm)


### PR DESCRIPTION
Fixes #2596.

## Root cause

Two distinct facts were hidden behind the old setup error:

1. PR #2628 already fixed the reboot readiness timeout: `reboot_vm()` no longer requires the package-metadata sentinel by default. The exact current row proceeds after the real platform-boot and changed-`kern.boottime` gates even while `rc.update_pkg_metadata` / `pfSense-upgrade -uf` remains running. No metadata timeout or reboot-helper change belongs here.
2. The recovered test still encoded the pre-ADR-43 oracle. It hand-seeded `cron` and required that exact `next_due` byte value after reboot. `cron` is a derived cache row; a post-reboot tick may legitimately rebuild it from the configured feed schedule. The durable contract is survival of the ledger file through the #468 archive/earlyshellcmd path.

## Change

Test-only, two files. The live row now:

- writes a unique non-derived `reboot_persistence_probe` row plus a deliberately stale ten-year `cron` row;
- archives the ledger through the real `pfb_aliastables('update')` path;
- performs the real MFS /var reboot and keeps the existing wipe-sentinel proof;
- proves the unique row was restored before doing any regeneration;
- runs a real post-reboot tick, proves the probe remains, and requires `cron` to become a current daily derived schedule rather than remain byte-stable.

The hermetic consumer pin models archive restore, lost-file state, and byte-stable derived-cache state. Both negative branches self-exercise the smoke oracle. Production scheduler and reboot metadata behavior are untouched.

## Executed evidence

- **Current-base exact row / #2628 discriminator**, `d4c7dfbdd34bd008621d7f4ad691ee69a64adea6`, RUN_ID `local-100037-1788071772-fd6f58418b4fe65c`, box `root@10.0.0.37`: `1 passed, 1045 deselected in 240.77s`. Setup, body, and teardown reboots each observed changed `kern.boottime`; final diagnostics still captured the four-process metadata-refresh tree, proving readiness no longer depends on it.
- **Frozen RED**, untouched base smoke oracle with new consumer test: `test_reboot_ledger_oracle_rejects_byte_stable_derived_cron` failed `DID NOT RAISE AssertionError`. Frozen test blob: `ced7fde223ed7a0386c0d1cdcb578ee0bab679df`.
- **Hermetic GREEN**, same test blob: `5 passed in 0.05s`.
- **Mutation proof**: neutralizing both persistence-probe equality assertions makes the lost-probe pin fail `DID NOT RAISE`; neutralizing both derived-row freshness assertions makes the byte-stable pin fail `DID NOT RAISE`. Source restored to blob `291c19a6f36b77296b41f2f2d019e8b74e74a689` after every mutation.
- **Focused live GREEN**, exact head `d28e0a346ff5b23f21ec95dcb2ea1414af126b76`, RUN_ID `local-100035-1788072504-3f53ecd06c922322`, box `root@10.0.0.35`: `1 passed, 1045 deselected in 240.26s`. The real MFS reboot, archive restore, persistence probe, real tick, and derived regeneration assertions all executed. The metadata-refresh process tree was still running in the authenticated teardown archive.
- **Canonical gates**, `scripts/agent/run-gates.sh --diff origin/devel`: coverage pairing, pytest, ruff check, ruff format check, and mypy all `PASS`; final line `GATES: PASS`.

🤖 Generated by Oh My Pi and posted on behalf of @andrebrait.