### PR TITLE
www/wizards: stop advertising a sinkhole VIP range the picker retired

### DIFF
--- a/docs/misc/architecture-notes.md
+++ b/docs/misc/architecture-notes.md
@@ -524,9 +524,11 @@ force-disables DNSBL if it is missing or invalid.
 **Create VIPs automatically** (`pfb_dnsvip_auto`, default off): when set, pfBlockerNG owns the
 sinkhole VIP(s) end-to-end — no manual Firewall > Virtual IPs entry.
 
-- **Address scheme.** Preferred `10.10.10.53/32` (v4) and `fd00::53/128` (v6, ULA). On conflict
-  it sweeps `10.10.X.53` / `fd00:X::53` (X = 0..15) and picks the first that overlaps no existing
-  VIP or configured subnet.
+- **Address scheme.** A fixed ordered candidate list from `pfb_dnsbl_vip_candidates()` — v4
+  `172.16.53.53`, `192.168.53.53`, `10.53.53.53` (least-used RFC1918 range first); v6 the single
+  ULA `fd00:53:53:53:53:53:53:53`. The picker takes the first that overlaps no existing VIP or
+  configured subnet, and returns null on conflict for the user to resolve. This superseded the
+  earlier sweep pool (ADR-13, issue #487); `DnsblVipCandidatesTest` pins the list.
 - **Ownership marker.** Auto-created VIPs carry the description `pfB_AUTO_VIP_v4` /
   `pfB_AUTO_VIP_v6`; only VIPs with that exact marker are ever managed or removed — a
   manually-created VIP is never touched.

--- a/docs/misc/architecture-notes.md
+++ b/docs/misc/architecture-notes.md
@@ -539,7 +539,7 @@ sinkhole VIP(s) end-to-end — no manual Firewall > Virtual IPs entry.
   disabled+unchecked with a warning while `pfb_dnsvip_auto` stays `on` until the next save; the
   lifecycle manager no-ops safely (logs, leaves config untouched).
 - **IPv6.** When the resolver listens on IPv6, AAAA blocks should sink to a v6 VIP. Auto mode
-  provisions `fd00::53`; manual mode is recommended-but-not-required — with no v6 VIP,
+  provisions the ULA candidate `fd00:53:53:53:53:53:53:53`; manual mode is recommended-but-not-required — with no v6 VIP,
   pfBlockerNG logs a non-blocking warning and keeps running on IPv4 (AAAA simply not sinkholed),
   never force-disabling DNSBL.
 - **HA/CARP.** `pfb_dnsvip_auto` and the address live in `config.xml` and replicate; each node

--- a/docs/misc/architecture-notes.md
+++ b/docs/misc/architecture-notes.md
@@ -527,8 +527,9 @@ sinkhole VIP(s) end-to-end — no manual Firewall > Virtual IPs entry.
 - **Address scheme.** A fixed ordered candidate list from `pfb_dnsbl_vip_candidates()` — v4
   `172.16.53.53`, `192.168.53.53`, `10.53.53.53` (least-used RFC1918 range first); v6 the single
   ULA `fd00:53:53:53:53:53:53:53`. The picker takes the first that overlaps no existing VIP or
-  configured subnet, and returns null on conflict for the user to resolve. This superseded the
-  earlier sweep pool (ADR-13, issue #487); `DnsblVipCandidatesTest` pins the list.
+  configured subnet, and returns null on conflict for the user to resolve. This superseded both the
+  original sweep pool and the #487 interim pool (ADR-13 Amendment #473); `DnsblVipCandidatesTest`
+  pins the list.
 - **Ownership marker.** Auto-created VIPs carry the description `pfB_AUTO_VIP_v4` /
   `pfB_AUTO_VIP_v6`; only VIPs with that exact marker are ever managed or removed — a
   manually-created VIP is never touched.

--- a/src/usr/local/www/wizards/pfblockerng_wizard.xml
+++ b/src/usr/local/www/wizards/pfblockerng_wizard.xml
@@ -263,7 +263,7 @@
 			<name>pfb_dnsvip_auto</name>
 			<displayname>Auto VIP</displayname>
 			<bindstofield>pfblockerng_wizard-&gt;step3-&gt;pfb_dnsvip_auto</bindstofield>
-			<description><![CDATA[Create VIPs automatically. When enabled, pfBlockerNG creates and manages the DNSBL sinkhole Virtual IP in the <strong>10.10.X.53</strong> range (IPv6: <strong>fd00:X::53</strong>) &#8212; the manual selections below are ignored.<br /><span class="text-danger">Note:</span> auto-created VIPs are <strong>not HA/CARP aware</strong>. On a CARP/HA cluster, configure the DNSBL Virtual IP manually instead.]]></description>
+			<description><![CDATA[Create VIPs automatically. When enabled, pfBlockerNG picks and manages the DNSBL sinkhole Virtual IP itself &#8212; the manual selections below are ignored. The address it chose is shown on the DNSBL page once the wizard finishes.<br /><span class="text-danger">Note:</span> auto-created VIPs are <strong>not HA/CARP aware</strong>. On a CARP/HA cluster, configure the DNSBL Virtual IP manually instead.]]></description>
 			<type>checkbox</type>
 			<value>on</value>
 		</field>

--- a/tests/php/WizardVipCopyTest.php
+++ b/tests/php/WizardVipCopyTest.php
@@ -53,9 +53,10 @@ final class WizardVipCopyTest extends TestCase
 		$candidates = pfb_dnsbl_vip_candidates(AF_INET6);
 		$this->assertNotSame([], $candidates, 'the picker must have v6 candidates to compare against');
 
-		preg_match_all('/\bfd[0-9a-f]{2}:[0-9a-fA-FxX:]*[0-9a-fA-FxX]\b/', $wizard, $matches);
+		// Case-insensitive: a literal is no less wrong for being written FD00.
+		preg_match_all('/\bfd[0-9a-f]{2}:[0-9a-f:xX]*[0-9a-f]\b/i', $wizard, $matches);
 		$claimed = array_values(array_unique($matches[0]));
-		$invented = array_values(array_diff($claimed, $candidates));
+		$invented = array_values(array_udiff($claimed, $candidates, 'strcasecmp'));
 
 		$this->assertSame([], $invented,
 			'the wizard names IPv6 sinkhole addresses the picker never returns: '

--- a/tests/php/WizardVipCopyTest.php
+++ b/tests/php/WizardVipCopyTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * User-facing copy may not name a sinkhole VIP address the picker cannot produce.
+ *
+ * The wizard and the architecture notes both described the sweep pool retired with
+ * ADR-13 (issue #2869), sending an admin looking for an address the package never
+ * assigns. pfb_dnsbl_vip_candidates() is the only source of truth for these.
+ */
+final class WizardVipCopyTest extends TestCase
+{
+	private const WIZARD = __DIR__ . '/../../src/usr/local/www/wizards/pfblockerng_wizard.xml';
+
+	private const NOTES = __DIR__ . '/../../docs/misc/architecture-notes.md';
+
+	private static function read(string $path): string
+	{
+		$body = file_get_contents($path);
+		self::assertIsString($body, "{$path} must be readable");
+		return $body;
+	}
+
+	/**
+	 * Any IPv4 literal the wizard shows for the auto-VIP must be one the picker
+	 * actually returns -- a literal that drifts is worse than no literal at all.
+	 */
+	public function testWizardNamesNoVipAddressThePickerCannotProduce(): void
+	{
+		$wizard = self::read(self::WIZARD);
+		$candidates = pfb_dnsbl_vip_candidates(AF_INET);
+		$this->assertNotSame([], $candidates, 'the picker must have candidates to compare against');
+
+		preg_match_all('/\b(?:(?:\d{1,3}|[xX])\.){3}(?:\d{1,3}|[xX])\b/', $wizard, $matches);
+		$claimed = array_values(array_unique($matches[0]));
+		$invented = array_values(array_diff($claimed, $candidates));
+
+		$this->assertSame([], $invented,
+			'the wizard names IPv4 sinkhole addresses the picker never returns: '
+			. implode(', ', $invented) . ' (picker returns: ' . implode(', ', $candidates) . ')');
+	}
+
+	/** The retired sweep pool must not survive in shipped copy or in the notes. */
+	public function testRetiredSweepPoolIsGoneFromCopyAndNotes(): void
+	{
+		foreach ([self::WIZARD, self::NOTES] as $path) {
+			$body = self::read($path);
+			foreach (['10.10.X.53', '10.10.x.53', 'fd00:X::53'] as $retired) {
+				$this->assertStringNotContainsString($retired, $body,
+					basename($path) . ' still describes the sweep pool ADR-13 retired: ' . $retired);
+			}
+		}
+	}
+}

--- a/tests/php/WizardVipCopyTest.php
+++ b/tests/php/WizardVipCopyTest.php
@@ -43,12 +43,31 @@ final class WizardVipCopyTest extends TestCase
 			. implode(', ', $invented) . ' (picker returns: ' . implode(', ', $candidates) . ')');
 	}
 
+	/**
+	 * The v6 half of the same claim. The defect had one, so the guard needs one: an
+	 * invented ULA in the wizard passed every check while only IPv4 was scanned.
+	 */
+	public function testWizardNamesNoIpv6AddressThePickerCannotProduce(): void
+	{
+		$wizard = self::read(self::WIZARD);
+		$candidates = pfb_dnsbl_vip_candidates(AF_INET6);
+		$this->assertNotSame([], $candidates, 'the picker must have v6 candidates to compare against');
+
+		preg_match_all('/\bfd[0-9a-f]{2}:[0-9a-fA-FxX:]*[0-9a-fA-FxX]\b/', $wizard, $matches);
+		$claimed = array_values(array_unique($matches[0]));
+		$invented = array_values(array_diff($claimed, $candidates));
+
+		$this->assertSame([], $invented,
+			'the wizard names IPv6 sinkhole addresses the picker never returns: '
+			. implode(', ', $invented) . ' (picker returns: ' . implode(', ', $candidates) . ')');
+	}
+
 	/** The retired sweep pool must not survive in shipped copy or in the notes. */
 	public function testRetiredSweepPoolIsGoneFromCopyAndNotes(): void
 	{
 		foreach ([self::WIZARD, self::NOTES] as $path) {
 			$body = self::read($path);
-			foreach (['10.10.X.53', '10.10.x.53', 'fd00:X::53'] as $retired) {
+			foreach (['10.10.X.53', '10.10.x.53', 'fd00:X::53', 'fd00::53', '10.10.10.53'] as $retired) {
 				$this->assertStringNotContainsString($retired, $body,
 					basename($path) . ' still describes the sweep pool ADR-13 retired: ' . $retired);
 			}

--- a/tests/smoke/ui/test_render_smoke.py
+++ b/tests/smoke/ui/test_render_smoke.py
@@ -2642,6 +2642,9 @@ def test_wizard_dnsbl_step_renders_auto_vip(webui: WebUI, php_error_log_guard: P
         "manual mode only",  # the pfb_dnsvip4/6 selectors' new mode-dependency note
     ):
         assert needle in body, f"wizard DNSBL step is missing the Auto VIP marker {needle!r}"
+    # issue #2869: the step must not name the sweep pool ADR-13 retired -- an admin who
+    # reads it goes looking for an address pfb_dnsbl_vip_candidates() never returns.
+    assert "10.10." not in body, "wizard DNSBL step still advertises the retired 10.10.X.53 pool"
 
 
 def test_general_wizard_disable_get_is_state_free(

--- a/tests/smoke/ui/test_render_smoke.py
+++ b/tests/smoke/ui/test_render_smoke.py
@@ -2644,7 +2644,10 @@ def test_wizard_dnsbl_step_renders_auto_vip(webui: WebUI, php_error_log_guard: P
         assert needle in body, f"wizard DNSBL step is missing the Auto VIP marker {needle!r}"
     # issue #2869: the step must not name the sweep pool ADR-13 retired -- an admin who
     # reads it goes looking for an address pfb_dnsbl_vip_candidates() never returns.
-    assert "10.10." not in body, "wizard DNSBL step still advertises the retired 10.10.X.53 pool"
+    # Scoped to the retired claim, not to "10.10.": the harness provisions a manual VIP at
+    # DEFAULT_DNSBL_VIP4 (10.10.10.1) which the step's VIP dropdown legitimately lists.
+    for retired in ("10.10.X.53", "10.10.x.53", "fd00:X::53"):
+        assert retired not in body, f"wizard DNSBL step still advertises the retired {retired} pool"
 
 
 def test_general_wizard_disable_get_is_state_free(


### PR DESCRIPTION
Fixes #2869

## The defect

The wizard told the user pfBlockerNG manages the DNSBL sinkhole VIP **"in the `10.10.X.53` range
(IPv6: `fd00:X::53`)"**. It does not. `pfb_dnsbl_vip_candidates()` is the only thing that
produces these:

```php
if ($family === AF_INET) {
    return ['172.16.53.53', '192.168.53.53', '10.53.53.53'];
} elseif ($family === AF_INET6) {
    return ['fd00:53:53:53:53:53:53:53'];
}
```

`DnsblVipCandidatesTest`'s own docblock records why: the fixed list *"supersedes the prior
sweep+disjoint-fallback pool from issue #487"*. The wizard was still advertising the retired
design, so an admin who read it went looking for an address the package never assigns.

## Wider than the issue recorded

The issue states the wizard is "the sole surviving occurrence in the tree." It is not —
`docs/misc/architecture-notes.md:528` carried the **same retired scheme**, describing a
`10.10.X.53` / `fd00:X::53` sweep as the address scheme. Both are corrected here.

| Source | Claimed | Actual |
| --- | --- | --- |
| `pfblockerng_wizard.xml:266` | `10.10.X.53` range | — |
| `architecture-notes.md:528` | prefers `10.10.10.53`, sweeps `10.10.X.53` | — |
| `pfb_dnsbl_vip_candidates()` | | `172.16.53.53`, `192.168.53.53`, `10.53.53.53`, one ULA |

## The fix

The wizard now names **no address at all** — it says pfBlockerNG picks and manages the VIP
itself and that the chosen address is shown on the DNSBL page. That follows the issue's own
advice: substituting today's literals would only relocate the drift, because nothing would hold
them to the function.

The architecture notes now name the real list and point at the test that pins it.

## The guard

Rather than banning one string, `WizardVipCopyTest` asserts that **any IPv4 literal in the
wizard must be one `pfb_dnsbl_vip_candidates()` actually returns**. A future literal has to be
true to survive. A second case keeps the retired sweep spellings out of both the wizard and the
notes.

Tier A additionally proves the retired range does not reach the browser — the existing
`test_wizard_dnsbl_step_renders_auto_vip` already asserts the step's help text renders, and now
also asserts `10.10.` is absent from the rendered body.

## Tests

Written before the fix and run on the untouched tree: both cases failed, naming `10.10.X.53`
in each. Byte-identical between the red and green runs (`git hash-object` =
`83fc4897ffd488627b672312e24fffd60e33b45a`).

Worth recording: the first version of the literal-scanning regex required the placeholder in the
last octet, so it silently passed on `10.10.X.53`, where the `X` is third. It looked correct and
asserted nothing. Running it rather than reading it is what caught that.

## Verification

XML well-formed; PHPStan `[OK] No errors`; PHPCS clean; `WizardVipCopy|DnsblVipCandidates|WizardVipAuto|DnsblEvalOrderHelp`
23 tests / 83 assertions green; `ruff`, `ruff format`, `mypy` clean.

🤖 Generated by [Claude Code](https://claude.com/claude-code), posted via @BBcan177's account on their behalf.


## Review round 1 (see the correction comment below — this section was published before `a205ae9f` was committed)

**A third stale site, thirteen lines below my own edit.** `docs/misc/architecture-notes.md:542`
still read "Auto mode provisions `fd00::53`", contradicting the bullet corrected above it in the
same section. `pfb_dnsbl_vip_candidates(AF_INET6)` returns only
`fd00:53:53:53:53:53:53:53`. Corrected.

Neither guard could have caught it: the literal scan was IPv4-only, and the retired-string list
checked `fd00:X::53`, not `fd00::53`. The reviewer proved both blind spots by mutation. So the
guard is now symmetric — a second case diffs any `fd00:` literal in the wizard against
`pfb_dnsbl_vip_candidates(AF_INET6)`, and the retired list covers `fd00::53` and `10.10.10.53`.

Verified against the reviewer's own mutations:

```text
invented fd00:99::53 in wizard   red (caught)     <- previously passed
fd00::53 back in the notes       red (caught)     <- previously passed
real ULA named in wizard         green            <- correct: a true literal is allowed
```

That last line is the point of the guard's shape. It does not ban addresses; it bans addresses
the picker cannot produce.

### Also confirmed by the review

`pfb_dnsbl_vip_candidates()` has exactly one consumer, `pfb_pick_free_dnsbl_vip()`, whose
callers are the marked-VIP lifecycle creator and the DNSBL page's pre-fill — so it genuinely is
the only producer, and the authority claim holds. The replacement copy's promise that the chosen
address "is shown on the DNSBL page" was traced to `enable_dnsvip_auto()`, which injects it as
the selected option on document-ready; it is true on every reachable path where a VIP is
actually chosen.



## Review round 3

The fix is confirmed present in the tree this time, and all three holes closed by mutation. One
new finding, which contradicted the previous commit message: the v6 regex anchored on lowercase
`fd` and lowercase hex, so `FD00:99::53` passed while `fd00:99::53` was caught. The claim that
"any `fd00:` literal is diffed" was therefore not true. Matching and comparison are both
case-insensitive now:

```text
must be RED:    FD00:99::53  red · fd00:99::53  red
must be GREEN:  fd00:53:53:53:53:53:53:53  green · FD00:53:53:53:53:53:53:53  green
```

The review also pinned down the citation more precisely than round 2 had. ADR-13's amendment is
titled **"Amendment (#473)"** and supersedes the original sweep *and* the `#487` interim pool — so
`#487` was one of the things retired, not the thing that retired them. The notes now name both.

### Still open, and disclosed rather than claimed

An invented IPv4 literal in the **notes prose** remains uncaught: the notes are guarded by exact
retired strings, not by a candidate diff like the wizard. The reviewer judged that acceptable —
the notes are developer documentation, while the surface that actually misleads an admin is the
wizard, which is now guarded in both families. Recorded here rather than quietly closed.


## Review round 4 — converged

No blocking findings. Round 3's two fixes were re-verified by direct mutation rather than
re-reading, in both directions and both cases:

```text
must be RED:    FD00:99::53 · fd00:99::53
must be GREEN:  fd00:53:53:53:53:53:53:53 · FD00:53:53:53:53:53:53:53
```

The reviewer also checked `array_udiff`/`strcasecmp` against duplicates and mixed cases of the
same address — a real ULA written twice in different cases still passes; an invented one written
twice in different cases fails and lists both.

### The CI fix in `22fbfbac`

Not previously narrated here, which round 4 flagged. The Tier A assertion banned `"10.10."`
anywhere in the rendered wizard DNSBL step and failed on all four legs, because
`tests/smoke/helpers.py` sets `DEFAULT_DNSBL_VIP4 = "10.10.10.1"` and that step's VIP dropdown
lists it. Round 1 had called the needle too broad and I recorded it as an acceptable tripwire; it
was not — it could never have passed. Now scoped to the three retired spellings.

Round 4 confirmed that scoping is right rather than merely narrower: those three strings are
exactly what the pre-fix wizard actually rendered, and a reintroduced literal in any other
digit-based spelling is still caught at the unit level by the candidate diff, which scans the
source. Tier A's remaining job is only to prove the historical string doesn't survive into the
rendered DOM.

### Count correction

The "23 tests / 83 assertions" figure describes **this head**. Round 4 established it was never
accurate for the commit it was originally attached to (`1bd014d4` ran 22/76) — round 1's changes
happened to add exactly the difference. Stating that rather than leaving a number that reads as
verified when it was not.

### Noted, out of scope

`tests/php/DnsblVipCandidatesTest.php`'s docblock still attributes the supersession to `#487`
alone — the same imprecision round 3 corrected in the architecture notes. That file is untouched
by this PR, so it is pre-existing and left for a follow-up rather than widened into this change.
