### PR TITLE
tests/php: restore MIME fixture allow-list state

### DIFF
--- a/tests/php/OctetStreamRecoveryWiringTest.php
+++ b/tests/php/OctetStreamRecoveryWiringTest.php
@@ -37,6 +37,9 @@ final class OctetStreamRecoveryWiringTest extends TestCase
 	private string $junkPrefixedZip;
 	private string $junkBlob;
 
+	/** @var array<string,mixed> saved $GLOBALS['pfb'] keys (sentinel FALSE = was unset) */
+	private array $saved = [];
+
 	protected function setUp(): void
 	{
 		// Both tests build the fixture ZIP via ZipArchive; without php-zip the suite
@@ -69,6 +72,10 @@ final class OctetStreamRecoveryWiringTest extends TestCase
 		// by file(1) on both macOS and Linux; not a ZIP/gzip/bzip2 archive.
 		file_put_contents($this->junkBlob, str_repeat("\x00\x01\x02\x03", 256));
 
+		$this->saved['mime_types'] = array_key_exists('mime_types', $GLOBALS['pfb'] ?? [])
+			? $GLOBALS['pfb']['mime_types']
+			: FALSE;
+
 		// Allow-list: application/zip present; application/octet-stream absent (it is
 		// never added to the allow-list — recovery is the only admittance path).
 		$GLOBALS['pfb']['mime_types'] = ['application/zip' => 1];
@@ -89,7 +96,13 @@ final class OctetStreamRecoveryWiringTest extends TestCase
 		@unlink($this->junkPrefixedZip);
 		@unlink($this->junkBlob);
 		@rmdir($this->dir);
-		unset($GLOBALS['pfb']['mime_types']);
+		foreach ($this->saved as $k => $prev) {
+			if ($prev === FALSE) {
+				unset($GLOBALS['pfb'][$k]);
+			} else {
+				$GLOBALS['pfb'][$k] = $prev;
+			}
+		}
 	}
 
 	/**

--- a/tests/php/PfbFileMimeNormaliseWiringTest.php
+++ b/tests/php/PfbFileMimeNormaliseWiringTest.php
@@ -43,6 +43,9 @@ final class PfbFileMimeNormaliseWiringTest extends TestCase
 	private string $cwd;
 	private string $epubPath;
 
+	/** @var array<string,mixed> saved $GLOBALS['pfb'] keys (sentinel FALSE = was unset) */
+	private array $saved = [];
+
 	protected function setUp(): void
 	{
 		$this->dir      = sys_get_temp_dir() . '/pfb_mime_wiring_' . uniqid('', TRUE);
@@ -51,6 +54,10 @@ final class PfbFileMimeNormaliseWiringTest extends TestCase
 		$this->epubPath = $this->dir . '/book.epub';
 
 		file_put_contents($this->epubPath, base64_decode(self::EPUB_B64, TRUE));
+
+		$this->saved['mime_types'] = array_key_exists('mime_types', $GLOBALS['pfb'] ?? [])
+			? $GLOBALS['pfb']['mime_types']
+			: FALSE;
 
 		// Only the wiring test's allow-list: application/zip is present,
 		// application/epub+zip is deliberately absent.
@@ -62,7 +69,13 @@ final class PfbFileMimeNormaliseWiringTest extends TestCase
 		chdir($this->cwd);
 		@unlink($this->epubPath);
 		@rmdir($this->dir);
-		unset($GLOBALS['pfb']['mime_types']);
+		foreach ($this->saved as $k => $prev) {
+			if ($prev === FALSE) {
+				unset($GLOBALS['pfb'][$k]);
+			} else {
+				$GLOBALS['pfb'][$k] = $prev;
+			}
+		}
 	}
 
 	/**

--- a/tests/php/PfbFileMimeSinkEscapeTest.php
+++ b/tests/php/PfbFileMimeSinkEscapeTest.php
@@ -22,6 +22,9 @@ final class PfbFileMimeSinkEscapeTest extends TestCase
 	private string $dir;
 	private string $cwd;
 
+	/** @var array<string,mixed> saved $GLOBALS['pfb'] keys (sentinel FALSE = was unset) */
+	private array $saved = [];
+
 	protected function setUp(): void
 	{
 		$this->dir = sys_get_temp_dir() . '/pfb_mime_' . uniqid('', true);
@@ -30,6 +33,10 @@ final class PfbFileMimeSinkEscapeTest extends TestCase
 		// not itself contain '/') and its sentinel are addressed by bare name.
 		$this->cwd = (string) getcwd();
 		chdir($this->dir);
+		$this->saved['mime_types'] = array_key_exists('mime_types', $GLOBALS['pfb'] ?? [])
+			? $GLOBALS['pfb']['mime_types']
+			: FALSE;
+
 		// FILE_MIME accepts the probed type only when it is a known mime_type.
 		$GLOBALS['pfb']['mime_types'] = ['text/plain' => 1];
 	}
@@ -41,7 +48,13 @@ final class PfbFileMimeSinkEscapeTest extends TestCase
 			@unlink($f);
 		}
 		@rmdir($this->dir);
-		unset($GLOBALS['pfb']['mime_types']);
+		foreach ($this->saved as $k => $prev) {
+			if ($prev === FALSE) {
+				unset($GLOBALS['pfb'][$k]);
+			} else {
+				$GLOBALS['pfb'][$k] = $prev;
+			}
+		}
 	}
 
 	public function testBenignPathProbesMimeUnchanged(): void

--- a/tests/php/PfbMimeAllowlistTest.php
+++ b/tests/php/PfbMimeAllowlistTest.php
@@ -9,9 +9,8 @@ use PHPUnit\Framework\TestCase;
  * Oracle tests for pfb_mime_in_allowlist() — extracted pure helper that
  * encapsulates the $pfb['mime_types'] membership lookup.
  *
- * These tests pin the shipped allow-list behaviour. setUp() repopulates
- * $pfb['mime_types'] from the canonical list on every run so sibling-test
- * tearDown() calls that unset the global do not affect these oracles.
+ * These tests pin the shipped allow-list behaviour. setUp() installs the
+ * canonical fixture for each run; tearDown() restores the prior global state.
  *
  * Entries (b) and (c) pin defensive baseline strings — types NOT emitted by
  * stock FreeBSD libmagic for real ZIPs, but canonicalised by pfb_mime_normalise()
@@ -24,11 +23,17 @@ final class PfbMimeAllowlistTest extends TestCase
 {
 	private array $allowlist;
 
+	/** @var array<string,mixed> saved $GLOBALS['pfb'] keys (sentinel FALSE = was unset) */
+	private array $saved = [];
+
 	protected function setUp(): void
 	{
-		// Always repopulate from the canonical shipped list (pfblockerng.inc:274-289)
-		// so sibling-test tearDown() calls that unset $pfb['mime_types'] cannot
-		// affect these oracles. If the shipped list changes, update this mirror.
+		$this->saved['mime_types'] = array_key_exists('mime_types', $GLOBALS['pfb'] ?? [])
+			? $GLOBALS['pfb']['mime_types']
+			: FALSE;
+
+		// Use the canonical shipped-list mirror for these allow-list oracles.
+		// If the shipped list changes, update this mirror.
 		$GLOBALS['pfb']['mime_types'] = array_flip([
 			'inode/x-empty', 'text/x-file',
 			'text/plain', 'text/html', 'text/xml', 'text/csv',
@@ -42,7 +47,13 @@ final class PfbMimeAllowlistTest extends TestCase
 
 	protected function tearDown(): void
 	{
-		unset($GLOBALS['pfb']['mime_types']);
+		foreach ($this->saved as $k => $prev) {
+			if ($prev === FALSE) {
+				unset($GLOBALS['pfb'][$k]);
+			} else {
+				$GLOBALS['pfb'][$k] = $prev;
+			}
+		}
 	}
 
 	public function test_pfb_mime_allowlist_accepts_canonical_zip(): void

--- a/tests/php/PfbMimeTypesProducerAbsentStateTest.php
+++ b/tests/php/PfbMimeTypesProducerAbsentStateTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/PfbMimeTypesProducerHygieneTest.php';
+
+/** Issue #2906: MIME fixture producers must preserve a previously absent key. */
+final class PfbMimeTypesProducerAbsentStateTest extends TestCase
+{
+	public static function producer(): array
+	{
+		return PfbMimeTypesProducerHygieneTest::producer();
+	}
+
+	#[DataProvider('producer')]
+	public function testProducerLifecycleRestoresAbsentMimeTypes(string $class, string $method): void
+	{
+		$hadMimeTypes = array_key_exists('mime_types', $GLOBALS['pfb']);
+		$previous = $GLOBALS['pfb']['mime_types'] ?? null;
+		unset($GLOBALS['pfb']['mime_types']);
+
+		try {
+			$suite = new $class($method);
+			$ref = new ReflectionClass($suite);
+			$setUp = $ref->getMethod('setUp');
+			$tearDown = $ref->getMethod('tearDown');
+			$setUpComplete = false;
+
+			try {
+				$setUp->invoke($suite);
+				$setUpComplete = true;
+				$this->assertArrayHasKey(
+					'mime_types',
+					$GLOBALS['pfb'],
+					"{$class} setUp must install its MIME fixture"
+				);
+			} finally {
+				if ($setUpComplete) {
+					$tearDown->invoke($suite);
+				}
+			}
+
+			$this->assertArrayNotHasKey(
+				'mime_types',
+				$GLOBALS['pfb'],
+				"{$class} teardown must preserve a previously absent MIME allow-list"
+			);
+		} finally {
+			if ($hadMimeTypes) {
+				$GLOBALS['pfb']['mime_types'] = $previous;
+			} else {
+				unset($GLOBALS['pfb']['mime_types']);
+			}
+		}
+	}
+}

--- a/tests/php/PfbMimeTypesProducerHygieneTest.php
+++ b/tests/php/PfbMimeTypesProducerHygieneTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/OctetStreamRecoveryWiringTest.php';
+require_once __DIR__ . '/PfbFileMimeNormaliseWiringTest.php';
+require_once __DIR__ . '/PfbFileMimeSinkEscapeTest.php';
+require_once __DIR__ . '/PfbMimeAllowlistTest.php';
+
+/** Issue #2906: MIME fixture producers must restore the bootstrap allow-list. */
+final class PfbMimeTypesProducerHygieneTest extends TestCase
+{
+	public static function producer(): array
+	{
+		return [
+			'OctetStreamRecoveryWiringTest' => [
+				OctetStreamRecoveryWiringTest::class,
+				'test_octet_stream_archive_recovered_to_zip',
+			],
+			'PfbFileMimeNormaliseWiringTest' => [
+				PfbFileMimeNormaliseWiringTest::class,
+				'test_epub_zip_passes_via_normalise_wiring',
+			],
+			'PfbFileMimeSinkEscapeTest' => [
+				PfbFileMimeSinkEscapeTest::class,
+				'testBenignPathProbesMimeUnchanged',
+			],
+			'PfbMimeAllowlistTest' => [
+				PfbMimeAllowlistTest::class,
+				'test_pfb_mime_allowlist_accepts_canonical_zip',
+			],
+		];
+	}
+
+	#[DataProvider('producer')]
+	public function testProducerLifecycleRestoresBootstrapMimeTypes(string $class, string $method): void
+	{
+		$hadMimeTypes = array_key_exists('mime_types', $GLOBALS['pfb']);
+		$previous = $GLOBALS['pfb']['mime_types'] ?? null;
+		$bootstrap = ['application/x-pfb-bootstrap-sentinel' => 2906];
+		$GLOBALS['pfb']['mime_types'] = $bootstrap;
+
+		try {
+			$suite = new $class($method);
+			$ref = new ReflectionClass($suite);
+			$setUp = $ref->getMethod('setUp');
+			$tearDown = $ref->getMethod('tearDown');
+			$setUpComplete = false;
+
+			try {
+				$setUp->invoke($suite);
+				$setUpComplete = true;
+			} finally {
+				if ($setUpComplete) {
+					$tearDown->invoke($suite);
+				}
+			}
+
+			$this->assertArrayHasKey(
+				'mime_types',
+				$GLOBALS['pfb'],
+				"{$class} teardown must not remove the bootstrap MIME allow-list"
+			);
+			$this->assertSame(
+				$bootstrap,
+				$GLOBALS['pfb']['mime_types'],
+				"{$class} teardown must restore the exact bootstrap MIME allow-list"
+			);
+		} finally {
+			if ($hadMimeTypes) {
+				$GLOBALS['pfb']['mime_types'] = $previous;
+			} else {
+				unset($GLOBALS['pfb']['mime_types']);
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Save the prior `$pfb['mime_types']` state in the four fixture-producing PHPUnit suites.
- Restore the exact prior bootstrap value, or restore key absence when the key did not previously exist.
- Add real-lifecycle regression rows for both prior-present and prior-absent state.

Fixes #2906

## Root-cause probe

A focused real-lifecycle probe seeded a sentinel before each producer's `setUp()`/`tearDown()` pair. On the unmodified base, every row ended with the key absent:

```text
OctetStreamRecoveryWiringTest before=present after=absent value=null
PfbFileMimeNormaliseWiringTest before=present after=absent value=null
PfbFileMimeSinkEscapeTest before=present after=absent value=null
PfbMimeAllowlistTest before=present after=absent value=null
```

This confirms producer teardown corruption rather than a consumer-setup defect.

## Test-first and mutation evidence

Present-state RED on the unmodified producers:

```text
vendor/bin/phpunit --do-not-cache-result tests/php/PfbMimeTypesProducerHygieneTest.php
FFFF
Tests: 4, Assertions: 4, Failures: 4.
```

All four rows failed because teardown removed `mime_types`. The frozen RED-time and committed test hash is:

```text
993c400c0d0e39f3de58e703bdc4117e2b7f4637
```

The separate absent-state test invokes each real lifecycle, asserts the fixture key exists during `setUp()`, and asserts it is absent after `tearDown()`. Mutating all four absent restore branches from `unset(...)` to assignment of `FALSE` produced:

```text
FFFF
Tests: 4, Assertions: 8, Failures: 4.
```

Restoring the implementation produced `OK (4 tests, 8 assertions)`. The committed absent-state test hash is:

```text
267f360eb28edfd2c12afa24d026c20da5a29cc7
```

## Focused verification

Exact-head focused random-order runs included the four producers, both lifecycle regressions, and `DownloadSizeRefusalTest`:

```text
Random Seed: 1951
Tests: 27, Assertions: 61, Deprecations: 1, Notices: 1.
Exit: 0

Random Seed: 20260830
Tests: 27, Assertions: 61, Deprecations: 1, Notices: 1.
Exit: 0
```

The pre-existing deprecation and notice are emitted by the focused consumer path; neither run has an error or failure.

An independent exact-head verifier also replayed base RED/head GREEN, both hashes, all four present/absent mutations, focused random-order consumer coverage, and the canonical gate set. Result: 13/13 gates passed, 0 failed, 0 skipped; tree and hashes unchanged at `abf851e436cb041886c6ffc3bf95db57a3a89416`.

## Scope

No production code, defensive consumer reseeds, unrelated fixture cleanup, or broad suite cleanup.

🤖 Generated by Oh My Pi and posted on behalf of @andrebrait.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test isolation by preserving and restoring existing MIME configuration during test setup and cleanup.
  * Added coverage to verify EPUB MIME types are normalized correctly during file filtering.
  * Ensured MIME fixture setup restores both previously configured and previously absent states.

* **Tests**
  * Added lifecycle hygiene coverage for MIME fixture producers.
  * Added safeguards for cleanup when test setup does not complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->