### PR TITLE
tests: require owned HTTP fixture readiness

### DIFF
--- a/tests/php/DownloadExtractedPayloadSanityTest.php
+++ b/tests/php/DownloadExtractedPayloadSanityTest.php
@@ -6,6 +6,8 @@ use PHPUnit\Framework\Attributes\CoversFunction;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
+require_once __DIR__ . '/support/HttpFixtureReadiness.php';
+
 /**
  * Issue #2660 — the content-sanity verdicts must also cover an archive feed's
  * EXTRACTED payload, not only a body libmagic already calls text.
@@ -341,25 +343,40 @@ final class DownloadExtractedPayloadSanityTest extends TestCase
 		$this->assertSame($flag, PfbConfig::read('gen/pfb_feed_sanity'), 'the scan flag must be set for this row');
 
 		$router = "{$this->dir}/router.php";
-		$this->assertNotFalse(file_put_contents($router, "<?php\nreadfile(" . var_export($source, TRUE) . ");\n"));
-		$descriptors = [1 => ['file', '/dev/null', 'w'], 2 => ['file', '/dev/null', 'w']];
+		$routerSrc = <<<'PHP'
+<?php
+$uri = $_SERVER['REQUEST_URI'] ?? '';
+if (str_starts_with($uri, '/__pfb_ready/')) {
+	if ($uri === '/__pfb_ready/' . getenv('READY_TOKEN')) {
+		echo getenv('READY_TOKEN');
+	}
+	return;
+}
+readfile(%s);
+PHP;
+		$this->assertNotFalse(file_put_contents($router, sprintf($routerSrc, var_export($source, TRUE))));
+		$failures = [];
 		$port = 0;
 		for ($try = 0; $try < 10 && $port === 0; $try++) {
 			$candidate = random_int(20000, 60000);
+			$nonce = bin2hex(random_bytes(16));
+			$stderr = "{$this->dir}/server-{$candidate}-{$try}.stderr";
 			$proc = proc_open(
 				['php', '-S', "127.0.0.1:{$candidate}", $router],
-				$descriptors,
+				[1 => ['file', '/dev/null', 'w'], 2 => ['file', $stderr, 'w']],
 				$pipes,
 				$this->dir,
-				['PATH' => (string) getenv('PATH')]
+				[
+					'READY_TOKEN' => $nonce,
+					'PATH' => (string) getenv('PATH'),
+				]
 			);
 			if (!is_resource($proc)) {
+				$failures[] = "port {$candidate}: process=proc_open failed stderr=(unavailable)";
 				continue;
 			}
 			for ($poll = 0; $poll < 40; $poll++) {
-				$sock = @fsockopen('127.0.0.1', $candidate, $errno, $errstr, 0.05);
-				if ($sock !== FALSE) {
-					fclose($sock);
+				if (pfb_test_http_fixture_event_received($candidate, $nonce)) {
 					$this->server = $proc;
 					$port = $candidate;
 					break;
@@ -367,11 +384,27 @@ final class DownloadExtractedPayloadSanityTest extends TestCase
 				usleep(50000);
 			}
 			if ($port === 0) {
-				proc_terminate($proc);
-				proc_close($proc);
+				$status = proc_get_status($proc);
+				if ($status['running']) {
+					proc_terminate($proc);
+				}
+				$closeExit = proc_close($proc);
+				$stderrText = trim((string) @file_get_contents($stderr));
+				$failures[] = sprintf(
+					'port %d: process[running=%s exit=%d close=%d] stderr=%s',
+					$candidate,
+					$status['running'] ? 'true' : 'false',
+					$status['exitcode'],
+					$closeExit,
+					$stderrText === '' ? '(empty)' : $stderrText
+				);
 			}
 		}
-		$this->assertGreaterThan(0, $port, 'loopback HTTP fixture unavailable');
+		$this->assertGreaterThan(
+			0,
+			$port,
+			'loopback HTTP fixture unavailable; ' . implode(' | ', $failures)
+		);
 
 		return pfb_download(new PfbDownloadRequest(
 			listUrl: "http://127.0.0.1:{$port}/feed",

--- a/tests/php/DownloadExtractedPayloadSanityTest.php
+++ b/tests/php/DownloadExtractedPayloadSanityTest.php
@@ -346,8 +346,8 @@ final class DownloadExtractedPayloadSanityTest extends TestCase
 		$routerSrc = <<<'PHP'
 <?php
 $uri = $_SERVER['REQUEST_URI'] ?? '';
-if (str_starts_with($uri, '/__pfb_ready/')) {
-	if ($uri === '/__pfb_ready/' . getenv('READY_TOKEN')) {
+if ($uri === '/__pfb_ready' || str_starts_with($uri, '/__pfb_ready/')) {
+	if ($uri === '/__pfb_ready') {
 		echo getenv('READY_TOKEN');
 	}
 	return;

--- a/tests/php/DownloadRedirectCredentialScopeTest.php
+++ b/tests/php/DownloadRedirectCredentialScopeTest.php
@@ -129,8 +129,8 @@ file_put_contents(getenv('EVENT_LOG'), json_encode([
 	(int) $_SERVER['SERVER_PORT'],
 	$uri,
 ]) . PHP_EOL, FILE_APPEND);
-if (str_starts_with($uri, '/__pfb_ready/')) {
-	if ($uri === '/__pfb_ready/' . getenv('READY_TOKEN')) {
+if ($uri === '/__pfb_ready' || str_starts_with($uri, '/__pfb_ready/')) {
+	if ($uri === '/__pfb_ready') {
 		echo getenv('READY_TOKEN');
 	}
 	return;

--- a/tests/php/DownloadRedirectCredentialScopeTest.php
+++ b/tests/php/DownloadRedirectCredentialScopeTest.php
@@ -125,16 +125,16 @@ final class DownloadRedirectCredentialScopeTest extends TestCase
 		$routerSrc = <<<'PHP'
 <?php
 $uri = $_SERVER['REQUEST_URI'] ?? '';
-file_put_contents(getenv('EVENT_LOG'), json_encode([
-	(int) $_SERVER['SERVER_PORT'],
-	$uri,
-]) . PHP_EOL, FILE_APPEND);
 if ($uri === '/__pfb_ready' || str_starts_with($uri, '/__pfb_ready/')) {
 	if ($uri === '/__pfb_ready') {
 		echo getenv('READY_TOKEN');
 	}
 	return;
 }
+file_put_contents(getenv('EVENT_LOG'), json_encode([
+	(int) $_SERVER['SERVER_PORT'],
+	$uri,
+]) . PHP_EOL, FILE_APPEND);
 file_put_contents(getenv('AUTH_LOG'), json_encode([
 	(int) $_SERVER['SERVER_PORT'],
 	$_SERVER['REQUEST_URI'] ?? '',

--- a/tests/php/DownloadRedirectFixtureReadinessHygieneTest.php
+++ b/tests/php/DownloadRedirectFixtureReadinessHygieneTest.php
@@ -10,23 +10,27 @@ require_once __DIR__ . '/HttpFixtureReadinessTest.php';
 /** Issue #2065: fixture diagnostics and readiness traffic stay distinct from credential hops. */
 final class DownloadRedirectFixtureReadinessHygieneTest extends TestCase
 {
-	public function testForeignReadinessNonceDoesNotPolluteCredentialLog(): void
+	public function testForeignReadinessSecretDoesNotPolluteFixtureLogs(): void
 	{
 		$this->withFixture(function (DownloadRedirectCredentialScopeTest $suite, ReflectionClass $ref): void {
-			$port = $ref->getProperty('originPort');
-			$workdir = $ref->getProperty('workdir');
+			$port = (int) $ref->getProperty('originPort')->getValue($suite);
+			$workdir = (string) $ref->getProperty('workdir')->getValue($suite);
+			$eventLog = "{$workdir}/events.log";
+			$eventsBefore = @file($eventLog, FILE_IGNORE_NEW_LINES) ?: [];
+
 			$this->assertFalse(
-				pfb_test_http_fixture_event_received((int) $port->getValue($suite), bin2hex(random_bytes(16))),
-				'a nonce for another fixture must not satisfy this router readiness event'
+				pfb_test_http_fixture_event_received($port, bin2hex(random_bytes(16))),
+				'a secret for another fixture must not satisfy this router readiness event'
 			);
-			$authLines = @file(
-				(string) $workdir->getValue($suite) . '/auth.log',
-				FILE_IGNORE_NEW_LINES
+			$this->assertSame(
+				$eventsBefore,
+				@file($eventLog, FILE_IGNORE_NEW_LINES) ?: [],
+				'a foreign readiness secret must not appear as a normal redirect event'
 			);
 			$this->assertSame(
 				[],
-				$authLines ?: [],
-				'a foreign readiness nonce must not appear as a credential-bearing redirect hop'
+				@file("{$workdir}/auth.log", FILE_IGNORE_NEW_LINES) ?: [],
+				'a foreign readiness secret must not appear as a credential-bearing redirect hop'
 			);
 		});
 	}
@@ -36,6 +40,8 @@ final class DownloadRedirectFixtureReadinessHygieneTest extends TestCase
 		$this->withFixture(function (DownloadRedirectCredentialScopeTest $suite, ReflectionClass $ref): void {
 			$port = (int) $ref->getProperty('originPort')->getValue($suite);
 			$workdir = (string) $ref->getProperty('workdir')->getValue($suite);
+			$eventLog = "{$workdir}/events.log";
+			$eventsBefore = @file($eventLog, FILE_IGNORE_NEW_LINES) ?: [];
 			$context = stream_context_create(['http' => ['timeout' => 0.05, 'ignore_errors' => TRUE]]);
 			$body = @file_get_contents(
 				"http://127.0.0.1:{$port}/__pfb_ready/legacy-probe",
@@ -44,12 +50,37 @@ final class DownloadRedirectFixtureReadinessHygieneTest extends TestCase
 			);
 
 			$this->assertSame('', $body, 'legacy readiness subpaths must be reserved without a response');
-			$authLines = @file("{$workdir}/auth.log", FILE_IGNORE_NEW_LINES);
+			$this->assertSame(
+				$eventsBefore,
+				@file($eventLog, FILE_IGNORE_NEW_LINES) ?: [],
+				'legacy readiness subpaths must not appear as normal redirect events'
+			);
 			$this->assertSame(
 				[],
-				$authLines ?: [],
+				@file("{$workdir}/auth.log", FILE_IGNORE_NEW_LINES) ?: [],
 				'legacy readiness subpaths must not reach credential-bearing router effects'
 			);
+		});
+	}
+
+	public function testNormalRequestStillReachesEventLog(): void
+	{
+		$this->withFixture(function (DownloadRedirectCredentialScopeTest $suite, ReflectionClass $ref): void {
+			$port = (int) $ref->getProperty('originPort')->getValue($suite);
+			$workdir = (string) $ref->getProperty('workdir')->getValue($suite);
+			$eventLog = "{$workdir}/events.log";
+			$eventsBefore = @file($eventLog, FILE_IGNORE_NEW_LINES) ?: [];
+			$context = stream_context_create(['http' => ['timeout' => 0.05, 'ignore_errors' => TRUE]]);
+
+			$this->assertSame(
+				'BODY',
+				@file_get_contents("http://127.0.0.1:{$port}/final", FALSE, $context)
+			);
+			$eventsAfter = @file($eventLog, FILE_IGNORE_NEW_LINES) ?: [];
+			$this->assertCount(count($eventsBefore) + 1, $eventsAfter);
+			$event = json_decode((string) end($eventsAfter), TRUE);
+			$this->assertIsArray($event);
+			$this->assertSame('/final', $event[1] ?? NULL);
 		});
 	}
 
@@ -66,7 +97,7 @@ final class DownloadRedirectFixtureReadinessHygieneTest extends TestCase
 
 			$this->assertStringContainsString('response status=599', $message);
 			$this->assertStringContainsString('events=', $message);
-			$this->assertStringContainsString('__pfb_ready', $message);
+			$this->assertStringNotContainsString('__pfb_ready', $message);
 			$this->assertStringContainsString(
 				"ports=origin:{$origin} target:{$target} alt:{$alt}",
 				$message

--- a/tests/php/DownloadRedirectFixtureReadinessHygieneTest.php
+++ b/tests/php/DownloadRedirectFixtureReadinessHygieneTest.php
@@ -31,6 +31,28 @@ final class DownloadRedirectFixtureReadinessHygieneTest extends TestCase
 		});
 	}
 
+	public function testLegacyReadinessSubpathDoesNotReachCredentialEffects(): void
+	{
+		$this->withFixture(function (DownloadRedirectCredentialScopeTest $suite, ReflectionClass $ref): void {
+			$port = (int) $ref->getProperty('originPort')->getValue($suite);
+			$workdir = (string) $ref->getProperty('workdir')->getValue($suite);
+			$context = stream_context_create(['http' => ['timeout' => 0.05, 'ignore_errors' => TRUE]]);
+			$body = @file_get_contents(
+				"http://127.0.0.1:{$port}/__pfb_ready/legacy-probe",
+				FALSE,
+				$context
+			);
+
+			$this->assertSame('', $body, 'legacy readiness subpaths must be reserved without a response');
+			$authLines = @file("{$workdir}/auth.log", FILE_IGNORE_NEW_LINES);
+			$this->assertSame(
+				[],
+				$authLines ?: [],
+				'legacy readiness subpaths must not reach credential-bearing router effects'
+			);
+		});
+	}
+
 	public function testFailureDiagnosticsNameResponseHopsPortsAndProcesses(): void
 	{
 		$this->withFixture(function (DownloadRedirectCredentialScopeTest $suite, ReflectionClass $ref): void {
@@ -62,7 +84,7 @@ final class DownloadRedirectFixtureReadinessHygieneTest extends TestCase
 		$sentinel = "{$root}/match/sentinel";
 		$this->assertNotFalse(file_put_contents($sentinel, 'keep'));
 
-		$suite = new HttpFixtureReadinessTest('testProbeRejectsReachableForeignListener');
+		$suite = new HttpFixtureReadinessTest('testProbeRejectsReflectiveForeignListener');
 		$ref = new ReflectionClass($suite);
 		$ref->getProperty('workdir')->setValue($suite, "{$root}/*");
 

--- a/tests/php/DownloadRejectValidatorClearTest.php
+++ b/tests/php/DownloadRejectValidatorClearTest.php
@@ -724,8 +724,8 @@ final class DownloadRejectValidatorClearTest extends TestCase
 		$this->assertNotFalse(file_put_contents($router, <<<'ROUTER'
 			<?php
 			$uri = $_SERVER['REQUEST_URI'] ?? '';
-			if (str_starts_with($uri, '/__pfb_ready/')) {
-				if ($uri === '/__pfb_ready/' . getenv('READY_TOKEN')) {
+			if ($uri === '/__pfb_ready' || str_starts_with($uri, '/__pfb_ready/')) {
+				if ($uri === '/__pfb_ready') {
 					echo getenv('READY_TOKEN');
 				}
 				return;

--- a/tests/php/DownloadRejectValidatorClearTest.php
+++ b/tests/php/DownloadRejectValidatorClearTest.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 require_once __DIR__ . '/../../src/usr/local/pkg/pfblockerng/pfblockerng_cron.inc';
+require_once __DIR__ . '/support/HttpFixtureReadiness.php';
 
 /**
  * Issue #2820 — a content-rejected feed must not be able to hide behind the rejected
@@ -722,6 +723,13 @@ final class DownloadRejectValidatorClearTest extends TestCase
 		$router = "{$this->dir}/router.php";
 		$this->assertNotFalse(file_put_contents($router, <<<'ROUTER'
 			<?php
+			$uri = $_SERVER['REQUEST_URI'] ?? '';
+			if (str_starts_with($uri, '/__pfb_ready/')) {
+				if ($uri === '/__pfb_ready/' . getenv('READY_TOKEN')) {
+					echo getenv('READY_TOKEN');
+				}
+				return;
+			}
 			$dir = __DIR__;
 			$ctl = json_decode((string) file_get_contents("{$dir}/control.json"), TRUE) ?: [];
 			file_put_contents("{$dir}/requests.log", json_encode([
@@ -747,23 +755,24 @@ final class DownloadRejectValidatorClearTest extends TestCase
 		$this->serveControl('', 0);
 		$this->assertNotFalse(file_put_contents("{$this->dir}/body.bin", ''));
 
-		$descriptors = [1 => ['file', '/dev/null', 'w'], 2 => ['file', "{$this->dir}/origin.log", 'a']];
+		$failures = [];
 		for ($try = 0; $try < 20 && $this->port === 0; $try++) {
 			$candidate = random_int(20000, 60000);
+			$nonce = bin2hex(random_bytes(16));
+			$stderr = "{$this->dir}/server-{$candidate}-{$try}.stderr";
 			$proc = proc_open(
 				['php', '-S', "127.0.0.1:{$candidate}", $router],
-				$descriptors,
+				[1 => ['file', '/dev/null', 'w'], 2 => ['file', $stderr, 'w']],
 				$pipes,
 				$this->dir,
-				['PATH' => (string) getenv('PATH')]
+				['READY_TOKEN' => $nonce, 'PATH' => (string) getenv('PATH')]
 			);
 			if (!is_resource($proc)) {
+				$failures[] = "port {$candidate}: process=proc_open failed stderr=(unavailable)";
 				continue;
 			}
 			for ($poll = 0; $poll < 40; $poll++) {
-				$sock = @fsockopen('127.0.0.1', $candidate, $errno, $errstr, 0.05);
-				if ($sock !== FALSE) {
-					fclose($sock);
+				if (pfb_test_http_fixture_event_received($candidate, $nonce)) {
 					$this->server = $proc;
 					$this->port = $candidate;
 					break;
@@ -771,11 +780,27 @@ final class DownloadRejectValidatorClearTest extends TestCase
 				usleep(50000);
 			}
 			if ($this->port === 0) {
-				proc_terminate($proc);
-				proc_close($proc);
+				$status = proc_get_status($proc);
+				if ($status['running']) {
+					proc_terminate($proc);
+				}
+				$closeExit = proc_close($proc);
+				$stderrText = trim((string) @file_get_contents($stderr));
+				$failures[] = sprintf(
+					'port %d: process[running=%s exit=%d close=%d] stderr=%s',
+					$candidate,
+					$status['running'] ? 'true' : 'false',
+					$status['exitcode'],
+					$closeExit,
+					$stderrText === '' ? '(empty)' : $stderrText
+				);
 			}
 		}
-		$this->assertGreaterThan(0, $this->port, 'loopback HTTP fixture unavailable');
+		$this->assertGreaterThan(
+			0,
+			$this->port,
+			'loopback HTTP fixture unavailable; ' . implode(' | ', $failures)
+		);
 	}
 
 	private function serveControl(string $etag, int $lastmod): void

--- a/tests/php/DownloadRetryBodyResetTest.php
+++ b/tests/php/DownloadRetryBodyResetTest.php
@@ -110,8 +110,8 @@ final class DownloadRetryBodyResetTest extends TestCase
 		$routerSrc = <<<PHP
 <?php
 \$uri = \$_SERVER['REQUEST_URI'] ?? '';
-if (str_starts_with(\$uri, '/__pfb_ready/')) {
-	if (\$uri === '/__pfb_ready/' . getenv('READY_TOKEN')) {
+if (\$uri === '/__pfb_ready' || str_starts_with(\$uri, '/__pfb_ready/')) {
+	if (\$uri === '/__pfb_ready') {
 		echo getenv('READY_TOKEN');
 	}
 	return;

--- a/tests/php/DownloadRetryBodyResetTest.php
+++ b/tests/php/DownloadRetryBodyResetTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 use PHPUnit\Framework\Attributes\CoversFunction;
 use PHPUnit\Framework\TestCase;
 
+require_once __DIR__ . '/support/HttpFixtureReadiness.php';
+
 /**
  * pfb_download() retry-attempt body reset (issue #1072).
  *
@@ -107,6 +109,13 @@ final class DownloadRetryBodyResetTest extends TestCase
 		$this->assertSame(64, strlen($body));
 		$routerSrc = <<<PHP
 <?php
+\$uri = \$_SERVER['REQUEST_URI'] ?? '';
+if (str_starts_with(\$uri, '/__pfb_ready/')) {
+	if (\$uri === '/__pfb_ready/' . getenv('READY_TOKEN')) {
+		echo getenv('READY_TOKEN');
+	}
+	return;
+}
 \$authLog = getenv('AUTH_LOG');
 if (str_starts_with(\$_SERVER['REQUEST_URI'] ?? '', '/auth')) {
 	file_put_contents(\$authLog, json_encode([
@@ -129,38 +138,52 @@ echo '{$body}';
 PHP;
 		$this->assertNotFalse(file_put_contents($router, $routerSrc));
 
-		$descriptors = [1 => ['file', '/dev/null', 'w'], 2 => ['file', '/dev/null', 'w']];
+		$failures = [];
 		for ($try = 0; $try < 10; $try++) {
-			$port = random_int(20000, 60000);
-			$proc = proc_open(
+			$port   = random_int(20000, 60000);
+			$nonce  = bin2hex(random_bytes(16));
+			$stderr = "{$this->workdir}/server-{$port}-{$try}.stderr";
+			$proc   = proc_open(
 				['php', '-S', "127.0.0.1:{$port}", $router],
-				$descriptors,
+				[1 => ['file', '/dev/null', 'w'], 2 => ['file', $stderr, 'w']],
 				$pipes,
 				$this->workdir,
 				[
-					'AUTH_LOG' => "{$this->workdir}/auth.log",
+					'AUTH_LOG'    => "{$this->workdir}/auth.log",
 					'FLAKY_STATE' => "{$this->workdir}/state.flag",
-					'PATH' => (string) getenv('PATH'),
+					'READY_TOKEN' => $nonce,
+					'PATH'        => (string) getenv('PATH'),
 				]
 			);
 			if (!is_resource($proc)) {
+				$failures[] = "port {$port}: process=proc_open failed stderr=(unavailable)";
 				continue;
 			}
-			// Poll readiness instead of a fixed wait (up to ~2s).
 			for ($i = 0; $i < 40; $i++) {
-				$sock = @fsockopen('127.0.0.1', $port, $errno, $errstr, 0.05);
-				if ($sock !== FALSE) {
-					fclose($sock);
+				if (pfb_test_http_fixture_event_received($port, $nonce)) {
 					$this->server = $proc;
 					$this->port = $port;
 					return;
 				}
 				usleep(50000);
 			}
-			proc_terminate($proc);
-			proc_close($proc);
+
+			$status = proc_get_status($proc);
+			if ($status['running']) {
+				proc_terminate($proc);
+			}
+			$closeExit = proc_close($proc);
+			$stderrText = trim((string) @file_get_contents($stderr));
+			$failures[] = sprintf(
+				'port %d: process[running=%s exit=%d close=%d] stderr=%s',
+				$port,
+				$status['running'] ? 'true' : 'false',
+				$status['exitcode'],
+				$closeExit,
+				$stderrText === '' ? '(empty)' : $stderrText
+			);
 		}
-		$this->fail('could not start the flaky php -S fixture server');
+		$this->fail('could not start the flaky php -S fixture server; ' . implode(' | ', $failures));
 	}
 
 	public function testRetryAfterPartialBodyYieldsExactFinalBody(): void

--- a/tests/php/DownloadSizeRefusalTest.php
+++ b/tests/php/DownloadSizeRefusalTest.php
@@ -137,8 +137,8 @@ final class DownloadSizeRefusalTest extends TestCase
 		$routerSrc = <<<'PHP'
 <?php
 $uri = $_SERVER['REQUEST_URI'] ?? '';
-if (str_starts_with($uri, '/__pfb_ready/')) {
-	if ($uri === '/__pfb_ready/' . getenv('READY_TOKEN')) {
+if ($uri === '/__pfb_ready' || str_starts_with($uri, '/__pfb_ready/')) {
+	if ($uri === '/__pfb_ready') {
 		echo getenv('READY_TOKEN');
 	}
 	return;

--- a/tests/php/DownloadSizeRefusalTest.php
+++ b/tests/php/DownloadSizeRefusalTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 use PHPUnit\Framework\Attributes\CoversFunction;
 use PHPUnit\Framework\TestCase;
 
+require_once __DIR__ . '/support/HttpFixtureReadiness.php';
+
 /**
  * Issue #2658 — an over-large feed body is refused at download, once.
  *
@@ -134,10 +136,17 @@ final class DownloadSizeRefusalTest extends TestCase
 		$router = "{$this->workdir}/router.php";
 		$routerSrc = <<<'PHP'
 <?php
-file_put_contents(getenv('REQ_LOG'), ($_SERVER['REQUEST_URI'] ?? '') . PHP_EOL, FILE_APPEND);
+$uri = $_SERVER['REQUEST_URI'] ?? '';
+if (str_starts_with($uri, '/__pfb_ready/')) {
+	if ($uri === '/__pfb_ready/' . getenv('READY_TOKEN')) {
+		echo getenv('READY_TOKEN');
+	}
+	return;
+}
+file_put_contents(getenv('REQ_LOG'), $uri . PHP_EOL, FILE_APPEND);
 $chunk = str_repeat('A', 1024);
 header('Content-Type: text/plain');
-if (str_starts_with($_SERVER['REQUEST_URI'] ?? '', '/declared')) {
+if (str_starts_with($uri, '/declared')) {
 	header('Content-Length: ' . (string) (4 * 1024));
 }
 for ($i = 0; $i < 4; $i++) {
@@ -147,33 +156,50 @@ for ($i = 0; $i < 4; $i++) {
 PHP;
 		$this->assertNotFalse(file_put_contents($router, $routerSrc));
 
-		$descriptors = [1 => ['file', '/dev/null', 'w'], 2 => ['file', '/dev/null', 'w']];
+		$failures = [];
 		for ($try = 0; $try < 10; $try++) {
 			$port = random_int(20000, 60000);
+			$nonce = bin2hex(random_bytes(16));
+			$stderr = "{$this->workdir}/server-{$port}-{$try}.stderr";
 			$proc = proc_open(
 				['php', '-S', "127.0.0.1:{$port}", $router],
-				$descriptors,
+				[1 => ['file', '/dev/null', 'w'], 2 => ['file', $stderr, 'w']],
 				$pipes,
 				$this->workdir,
-				['REQ_LOG' => "{$this->workdir}/requests.log", 'PATH' => (string) getenv('PATH')]
+				[
+					'REQ_LOG' => "{$this->workdir}/requests.log",
+					'READY_TOKEN' => $nonce,
+					'PATH' => (string) getenv('PATH'),
+				]
 			);
 			if (!is_resource($proc)) {
+				$failures[] = "port {$port}: process=proc_open failed stderr=(unavailable)";
 				continue;
 			}
 			for ($i = 0; $i < 40; $i++) {
-				$sock = @fsockopen('127.0.0.1', $port, $errno, $errstr, 0.05);
-				if ($sock !== FALSE) {
-					fclose($sock);
+				if (pfb_test_http_fixture_event_received($port, $nonce)) {
 					$this->server = $proc;
 					$this->port = $port;
 					return;
 				}
 				usleep(50000);
 			}
-			proc_terminate($proc);
-			proc_close($proc);
+			$status = proc_get_status($proc);
+			if ($status['running']) {
+				proc_terminate($proc);
+			}
+			$closeExit = proc_close($proc);
+			$stderrText = trim((string) @file_get_contents($stderr));
+			$failures[] = sprintf(
+				'port %d: process[running=%s exit=%d close=%d] stderr=%s',
+				$port,
+				$status['running'] ? 'true' : 'false',
+				$status['exitcode'],
+				$closeExit,
+				$stderrText === '' ? '(empty)' : $stderrText
+			);
 		}
-		$this->fail('could not start the php -S fixture server');
+		$this->fail('could not start the php -S fixture server; ' . implode(' | ', $failures));
 	}
 
 	/** @return int the number of requests the fixture server saw */

--- a/tests/php/GeoipZipPublicationTest.php
+++ b/tests/php/GeoipZipPublicationTest.php
@@ -115,8 +115,8 @@ final class GeoipZipPublicationTest extends TestCase
 		$routerSrc = <<<'PHP'
 <?php
 $uri = $_SERVER['REQUEST_URI'] ?? '';
-if (str_starts_with($uri, '/__pfb_ready/')) {
-	if ($uri === '/__pfb_ready/' . getenv('READY_TOKEN')) {
+if ($uri === '/__pfb_ready' || str_starts_with($uri, '/__pfb_ready/')) {
+	if ($uri === '/__pfb_ready') {
 		echo getenv('READY_TOKEN');
 	}
 	return;

--- a/tests/php/GeoipZipPublicationTest.php
+++ b/tests/php/GeoipZipPublicationTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 use PHPUnit\Framework\Attributes\CoversFunction;
 use PHPUnit\Framework\TestCase;
 
+require_once __DIR__ . '/support/HttpFixtureReadiness.php';
+
 /**
  * GeoIP ZIP downloads publish every safe archive member to the directory
  * target and never create TOP1M detector artifacts.
@@ -110,25 +112,40 @@ final class GeoipZipPublicationTest extends TestCase
 	private function downloadGeoip(string $source, string $base, string $target): PfbDownloadResult
 	{
 		$router = "{$this->dir}/router.php";
-		$this->assertNotFalse(file_put_contents($router, "<?php\nreadfile(" . var_export($source, TRUE) . ");\n"));
-		$descriptors = [1 => ['file', '/dev/null', 'w'], 2 => ['file', '/dev/null', 'w']];
+		$routerSrc = <<<'PHP'
+<?php
+$uri = $_SERVER['REQUEST_URI'] ?? '';
+if (str_starts_with($uri, '/__pfb_ready/')) {
+	if ($uri === '/__pfb_ready/' . getenv('READY_TOKEN')) {
+		echo getenv('READY_TOKEN');
+	}
+	return;
+}
+readfile(%s);
+PHP;
+		$this->assertNotFalse(file_put_contents($router, sprintf($routerSrc, var_export($source, TRUE))));
+		$failures = [];
 		$port = 0;
 		for ($try = 0; $try < 10 && $port === 0; $try++) {
 			$candidate = random_int(20000, 60000);
+			$nonce = bin2hex(random_bytes(16));
+			$stderr = "{$this->dir}/server-{$candidate}-{$try}.stderr";
 			$proc = proc_open(
 				['php', '-S', "127.0.0.1:{$candidate}", $router],
-				$descriptors,
+				[1 => ['file', '/dev/null', 'w'], 2 => ['file', $stderr, 'w']],
 				$pipes,
 				$this->dir,
-				['PATH' => (string) getenv('PATH')]
+				[
+					'READY_TOKEN' => $nonce,
+					'PATH' => (string) getenv('PATH'),
+				]
 			);
 			if (!is_resource($proc)) {
+				$failures[] = "port {$candidate}: process=proc_open failed stderr=(unavailable)";
 				continue;
 			}
 			for ($poll = 0; $poll < 40; $poll++) {
-				$sock = @fsockopen('127.0.0.1', $candidate, $errno, $errstr, 0.05);
-				if ($sock !== FALSE) {
-					fclose($sock);
+				if (pfb_test_http_fixture_event_received($candidate, $nonce)) {
 					$this->server = $proc;
 					$port = $candidate;
 					break;
@@ -136,12 +153,26 @@ final class GeoipZipPublicationTest extends TestCase
 				usleep(50000);
 			}
 			if ($port === 0) {
-				proc_terminate($proc);
-				proc_close($proc);
+				$status = proc_get_status($proc);
+				if ($status['running']) {
+					proc_terminate($proc);
+				}
+				$closeExit = proc_close($proc);
+				$stderrText = trim((string) @file_get_contents($stderr));
+				$failures[] = sprintf(
+					'port %d: process[running=%s exit=%d close=%d] stderr=%s',
+					$candidate,
+					$status['running'] ? 'true' : 'false',
+					$status['exitcode'],
+					$closeExit,
+					$stderrText === '' ? '(empty)' : $stderrText
+				);
 			}
 		}
 		if ($port === 0) {
-			$this->markTestSkipped('loopback HTTP fixture unavailable');
+			$this->markTestSkipped(
+				'loopback HTTP fixture unavailable; ' . implode(' | ', $failures)
+			);
 		}
 		return pfb_download(new PfbDownloadRequest(
 			"http://127.0.0.1:{$port}/feed",

--- a/tests/php/HttpFixtureReadinessBehaviorTest.php
+++ b/tests/php/HttpFixtureReadinessBehaviorTest.php
@@ -54,6 +54,7 @@ final class HttpFixtureReadinessBehaviorTest extends TestCase
 	public static function fixtureSites(): array
 	{
 		return [
+			'redirect credential servers' => [DownloadRedirectCredentialScopeTest::class, __DIR__ . '/DownloadRedirectCredentialScopeTest.php', 'startOneServer', 'setup', 10, FALSE],
 			'extracted payload archive' => [DownloadExtractedPayloadSanityTest::class, __DIR__ . '/DownloadExtractedPayloadSanityTest.php', 'downloadArchive', 'extracted', 10, FALSE],
 			'rejected validator origin' => [DownloadRejectValidatorClearTest::class, __DIR__ . '/DownloadRejectValidatorClearTest.php', 'startOrigin', 'setup', 20, FALSE],
 			'retry body reset origin' => [DownloadRetryBodyResetTest::class, __DIR__ . '/DownloadRetryBodyResetTest.php', 'startFlakyServer', 'setup', 10, FALSE],

--- a/tests/php/HttpFixtureReadinessBehaviorTest.php
+++ b/tests/php/HttpFixtureReadinessBehaviorTest.php
@@ -1,0 +1,388 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\SkippedTest;
+use PHPUnit\Framework\TestCase;
+
+/** Issue #2904: occupied-port retries keep nonce, bound, and bind diagnostics observable. */
+final class HttpFixtureReadinessBehaviorTest extends TestCase
+{
+	/** @var resource|null */
+	private $foreignServer = NULL;
+	private string $workdir = '';
+	private static int $foreignPort = 0;
+	/** @var list<string> */
+	private static array $probeNonces = [];
+	/** @var list<int> */
+	private static array $pollPauses = [];
+	/** @var list<string> */
+	private static array $stderrPaths = [];
+	/** @var list<resource> */
+	private static array $fixtureProcesses = [];
+
+	protected function setUp(): void
+	{
+		require_once __DIR__ . '/support/HttpFixtureReadiness.php';
+		$workdir = tempnam(sys_get_temp_dir(), 'pfbready2904b');
+		$this->assertNotFalse($workdir);
+		$this->assertTrue(unlink($workdir) && mkdir($workdir, 0700));
+		$this->workdir = $workdir;
+		self::$probeNonces = [];
+		self::$pollPauses = [];
+		self::$stderrPaths = [];
+		self::$fixtureProcesses = [];
+		self::$foreignPort = $this->startForeignServer();
+	}
+
+	protected function tearDown(): void
+	{
+		if (is_resource($this->foreignServer)) {
+			proc_terminate($this->foreignServer);
+			proc_close($this->foreignServer);
+		}
+		if ($this->workdir !== '' && is_dir($this->workdir)) {
+			$this->removeTree($this->workdir);
+		}
+	}
+
+	/** @return array<string,array{class-string,file-string,string,string,int,bool}> */
+	public static function fixtureSites(): array
+	{
+		return [
+			'extracted payload archive' => [DownloadExtractedPayloadSanityTest::class, __DIR__ . '/DownloadExtractedPayloadSanityTest.php', 'downloadArchive', 'extracted', 10, FALSE],
+			'rejected validator origin' => [DownloadRejectValidatorClearTest::class, __DIR__ . '/DownloadRejectValidatorClearTest.php', 'startOrigin', 'setup', 20, FALSE],
+			'retry body reset origin' => [DownloadRetryBodyResetTest::class, __DIR__ . '/DownloadRetryBodyResetTest.php', 'startFlakyServer', 'setup', 10, FALSE],
+			'download size refusal origin' => [DownloadSizeRefusalTest::class, __DIR__ . '/DownloadSizeRefusalTest.php', 'startServer', 'setup', 10, FALSE],
+			'GeoIP ZIP publication' => [GeoipZipPublicationTest::class, __DIR__ . '/GeoipZipPublicationTest.php', 'downloadGeoip', 'geoip', 10, TRUE],
+			'TOP1M change-detect probe' => [Top1mDccDetectorTest::class, __DIR__ . '/Top1mDccDetectorTest.php', 'testChangeDetectUsesActualHttpProbeBodyAndMetadata', 'method', 10, FALSE],
+			'TOP1M DCC download' => [Top1mDccDetectorTest::class, __DIR__ . '/Top1mDccDetectorTest.php', 'downloadTop1m', 'dcc-download', 10, FALSE],
+			'TOP1M semantic validation' => [Top1mDownloadSemanticValidationTest::class, __DIR__ . '/Top1mDownloadSemanticValidationTest.php', 'downloadBody', 'semantic', 10, TRUE],
+			'TOP1M provider matrix' => [Top1mSemanticMatrixTest::class, __DIR__ . '/Top1mSemanticMatrixTest.php', 'downloadSource', 'matrix', 10, TRUE],
+		];
+	}
+
+	#[DataProvider('fixtureSites')]
+	public function testOccupiedPortExhaustionPreservesNonceBoundAndBindDiagnostics(
+		string $class,
+		string $file,
+		string $method,
+		string $entry,
+		int $tries,
+		bool $expectedSkip
+	): void {
+		$instrumentedClass = $this->loadInstrumentedFixture($class, $file);
+		$reflection = new ReflectionClass($instrumentedClass);
+		$testName = NULL;
+		foreach ($reflection->getMethods(ReflectionMethod::IS_PUBLIC) as $candidate) {
+			if (str_starts_with($candidate->getName(), 'test')) {
+				$testName = $candidate->getName();
+				break;
+			}
+		}
+		$this->assertIsString($testName);
+		$suite = $reflection->newInstance($testName);
+		$failure = NULL;
+		$setUp = $reflection->getMethod('setUp');
+		$tearDown = $reflection->getMethod('tearDown');
+		$savedGlobals = $this->saveFixtureGlobals();
+
+		try {
+			try {
+				if ($entry === 'setup') {
+					$setUp->invoke($suite);
+				} else {
+					$setUp->invoke($suite);
+					$this->invokeStartupEntry($reflection, $suite, $method, $entry);
+				}
+			} catch (Throwable $error) {
+				$failure = $error;
+			}
+		} finally {
+			try {
+				$tearDown->invoke($suite);
+			} catch (Throwable $tearDownError) {
+				$failure ??= $tearDownError;
+			}
+			$this->restoreFixtureGlobals($savedGlobals);
+		}
+
+		$this->assertNotNull($failure, "{$file}::{$method} adopted the planted foreign listener");
+		$this->assertNotSame(
+			[],
+			self::$probeNonces,
+			"{$file}::{$method} adopted the planted foreign listener without an owned nonce event"
+		);
+		$this->assertSame(
+			$expectedSkip,
+			$failure instanceof SkippedTest,
+			"{$file}::{$method} changed its exhausted-startup verdict"
+		);
+		$message = $failure->getMessage();
+		$this->assertStringContainsString('port ' . self::$foreignPort . ':', $message);
+		$this->assertStringContainsString('process[running=', $message);
+		$this->assertStringContainsString('exit=', $message);
+		$this->assertStringContainsString('close=', $message);
+		$this->assertStringContainsString('stderr=', $message);
+		$this->assertStringContainsString('Failed to listen', $message);
+		$this->assertCount($tries, self::$stderrPaths, "{$file}::{$method} changed the stderr file count");
+		$this->assertCount($tries, array_unique(self::$stderrPaths), "{$file}::{$method} must use a fresh stderr file per attempt");
+		$this->assertCount($tries, self::$fixtureProcesses, "{$file}::{$method} changed the child-process count");
+		foreach (self::$fixtureProcesses as $process) {
+			$this->assertFalse(is_resource($process), "{$file}::{$method} left a failed fixture child open");
+		}
+
+		$expectedPolls = $tries * 40;
+		$this->assertCount($expectedPolls, self::$probeNonces, "{$file}::{$method} changed the 40-poll bound");
+		$this->assertCount($expectedPolls, self::$pollPauses, "{$file}::{$method} changed the poll pause count");
+		foreach (self::$pollPauses as $pause) {
+			$this->assertSame(50000, $pause, "{$file}::{$method} changed the poll pause");
+		}
+
+		$attemptNonces = [];
+		for ($attempt = 0; $attempt < $tries; $attempt++) {
+			$pollNonces = array_slice(self::$probeNonces, $attempt * 40, 40);
+			$this->assertCount(1, array_unique($pollNonces), "{$file}::{$method} changed nonce inside one attempt");
+			$attemptNonces[] = $pollNonces[0];
+		}
+		$this->assertCount($tries, array_unique($attemptNonces), "{$file}::{$method} must generate a fresh nonce per attempt");
+	}
+
+	public static function candidatePort(int $minimum, int $maximum): int
+	{
+		if (self::$foreignPort < $minimum || self::$foreignPort > $maximum) {
+			throw new RuntimeException('planted foreign port is outside the fixture candidate range');
+		}
+		return self::$foreignPort;
+	}
+
+	public static function observeProbe(int $port, string $nonce): bool
+	{
+		if (self::$probeNonces === [] || self::$probeNonces[array_key_last(self::$probeNonces)] !== $nonce) {
+			usleep(100000);
+		}
+		self::$probeNonces[] = $nonce;
+		return pfb_test_http_fixture_event_received($port, $nonce);
+	}
+
+	public static function recordPollPause(int $microseconds): void
+	{
+		self::$pollPauses[] = $microseconds;
+	}
+
+	/** @return resource|false */
+	public static function openFixtureProcess(
+		array $command,
+		array $descriptorSpec,
+		&$pipes,
+		?string $cwd,
+		?array $environment,
+		?array $options = NULL
+	) {
+		$stderr = $descriptorSpec[2][1] ?? NULL;
+		if (is_string($stderr)) {
+			self::$stderrPaths[] = $stderr;
+		}
+		$process = proc_open($command, $descriptorSpec, $pipes, $cwd, $environment, $options);
+		if (is_resource($process)) {
+			self::$fixtureProcesses[] = $process;
+		}
+		return $process;
+	}
+
+	private function loadInstrumentedFixture(string $class, string $file): string
+	{
+		$source = file_get_contents($file);
+		$this->assertIsString($source);
+		$namespace = 'PfbIssue2904\\Site' . bin2hex(random_bytes(6));
+		$instrumentation = <<<PHP
+
+namespace {$namespace};
+
+function random_int(int \$minimum, int \$maximum): int
+{
+	return \\HttpFixtureReadinessBehaviorTest::candidatePort(\$minimum, \$maximum);
+}
+
+function usleep(int \$microseconds): void
+{
+	\\HttpFixtureReadinessBehaviorTest::recordPollPause(\$microseconds);
+}
+
+function pfb_test_http_fixture_event_received(int \$port, string \$nonce): bool
+{
+	return \\HttpFixtureReadinessBehaviorTest::observeProbe(\$port, \$nonce);
+}
+
+function proc_open(
+	array \$command,
+	array \$descriptorSpec,
+	&\$pipes,
+	?string \$cwd,
+	?array \$environment,
+	?array \$options = null
+) {
+	return \\HttpFixtureReadinessBehaviorTest::openFixtureProcess(
+		\$command,
+		\$descriptorSpec,
+		\$pipes,
+		\$cwd,
+		\$environment,
+		\$options
+	);
+}
+
+foreach (['PfbConfig', 'PfbDownloadRequest', 'PfbDownloadResult', 'PfbToggle'] as \$global) {
+	if (class_exists(\$global) || enum_exists(\$global)) {
+		class_alias(\$global, __NAMESPACE__ . '\\\\' . \$global);
+	}
+}
+
+\\spl_autoload_register(static function (string \$name): void {
+	\$prefix = __NAMESPACE__ . '\\\\';
+	if (!str_starts_with(\$name, \$prefix)) {
+		return;
+	}
+	\$global = substr(\$name, strlen(\$prefix));
+	if (class_exists(\$global) || interface_exists(\$global) || enum_exists(\$global)) {
+		class_alias(\$global, \$name);
+	}
+});
+PHP;
+		$source = str_replace("declare(strict_types=1);\n", "declare(strict_types=1);{$instrumentation}\n", $source);
+		$source = preg_replace('/^require_once __DIR__ .*;\R/m', '', $source);
+		$this->assertIsString($source);
+		$mirror = "{$this->workdir}/mirror";
+		$this->assertTrue(is_dir("{$mirror}/tests/php") || mkdir("{$mirror}/tests/php", 0700, TRUE));
+		if ($class === Top1mDccDetectorTest::class) {
+			$sourceDir = "{$mirror}/src/usr/local/www/pfblockerng";
+			$this->assertTrue(is_dir($sourceDir) || mkdir($sourceDir, 0700, TRUE));
+			$this->assertTrue(copy(
+				dirname(__DIR__, 2) . '/src/usr/local/www/pfblockerng/pfblockerng.php',
+				"{$sourceDir}/pfblockerng.php"
+			));
+		}
+		$path = "{$mirror}/tests/php/fixture-" . bin2hex(random_bytes(6)) . '.php';
+		$this->assertNotFalse(file_put_contents($path, $source));
+		require $path;
+
+		return "{$namespace}\\{$class}";
+	}
+
+	private function invokeStartupEntry(
+		ReflectionClass $reflection,
+		object $suite,
+		string $method,
+		string $entry
+	): void {
+		$startup = $reflection->getMethod($method);
+		$dirProperty = $reflection->hasProperty('dir') ? 'dir' : 'workdir';
+		$dir = (string) $reflection->getProperty($dirProperty)->getValue($suite);
+
+		switch ($entry) {
+			case 'extracted':
+				$startup->invoke($suite, 'gz', "192.0.2.1\n", "{$dir}/candidate.gz", PfbToggle::On);
+				break;
+			case 'geoip':
+				$source = "{$dir}/source.zip";
+				$this->assertNotFalse(file_put_contents($source, 'fixture'));
+				$startup->invoke($suite, $source, "{$dir}/candidate.zip", "{$dir}/published");
+				break;
+			case 'method':
+				$startup->invoke($suite);
+				break;
+			case 'dcc-download':
+				$source = "{$dir}/source.csv";
+				$this->assertNotFalse(file_put_contents($source, "1,example.test\n"));
+				$startup->invoke($suite, $source, "{$dir}/candidate.csv", "{$dir}/active.csv");
+				break;
+			case 'semantic':
+				$startup->invoke($suite, "1,example.test\n", "{$dir}/candidate.csv", "{$dir}/active.csv");
+				break;
+			case 'matrix':
+				$source = "{$dir}/source.csv";
+				$this->assertNotFalse(file_put_contents($source, "1,example.test\n"));
+				$startup->invoke($suite, $source, "{$dir}/candidate.csv", "{$dir}/active.csv");
+				break;
+			default:
+				throw new InvalidArgumentException("unknown fixture entry {$entry}");
+		}
+	}
+
+	/** @return array<string,array{had:bool,value:mixed}> */
+	private function saveFixtureGlobals(): array
+	{
+		$saved = [];
+		foreach (['config', 'pfb', 'pfb_test_resolve_map', 'pfb_test_configured_ips'] as $name) {
+			$saved[$name] = [
+				'had' => array_key_exists($name, $GLOBALS),
+				'value' => $GLOBALS[$name] ?? NULL,
+			];
+		}
+		return $saved;
+	}
+
+	/** @param array<string,array{had:bool,value:mixed}> $saved */
+	private function restoreFixtureGlobals(array $saved): void
+	{
+		foreach ($saved as $name => $state) {
+			if ($state['had']) {
+				$GLOBALS[$name] = $state['value'];
+			} else {
+				unset($GLOBALS[$name]);
+			}
+		}
+	}
+
+	private function startForeignServer(): int
+	{
+		$router = "{$this->workdir}/foreign-router.php";
+		$this->assertNotFalse(file_put_contents($router, <<<'PHP'
+			<?php
+			if (($_SERVER['REQUEST_URI'] ?? '') === '/setup') {
+				echo 'FOREIGN';
+				return;
+			}
+			echo 'wrong-owner';
+			PHP));
+		$context = stream_context_create(['http' => ['timeout' => 0.05, 'ignore_errors' => TRUE]]);
+
+		for ($try = 0; $try < 10; $try++) {
+			$port = random_int(20000, 60000);
+			$server = proc_open(
+				['php', '-S', "127.0.0.1:{$port}", $router],
+				[1 => ['file', '/dev/null', 'w'], 2 => ['file', "{$this->workdir}/foreign.stderr", 'w']],
+				$pipes,
+				$this->workdir,
+				['PATH' => (string) getenv('PATH')]
+			);
+			if (!is_resource($server)) {
+				continue;
+			}
+			for ($poll = 0; $poll < 40; $poll++) {
+				if (@file_get_contents("http://127.0.0.1:{$port}/setup", FALSE, $context) === 'FOREIGN') {
+					$this->foreignServer = $server;
+					return $port;
+				}
+				usleep(50000);
+			}
+			proc_terminate($server);
+			proc_close($server);
+		}
+
+		$this->fail('could not start planted foreign HTTP fixture');
+	}
+
+	private function removeTree(string $path): void
+	{
+		$iterator = new RecursiveIteratorIterator(
+			new RecursiveDirectoryIterator($path, FilesystemIterator::SKIP_DOTS),
+			RecursiveIteratorIterator::CHILD_FIRST
+		);
+		foreach ($iterator as $item) {
+			$item->isDir() ? rmdir($item->getPathname()) : unlink($item->getPathname());
+		}
+		rmdir($path);
+	}
+}

--- a/tests/php/HttpFixtureReadinessBehaviorTest.php
+++ b/tests/php/HttpFixtureReadinessBehaviorTest.php
@@ -21,6 +21,8 @@ final class HttpFixtureReadinessBehaviorTest extends TestCase
 	private static array $stderrPaths = [];
 	/** @var list<resource> */
 	private static array $fixtureProcesses = [];
+	/** @var list<resource> */
+	private static array $terminatedFixtureProcesses = [];
 
 	protected function setUp(): void
 	{
@@ -33,6 +35,7 @@ final class HttpFixtureReadinessBehaviorTest extends TestCase
 		self::$pollPauses = [];
 		self::$stderrPaths = [];
 		self::$fixtureProcesses = [];
+		self::$terminatedFixtureProcesses = [];
 		self::$foreignPort = $this->startForeignServer();
 	}
 
@@ -132,6 +135,11 @@ final class HttpFixtureReadinessBehaviorTest extends TestCase
 		foreach (self::$fixtureProcesses as $process) {
 			$this->assertFalse(is_resource($process), "{$file}::{$method} left a failed fixture child open");
 		}
+		$this->assertSame(
+			[],
+			self::$terminatedFixtureProcesses,
+			"{$file}::{$method} tried to terminate an already-exited fixture child"
+		);
 
 		$expectedPolls = $tries * 40;
 		$this->assertCount($expectedPolls, self::$probeNonces, "{$file}::{$method} changed the 40-poll bound");
@@ -191,6 +199,13 @@ final class HttpFixtureReadinessBehaviorTest extends TestCase
 		return $process;
 	}
 
+	/** @param resource $process */
+	public static function terminateFixtureProcess($process, int $signal = 15): bool
+	{
+		self::$terminatedFixtureProcesses[] = $process;
+		return proc_terminate($process, $signal);
+	}
+
 	private function loadInstrumentedFixture(string $class, string $file): string
 	{
 		$source = file_get_contents($file);
@@ -231,6 +246,12 @@ function proc_open(
 		\$environment,
 		\$options
 	);
+}
+
+/** @param resource \$process */
+function proc_terminate(\$process, int \$signal = 15): bool
+{
+	return \\HttpFixtureReadinessBehaviorTest::terminateFixtureProcess(\$process, \$signal);
 }
 
 foreach (['PfbConfig', 'PfbDownloadRequest', 'PfbDownloadResult', 'PfbToggle'] as \$global) {
@@ -344,7 +365,8 @@ PHP;
 				echo 'FOREIGN';
 				return;
 			}
-			echo 'wrong-owner';
+			$path = parse_url($_SERVER['REQUEST_URI'] ?? '', PHP_URL_PATH);
+			echo basename(is_string($path) ? $path : '');
 			PHP));
 		$context = stream_context_create(['http' => ['timeout' => 0.05, 'ignore_errors' => TRUE]]);
 

--- a/tests/php/HttpFixtureReadinessBehaviorTest.php
+++ b/tests/php/HttpFixtureReadinessBehaviorTest.php
@@ -50,7 +50,7 @@ final class HttpFixtureReadinessBehaviorTest extends TestCase
 		}
 	}
 
-	/** @return array<string,array{class-string,file-string,string,string,int,bool}> */
+	/** @return array<string,array{class-string,string,string,string,int,bool}> */
 	public static function fixtureSites(): array
 	{
 		return [

--- a/tests/php/HttpFixtureReadinessMigrationTest.php
+++ b/tests/php/HttpFixtureReadinessMigrationTest.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/** Issue #2904: every php -S fixture proves its own nonce event before use. */
+final class HttpFixtureReadinessMigrationTest extends TestCase
+{
+	/** @var array<int,resource> */
+	private array $servers = [];
+	private string $workdir = '';
+
+	protected function setUp(): void
+	{
+		$workdir = tempnam(sys_get_temp_dir(), 'pfbready2904');
+		$this->assertNotFalse($workdir);
+		$this->assertTrue(unlink($workdir) && mkdir($workdir, 0700));
+		$this->workdir = $workdir;
+		require_once __DIR__ . '/support/HttpFixtureReadiness.php';
+	}
+
+	protected function tearDown(): void
+	{
+		foreach ($this->servers as $server) {
+			if (is_resource($server)) {
+				proc_terminate($server);
+				proc_close($server);
+			}
+		}
+		if ($this->workdir !== '' && is_dir($this->workdir)) {
+			foreach ((array) glob("{$this->workdir}/*") as $path) {
+				@unlink((string) $path);
+			}
+			rmdir($this->workdir);
+		}
+	}
+
+	/** @return array<string,array{class-string,file-string,string}> */
+	public static function rawReadinessSites(): array
+	{
+		return [
+			'extracted payload archive' => [DownloadExtractedPayloadSanityTest::class, __DIR__ . '/DownloadExtractedPayloadSanityTest.php', 'downloadArchive'],
+			'rejected validator origin' => [DownloadRejectValidatorClearTest::class, __DIR__ . '/DownloadRejectValidatorClearTest.php', 'startOrigin'],
+			'retry body reset origin' => [DownloadRetryBodyResetTest::class, __DIR__ . '/DownloadRetryBodyResetTest.php', 'startFlakyServer'],
+			'download size refusal origin' => [DownloadSizeRefusalTest::class, __DIR__ . '/DownloadSizeRefusalTest.php', 'startServer'],
+			'GeoIP ZIP publication' => [GeoipZipPublicationTest::class, __DIR__ . '/GeoipZipPublicationTest.php', 'downloadGeoip'],
+			'TOP1M change-detect probe' => [Top1mDccDetectorTest::class, __DIR__ . '/Top1mDccDetectorTest.php', 'testChangeDetectUsesActualHttpProbeBodyAndMetadata'],
+			'TOP1M DCC download' => [Top1mDccDetectorTest::class, __DIR__ . '/Top1mDccDetectorTest.php', 'downloadTop1m'],
+			'TOP1M semantic validation' => [Top1mDownloadSemanticValidationTest::class, __DIR__ . '/Top1mDownloadSemanticValidationTest.php', 'downloadBody'],
+			'TOP1M provider matrix' => [Top1mSemanticMatrixTest::class, __DIR__ . '/Top1mSemanticMatrixTest.php', 'downloadSource'],
+		];
+	}
+
+	#[DataProvider('rawReadinessSites')]
+	public function testFixtureSiteRequiresOwnedNonceEventAndBindDiagnostics(
+		string $class,
+		string $file,
+		string $method
+	): void {
+		require_once $file;
+		$reflection = new ReflectionMethod($class, $method);
+		$lines = file($file);
+		$this->assertIsArray($lines);
+		$source = implode('', array_slice(
+			$lines,
+			$reflection->getStartLine() - 1,
+			$reflection->getEndLine() - $reflection->getStartLine() + 1
+		));
+
+		$this->assertStringNotContainsString(
+			'fsockopen(',
+			$source,
+			"{$file}::{$method} must not accept raw connectivity as fixture readiness"
+		);
+		$this->assertStringContainsString(
+			'pfb_test_http_fixture_event_received(',
+			$source,
+			"{$file}::{$method} must wait for its router's exact nonce event"
+		);
+		$this->assertStringContainsString('READY_TOKEN', $source);
+		$this->assertStringContainsString('/__pfb_ready/', $source);
+		$this->assertStringContainsString('proc_get_status(', $source);
+		$this->assertStringContainsString('stderr=', $source);
+	}
+
+	public function testReachableForeignListenerCannotSatisfyNonceReadiness(): void
+	{
+		$port = $this->startForeignServer();
+		$socket = @stream_socket_client("tcp://127.0.0.1:{$port}", $errno, $errstr, 0.05);
+		$this->assertIsResource($socket, 'planted listener must be reachable by a raw connection');
+		fclose($socket);
+
+		$this->assertFalse(
+			pfb_test_http_fixture_event_received($port, bin2hex(random_bytes(16))),
+			'a reachable listener without the exact fixture nonce event must be rejected'
+		);
+	}
+
+	private function startForeignServer(): int
+	{
+		$router = "{$this->workdir}/foreign-router.php";
+		$this->assertNotFalse(file_put_contents($router, <<<'PHP'
+			<?php
+			if (($_SERVER['REQUEST_URI'] ?? '') === '/setup') {
+				echo 'FOREIGN';
+				return;
+			}
+			echo 'wrong-owner';
+			PHP));
+		$context = stream_context_create(['http' => ['timeout' => 0.05, 'ignore_errors' => TRUE]]);
+
+		for ($try = 0; $try < 10; $try++) {
+			$port = random_int(20000, 60000);
+			$server = proc_open(
+				['php', '-S', "127.0.0.1:{$port}", $router],
+				[1 => ['file', '/dev/null', 'w'], 2 => ['file', "{$this->workdir}/foreign.stderr", 'w']],
+				$pipes,
+				$this->workdir,
+				['PATH' => (string) getenv('PATH')]
+			);
+			if (!is_resource($server)) {
+				continue;
+			}
+			for ($poll = 0; $poll < 40; $poll++) {
+				if (@file_get_contents("http://127.0.0.1:{$port}/setup", FALSE, $context) === 'FOREIGN') {
+					$this->servers[] = $server;
+					return $port;
+				}
+				usleep(50000);
+			}
+			proc_terminate($server);
+			proc_close($server);
+		}
+
+		$this->fail('could not start planted foreign HTTP fixture');
+	}
+}

--- a/tests/php/HttpFixtureReadinessMigrationTest.php
+++ b/tests/php/HttpFixtureReadinessMigrationTest.php
@@ -37,10 +37,11 @@ final class HttpFixtureReadinessMigrationTest extends TestCase
 		}
 	}
 
-	/** @return array<string,array{class-string,file-string,string}> */
+	/** @return array<string,array{class-string,file-string,string,3?:string}> */
 	public static function rawReadinessSites(): array
 	{
 		return [
+			'redirect credential servers' => [DownloadRedirectCredentialScopeTest::class, __DIR__ . '/DownloadRedirectCredentialScopeTest.php', 'startOneServer', 'startServers'],
 			'extracted payload archive' => [DownloadExtractedPayloadSanityTest::class, __DIR__ . '/DownloadExtractedPayloadSanityTest.php', 'downloadArchive'],
 			'rejected validator origin' => [DownloadRejectValidatorClearTest::class, __DIR__ . '/DownloadRejectValidatorClearTest.php', 'startOrigin'],
 			'retry body reset origin' => [DownloadRetryBodyResetTest::class, __DIR__ . '/DownloadRetryBodyResetTest.php', 'startFlakyServer'],
@@ -57,7 +58,8 @@ final class HttpFixtureReadinessMigrationTest extends TestCase
 	public function testFixtureSiteRequiresOwnedNonceEventAndBindDiagnostics(
 		string $class,
 		string $file,
-		string $method
+		string $method,
+		?string $routerMethod = NULL
 	): void {
 		require_once $file;
 		$reflection = new ReflectionMethod($class, $method);
@@ -68,6 +70,14 @@ final class HttpFixtureReadinessMigrationTest extends TestCase
 			$reflection->getStartLine() - 1,
 			$reflection->getEndLine() - $reflection->getStartLine() + 1
 		));
+		if ($routerMethod !== NULL) {
+			$routerReflection = new ReflectionMethod($class, $routerMethod);
+			$source .= implode('', array_slice(
+				$lines,
+				$routerReflection->getStartLine() - 1,
+				$routerReflection->getEndLine() - $routerReflection->getStartLine() + 1
+			));
+		}
 
 		$this->assertStringNotContainsString(
 			'fsockopen(',

--- a/tests/php/HttpFixtureReadinessTest.php
+++ b/tests/php/HttpFixtureReadinessTest.php
@@ -84,14 +84,25 @@ final class HttpFixtureReadinessTest extends TestCase
 	public function testProbeUsesExactTransportTimeout(): void
 	{
 		$this->requireReadinessHelper();
-		$context = pfb_test_http_fixture_stream_context();
-		$this->assertIsResource($context);
-		$options = stream_context_get_options($context);
+		$secret = 'owned-readiness-secret';
+		$observedUrl = NULL;
+		$observedOptions = NULL;
+		$matched = pfb_test_http_fixture_event_received(
+			1,
+			$secret,
+			static function (string $url, $context) use (&$observedUrl, &$observedOptions, $secret): string {
+				$observedUrl = $url;
+				$observedOptions = stream_context_get_options($context);
+				return $secret;
+			}
+		);
 
+		$this->assertTrue($matched, 'the request seam must return through the real readiness matcher');
+		$this->assertSame('http://127.0.0.1:1/__pfb_ready', $observedUrl);
 		$this->assertSame(
-			0.05,
-			$options['http']['timeout'] ?? NULL,
-			'fixture readiness must keep the exact bounded transport timeout'
+			['timeout' => 0.05, 'ignore_errors' => TRUE],
+			$observedOptions['http'] ?? NULL,
+			'fixture readiness must consume the exact bounded HTTP options'
 		);
 	}
 

--- a/tests/php/HttpFixtureReadinessTest.php
+++ b/tests/php/HttpFixtureReadinessTest.php
@@ -75,12 +75,24 @@ final class HttpFixtureReadinessTest extends TestCase
 			http_response_code(404);
 			PHP, 'READY', ['READY_TOKEN' => $token]);
 
-		$started = hrtime(TRUE);
-		$matched = pfb_test_http_fixture_event_received($port, $token);
-		$elapsed = (hrtime(TRUE) - $started) / 1e9;
+		$this->assertFalse(
+			pfb_test_http_fixture_event_received($port, $token),
+			'a stalled readiness response must exceed the helper transport timeout'
+		);
+	}
 
-		$this->assertFalse($matched, 'a stalled readiness response must exceed the helper transport timeout');
-		$this->assertLessThan(0.25, $elapsed, 'readiness transport timeout widened beyond the bounded probe');
+	public function testProbeUsesExactTransportTimeout(): void
+	{
+		$this->requireReadinessHelper();
+		$context = pfb_test_http_fixture_stream_context();
+		$this->assertIsResource($context);
+		$options = stream_context_get_options($context);
+
+		$this->assertSame(
+			0.05,
+			$options['http']['timeout'] ?? NULL,
+			'fixture readiness must keep the exact bounded transport timeout'
+		);
 	}
 
 	public function testProbeAcceptsMatchingFixtureEvent(): void

--- a/tests/php/HttpFixtureReadinessTest.php
+++ b/tests/php/HttpFixtureReadinessTest.php
@@ -4,6 +4,49 @@ declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
 
+final class HttpFixtureReadinessStreamSpy
+{
+	/** @var resource */
+	public $context;
+	public static ?string $url = NULL;
+	/** @var array<string,mixed>|null */
+	public static ?array $options = NULL;
+	private static string $response = '';
+	private int $offset = 0;
+
+	public static function reset(string $response): void
+	{
+		self::$url = NULL;
+		self::$options = NULL;
+		self::$response = $response;
+	}
+
+	public function stream_open(string $path, string $mode, int $options, ?string &$openedPath): bool
+	{
+		self::$url = $path;
+		self::$options = stream_context_get_options($this->context);
+		return TRUE;
+	}
+
+	public function stream_read(int $count): string
+	{
+		$chunk = substr(self::$response, $this->offset, $count);
+		$this->offset += strlen($chunk);
+		return $chunk;
+	}
+
+	public function stream_eof(): bool
+	{
+		return $this->offset >= strlen(self::$response);
+	}
+
+	/** @return array<string,mixed> */
+	public function stream_stat(): array
+	{
+		return [];
+	}
+}
+
 /** Issue #2065: HTTP fixture readiness proves which process owns the selected port. */
 final class HttpFixtureReadinessTest extends TestCase
 {
@@ -85,25 +128,26 @@ final class HttpFixtureReadinessTest extends TestCase
 	{
 		$this->requireReadinessHelper();
 		$secret = 'owned-readiness-secret';
-		$observedUrl = NULL;
-		$observedOptions = NULL;
-		$matched = pfb_test_http_fixture_event_received(
-			1,
-			$secret,
-			static function (string $url, $context) use (&$observedUrl, &$observedOptions, $secret): string {
-				$observedUrl = $url;
-				$observedOptions = stream_context_get_options($context);
-				return $secret;
+		HttpFixtureReadinessStreamSpy::reset($secret);
+		$this->assertTrue(stream_wrapper_unregister('http'));
+		try {
+			$this->assertTrue(stream_wrapper_register('http', HttpFixtureReadinessStreamSpy::class));
+			$this->assertTrue(
+				pfb_test_http_fixture_event_received(1, $secret),
+				'the default HTTP transport must return through the real readiness matcher'
+			);
+			$this->assertSame('http://127.0.0.1:1/__pfb_ready', HttpFixtureReadinessStreamSpy::$url);
+			$this->assertSame(
+				['timeout' => 0.05, 'ignore_errors' => TRUE],
+				HttpFixtureReadinessStreamSpy::$options['http'] ?? NULL,
+				'fixture readiness must consume the exact bounded HTTP options'
+			);
+		} finally {
+			if (in_array('http', stream_get_wrappers(), TRUE)) {
+				stream_wrapper_unregister('http');
 			}
-		);
-
-		$this->assertTrue($matched, 'the request seam must return through the real readiness matcher');
-		$this->assertSame('http://127.0.0.1:1/__pfb_ready', $observedUrl);
-		$this->assertSame(
-			['timeout' => 0.05, 'ignore_errors' => TRUE],
-			$observedOptions['http'] ?? NULL,
-			'fixture readiness must consume the exact bounded HTTP options'
-		);
+			$this->assertTrue(stream_wrapper_restore('http'));
+		}
 	}
 
 	public function testProbeAcceptsMatchingFixtureEvent(): void

--- a/tests/php/HttpFixtureReadinessTest.php
+++ b/tests/php/HttpFixtureReadinessTest.php
@@ -35,22 +35,52 @@ final class HttpFixtureReadinessTest extends TestCase
 		}
 	}
 
-	public function testProbeRejectsReachableForeignListener(): void
+	public function testProbeRejectsReflectiveForeignListener(): void
 	{
 		$this->requireReadinessHelper();
 		$port = $this->startServer(<<<'PHP'
 			<?php
-			if (($_SERVER['REQUEST_URI'] ?? '') === '/setup') {
+			$uri = $_SERVER['REQUEST_URI'] ?? '';
+			if ($uri === '/setup') {
 				echo 'FOREIGN';
 				return;
 			}
-			echo 'not-the-readiness-token';
+			$path = parse_url($uri, PHP_URL_PATH);
+			echo basename(is_string($path) ? $path : '');
 			PHP, 'FOREIGN');
 
 		$this->assertFalse(
 			pfb_test_http_fixture_event_received($port, 'expected-readiness-token'),
-			'a reachable listener that did not handle the nonce-bearing fixture event must not count as ready'
+			'a listener that reflects the disclosed request nonce must not count as the fixture owner'
 		);
+	}
+
+	public function testProbeKeepsShortResponseTimeout(): void
+	{
+		$this->requireReadinessHelper();
+		$token = bin2hex(random_bytes(12));
+		$port = $this->startServer(<<<'PHP'
+			<?php
+			$uri = $_SERVER['REQUEST_URI'] ?? '';
+			if ($uri === '/setup') {
+				echo 'READY';
+				return;
+			}
+			$token = getenv('READY_TOKEN');
+			if ($uri === '/__pfb_ready') {
+				usleep(1000000);
+				echo $token;
+				return;
+			}
+			http_response_code(404);
+			PHP, 'READY', ['READY_TOKEN' => $token]);
+
+		$started = hrtime(TRUE);
+		$matched = pfb_test_http_fixture_event_received($port, $token);
+		$elapsed = (hrtime(TRUE) - $started) / 1e9;
+
+		$this->assertFalse($matched, 'a stalled readiness response must exceed the helper transport timeout');
+		$this->assertLessThan(0.25, $elapsed, 'readiness transport timeout widened beyond the bounded probe');
 	}
 
 	public function testProbeAcceptsMatchingFixtureEvent(): void
@@ -65,7 +95,7 @@ final class HttpFixtureReadinessTest extends TestCase
 				return;
 			}
 			$token = getenv('READY_TOKEN');
-			if ($uri === '/__pfb_ready/' . $token) {
+			if ($uri === '/__pfb_ready') {
 				echo $token;
 				return;
 			}
@@ -74,7 +104,7 @@ final class HttpFixtureReadinessTest extends TestCase
 
 		$this->assertTrue(
 			pfb_test_http_fixture_event_received($port, $token),
-			'the fixture router must count as ready after it echoes the exact request nonce'
+			'the fixture router must count as ready after it returns the child-owned secret'
 		);
 	}
 

--- a/tests/php/Top1mDccDetectorTest.php
+++ b/tests/php/Top1mDccDetectorTest.php
@@ -210,8 +210,8 @@ final class Top1mDccDetectorTest extends TestCase
 		$routerSource = <<<'PHP'
 <?php
 $uri = $_SERVER['REQUEST_URI'] ?? '';
-if (str_starts_with($uri, '/__pfb_ready/')) {
-	if ($uri === '/__pfb_ready/' . getenv('READY_TOKEN')) {
+if ($uri === '/__pfb_ready' || str_starts_with($uri, '/__pfb_ready/')) {
+	if ($uri === '/__pfb_ready') {
 		echo getenv('READY_TOKEN');
 	}
 	return;
@@ -498,8 +498,8 @@ PHP;
 		$routerSource = <<<'PHP'
 <?php
 $uri = $_SERVER['REQUEST_URI'] ?? '';
-if (str_starts_with($uri, '/__pfb_ready/')) {
-	if ($uri === '/__pfb_ready/' . getenv('READY_TOKEN')) {
+if ($uri === '/__pfb_ready' || str_starts_with($uri, '/__pfb_ready/')) {
+	if ($uri === '/__pfb_ready') {
 		echo getenv('READY_TOKEN');
 	}
 	return;

--- a/tests/php/Top1mDccDetectorTest.php
+++ b/tests/php/Top1mDccDetectorTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 use PHPUnit\Framework\Attributes\CoversFunction;
 use PHPUnit\Framework\TestCase;
 
+require_once __DIR__ . '/support/HttpFixtureReadiness.php';
+
 /**
  * Issue #1542 — TOP1M's daily DCC detector and fail-safe publication contract.
  *
@@ -205,28 +207,64 @@ final class Top1mDccDetectorTest extends TestCase
 		$this->requireLocalListenerCapability();
 		$body = "1,example.com\n";
 		$router = "{$this->dir}/router.php";
-		$this->assertNotFalse(file_put_contents($router, "<?php\nheader('ETag: \\\"followup-v1\\\"');\necho " . var_export($body, TRUE) . ";\n"));
-		$descriptors = [1 => ['file', '/dev/null', 'w'], 2 => ['file', '/dev/null', 'w']];
+		$routerSource = <<<'PHP'
+<?php
+$uri = $_SERVER['REQUEST_URI'] ?? '';
+if (str_starts_with($uri, '/__pfb_ready/')) {
+	if ($uri === '/__pfb_ready/' . getenv('READY_TOKEN')) {
+		echo getenv('READY_TOKEN');
+	}
+	return;
+}
+header('ETag: "followup-v1"');
+echo %s;
+PHP;
+		$this->assertNotFalse(file_put_contents($router, sprintf($routerSource, var_export($body, TRUE))));
+		$failures = [];
 		for ($try = 0; $try < 10; $try++) {
 			$port = random_int(20000, 60000);
-			$proc = proc_open(['php', '-S', "127.0.0.1:{$port}", $router], $descriptors, $pipes, $this->dir, ['PATH' => (string) getenv('PATH')]);
+			$nonce = bin2hex(random_bytes(16));
+			$stderr = "{$this->dir}/server-{$port}-{$try}-{$nonce}.stderr";
+			$proc = proc_open(
+				['php', '-S', "127.0.0.1:{$port}", $router],
+				[1 => ['file', '/dev/null', 'w'], 2 => ['file', $stderr, 'w']],
+				$pipes,
+				$this->dir,
+				['PATH' => (string) getenv('PATH'), 'READY_TOKEN' => $nonce]
+			);
 			if (!is_resource($proc)) {
+				$failures[] = "port {$port}: process=proc_open failed stderr=(unavailable)";
 				continue;
 			}
 			for ($poll = 0; $poll < 40; $poll++) {
-				$sock = @fsockopen('127.0.0.1', $port, $errno, $errstr, 0.05);
-				if ($sock !== FALSE) {
-					fclose($sock);
+				if (pfb_test_http_fixture_event_received($port, $nonce)) {
 					$this->server = $proc;
 					$this->port = $port;
 					break 2;
 				}
 				usleep(50000);
 			}
-			proc_terminate($proc);
-			proc_close($proc);
+
+			$status = proc_get_status($proc);
+			if ($status['running']) {
+				proc_terminate($proc);
+			}
+			$closeExit = proc_close($proc);
+			$stderrText = trim((string) @file_get_contents($stderr));
+			$failures[] = sprintf(
+				'port %d: process[running=%s exit=%d close=%d] stderr=%s',
+				$port,
+				$status['running'] ? 'true' : 'false',
+				$status['exitcode'],
+				$closeExit,
+				$stderrText === '' ? '(empty)' : $stderrText
+			);
 		}
-		$this->assertNotSame(0, $this->port, 'could not start local HTTP fixture');
+		$this->assertNotSame(
+			0,
+			$this->port,
+			'could not start local HTTP fixture; ' . implode(' | ', $failures)
+		);
 
 		$target = $this->dir . '/top-1m.csv.zip.md5';
 		$result = pfb_download(new PfbDownloadRequest(
@@ -457,25 +495,37 @@ final class Top1mDccDetectorTest extends TestCase
 		$GLOBALS['pfb']['dbdir'] = $this->dir . '/db';
 		$this->assertTrue(is_dir($GLOBALS['pfb']['dbdir']) || mkdir($GLOBALS['pfb']['dbdir']));
 		$router = $this->dir . '/router.php';
-		$this->assertNotFalse(file_put_contents($router, "<?php\nreadfile(" . var_export($source, TRUE) . ");\n"));
-		$descriptors = [1 => ['file', '/dev/null', 'w'], 2 => ['file', '/dev/null', 'w']];
+		$routerSource = <<<'PHP'
+<?php
+$uri = $_SERVER['REQUEST_URI'] ?? '';
+if (str_starts_with($uri, '/__pfb_ready/')) {
+	if ($uri === '/__pfb_ready/' . getenv('READY_TOKEN')) {
+		echo getenv('READY_TOKEN');
+	}
+	return;
+}
+readfile(%s);
+PHP;
+		$this->assertNotFalse(file_put_contents($router, sprintf($routerSource, var_export($source, TRUE))));
+		$failures = [];
 		$port = 0;
 		for ($try = 0; $try < 10 && $port === 0; $try++) {
 			$candidate = random_int(20000, 60000);
+			$nonce = bin2hex(random_bytes(16));
+			$stderr = "{$this->dir}/server-{$candidate}-{$try}-{$nonce}.stderr";
 			$proc = proc_open(
 				['php', '-S', "127.0.0.1:{$candidate}", $router],
-				$descriptors,
+				[1 => ['file', '/dev/null', 'w'], 2 => ['file', $stderr, 'w']],
 				$pipes,
 				$this->dir,
-				['PATH' => (string) getenv('PATH')]
+				['PATH' => (string) getenv('PATH'), 'READY_TOKEN' => $nonce]
 			);
 			if (!is_resource($proc)) {
+				$failures[] = "port {$candidate}: process=proc_open failed stderr=(unavailable)";
 				continue;
 			}
 			for ($poll = 0; $poll < 40; $poll++) {
-				$sock = @fsockopen('127.0.0.1', $candidate, $errno, $errstr, 0.05);
-				if ($sock !== FALSE) {
-					fclose($sock);
+				if (pfb_test_http_fixture_event_received($candidate, $nonce)) {
 					$this->server = $proc;
 					$port = $candidate;
 					break;
@@ -483,12 +533,24 @@ final class Top1mDccDetectorTest extends TestCase
 				usleep(50000);
 			}
 			if ($port === 0) {
-				proc_terminate($proc);
-				proc_close($proc);
+				$status = proc_get_status($proc);
+				if ($status['running']) {
+					proc_terminate($proc);
+				}
+				$closeExit = proc_close($proc);
+				$stderrText = trim((string) @file_get_contents($stderr));
+				$failures[] = sprintf(
+					'port %d: process[running=%s exit=%d close=%d] stderr=%s',
+					$candidate,
+					$status['running'] ? 'true' : 'false',
+					$status['exitcode'],
+					$closeExit,
+					$stderrText === '' ? '(empty)' : $stderrText
+				);
 			}
 		}
 		if ($port === 0) {
-			$this->fail('could not start local HTTP fixture');
+			$this->fail('could not start local HTTP fixture; ' . implode(' | ', $failures));
 		}
 		return pfb_download(new PfbDownloadRequest(
 			listUrl: "http://127.0.0.1:{$port}/feed",

--- a/tests/php/Top1mDownloadSemanticValidationTest.php
+++ b/tests/php/Top1mDownloadSemanticValidationTest.php
@@ -165,8 +165,8 @@ final class Top1mDownloadSemanticValidationTest extends TestCase
 		$routerSource = <<<'PHP'
 <?php
 $uri = $_SERVER['REQUEST_URI'] ?? '';
-if (str_starts_with($uri, '/__pfb_ready/')) {
-	if ($uri === '/__pfb_ready/' . getenv('READY_TOKEN')) {
+if ($uri === '/__pfb_ready' || str_starts_with($uri, '/__pfb_ready/')) {
+	if ($uri === '/__pfb_ready') {
 		echo getenv('READY_TOKEN');
 	}
 	return;

--- a/tests/php/Top1mDownloadSemanticValidationTest.php
+++ b/tests/php/Top1mDownloadSemanticValidationTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 use PHPUnit\Framework\Attributes\CoversFunction;
 use PHPUnit\Framework\TestCase;
 
+require_once __DIR__ . '/support/HttpFixtureReadiness.php';
+
 /**
  * Issue #1542 — TOP1M candidates must pass semantic validation before publication.
  */
@@ -160,36 +162,65 @@ final class Top1mDownloadSemanticValidationTest extends TestCase
 		$source = "{$this->dir}/feed-body";
 		$this->assertNotFalse(file_put_contents($source, $body));
 		$router = "{$this->dir}/router.php";
-		$this->assertNotFalse(file_put_contents($router, "<?php\nreadfile(" . var_export($source, TRUE) . ");\n"));
-		$descriptors = [1 => ['file', '/dev/null', 'w'], 2 => ['file', '/dev/null', 'w']];
+		$routerSource = <<<'PHP'
+<?php
+$uri = $_SERVER['REQUEST_URI'] ?? '';
+if (str_starts_with($uri, '/__pfb_ready/')) {
+	if ($uri === '/__pfb_ready/' . getenv('READY_TOKEN')) {
+		echo getenv('READY_TOKEN');
+	}
+	return;
+}
+PHP;
+		$this->assertNotFalse(file_put_contents(
+			$router,
+			$routerSource . "\nreadfile(" . var_export($source, TRUE) . ");\n"
+		));
 		$port = 0;
+		$failures = [];
 		for ($try = 0; $try < 10 && $port === 0; $try++) {
 			$candidate = random_int(20000, 60000);
+			$nonce = bin2hex(random_bytes(16));
+			$stderr = "{$this->dir}/server-{$candidate}-{$try}.stderr";
 			$proc = proc_open(
 				['php', '-S', "127.0.0.1:{$candidate}", $router],
-				$descriptors,
+				[1 => ['file', '/dev/null', 'w'], 2 => ['file', $stderr, 'w']],
 				$pipes,
 				$this->dir,
-				['PATH' => (string) getenv('PATH')]
+				['READY_TOKEN' => $nonce, 'PATH' => (string) getenv('PATH')]
 			);
 			if (!is_resource($proc)) {
+				$failures[] = "port {$candidate}: process=proc_open failed stderr=(unavailable)";
 				continue;
 			}
 			for ($poll = 0; $poll < 40; $poll++) {
-				$sock = @fsockopen('127.0.0.1', $candidate, $errno, $errstr, 0.05);
-				if ($sock !== FALSE) {
-					fclose($sock);
+				if (pfb_test_http_fixture_event_received($candidate, $nonce)) {
 					$this->server = $proc;
 					$port = $candidate;
 					break 2;
 				}
 				usleep(50000);
 			}
-			proc_terminate($proc);
-			proc_close($proc);
+
+			$status = proc_get_status($proc);
+			if ($status['running']) {
+				proc_terminate($proc);
+			}
+			$closeExit = proc_close($proc);
+			$stderrText = trim((string) @file_get_contents($stderr));
+			$failures[] = sprintf(
+				'port %d: process[running=%s exit=%d close=%d] stderr=%s',
+				$candidate,
+				$status['running'] ? 'true' : 'false',
+				$status['exitcode'],
+				$closeExit,
+				$stderrText === '' ? '(empty)' : $stderrText
+			);
 		}
 		if ($port === 0) {
-			$this->markTestSkipped('loopback HTTP fixture unavailable');
+			$this->markTestSkipped(
+				'loopback HTTP fixture unavailable; ' . implode(' | ', $failures)
+			);
 		}
 		return pfb_download(new PfbDownloadRequest(
 			listUrl: "http://127.0.0.1:{$port}/feed",

--- a/tests/php/Top1mSemanticMatrixTest.php
+++ b/tests/php/Top1mSemanticMatrixTest.php
@@ -286,8 +286,8 @@ final class Top1mSemanticMatrixTest extends TestCase
 		$routerSource = <<<'PHP'
 <?php
 $uri = $_SERVER['REQUEST_URI'] ?? '';
-if (str_starts_with($uri, '/__pfb_ready/')) {
-	if ($uri === '/__pfb_ready/' . getenv('READY_TOKEN')) {
+if ($uri === '/__pfb_ready' || str_starts_with($uri, '/__pfb_ready/')) {
+	if ($uri === '/__pfb_ready') {
 		echo getenv('READY_TOKEN');
 	}
 	return;

--- a/tests/php/Top1mSemanticMatrixTest.php
+++ b/tests/php/Top1mSemanticMatrixTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 use PHPUnit\Framework\Attributes\CoversFunction;
 use PHPUnit\Framework\TestCase;
 
+require_once __DIR__ . '/support/HttpFixtureReadiness.php';
+
 /**
  * Issue #1542 — provider-shaped TOP1M rows and compressed candidates.
  *
@@ -281,30 +283,65 @@ final class Top1mSemanticMatrixTest extends TestCase
 	{
 		$this->stopServer();
 		$router = "{$this->dir}/router.php";
-		$this->assertNotFalse(file_put_contents($router, "<?php\nreadfile(" . var_export($source, TRUE) . ");\n"));
-		$descriptors = [1 => ['file', '/dev/null', 'w'], 2 => ['file', '/dev/null', 'w']];
+		$routerSource = <<<'PHP'
+<?php
+$uri = $_SERVER['REQUEST_URI'] ?? '';
+if (str_starts_with($uri, '/__pfb_ready/')) {
+	if ($uri === '/__pfb_ready/' . getenv('READY_TOKEN')) {
+		echo getenv('READY_TOKEN');
+	}
+	return;
+}
+PHP;
+		$this->assertNotFalse(file_put_contents(
+			$router,
+			$routerSource . "\nreadfile(" . var_export($source, TRUE) . ");\n"
+		));
 		$port = 0;
+		$failures = [];
 		for ($try = 0; $try < 10 && $port === 0; $try++) {
 			$candidate = random_int(20000, 60000);
-			$proc = proc_open(['php', '-S', "127.0.0.1:{$candidate}", $router], $descriptors, $pipes, $this->dir, ['PATH' => (string) getenv('PATH')]);
+			$nonce = bin2hex(random_bytes(16));
+			$stderr = "{$this->dir}/server-{$candidate}-{$try}.stderr";
+			$proc = proc_open(
+				['php', '-S', "127.0.0.1:{$candidate}", $router],
+				[1 => ['file', '/dev/null', 'w'], 2 => ['file', $stderr, 'w']],
+				$pipes,
+				$this->dir,
+				['READY_TOKEN' => $nonce, 'PATH' => (string) getenv('PATH')]
+			);
 			if (!is_resource($proc)) {
+				$failures[] = "port {$candidate}: process=proc_open failed stderr=(unavailable)";
 				continue;
 			}
 			for ($poll = 0; $poll < 40; $poll++) {
-				$sock = @fsockopen('127.0.0.1', $candidate, $errno, $errstr, 0.05);
-				if ($sock !== FALSE) {
-					fclose($sock);
+				if (pfb_test_http_fixture_event_received($candidate, $nonce)) {
 					$this->server = $proc;
 					$port = $candidate;
 					break 2;
 				}
 				usleep(50000);
 			}
-			proc_terminate($proc);
-			proc_close($proc);
+
+			$status = proc_get_status($proc);
+			if ($status['running']) {
+				proc_terminate($proc);
+			}
+			$closeExit = proc_close($proc);
+			$stderrText = trim((string) @file_get_contents($stderr));
+			$failures[] = sprintf(
+				'port %d: process[running=%s exit=%d close=%d] stderr=%s',
+				$candidate,
+				$status['running'] ? 'true' : 'false',
+				$status['exitcode'],
+				$closeExit,
+				$stderrText === '' ? '(empty)' : $stderrText
+			);
 		}
 		if ($port === 0) {
-			$this->markTestSkipped('loopback HTTP fixture unavailable');
+			$this->markTestSkipped(
+				'loopback HTTP fixture unavailable; ' . implode(' | ', $failures)
+			);
 		}
 		return pfb_download(new PfbDownloadRequest(
 			listUrl: "http://127.0.0.1:{$port}/feed",

--- a/tests/php/support/HttpFixtureReadiness.php
+++ b/tests/php/support/HttpFixtureReadiness.php
@@ -2,24 +2,12 @@
 
 declare(strict_types=1);
 
-/** @return resource */
-function pfb_test_http_fixture_stream_context()
+function pfb_test_http_fixture_event_received(int $port, string $secret): bool
 {
-	return stream_context_create([
+	$context = stream_context_create([
 		'http' => ['timeout' => 0.05, 'ignore_errors' => TRUE],
 	]);
-}
-
-function pfb_test_http_fixture_event_received(
-	int $port,
-	string $secret,
-	?callable $request = NULL
-): bool {
-	$context = pfb_test_http_fixture_stream_context();
-	$url = "http://127.0.0.1:{$port}/__pfb_ready";
-	$body = $request === NULL
-		? @file_get_contents($url, FALSE, $context)
-		: $request($url, $context);
+	$body = @file_get_contents("http://127.0.0.1:{$port}/__pfb_ready", FALSE, $context);
 
 	return is_string($body) && hash_equals($secret, $body);
 }

--- a/tests/php/support/HttpFixtureReadiness.php
+++ b/tests/php/support/HttpFixtureReadiness.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-function pfb_test_http_fixture_event_received(int $port, string $nonce): bool
+function pfb_test_http_fixture_event_received(int $port, string $secret): bool
 {
 	$context = stream_context_create([
 		'http' => ['timeout' => 0.05, 'ignore_errors' => TRUE],
 	]);
-	$body = @file_get_contents("http://127.0.0.1:{$port}/__pfb_ready/{$nonce}", FALSE, $context);
+	$body = @file_get_contents("http://127.0.0.1:{$port}/__pfb_ready", FALSE, $context);
 
-	return is_string($body) && hash_equals($nonce, $body);
+	return is_string($body) && hash_equals($secret, $body);
 }

--- a/tests/php/support/HttpFixtureReadiness.php
+++ b/tests/php/support/HttpFixtureReadiness.php
@@ -10,10 +10,16 @@ function pfb_test_http_fixture_stream_context()
 	]);
 }
 
-function pfb_test_http_fixture_event_received(int $port, string $secret): bool
-{
+function pfb_test_http_fixture_event_received(
+	int $port,
+	string $secret,
+	?callable $request = NULL
+): bool {
 	$context = pfb_test_http_fixture_stream_context();
-	$body = @file_get_contents("http://127.0.0.1:{$port}/__pfb_ready", FALSE, $context);
+	$url = "http://127.0.0.1:{$port}/__pfb_ready";
+	$body = $request === NULL
+		? @file_get_contents($url, FALSE, $context)
+		: $request($url, $context);
 
 	return is_string($body) && hash_equals($secret, $body);
 }

--- a/tests/php/support/HttpFixtureReadiness.php
+++ b/tests/php/support/HttpFixtureReadiness.php
@@ -2,11 +2,17 @@
 
 declare(strict_types=1);
 
-function pfb_test_http_fixture_event_received(int $port, string $secret): bool
+/** @return resource */
+function pfb_test_http_fixture_stream_context()
 {
-	$context = stream_context_create([
+	return stream_context_create([
 		'http' => ['timeout' => 0.05, 'ignore_errors' => TRUE],
 	]);
+}
+
+function pfb_test_http_fixture_event_received(int $port, string $secret): bool
+{
+	$context = pfb_test_http_fixture_stream_context();
 	$body = @file_get_contents("http://127.0.0.1:{$port}/__pfb_ready", FALSE, $context);
 
 	return is_string($body) && hash_equals($secret, $body);


### PR DESCRIPTION
## Summary

- migrate all ten current `php -S` test-fixture startup paths across nine files to a fixed readiness endpoint whose response must match a per-attempt child-owned secret
- reserve fixed and legacy readiness paths before fixture-specific event, auth, request, state, header, body, and publication effects
- retain bounded polling plus bind/process/stderr diagnostics, and cover every startup with a planted reflective foreign listener

The protocol lives entirely in the PHP test suite and `tests/php/support/HttpFixtureReadiness.php`; no production code changes.

## Verification

### Protocol RED → GREEN

The final ten-row protocol regression was replayed over the pre-fix protocol on PHP 8.3.33 and PHP 8.5.10: `13 tests, 158 assertions, 12 failures`; the corrected protocol passed `13 tests, 4925 assertions` on both runtimes. The honest RED contains the reflective-listener rejection, the positive fixed-path mismatch on the old protocol, and all ten real startup rows.

### Final focused evidence

Current head `9f0850d42075b2b430babddd61ae6fb453582e13` passes on both runtimes:

- real default HTTP transport, reflective-listener rejection, stalled response, and matching child response: `4 tests, 24 assertions`
- ten-row behavior + migration continuity: `21 tests, 5004 assertions`
- all 13 affected PHPUnit files: `113 tests, 6355 assertions` (PHP 8.3: one notice; PHP 8.5: one deprecation and one notice; no failures or skips)

Current key blobs:

- default-transport helper tests: `d3d919af9963b11da7ee5334bba96039f274f418`
- shared helper: `17727da651e7b8daa028e4c91a2a15d9af122848`
- redirect fixture: `b2a333a82bdf40d9ebd1452eab4196dc680131bc`
- redirect hygiene: `9f0fd62b4a4275084de7837064df25f6c5b4d7c6`
- ten-row behavior: `94e7d28529c1b649f604175044b14754bc35de80`
- ten-row migration: `3b4b513b40291e82130628f7e400f195f515a37e`

### Mutation proof

- original seven regression classes: 57/57 killed
- unconditional termination: all ten startup rows killed (`10 tests, 369 assertions, 10 failures`)
- RedirectCredential old-prefix removal: killed (`15 tests, 118 assertions, 2 failures`)
- RedirectCredential lifecycle: 6/6 killed
- raw readiness caller: killed
- actual default HTTP context timeout 0.05 → 0.1 and → 0.2: each killed deterministically on PHP 8.3 and 8.5 (`1 test, 9 assertions, 1 failure`)
- actual default HTTP context `ignore_errors` TRUE → FALSE: killed on both runtimes (`1/9/1`)
- moving readiness handling after EVENT_LOG: killed on both runtimes (`5 tests, 31 assertions, 3 failures`); normal `/final` event logging remains green

The helper remains a two-argument default `file_get_contents` path; the test temporarily replaces and strictly restores PHP's `http` stream wrapper to inspect the context actually consumed by that production branch.

The branch is based on `origin/devel` `181b2d8ca25938cf024b70554b91c6e766f0dfcd`. Exact-head canonical gates and final reviews are dispatched separately.

Fixes #2904

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved local HTTP fixture startup reliability with token-based readiness checks.
  * Added detailed diagnostics for failed server launches, including process status and captured errors.
  * Prevented foreign or malformed readiness requests from being mistaken for valid fixture readiness.
  * Added coverage for occupied ports, retry limits, timeout behavior, and readiness security.
  * Standardized readiness handling across download, GeoIP, and Top 1M test scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->