### PR TITLE
tests: isolate Issue1840 postinstall globals

### DIFF
--- a/graphify-out/memory/query_20260830_071912_which_tests_pollute_issue1840suppupdatenullpostins.md
+++ b/graphify-out/memory/query_20260830_071912_which_tests_pollute_issue1840suppupdatenullpostins.md
@@ -1,0 +1,19 @@
+---
+type: "query"
+date: "2026-08-30T07:19:12.817203+00:00"
+question: "Which tests pollute Issue1840SuppUpdateNullPostinstallTest globals under random PHPUnit order?"
+contributor: "graphify"
+outcome: "dead_end"
+correction: "Use CodeGraph source flow plus executed pinned-order/filter probes to identify the producer."
+---
+
+# Q: Which tests pollute Issue1840SuppUpdateNullPostinstallTest globals under random PHPUnit order?
+
+## Answer
+
+The graph located Issue1840SuppUpdateNullPostinstallTest and its production dependency but did not identify the state producer.
+
+## Outcome
+
+- Signal: dead_end
+- Correction: Use CodeGraph source flow plus executed pinned-order/filter probes to identify the producer.

--- a/tests/php/Issue1840SuppUpdateNullPostinstallAbsentGlobalIsolationTest.php
+++ b/tests/php/Issue1840SuppUpdateNullPostinstallAbsentGlobalIsolationTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/TickExtrasOrderingTest.php';
+require_once __DIR__ . '/Issue1840SuppUpdateNullPostinstallTest.php';
+
+final class Issue1840SuppUpdateNullPostinstallAbsentGlobalIsolationTest extends TestCase
+{
+	public function testTickExtrasRestoresAbsentGlobalG(): void
+	{
+		$this->assertRestoresAbsentGlobalG(
+			new TickExtrasOrderingTest('testDueExtrasRunDccThenBlThenFeedAndIgnoreApplyWindow'),
+			"TickExtrasOrderingTest::tearDown() must leave absent \$GLOBALS['g'] absent"
+		);
+	}
+
+	public function testIssue1840RestoresAbsentGlobalG(): void
+	{
+		$this->assertRestoresAbsentGlobalG(
+			new Issue1840SuppUpdateNullPostinstallTest('testPostInstallResyncDoesNotCrashOnNullSuppUpdateV4'),
+			"Issue1840SuppUpdateNullPostinstallTest::tearDown() must leave absent \$GLOBALS['g'] absent"
+		);
+	}
+
+	private function assertRestoresAbsentGlobalG(TestCase $fixture, string $message): void
+	{
+		$hadPfb = array_key_exists('pfb', $GLOBALS);
+		$originalPfb = $GLOBALS['pfb'] ?? NULL;
+		$hadConfig = array_key_exists('config', $GLOBALS);
+		$originalConfig = $GLOBALS['config'] ?? NULL;
+		$hadG = array_key_exists('g', $GLOBALS);
+		$originalG = $GLOBALS['g'] ?? NULL;
+
+		try {
+			unset($GLOBALS['g']);
+			$setUp = new ReflectionMethod($fixture, 'setUp');
+			$tearDown = new ReflectionMethod($fixture, 'tearDown');
+
+			try {
+				$setUp->invoke($fixture);
+				$GLOBALS['g'] = ['hostile_sentinel' => 'must be removed'];
+			} finally {
+				$tearDown->invoke($fixture);
+			}
+
+			$this->assertArrayNotHasKey('g', $GLOBALS, $message);
+		} finally {
+			if ($hadPfb) {
+				$GLOBALS['pfb'] = $originalPfb;
+			} else {
+				unset($GLOBALS['pfb']);
+			}
+			if ($hadConfig) {
+				$GLOBALS['config'] = $originalConfig;
+			} else {
+				unset($GLOBALS['config']);
+			}
+			if ($hadG) {
+				$GLOBALS['g'] = $originalG;
+			} else {
+				unset($GLOBALS['g']);
+			}
+		}
+	}
+}

--- a/tests/php/Issue1840SuppUpdateNullPostinstallFixtureIsolationTest.php
+++ b/tests/php/Issue1840SuppUpdateNullPostinstallFixtureIsolationTest.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/TickExtrasOrderingTest.php';
+require_once __DIR__ . '/Issue1840SuppUpdateNullPostinstallTest.php';
+
+final class Issue1840SuppUpdateNullPostinstallFixtureIsolationTest extends TestCase
+{
+	public function testTickExtrasRestoresWholeGlobalG(): void
+	{
+		$hadPfb = array_key_exists('pfb', $GLOBALS);
+		$originalPfb = $GLOBALS['pfb'] ?? NULL;
+		$hadConfig = array_key_exists('config', $GLOBALS);
+		$originalConfig = $GLOBALS['config'] ?? NULL;
+		$hadG = array_key_exists('g', $GLOBALS);
+		$originalG = $GLOBALS['g'] ?? NULL;
+		$incomingG = [
+			'pfblockerng_install' => FALSE,
+			'unbound_chroot_path' => '/sentinel/tick-extras',
+			'unrelated_sentinel' => ['keep' => 'exactly'],
+		];
+
+		try {
+			$GLOBALS['g'] = $incomingG;
+			$fixture = new TickExtrasOrderingTest('testDueExtrasRunDccThenBlThenFeedAndIgnoreApplyWindow');
+			$setUp = new ReflectionMethod($fixture, 'setUp');
+			$tearDown = new ReflectionMethod($fixture, 'tearDown');
+
+			try {
+				$setUp->invoke($fixture);
+			} finally {
+				$tearDown->invoke($fixture);
+			}
+
+			$this->assertSame(
+				$incomingG,
+				$GLOBALS['g'] ?? NULL,
+				"TickExtrasOrderingTest::tearDown() must restore the exact incoming \$GLOBALS['g'] array"
+			);
+		} finally {
+			if ($hadPfb) {
+				$GLOBALS['pfb'] = $originalPfb;
+			} else {
+				unset($GLOBALS['pfb']);
+			}
+			if ($hadConfig) {
+				$GLOBALS['config'] = $originalConfig;
+			} else {
+				unset($GLOBALS['config']);
+			}
+			if ($hadG) {
+				$GLOBALS['g'] = $originalG;
+			} else {
+				unset($GLOBALS['g']);
+			}
+		}
+	}
+
+	public function testIssue1840SeedsClearedPostinstallerGlobalsAndRestoresWholeGlobalG(): void
+	{
+		$hadPfb = array_key_exists('pfb', $GLOBALS);
+		$originalPfb = $GLOBALS['pfb'] ?? NULL;
+		$hadConfig = array_key_exists('config', $GLOBALS);
+		$originalConfig = $GLOBALS['config'] ?? NULL;
+		$hadG = array_key_exists('g', $GLOBALS);
+		$originalG = $GLOBALS['g'] ?? NULL;
+		$incomingG = [
+			'unbound_chroot_path' => '/sentinel/issue1840',
+			'unrelated_sentinel' => ['keep' => 'exactly'],
+		];
+
+		try {
+			$GLOBALS['g'] = $incomingG;
+			$fixture = new Issue1840SuppUpdateNullPostinstallTest('testPostInstallResyncDoesNotCrashOnNullSuppUpdateV4');
+			$setUp = new ReflectionMethod($fixture, 'setUp');
+			$tearDown = new ReflectionMethod($fixture, 'tearDown');
+
+			try {
+				$setUp->invoke($fixture);
+				$this->assertSame(
+					FALSE,
+					$GLOBALS['g']['pfblockerng_install'] ?? NULL,
+					'Issue1840SuppUpdateNullPostinstallTest::setUp() must seed cleared pfblockerng_install FALSE'
+				);
+				$this->assertSame(
+					'/var/unbound',
+					$GLOBALS['g']['unbound_chroot_path'] ?? NULL,
+					'Issue1840SuppUpdateNullPostinstallTest::setUp() must force unbound_chroot_path to /var/unbound'
+				);
+			} finally {
+				$tearDown->invoke($fixture);
+			}
+
+			$this->assertSame(
+				$incomingG,
+				$GLOBALS['g'] ?? NULL,
+				"Issue1840SuppUpdateNullPostinstallTest::tearDown() must restore the exact incoming \$GLOBALS['g'] array"
+			);
+		} finally {
+			if ($hadPfb) {
+				$GLOBALS['pfb'] = $originalPfb;
+			} else {
+				unset($GLOBALS['pfb']);
+			}
+			if ($hadConfig) {
+				$GLOBALS['config'] = $originalConfig;
+			} else {
+				unset($GLOBALS['config']);
+			}
+			if ($hadG) {
+				$GLOBALS['g'] = $originalG;
+			} else {
+				unset($GLOBALS['g']);
+			}
+		}
+	}
+}

--- a/tests/php/Issue1840SuppUpdateNullPostinstallTest.php
+++ b/tests/php/Issue1840SuppUpdateNullPostinstallTest.php
@@ -52,6 +52,8 @@ final class Issue1840SuppUpdateNullPostinstallTest extends TestCase
 	private array $originalPfb = [];
 	private bool $hadConfig = FALSE;
 	private mixed $originalConfig = NULL;
+	private bool $hadG = FALSE;
+	private mixed $originalG = NULL;
 
 	protected function setUp(): void
 	{
@@ -59,6 +61,8 @@ final class Issue1840SuppUpdateNullPostinstallTest extends TestCase
 		$this->originalPfb = $GLOBALS['pfb'] ?? [];
 		$this->hadConfig      = array_key_exists('config', $GLOBALS);
 		$this->originalConfig = $GLOBALS['config'] ?? NULL;
+		$this->hadG = array_key_exists('g', $GLOBALS);
+		$this->originalG = $GLOBALS['g'] ?? NULL;
 
 		$this->dbdir = sys_get_temp_dir() . '/pfb_issue1840_' . uniqid('', TRUE);
 		mkdir($this->dbdir, 0755, TRUE);
@@ -150,9 +154,8 @@ final class Issue1840SuppUpdateNullPostinstallTest extends TestCase
 		config_set_path("{$dnsbl}/tld_wildcard",    '');
 		config_set_path("{$dnsbl}/pfb_control",     '');
 
-		if (!isset($GLOBALS['g']['unbound_chroot_path'])) {
-			$GLOBALS['g']['unbound_chroot_path'] = '/var/unbound';
-		}
+		$GLOBALS['g']['pfblockerng_install'] = FALSE;
+		$GLOBALS['g']['unbound_chroot_path'] = '/var/unbound';
 
 		// Plain runtime flags pfb_global()/the (skipped, save=TRUE) DNSBL block would
 		// otherwise leave unset -- unrelated to issue #1840, seeded only to keep this
@@ -219,6 +222,11 @@ final class Issue1840SuppUpdateNullPostinstallTest extends TestCase
 			$GLOBALS['config'] = $this->originalConfig;
 		} else {
 			unset($GLOBALS['config']);
+		}
+		if ($this->hadG) {
+			$GLOBALS['g'] = $this->originalG;
+		} else {
+			unset($GLOBALS['g']);
 		}
 		$this->rrmdir($this->dbdir);
 	}

--- a/tests/php/TickExtrasOrderingTest.php
+++ b/tests/php/TickExtrasOrderingTest.php
@@ -10,11 +10,15 @@ final class TickExtrasOrderingTest extends TestCase
 	private string $dir = '';
 	private mixed $pfb = NULL;
 	private mixed $config = NULL;
+	private bool $hadG = FALSE;
+	private mixed $originalG = NULL;
 
 	protected function setUp(): void
 	{
 		$this->pfb = $GLOBALS['pfb'];
 		$this->config = $GLOBALS['config'] ?? NULL;
+		$this->hadG = array_key_exists('g', $GLOBALS);
+		$this->originalG = $GLOBALS['g'] ?? NULL;
 		$this->dir = sys_get_temp_dir() . '/pfb_tick_extras_' . getmypid() . '_' . uniqid();
 		mkdir($this->dir . '/state', 0777, TRUE);
 		$GLOBALS['pfb']['dbdir'] = $this->dir;
@@ -66,7 +70,11 @@ final class TickExtrasOrderingTest extends TestCase
 
 	protected function tearDown(): void
 	{
-		unset($GLOBALS['g']['pfblockerng_install']);
+		if ($this->hadG) {
+			$GLOBALS['g'] = $this->originalG;
+		} else {
+			unset($GLOBALS['g']);
+		}
 		$GLOBALS['pfb'] = $this->pfb;
 		$GLOBALS['config'] = $this->config;
 		$this->remove($this->dir);


### PR DESCRIPTION
## What this changes

The final unresolved #1951 row was test-fixture global-state leakage, not a product timing failure.

`TickExtrasOrderingTest` changed `$GLOBALS['g']`, then removed only `pfblockerng_install` and left its chroot mutation behind. A later `Issue1840SuppUpdateNullPostinstallTest` could therefore inherit a state that did not model the post-installer resync. This change:

- snapshots and restores the exact incoming whole `$GLOBALS['g']` in `TickExtrasOrderingTest`;
- makes the Issue1840 fixture explicitly model the cleared post-installer state (`pfblockerng_install === FALSE`, chroot `/var/unbound`) and restores its exact incoming whole `g` afterward;
- adds a strict lifecycle regression with distinct sentinels for both fixtures.

There is no production/configuration change and the existing Issue1840 IPv4/IPv6 behavior assertions are unchanged. The two Graphify paths are generated audit artifacts from the investigation.

## Diagnosis

The file-scope `PFB_ISSUE1840_PFB_BASELINE` hypothesis was refuted: PHPUnit loads the suite before executing tests, so the baseline is captured before a predecessor can mutate globals. The host-process/cron hypothesis was also outside the exercised path because the fixture leaves the gating MaxMind and Top1M fields empty.

The supported producer was `TickExtrasOrderingTest`: focused random seed 5 put it before Issue1840 and reproduced two additional `Undefined array key "pfblockerng_install"` warnings; seed 1 reversed the classes and did not. The fix is at both fixture ownership boundaries rather than warning suppression or consumer-side fallback.

## Frozen RED → GREEN / mutation proof

Frozen lifecycle-test blob at RED, GREEN, committed head, and post-rebase head:

```text
656ca97934c9446451d73839d84cbc9fd4c7b5e3
```

The independent verifier kept that blob frozen and restored only the two fixture implementations to pre-fix `devel` bytes. That mutation produced the two intended assertion failures:

```text
FF  2 / 2
1) TickExtras teardown did not restore the exact incoming $GLOBALS['g']
2) Issue1840 setup did not seed cleared pfblockerng_install FALSE
Tests: 2, Assertions: 2, Failures: 2.  exit=1
```

Restoring the implementation bytes from this branch, with the identical frozen assertions:

```text
..  2 / 2
OK (2 tests, 4 assertions)  exit=0
```

The assertions compare strict whole-array values with distinct sentinels, so neither failure can pass vacuously.

## Focused order evidence

- Direct Issue1840: `2 tests, 2 assertions`, pass; the eight pre-existing warnings remain visible, with no `pfblockerng_install` warning.
- Random seed 5, producer first: `3 tests, 4 assertions`, pass; repeated 10/10 with the same result and no installer-key warning.
- Random seed 1, reverse order: `3 tests, 4 assertions`, pass.
- Combined three files: `14 tests, 34 assertions`, pass.

## Review-fix: originally absent `g`

Round-1 correctness review found that the original frozen lifecycle regression covered only a present incoming `$GLOBALS['g']`. Both real `hadG === FALSE` branches were correct but unproved: changing either `unset($GLOBALS['g'])` to `$GLOBALS['g'] = []` survived that test.

Commit `94e98e6` adds a separate two-row absent-state regression while preserving the original frozen blob. Each row starts with top-level `g` absent, invokes the real fixture setup, replaces setup state with a hostile whole-array sentinel, runs real teardown from `finally`, and requires the key to remain absent. With the new test frozen at `75c55c5d4f1a3f6fb7ef77311a40490343bf27f7`, the Tick mutant failed `F.`, the Issue1840 mutant failed `.F`, and restored exact-head code passed `OK (2 tests, 2 assertions)`.

The four-file matrix passed in default order and pinned seeds 1 and 5: `16 tests, 36 assertions, Warnings: 8`, with no installer-key warning.

## Fresh canonical gate after blocker landings

Exact head: `94e98e69701fd12d659a8f23305a3770013b9e1f`  
Exact base: `a56a04809ecb42ba05e4666ff71fab156d0036be`

```text
$ scripts/agent/run-gates.sh --diff a56a04809ecb42ba05e4666ff71fab156d0036be
12/12 gates passed
GATES: PASS
```

The run included the complete PHPUnit suite plus PHP syntax for all four touched tests, PHPStan, PHPCS, Composer/vendor checks, coverage pairing, toggle/reentry checks, and Markdown lint. It exited 0 after 3m52s. The former foreign-listener failure owned by closed #2904 did not recur. Head, merge-base, clean status, all six changed blobs, and the frozen test hash were identical before and after the gate.

PR #2907 already resolved the other named #1951 timing rows and wrapper attribution. Closed #2904, #2905, and #2906 own the adjacent roots discovered during that work. This PR resolves the sole remaining Issue1840 row.

## Exact-head required CI

`scripts/agent/wait-checks.sh` pinned to `94e98e69701fd12d659a8f23305a3770013b9e1f` returned `PASS`. Required PHP 8.3/8.5 PHPUnit, PHPStan, PHPCS and syntax legs plus pytest, shellspec, Node tests, mypy, Ruff, ShellCheck, actionlint, Markdown lint, coverage pairing, and the remaining required checks passed. Advisory live-VM fan-out and benchmark legs were skipped and were not treated as required.

Fixes #1951

🤖 Generated by Oh My Pi and posted on behalf of @andrebrait.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved test isolation for post-install and ordering scenarios.
  - Ensured global state is fully restored after tests, including when values were initially absent.
  - Added regression coverage for restoring seeded, cleared, and hostile global values.
  - Standardized setup and teardown behavior to prevent state leakage between test cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->