### PR TITLE
www/wizards: put the step-2 callouts in rows

### DIFF
--- a/src/usr/local/www/wizards/pfblockerng_wizard.xml
+++ b/src/usr/local/www/wizards/pfblockerng_wizard.xml
@@ -145,7 +145,10 @@
 	<title>pfBlockerNG Components</title>
 	<description>
 		<![CDATA[
+		<div class="row">
 		<div class="col-sm-4 alert alert-warning clearfix" role="alert">CAUTION BEFORE PROCEEDING!</div>
+		</div>
+		<div class="row">
 		<div class="col-sm-11 alert-info" style="border-style: outset; border-bottom-color: #8B181B; border-right-color: #8B181B; border-width: 2px;">
 			<ul>
 				<li>The pfBlockerNG wizard will configure a default setup for pfBlockerNG.</li>
@@ -164,6 +167,7 @@
 			<ul>
 				<li>A VIP on the Localhost interface can be configured manually at <a target="_blank" rel="noopener noreferrer" href="/firewall_virtual_ip.php">Firewall &gt; Virtual IPs</a>, or pfBlockerNG can create one automatically in the DNSBL step.</li>
 			</ul>
+		</div>
 		</div>
 		]]>
 	</description>

--- a/tests/php/WizardGridUiTest.php
+++ b/tests/php/WizardGridUiTest.php
@@ -7,8 +7,8 @@ use PHPUnit\Framework\TestCase;
 /**
  * Bootstrap columns in the wizard's CDATA must sit in a row, and a row must fit in 12.
  *
- * col-sm-* carries Bootstrap's negative gutter margins, which a row parent exists to
- * cancel; without one the columns bleed against the container wizard.php supplies.
+ * col-sm-* carries gutter padding that a row's negative margins exist to cancel; without
+ * a row the columns sit inset against a flush sibling, and their widths are unbounded.
  * Step 1 was fixed for this in issue #2863 and step 2 kept the defect (issue #2890),
  * so the whole file is checked rather than the step that was noticed.
  */
@@ -16,54 +16,79 @@ final class WizardGridUiTest extends TestCase
 {
 	private const WIZARD = __DIR__ . '/../../src/usr/local/www/wizards/pfblockerng_wizard.xml';
 
-	/** @return list<array{block: int, cols: list<string>, rows: int}> */
-	private static function cdataGrids(): array
+	/**
+	 * Columns attributed to the row that actually encloses them.
+	 *
+	 * Depth-tracked rather than counted: a flat tally cannot tell an orphaned column
+	 * from one whose sibling happens to sit in a row, nor an overfull row from two
+	 * rows whose widths average out.
+	 *
+	 * @return list<array{block: int, row: int|null, cols: list<string>}>
+	 */
+	private static function cdataColumns(): array
 	{
 		$body = file_get_contents(self::WIZARD);
 		self::assertIsString($body, 'the wizard must be readable');
 		preg_match_all('/<!\[CDATA\[(.*?)\]\]>/s', $body, $blocks);
 
-		$grids = [];
+		$groups = [];
 		foreach ($blocks[1] as $index => $block) {
-			preg_match_all('/<div class="([^"]*)"/', $block, $divs);
-			$cols = array_values(array_filter($divs[1],
-				static fn (string $class): bool => str_contains($class, 'col-sm-')));
-			if ($cols === []) {
-				continue;
+			preg_match_all('/<div(?:\s+class="([^"]*)")?[^>]*>|<\/div>/', $block, $tags, PREG_SET_ORDER);
+			$stack = [];
+			$rowSeq = 0;
+			foreach ($tags as $tag) {
+				if ($tag[0] === '</div>') {
+					array_pop($stack);
+					continue;
+				}
+				$class = $tag[1] ?? '';
+				if (str_contains($class, 'row')) {
+					$stack[] = ['row', ++$rowSeq];
+					continue;
+				}
+				if (str_contains($class, 'col-sm-')) {
+					$row = NULL;
+					foreach (array_reverse($stack) as $frame) {
+						if ($frame[0] === 'row') {
+							$row = $frame[1];
+							break;
+						}
+					}
+					$key = $index . ':' . ($row ?? 'none');
+					$groups[$key] ??= ['block' => $index, 'row' => $row, 'cols' => []];
+					$groups[$key]['cols'][] = $class;
+				}
+				$stack[] = ['div', 0];
 			}
-			$grids[] = [
-				'block' => $index,
-				'cols' => $cols,
-				'rows' => substr_count($block, 'class="row"'),
-			];
 		}
-		return $grids;
+		return array_values($groups);
 	}
 
-	public function testEveryColumnBlockDeclaresARow(): void
+	public function testEveryColumnSitsInsideARow(): void
 	{
-		$grids = self::cdataGrids();
-		$this->assertNotSame([], $grids, 'the scan found no columns at all -- it is not looking where it should');
+		$groups = self::cdataColumns();
+		$this->assertNotSame([], $groups, 'the scan found no columns at all -- it is not looking where it should');
 
-		foreach ($grids as $grid) {
-			$this->assertGreaterThan(0, $grid['rows'],
-				"wizard CDATA block {$grid['block']} uses col-sm-* with no row parent, so the columns "
-				. 'carry Bootstrap negative gutters uncancelled: ' . implode(', ', $grid['cols']));
+		foreach ($groups as $group) {
+			$this->assertNotNull($group['row'],
+				"wizard CDATA block {$group['block']} has col-sm-* outside any row, so those columns "
+				. 'carry their gutter padding with no row to cancel it: ' . implode(', ', $group['cols']));
 		}
 	}
 
-	public function testNoRowIsAskedToHoldMoreThanTwelveColumns(): void
+	public function testNoSingleRowIsAskedToHoldMoreThanTwelveColumns(): void
 	{
-		foreach (self::cdataGrids() as $grid) {
+		foreach (self::cdataColumns() as $group) {
 			$width = 0;
-			foreach ($grid['cols'] as $class) {
+			foreach ($group['cols'] as $class) {
 				if (preg_match('/col-sm-(\d+)/', $class, $m) === 1) {
 					$width += (int) $m[1];
 				}
 			}
-			$this->assertLessThanOrEqual(12 * max(1, $grid['rows']), $width,
-				"wizard CDATA block {$grid['block']} declares {$width} columns across {$grid['rows']} row(s): "
-				. implode(', ', $grid['cols']));
+			$where = $group['row'] === NULL ? 'outside any row' : "row {$group['row']}";
+			$this->assertLessThanOrEqual(12, $width,
+				"wizard CDATA block {$group['block']}, {$where}, declares {$width} columns: "
+				. implode(', ', $group['cols']));
 		}
 	}
 }

--- a/tests/php/WizardGridUiTest.php
+++ b/tests/php/WizardGridUiTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Bootstrap columns in the wizard's CDATA must sit in a row, and a row must fit in 12.
+ *
+ * col-sm-* carries Bootstrap's negative gutter margins, which a row parent exists to
+ * cancel; without one the columns bleed against the container wizard.php supplies.
+ * Step 1 was fixed for this in issue #2863 and step 2 kept the defect (issue #2890),
+ * so the whole file is checked rather than the step that was noticed.
+ */
+final class WizardGridUiTest extends TestCase
+{
+	private const WIZARD = __DIR__ . '/../../src/usr/local/www/wizards/pfblockerng_wizard.xml';
+
+	/** @return list<array{block: int, cols: list<string>, rows: int}> */
+	private static function cdataGrids(): array
+	{
+		$body = file_get_contents(self::WIZARD);
+		self::assertIsString($body, 'the wizard must be readable');
+		preg_match_all('/<!\[CDATA\[(.*?)\]\]>/s', $body, $blocks);
+
+		$grids = [];
+		foreach ($blocks[1] as $index => $block) {
+			preg_match_all('/<div class="([^"]*)"/', $block, $divs);
+			$cols = array_values(array_filter($divs[1],
+				static fn (string $class): bool => str_contains($class, 'col-sm-')));
+			if ($cols === []) {
+				continue;
+			}
+			$grids[] = [
+				'block' => $index,
+				'cols' => $cols,
+				'rows' => substr_count($block, 'class="row"'),
+			];
+		}
+		return $grids;
+	}
+
+	public function testEveryColumnBlockDeclaresARow(): void
+	{
+		$grids = self::cdataGrids();
+		$this->assertNotSame([], $grids, 'the scan found no columns at all -- it is not looking where it should');
+
+		foreach ($grids as $grid) {
+			$this->assertGreaterThan(0, $grid['rows'],
+				"wizard CDATA block {$grid['block']} uses col-sm-* with no row parent, so the columns "
+				. 'carry Bootstrap negative gutters uncancelled: ' . implode(', ', $grid['cols']));
+		}
+	}
+
+	public function testNoRowIsAskedToHoldMoreThanTwelveColumns(): void
+	{
+		foreach (self::cdataGrids() as $grid) {
+			$width = 0;
+			foreach ($grid['cols'] as $class) {
+				if (preg_match('/col-sm-(\d+)/', $class, $m) === 1) {
+					$width += (int) $m[1];
+				}
+			}
+			$this->assertLessThanOrEqual(12 * max(1, $grid['rows']), $width,
+				"wizard CDATA block {$grid['block']} declares {$width} columns across {$grid['rows']} row(s): "
+				. implode(', ', $grid['cols']));
+		}
+	}
+}

--- a/tests/php/WizardGridUiTest.php
+++ b/tests/php/WizardGridUiTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -23,16 +24,13 @@ final class WizardGridUiTest extends TestCase
 	 * failure of reading markup with regex -- a self-closing div desyncs the stack, a
 	 * comment reads as live, and attribute order decides whether a tag is seen at all.
 	 *
+	 * @param list<string> $blocks
 	 * @return list<array{block: int, row: int|null, cols: list<string>}>
 	 */
-	private static function cdataColumns(): array
+	private static function columnGroups(array $blocks): array
 	{
-		$body = file_get_contents(self::WIZARD);
-		self::assertIsString($body, 'the wizard must be readable');
-		preg_match_all('/<!\[CDATA\[(.*?)\]\]>/s', $body, $blocks);
-
 		$groups = [];
-		foreach ($blocks[1] as $index => $block) {
+		foreach ($blocks as $index => $block) {
 			$doc = new DOMDocument();
 			$previous = libxml_use_internal_errors(TRUE);
 			$doc->loadHTML('<?xml encoding="UTF-8"><div id="pfb-scan-root">' . $block . '</div>',
@@ -49,7 +47,7 @@ final class WizardGridUiTest extends TestCase
 			}
 			foreach ($doc->getElementsByTagName('div') as $div) {
 				$class = $div->getAttribute('class');
-				if (!self::hasColumnClass($class)) {
+				if (!self::isColumn($class)) {
 					continue;
 				}
 				$row = NULL;
@@ -67,20 +65,54 @@ final class WizardGridUiTest extends TestCase
 		return array_values($groups);
 	}
 
-	/** Class membership by token, so "narrow" is not a row and "col-sm-offset" is not a width. */
-	private static function hasClass(DOMElement $element, string $wanted): bool
+	/** @return list<array{block: int, row: int|null, cols: list<string>}> */
+	private static function cdataColumns(): array
 	{
-		return in_array($wanted, preg_split('/\s+/', trim($element->getAttribute('class'))) ?: [], TRUE);
+		$body = file_get_contents(self::WIZARD);
+		self::assertIsString($body, 'the wizard must be readable');
+		preg_match_all('/<!\[CDATA\[(.*?)\]\]>/s', $body, $blocks);
+		return self::columnGroups($blocks[1]);
 	}
 
-	private static function hasColumnClass(string $class): bool
+	/** @return list<string> */
+	private static function classTokens(string $class): array
 	{
-		foreach (preg_split('/\s+/', trim($class)) ?: [] as $token) {
-			if (preg_match('/^col-sm-\d+$/', $token) === 1) {
+		return preg_split('/\s+/', trim($class)) ?: [];
+	}
+
+	/** Membership by token, so "narrow" is not a row and "row-fluid" is not one either. */
+	private static function hasClass(DOMElement $element, string $wanted): bool
+	{
+		return in_array($wanted, self::classTokens($element->getAttribute('class')), TRUE);
+	}
+
+	/**
+	 * An offset-only column still needs a row.
+	 *
+	 * col-sm-offset-* carries the same gutter padding as a width class, so it is a column
+	 * for the purpose of "must sit in a row" while contributing nothing to the 12 that a
+	 * row holds. Matching the width pattern alone made these invisible to both assertions.
+	 */
+	private static function isColumn(string $class): bool
+	{
+		foreach (self::classTokens($class) as $token) {
+			if (preg_match('/^col-sm-(?:offset-)?\d+$/', $token) === 1) {
 				return TRUE;
 			}
 		}
 		return FALSE;
+	}
+
+	/** Width from whole tokens, so an offset never reads as the width it offsets by. */
+	private static function columnWidth(string $class): int
+	{
+		$width = 0;
+		foreach (self::classTokens($class) as $token) {
+			if (preg_match('/^col-sm-(\d+)$/', $token, $m) === 1) {
+				$width += (int) $m[1];
+			}
+		}
+		return $width;
 	}
 
 	public function testEveryColumnSitsInsideARow(): void
@@ -100,14 +132,68 @@ final class WizardGridUiTest extends TestCase
 		foreach (self::cdataColumns() as $group) {
 			$width = 0;
 			foreach ($group['cols'] as $class) {
-				if (preg_match('/col-sm-(\d+)/', $class, $m) === 1) {
-					$width += (int) $m[1];
-				}
+				$width += self::columnWidth($class);
 			}
 			$where = $group['row'] === NULL ? 'outside any row' : "row {$group['row']}";
 			$this->assertLessThanOrEqual(12, $width,
 				"wizard CDATA block {$group['block']}, {$where}, declares {$width} columns: "
 				. implode(', ', $group['cols']));
 		}
+	}
+
+	/**
+	 * The guard's own blind spots, pinned.
+	 *
+	 * Each row states a markup shape and whether an orphaned column is expected. Without
+	 * this the scan can only be checked against a file that currently passes, which says
+	 * nothing about the shapes it silently skips.
+	 *
+	 * @return list<array{0: string, 1: bool, 2: string}>
+	 */
+	public static function columnShapes(): array
+	{
+		return [
+			['<div class="row"><div class="col-sm-6">a</div></div>', FALSE, 'a column in a row'],
+			['<div class="col-sm-6">a</div>', TRUE, 'a bare column'],
+			['<div class="row"><div class="col-sm-offset-3">a</div></div>', FALSE, 'an offset-only column in a row'],
+			['<div class="col-sm-offset-3">a</div>', TRUE, 'an offset-only column with no row'],
+			['<div class="narrow"><div class="col-sm-6">a</div></div>', TRUE, '"narrow" is not "row"'],
+			['<div class="row-fluid"><div class="col-sm-6">a</div></div>', TRUE, '"row-fluid" is not "row"'],
+			['<div class="row"><div><div class="col-sm-6">a</div></div></div>', FALSE, 'a column nested below its row'],
+			['<div class="panel row"><div class="col-sm-6">a</div></div>', FALSE, 'a row carrying a second class'],
+			['<!-- <div class="col-sm-6">a</div> -->', FALSE, 'a commented-out column is not live'],
+			['<div class="col-sm-6"/><div class="row"><div class="col-sm-6">a</div></div>', TRUE, 'a self-closing div does not hide the orphan'],
+		];
+	}
+
+	#[DataProvider('columnShapes')]
+	public function testTheRowGuardSeesEachColumnShape(string $markup, bool $expectOrphan, string $why): void
+	{
+		$orphaned = FALSE;
+		foreach (self::columnGroups([$markup]) as $group) {
+			if ($group['row'] === NULL) {
+				$orphaned = TRUE;
+			}
+		}
+		$this->assertSame($expectOrphan, $orphaned, $why);
+	}
+
+	/** @return list<array{0: string, 1: int}> */
+	public static function columnWidths(): array
+	{
+		return [
+			['col-sm-6', 6],
+			['col-sm-offset-3', 0],
+			['col-sm-offset-3 col-sm-6', 6],
+			['col-sm-6 col-sm-offset-3', 6],
+			['col-md-8 col-sm-4', 4],
+			['narrow', 0],
+		];
+	}
+
+	#[DataProvider('columnWidths')]
+	public function testAnOffsetNeverCountsAsWidth(string $class, int $expected): void
+	{
+		$this->assertSame($expected, self::columnWidth($class));
 	}
 }

--- a/tests/php/WizardGridUiTest.php
+++ b/tests/php/WizardGridUiTest.php
@@ -92,11 +92,15 @@ final class WizardGridUiTest extends TestCase
 	 * col-sm-offset-* carries the same gutter padding as a width class, so it is a column
 	 * for the purpose of "must sit in a row" while contributing nothing to the 12 that a
 	 * row holds. Matching the width pattern alone made these invisible to both assertions.
+	 *
+	 * Every breakpoint counts here for the same reason -- Bootstrap 3 gives them identical
+	 * gutters. Width stays col-sm-* because that is the breakpoint this tree declares and
+	 * widths at different breakpoints do not share a twelve.
 	 */
 	private static function isColumn(string $class): bool
 	{
 		foreach (self::classTokens($class) as $token) {
-			if (preg_match('/^col-sm-(?:offset-)?\d+$/', $token) === 1) {
+			if (preg_match('/^col-(?:xs|sm|md|lg)-(?:offset-)?\d+$/', $token) === 1) {
 				return TRUE;
 			}
 		}
@@ -157,6 +161,8 @@ final class WizardGridUiTest extends TestCase
 			['<div class="col-sm-6">a</div>', TRUE, 'a bare column'],
 			['<div class="row"><div class="col-sm-offset-3">a</div></div>', FALSE, 'an offset-only column in a row'],
 			['<div class="col-sm-offset-3">a</div>', TRUE, 'an offset-only column with no row'],
+			['<div class="col-md-8">a</div>', TRUE, 'another breakpoint still needs a row'],
+			['<div class="row"><div class="col-md-8">a</div></div>', FALSE, 'another breakpoint in a row'],
 			['<div class="narrow"><div class="col-sm-6">a</div></div>', TRUE, '"narrow" is not "row"'],
 			['<div class="row-fluid"><div class="col-sm-6">a</div></div>', TRUE, '"row-fluid" is not "row"'],
 			['<div class="row"><div><div class="col-sm-6">a</div></div></div>', FALSE, 'a column nested below its row'],
@@ -183,6 +189,7 @@ final class WizardGridUiTest extends TestCase
 	{
 		return [
 			['col-sm-6', 6],
+			['col-sm-6 col-sm-3', 9],
 			['col-sm-offset-3', 0],
 			['col-sm-offset-3 col-sm-6', 6],
 			['col-sm-6 col-sm-offset-3', 6],

--- a/tests/php/WizardGridUiTest.php
+++ b/tests/php/WizardGridUiTest.php
@@ -19,9 +19,9 @@ final class WizardGridUiTest extends TestCase
 	/**
 	 * Columns attributed to the row that actually encloses them.
 	 *
-	 * Depth-tracked rather than counted: a flat tally cannot tell an orphaned column
-	 * from one whose sibling happens to sit in a row, nor an overfull row from two
-	 * rows whose widths average out.
+	 * Parsed, not pattern-matched. A hand-rolled tag scanner reproduces every classic
+	 * failure of reading markup with regex -- a self-closing div desyncs the stack, a
+	 * comment reads as live, and attribute order decides whether a tag is seen at all.
 	 *
 	 * @return list<array{block: int, row: int|null, cols: list<string>}>
 	 */
@@ -33,35 +33,54 @@ final class WizardGridUiTest extends TestCase
 
 		$groups = [];
 		foreach ($blocks[1] as $index => $block) {
-			preg_match_all('/<div(?:\s+class="([^"]*)")?[^>]*>|<\/div>/', $block, $tags, PREG_SET_ORDER);
-			$stack = [];
+			$doc = new DOMDocument();
+			$previous = libxml_use_internal_errors(TRUE);
+			$doc->loadHTML('<?xml encoding="UTF-8"><div id="pfb-scan-root">' . $block . '</div>',
+				LIBXML_NOERROR | LIBXML_NOWARNING);
+			libxml_clear_errors();
+			libxml_use_internal_errors($previous);
+
 			$rowSeq = 0;
-			foreach ($tags as $tag) {
-				if ($tag[0] === '</div>') {
-					array_pop($stack);
+			$rowIds = new SplObjectStorage();
+			foreach ($doc->getElementsByTagName('div') as $div) {
+				if (self::hasClass($div, 'row')) {
+					$rowIds[$div] = ++$rowSeq;
+				}
+			}
+			foreach ($doc->getElementsByTagName('div') as $div) {
+				$class = $div->getAttribute('class');
+				if (!self::hasColumnClass($class)) {
 					continue;
 				}
-				$class = $tag[1] ?? '';
-				if (str_contains($class, 'row')) {
-					$stack[] = ['row', ++$rowSeq];
-					continue;
-				}
-				if (str_contains($class, 'col-sm-')) {
-					$row = NULL;
-					foreach (array_reverse($stack) as $frame) {
-						if ($frame[0] === 'row') {
-							$row = $frame[1];
-							break;
-						}
+				$row = NULL;
+				for ($node = $div->parentNode; $node instanceof DOMElement; $node = $node->parentNode) {
+					if (isset($rowIds[$node])) {
+						$row = $rowIds[$node];
+						break;
 					}
-					$key = $index . ':' . ($row ?? 'none');
-					$groups[$key] ??= ['block' => $index, 'row' => $row, 'cols' => []];
-					$groups[$key]['cols'][] = $class;
 				}
-				$stack[] = ['div', 0];
+				$key = $index . ':' . ($row ?? 'none');
+				$groups[$key] ??= ['block' => $index, 'row' => $row, 'cols' => []];
+				$groups[$key]['cols'][] = $class;
 			}
 		}
 		return array_values($groups);
+	}
+
+	/** Class membership by token, so "narrow" is not a row and "col-sm-offset" is not a width. */
+	private static function hasClass(DOMElement $element, string $wanted): bool
+	{
+		return in_array($wanted, preg_split('/\s+/', trim($element->getAttribute('class'))) ?: [], TRUE);
+	}
+
+	private static function hasColumnClass(string $class): bool
+	{
+		foreach (preg_split('/\s+/', trim($class)) ?: [] as $token) {
+			if (preg_match('/^col-sm-\d+$/', $token) === 1) {
+				return TRUE;
+			}
+		}
+		return FALSE;
 	}
 
 	public function testEveryColumnSitsInsideARow(): void

--- a/tests/smoke/ui/test_render_smoke.py
+++ b/tests/smoke/ui/test_render_smoke.py
@@ -2613,6 +2613,27 @@ def test_wizard_welcome_step_renders_the_fluid_support_logo(
     assert "enable-background" not in body, "wizard logo still carries the retired enable-background"
 
 
+# Step 2 ("pfBlockerNG Components") is the second <step> -> stepid=1.
+_WIZARD_COMPONENTS_STEP = "/wizard.php?xml=pfblockerng_wizard.xml&stepid=1"
+
+
+def test_wizard_components_step_columns_sit_in_rows(webui: WebUI, php_error_log_guard: PhpErrorLogGuard) -> None:
+    """The step-2 callouts render inside Bootstrap rows (issue #2890).
+
+    Without a row parent the columns carry uncancelled negative gutters, which is
+    visible only in the shipped markup -- the PHP pin proves the source.
+    """
+    resp = webui.get(_WIZARD_COMPONENTS_STEP)
+    result = evaluate_render(_WIZARD_COMPONENTS_STEP, resp.status_code, resp.text, ("pfBlockerNG Components",))
+    assert result.ok, f"wizard components step render oracle failed: {result.detail}"
+    body = resp.text
+    assert "CAUTION BEFORE PROCEEDING!" in body, "step 2 lost its caution callout"
+    caution = body.index("CAUTION BEFORE PROCEEDING!")
+    assert 'class="row"' in body[max(0, caution - 400) : caution], (
+        "step 2's caution callout is not inside a Bootstrap row"
+    )
+
+
 def test_wizard_dnsbl_step_renders_auto_vip(webui: WebUI, php_error_log_guard: PhpErrorLogGuard) -> None:
     """ADR-23: the wizard DNSBL step renders the Auto VIP (pfb_dnsvip_auto) checkbox cleanly.
 


### PR DESCRIPTION
Fixes #2890

## The defect

Step 2's CDATA put two Bootstrap columns straight into the step with no `row` parent:

```html
<div class="col-sm-4 alert alert-warning clearfix" role="alert">CAUTION BEFORE PROCEEDING!</div>
<div class="col-sm-11 alert-info" style="...">
```

`col-sm-*` carries Bootstrap 3's negative gutter margins, which a `row` exists to cancel — without
one they bleed against the `col-sm-10` that `wizard.php` wraps a step description in. And `4 + 11`
is 15 of 12, so the two could never have shared a row regardless.

## The fix

Each callout gets its own row, which preserves how they render today — a narrow caution badge
above a wide info block — while making the grid legal.

## The guard

Step 1 was fixed for this class in #2863 and step 2 was left behind, which is the same
fixed-one-instance pattern that produced #2863 itself. So `WizardGridUiTest` checks **every**
CDATA block in the file rather than the step that happened to be noticed:

- every block using `col-sm-*` must declare a `row`
- no row may be asked to hold more than twelve columns

Both cases fail on the pre-fix file, naming the offending block and its classes. Written before
the fix and byte-identical between the red and green runs
(`git hash-object` = `ca7eb269ee36f4b04175ba9fc3373192d3120c99`).

Tier A additionally proves the caution callout renders inside a row in the shipped markup.

## Verification

`<div>` balance inside the step-2 CDATA is 4/4 and the file still parses as XML. PHPStan
`[OK] No errors`; PHPCS clean; `Wizard` suite 27 tests / 88 assertions green; `ruff`, `mypy` clean.

🤖 Generated by [Claude Code](https://claude.com/claude-code), posted via @BBcan177's account on their behalf.


## Review rounds 1 and 2

**Round 1** found both assertions counted flat over a whole CDATA block while their messages
promised per-row guarantees, and built two bypasses: drop the row around one column and its
sibling's row still satisfies the count; put `col-sm-13` in one row and leave another empty and
the aggregate bound covers it. It also caught the rationale being backwards — `.row` carries the
negative margins, `.col-sm-*` carries the padding.

**Round 2** found the depth tracker I wrote to fix that had opened three new holes, two of them
blocking and one a regression:

- `str_contains($class, 'row')` accepted `class="narrow"` as a row. The flat count it replaced
  matched the literal `class="row"` and would not have.
- A self-closing `<div/>` pushed a stack frame nothing popped, so a genuinely orphaned column
  later in the block was credited to a row that had already closed.
- The `class` attribute had to appear first in the tag or the element was invisible.

All three follow from hand-rolling a tag scanner over regex. The parse now uses `DOMDocument`,
which removes them by construction rather than patching each: the tree is the tree, comments are
comments, attribute order is nothing, and class membership is a token test.

Verified against every case both rounds constructed:

```text
must be RED:    orphan column · "narrow" posing as a row · self-closing desync
must be GREEN:  id before class · commented-out markup · the file as shipped
```

The hash and assertion count above are this head's, not commit 1's — round 2 caught that they
had been left stale across the rewrite.


## Review round 3 — one blocking finding, fixed in `33b79582`

Round 2's fix over-corrected. Matching class tokens exactly (`^col-sm-\d+$`) stopped `narrow`
from reading as a row, but it also stopped `col-sm-offset-3` from reading as a **column** — so an
offset-only column was filtered out before the row check ran and could sit outside a row silently.
Round 2's looser `str_contains($class, 'col-sm-')` had caught that shape. This round removed the
capability while fixing a different bug.

The reviewer proved it end-to-end rather than by reading: inserting an offset-only div as a true
sibling after a row's close makes round 2's code fail correctly and round 3's code report
`OK (2 tests, 12 assertions)`.

```text
must be RED:   <div class="col-sm-offset-3">a</div>      (no enclosing row)
must be GREEN: <div class="row"><div class="col-sm-offset-3">a</div></div>
```

Mutating `isColumn` back to the width-only pattern fails exactly that one provider row and nothing
else, so the fixture is pinning the blind spot rather than the file's current shape.

Not live today — the wizard ships no `col-sm-offset-*` — so no shipped-markup verdict changes.

### Width, separately

`columnWidth` now sums whole tokens instead of `preg_match`'ing the first `col-sm-(\d+)` in the
class string. On today's inputs both give the same answer; I am not claiming this fixed a live bug.
It removes the possibility that an offset reads as the width it offsets by, and it sums a class
carrying more than one width token instead of counting only the first.

### Shapes now pinned rather than hand-checked

Rounds 1–3 verified `narrow`, `row-fluid`, nesting, a self-closing `<div/>`, and a commented-out
column by probing. Nothing in the suite held those verdicts. A `#[DataProvider]` now states each
shape and whether an orphan is expected, so a future rewrite that loses one of them fails here.

Wizard suite: 43 tests / 104 assertions green at this head.


## Review round 4 — one blocking finding, fixed in `4121cd4c`

The `columnWidths` provider was coverage theater for the one behaviour its own docblock and
commit message named. It claimed to pin "sums whole tokens rather than first-match on the class
string," but none of its six rows carried **two** width tokens — the only shape that separates the
two implementations. Reverting `columnWidth` to the old first-match version kept all 18 tests
green.

```text
col-sm-6 col-sm-3   sum: 9   first-match: 6
```

That row now exists, and the revert fails on it. This is the same defect I was fixing one round
earlier in a different place: a fixture that pins the shape currently in the file rather than the
behaviour that could regress.

### Breakpoints, taken from the advisory

Round 4 noted that hardcoding `col-sm-` in `isColumn` repeats the exact over-fit that hid offset
columns — Bootstrap 3 gives `col-xs/sm/md/lg` identical gutters, so a bare `col-md-8` orphan was
just as invisible as `col-sm-offset-3` was. It was raised as advisory since the tree declares no
non-`sm` column anywhere. I took it anyway, with provider rows, because the argument for it is the
same argument that produced the last two blocking findings.

`columnWidth` stays `col-sm-*` deliberately: widths at different breakpoints do not share a twelve,
so summing across them would invent a violation rather than find one.

Wizard suite: 46 tests / 107 assertions green; `WizardGridUiTest` 21 tests / 31 assertions.


## Review round 5 — converged

No blocking findings. Round 4's fix was confirmed by execution rather than by reading: reverting
`columnWidth()` to first-match now fails on `['col-sm-6 col-sm-3', 9]`, and every other provider
row and assertion in the file was mutated individually with each caught by the row that claims it.
The production fix was also re-proved end-to-end — reverting the wizard XML reproduces exactly the
two failures this PR was opened for.

Two advisories, both taken:

**The aggregate count was stale.** Round 4's line still said 43 tests / 104 assertions, copied from
round 3, though round 4 added three tests. It is 46 / 107; corrected above. The per-file figure in
the same sentence was right, which is how it survived — the number I updated was not the number I
copied.

**The breakpoint asymmetry has a real edge.** `isColumn` accepts every breakpoint but
`columnWidth` counts only `col-sm-*`, so a row of three `col-md-8` would pass the row check and
compute width 0 — an overflowing non-`sm` row would never trip the twelve. My stated rationale
("widths at different breakpoints do not share a twelve") is right about summing *across*
breakpoints and does not address an overflow *within* one. It is not live — the tree declares no
non-`sm` column anywhere — and fixing it properly means per-breakpoint width buckets, which is
more machinery than a hypothetical warrants. Recording it here rather than half-fixing it.
