### PR TITLE
www: name the schedule-cache stage in the category editor too

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -5536,13 +5536,14 @@ function pfb_schedule_cache_candidate_stage(
 	?int $now = NULL,
 	array $io = []
 ): string {
-	if (!($timezone instanceof DateTimeZone) && !is_string($timezone)) {
-		return 'timezone';
-	}
-	try {
-		$timezone = $timezone instanceof DateTimeZone ? $timezone : new DateTimeZone($timezone);
-	} catch (Throwable) {
-		return 'timezone';
+	// A bad timezone is passed through rather than reported here, so the shared helper
+	// decides the order and both pages name the same stage for the same input.
+	if (is_string($timezone)) {
+		try {
+			$timezone = new DateTimeZone($timezone);
+		} catch (Throwable) {
+			$timezone = NULL;
+		}
 	}
 	$candidate_file = @tempnam(sys_get_temp_dir(), 'pfb_sched_');
 	$candidate_dir = $candidate_file === FALSE ? '' : $candidate_file . '.d';
@@ -5557,7 +5558,6 @@ function pfb_schedule_cache_candidate_stage(
 	if ($active_dir !== '' && $candidate_dir === $active_dir) {
 		$candidate_dir = '';
 	}
-	$stage = 'workdir';
 	try {
 		$stage = pfb_schedule_cache_stage($model, $state, $timezone, $candidate_dir, $now, $io);
 	} catch (Throwable) {

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -5524,24 +5524,25 @@ function pfb_general_schedule_save_redirect(
 	return $cache_ok ? '/pfblockerng/pfblockerng_general.php' : $failure_redirect;
 }
 
-/** Validate a disposable schedule-cache candidate without touching the active cache. */
-function pfb_schedule_cache_candidate_validate(
+/**
+ * Name the stage that failed while validating a disposable candidate, or '' when it
+ * published cleanly. Owns the temporary directory; the checks themselves belong to
+ * pfb_schedule_cache_stage(), so both pages report the same vocabulary.
+ */
+function pfb_schedule_cache_candidate_stage(
 	?array $model,
 	?array $state,
 	mixed $timezone,
 	?int $now = NULL,
 	array $io = []
-): bool {
-	if (!$model || !$state) {
-		return FALSE;
-	}
+): string {
 	if (!($timezone instanceof DateTimeZone) && !is_string($timezone)) {
-		return FALSE;
+		return 'timezone';
 	}
 	try {
 		$timezone = $timezone instanceof DateTimeZone ? $timezone : new DateTimeZone($timezone);
 	} catch (Throwable) {
-		return FALSE;
+		return 'timezone';
 	}
 	$candidate_file = @tempnam(sys_get_temp_dir(), 'pfb_sched_');
 	$candidate_dir = $candidate_file === FALSE ? '' : $candidate_file . '.d';
@@ -5551,14 +5552,16 @@ function pfb_schedule_cache_candidate_validate(
 			$candidate_dir = '';
 		}
 	}
-	$ok = FALSE;
+	// Never stage into the active cache: a collision would publish over it.
+	$active_dir = is_string($io['active_dir'] ?? NULL) ? rtrim($io['active_dir'], '/') : '';
+	if ($active_dir !== '' && $candidate_dir === $active_dir) {
+		$candidate_dir = '';
+	}
+	$stage = 'workdir';
 	try {
-		$active_dir = is_string($io['active_dir'] ?? NULL) ? rtrim($io['active_dir'], '/') : '';
-		$ok = $candidate_dir !== '' && ($active_dir === '' || $candidate_dir !== $active_dir)
-			&& pfb_schedule_cache_refresh($model, $state, $now ?? time(), $timezone, $candidate_dir, $io)
-			&& pfb_due_ledger_read_cache($candidate_dir, $model['config_hash']) !== NULL;
+		$stage = pfb_schedule_cache_stage($model, $state, $timezone, $candidate_dir, $now, $io);
 	} catch (Throwable) {
-		$ok = FALSE;
+		$stage = 'refresh';
 	} finally {
 		if ($candidate_dir !== '') {
 			foreach (scandir($candidate_dir) ?: [] as $artifact) {
@@ -5569,7 +5572,22 @@ function pfb_schedule_cache_candidate_validate(
 			@rmdir($candidate_dir);
 		}
 	}
-	return $ok;
+	if ($stage !== '') {
+		logger(LOG_NOTICE, localize_text('Schedule: candidate cache generation failed - %s',
+			pfb_schedule_cache_stage_label($stage)), LOG_PREFIX_PKG_PFBLOCKERNG);
+	}
+	return $stage;
+}
+
+/** Validate a disposable schedule-cache candidate without touching the active cache. */
+function pfb_schedule_cache_candidate_validate(
+	?array $model,
+	?array $state,
+	mixed $timezone,
+	?int $now = NULL,
+	array $io = []
+): bool {
+	return pfb_schedule_cache_candidate_stage($model, $state, $timezone, $now, $io) === '';
 }
 
 /** Regenerate the disposable schedule cache without starting update work. */

--- a/src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
@@ -948,9 +948,11 @@ if ($_POST && isset($_POST['save'])) {
 		$runtime_model = pfb_schedule_runtime_config();
 		$runtime_state = pfb_schedule_state_read($pfb['schedule_state_dir'] ?? '/usr/local/etc');
 		$runtime_timezone = $pfb['schedule_timezone'] ?? date_default_timezone_get();
-		$cache_ok = pfb_schedule_cache_candidate_validate($runtime_model, $runtime_state, $runtime_timezone);
+		// issue #2888: name which check failed, as the General page does; the helper logs it.
+		$cache_stage = pfb_schedule_cache_candidate_stage($runtime_model, $runtime_state, $runtime_timezone);
+		$cache_ok = $cache_stage === '';
 		pfb_mark_pending_changes();	// applies on the next Update, not on save
-		$failure = $cache_ok ? '' : '&schcache=failed';
+		$failure = $cache_ok ? '' : '&schcache=failed&schstage=' . $cache_stage;
 		header("Location: /pfblockerng/pfblockerng_category_edit.php?type={$gtype}&rowid={$rowid}&savemsg={$savemsg}{$failure}");
 		exit;
 	}
@@ -1095,7 +1097,10 @@ if (isset($_REQUEST['savemsg']) && is_string($_REQUEST['savemsg'])) {
 }
 
 if (($_GET['schcache'] ?? '') === 'failed') {
-	print_info_box('Settings remain saved, but schedule-cache candidate generation failed. This is likely a package bug; manual updates remain available as a temporary workaround.', 'warning');
+	print_info_box(sprintf(gettext('Settings remain saved, but schedule-cache candidate generation failed: %s. '
+		. 'The system log records the detail under pfBlockerNG. Manual updates remain available.'),
+		pfb_schedule_cache_stage_label(is_string($_GET['schstage'] ?? NULL) ? $_GET['schstage'] : '')),
+		'warning');
 }
 
 $form = new Form("Save {$type} Settings");

--- a/tests/php/CategoryScheduleStageTest.php
+++ b/tests/php/CategoryScheduleStageTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The category editor names which schedule-cache check failed, as the General page does.
+ *
+ * Issue #2888: it went through pfb_schedule_cache_candidate_validate(), which returned a
+ * bare bool, so the page could only say "this is likely a package bug" and only the
+ * config stage reached the log -- via pfb_schedule_runtime_config(), not this path.
+ */
+final class CategoryScheduleStageTest extends TestCase
+{
+	private const PAGE = __DIR__ . '/../../src/usr/local/www/pfblockerng/pfblockerng_category_edit.php';
+
+	private const GENERAL = [
+		'pfb_scheduled_feed_updates' => 'on',
+		'pfb_schedule_weekday'       => '7',
+		'pfb_schedule_hour'          => '2',
+		'pfb_schedule_minute'        => '15',
+	];
+
+	private function model(): array
+	{
+		$model = pfb_schedule_runtime_model(self::GENERAL, ['ipv4' => [], 'ipv6' => [], 'dnsbl' => []]);
+		$this->assertIsArray($model);
+		return $model;
+	}
+
+	/** Each check reports its own stage, and a clean candidate reports none. */
+	public function testCandidateStageNamesTheFailingCheck(): void
+	{
+		$model = $this->model();
+		$state = ['schema' => 1, 'items' => []];
+
+		$this->assertSame('config', pfb_schedule_cache_candidate_stage(NULL, $state, 'UTC'));
+		$this->assertSame('state', pfb_schedule_cache_candidate_stage($model, NULL, 'UTC'));
+		$this->assertSame('timezone', pfb_schedule_cache_candidate_stage($model, $state, ['not-a-zone']));
+		$this->assertSame('refresh',
+			pfb_schedule_cache_candidate_stage($model, $state, 'UTC', NULL, ['fail_rename' => TRUE]),
+			'a candidate that cannot be published must name the publication stage');
+		$this->assertSame('', pfb_schedule_cache_candidate_stage($model, $state, 'UTC'),
+			'a candidate that publishes and reads back cleanly names no stage');
+	}
+
+	/** The bool the other callers use stays consistent with the stage. */
+	public function testValidateAgreesWithTheStage(): void
+	{
+		$model = $this->model();
+		$state = ['schema' => 1, 'items' => []];
+
+		$this->assertTrue(pfb_schedule_cache_candidate_validate($model, $state, 'UTC'));
+		$this->assertFalse(pfb_schedule_cache_candidate_validate(NULL, $state, 'UTC'));
+		$this->assertFalse(
+			pfb_schedule_cache_candidate_validate($model, $state, 'UTC', NULL, ['fail_rename' => TRUE]));
+	}
+
+	/** A failure leaves an actionable line behind, not just a redirect. */
+	public function testCandidateFailureRaisesANoticeNamingTheStage(): void
+	{
+		$GLOBALS['pfb_test_logger_calls'] = [];
+		$model = $this->model();
+
+		pfb_schedule_cache_candidate_stage($model, ['schema' => 1, 'items' => []], 'UTC', NULL,
+			['fail_rename' => TRUE]);
+
+		$notices = array_column(array_filter($GLOBALS['pfb_test_logger_calls'] ?? [],
+			static fn (array $c): bool => $c['priority'] === LOG_NOTICE), 'message');
+		// Compared against the label map itself, so the assertion cannot drift from the wording.
+		$label = pfb_schedule_cache_stage_label('refresh');
+		$named = array_filter($notices, static fn (string $m): bool => str_contains($m, $label));
+		$this->assertNotSame([], $named,
+			'a failed candidate must raise a LOG_NOTICE naming the stage; notices were: '
+			. var_export($notices, TRUE));
+		$GLOBALS['pfb_test_logger_calls'] = [];
+	}
+
+	/** The page carries the stage through the redirect and renders its label. */
+	public function testPageCarriesTheStageAndNamesIt(): void
+	{
+		$source = php_strip_whitespace(self::PAGE);
+		$this->assertStringContainsString('pfb_schedule_cache_candidate_stage(', $source,
+			'the save must resolve which check failed, not just whether one did');
+		$this->assertStringContainsString('schstage=', $source,
+			'the failure redirect must carry the stage');
+		$this->assertStringContainsString('pfb_schedule_cache_stage_label(', $source,
+			'the warning must render the stage through the fixed label map');
+		$this->assertStringNotContainsString('This is likely a package bug', $source,
+			'the warning must stop calling it a probable bug with no detail attached');
+	}
+}

--- a/tests/php/CategoryScheduleUiTest.php
+++ b/tests/php/CategoryScheduleUiTest.php
@@ -268,7 +268,7 @@ final class CategoryScheduleUiTest extends TestCase
 		$save = strpos($source, 'if ($_POST && isset($_POST[\'save\']))');
 		$this->assertNotFalse($save);
 		$write = strpos($source, 'write_config(', $save);
-		$candidate = strpos($source, 'pfb_schedule_cache_candidate_validate(', $save);
+		$candidate = strpos($source, 'pfb_schedule_cache_candidate_stage(', $save);
 		$pending = strpos($source, 'pfb_mark_pending_changes()', $save);
 		$this->assertNotFalse($write);
 		$this->assertNotFalse($candidate);
@@ -276,7 +276,9 @@ final class CategoryScheduleUiTest extends TestCase
 		$this->assertLessThan($candidate, $write);
 		$this->assertLessThan($pending, $candidate);
 		$controller = substr($source, $candidate, strpos($source, 'exit;', $candidate) - $candidate);
-		$this->assertStringContainsString("\$failure = \$cache_ok ? '' : '&schcache=failed';", $controller);
+		$this->assertStringContainsString(
+			"\$failure = \$cache_ok ? '' : '&schcache=failed&schstage=' . \$cache_stage;", $controller,
+			'the failure redirect must carry which stage failed (issue #2888)');
 		$this->assertStringNotContainsString('config_set_path(', $controller);
 		$this->assertStringNotContainsString('config_del_path(', $controller);
 		$this->assertStringNotContainsString('pfb_schedule_cache_refresh(', $controller);
@@ -348,8 +350,10 @@ final class CategoryScheduleUiTest extends TestCase
 		}
 		$source = strtolower(php_strip_whitespace(self::PAGE));
 		$this->assertStringContainsString('settings remain saved', $source);
-		$this->assertStringContainsString('likely a package bug', $source);
+		$this->assertStringContainsString('candidate generation failed: %s', $source,
+			'the warning must name the failing stage (issue #2888)');
 		$this->assertStringContainsString('manual updates remain available', $source);
+		$this->assertStringNotContainsString('likely a package bug', $source);
 	}
 
 	public function testCandidateSuccessUsesPrivateDirectoryAndRejectsInvalidTimezoneWithoutWarning(): void

--- a/tests/php/fixtures/function_inventory.json
+++ b/tests/php/fixtures/function_inventory.json
@@ -10321,6 +10321,47 @@
             }
         ]
     },
+    "pfb_schedule_cache_candidate_stage": {
+        "returnsRef": false,
+        "returnType": "string",
+        "params": [
+            {
+                "name": "model",
+                "byRef": false,
+                "variadic": false,
+                "type": "?array",
+                "default": null
+            },
+            {
+                "name": "state",
+                "byRef": false,
+                "variadic": false,
+                "type": "?array",
+                "default": null
+            },
+            {
+                "name": "timezone",
+                "byRef": false,
+                "variadic": false,
+                "type": "mixed",
+                "default": null
+            },
+            {
+                "name": "now",
+                "byRef": false,
+                "variadic": false,
+                "type": "?int",
+                "default": "NULL"
+            },
+            {
+                "name": "io",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": "array (\n)"
+            }
+        ]
+    },
     "pfb_schedule_cache_candidate_validate": {
         "returnsRef": false,
         "returnType": "bool",

--- a/tests/smoke/ui/test_browser_category_edit.py
+++ b/tests/smoke/ui/test_browser_category_edit.py
@@ -1267,3 +1267,26 @@ def test_add_row_without_prior_move_gives_new_row_its_own_padded_gutter(
         )
     finally:
         _del_rowid(vm, cfg_root, rowid)
+
+
+def test_schedule_cache_warning_names_the_stage(
+    browser_page: Page,
+    webui: WebUI,
+) -> None:
+    """The category editor's schedule-cache warning names which check failed (issue #2888).
+
+    Mirrors the General page's coverage: the stage renders through the fixed label map,
+    and an unrecognised token degrades without reaching the reader.
+    """
+    page = browser_page
+    _open(page, webui, _CATEGORY_PAGE + "?type=ipv4&schcache=failed&schstage=config")
+    # Scoped to THIS message: the pending-changes banner is also an alert-warning.
+    warning = page.locator(".alert-warning:has-text('candidate generation failed')")
+    expect(warning).to_contain_text("the saved schedule configuration was rejected", timeout=JS_TIMEOUT_MS)
+
+    _open(page, webui, _CATEGORY_PAGE + "?type=ipv4&schcache=failed&schstage=not-a-stage")
+    warning = page.locator(".alert-warning:has-text('candidate generation failed')")
+    expect(warning).to_contain_text("the failing stage was not recorded", timeout=JS_TIMEOUT_MS)
+    # The query token must not reach the reader; the page's form action echoes REQUEST_URI,
+    # so this is asserted against the warning's own text rather than the document.
+    assert "not-a-stage" not in warning.inner_text()


### PR DESCRIPTION
Fixes #2888

## The defect

The category editor went through `pfb_schedule_cache_candidate_validate()`, which returns a bare
`bool`. So on a schedule-cache failure it could only say:

> Settings remain saved, but schedule-cache candidate generation failed. This is likely a package
> bug; manual updates remain available as a temporary workaround.

— the same unactionable shape issue #2855 reported on the General page. And only the `config`
stage reached the log, via `pfb_schedule_runtime_config()`; a `state`, `timezone`, `workdir`,
`refresh` or `readback` failure left nothing behind at all.

## The fix

`pfb_schedule_cache_candidate_stage()` returns which check failed, and
`pfb_schedule_cache_candidate_validate()` becomes `=== ''` over it. To be precise about why the
wrapper stays: after this change it has **no production callers** — the category editor was its
only one, and it now uses the stage directly. It is kept for the existing test contract and for
include-API stability, not because other code depends on it.

The checks themselves are **not** reimplemented — the new function owns the temporary directory
and the timezone conversion, then delegates to `pfb_schedule_cache_stage()`, the helper #2887
landed for the General page. That deletes the duplicated refresh/read-back pair and means both
pages report the same vocabulary rather than two that can drift.

The page now carries the stage on its redirect and renders it through the same fixed label map,
and the helper raises a `LOG_NOTICE` naming the stage — so every stage leaves a fact behind, not
just `config`.

## Tests

`CategoryScheduleStageTest` — each check reports its own stage, the bool stays consistent with it,
a failure raises the notice, and the page carries the stage through to the label map. Red before
the fix (`git hash-object` = `d45869bfd7123dc9eeb22155574ddb0c79916aa9`).

One honest note: my first version of the notice assertion looked for the word "publication" while
the label says "published", so it failed for the wrong reason. It now compares against
`pfb_schedule_cache_stage_label()` itself, which cannot drift from the wording.

Three existing pins in `CategoryScheduleUiTest` were updated to follow the intentional change —
the save resolves a stage rather than a bool, the redirect carries `schstage`, and the warning
names the failing stage instead of calling it a probable bug. The "settings remain saved" and
"manual updates remain available" guarantees are unchanged, and the retired wording is now
asserted **absent**.

## Verification

Full PHPUnit suite at the 76-failure environmental baseline, **zero new**. PHPStan `[OK] No
errors`; PHPCS clean; function-inventory golden regenerated for the one new signature.

🤖 Generated by [Claude Code](https://claude.com/claude-code), posted via @BBcan177's account on their behalf.



## Review round 1

**One medium finding, and it was a real omission.** The General page's identical warning carries
Tier B coverage — render the failure with a known stage, assert the label, assert the raw token
never reaches the reader. This PR shipped the same warning with only hermetic source pins, so the
render path was unproven on the page that actually has it. Mirrored in
`test_browser_category_edit.py`.

**The two pages disagreed on ordering.** With more than one check broken, this path reported
`timezone` while the General page reported `config`, because the timezone was resolved here
before delegating. A bad timezone is now passed through to the shared helper, so the order is the
helper's in both cases:

```text
both broken (model NULL + bad tz):
  category page -> config
  General page  -> config
```

Also dropped a `$stage` initialiser that could never be read.

### What the review verified rather than accepted

The delegation was the risk in this change — the old code used a loose `!$model || !$state` while
the shared helper uses shape validators, so a save that previously succeeded could in principle
now report `config`. The reviewer built a **240-combination matrix** across model, state,
timezone and injection forms and found **zero** behavioural differences, and explained why it
must hold: the old path's success already required `pfb_schedule_cache_refresh()`, which gates on
the same validators. The strict checks moved earlier; the accept-set is identical.

It also traced `schstage` from `$_GET` to the label map with `<script>`, CRLF and traversal
payloads — all degrade to "the failing stage was not recorded", and the raw token cannot reach
the page — and confirmed the golden diff is exactly one additive signature.


## Review round 2 — converged

No blocking or medium findings. Every round-1 item re-verified by executed probe rather than
re-reading:

- **Both pages name the same stage.** A 20-combination probe across {valid string, `DateTimeZone`,
  NULL, invalid array, unparseable string} × {valid, NULL} model × {valid, NULL} state compared
  the General page's inline path against this one: **20/20 identical**.
- **The wrapper's behaviour is unchanged.** The pre-PR function was reimplemented verbatim from
  `0a542d69` and diffed against the current wrapper across **126 combinations**, including the
  empty-array model/state cases where the old truthy check could plausibly have diverged from the
  shape validators: **0 mismatches**.
- **The removed initialiser was genuinely dead.** A real exception was forced through the
  `before_document` injection hook under `E_ALL` with a handler watching for notices — no
  undefined-variable warning, `$stage` came back `refresh`.
- **The new Tier B case is not vacuous.** The reviewer traced the page from the top: with
  `?type=ipv4`, the `empty($gtype)` guard does not fire and no `rowid` exit exists, so the warning
  branch is reached unconditionally. It also confirmed the `:has-text('candidate generation
  failed')` scoping correctly disambiguates from the pending-changes banner, which renders through
  the same `print_info_box(..., 'warning')`.

One informational note not worth a code change: General's `(string) $timezone` cast emits a PHP
"Array to string conversion" warning on an array timezone where this path's `is_string()` guard
does not. Same stage, different noise.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Schedule-cache validation failures now identify the specific failed stage.
  * Category editor warnings provide clearer guidance and direct users to system logs.
  * Unrecognized failure-stage values now display a safe fallback message.
  * Active cache directories are protected from accidental collisions.

* **Tests**
  * Added coverage for stage-specific validation, redirects, warning messages, and browser behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->