### PR TITLE
category_edit: pair the failed-download row, and stop a neighbouring colour laundering it

### DIFF
--- a/src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
@@ -1271,7 +1271,7 @@ foreach ($rowdata[$rowid] as $tags) {
 		// Indicate any failed downloads with yellow select field background
 		$failed_bg = '';
 		if ($folder && file_exists("{$folder}/{$row['header']}{$suffix}.fail")) {
-			$failed_bg = 'background-color: #FFFF00;';
+			$failed_bg = 'background-color: #FFFF00; color: black;';
 			$failed = "<span style=\"color: black; background-color: #FFFF00; border-style: groove;\">&emsp;Failed download(s) highlighted in yellow.&emsp;</span>";
 		}
 

--- a/tests/php/ThemeSafetyUiTest.php
+++ b/tests/php/ThemeSafetyUiTest.php
@@ -110,6 +110,10 @@ final class ThemeSafetyUiTest extends TestCase
 			// An apostrophe in prose is not a string opener.
 			'apostrophe in prose'       => ["/* don't */ .a { background-color: #123456; } .b { color: red; }", FALSE],
 			'apostrophe, pair below'    => ["/* it's fine */ .a { background-color: #123456;\n color: red; }", TRUE],
+			// A style attribute that is not this background's cannot pair it either.
+			'unrelated attribute'       => ['$s = ".a { background-color: #123456; } <span style=\"color: black;\"></span>";', FALSE],
+			'unrelated attr, no braces' => ['$s = \'background-color: #123456; <span style="color:black;"></span>\';', FALSE],
+			'own attribute pairs it'    => ['$s = "<input style=\"color: black; background-color: #123456;\">";', TRUE],
 			// The two fallbacks, each pinned by a pairing further away than the window.
 			'no scope at all'           => ['background-color: #123456;' . str_repeat(' ', 200) . 'color: red;', FALSE],
 			'unclosed block pairs'      => ['.a { background-color: #123456;' . str_repeat(' ', 200) . 'color: red;', TRUE],
@@ -367,8 +371,9 @@ final class ThemeSafetyUiTest extends TestCase
 				continue;
 			}
 			if ($source[$i] === $quote) {
-				return self::styleAttribute($source, $open, $i, $offset)
-					?? substr($source, $open, $i - $open + 1);
+				$literal = substr($source, $open, $i - $open + 1);
+				return self::styleAttribute($literal, $offset - $open)
+					?? self::withoutOtherAttributes($literal);
 			}
 		}
 		// The quote never closed on this line, so it was an apostrophe in prose, not a
@@ -378,33 +383,55 @@ final class ThemeSafetyUiTest extends TestCase
 	}
 
 	/**
-	 * The innermost style="..." attribute inside a literal, when the background is in one.
+	 * Spans of every style attribute's value inside a literal.
 	 *
-	 * A PHP string is routinely a whole HTML fragment, not one attribute -- several sites
-	 * build a <span> and an <input> in the same literal. Resolving to the literal lets one
-	 * element's colour pair another's background, which is the #2866 defect one scope out.
+	 * The closing delimiter is written exactly as the opener was: in a PHP double-quoted
+	 * literal that is \", so the backslash terminates rather than escapes. Skipping it as
+	 * an escape runs the span past the element it belongs to.
+	 *
+	 * @return list<array{0: int, 1: int}>
 	 */
-	private static function styleAttribute(string $source, int $open, int $close, int $offset): ?string
+	private static function styleAttributeSpans(string $literal): array
 	{
-		$literal = substr($source, $open, $close - $open + 1);
-		$rel = $offset - $open;
 		if (preg_match_all('/style\s*=\s*(\\\\?)(["\'])/i', $literal, $matches, PREG_OFFSET_CAPTURE) < 1) {
-			return NULL;
+			return [];
 		}
+		$spans = [];
 		$count = count($matches[0]);
 		for ($i = 0; $i < $count; $i++) {
 			$start = $matches[0][$i][1] + strlen($matches[0][$i][0]);
-			// The attribute's closing delimiter is written exactly as its opener was: in a
-			// PHP double-quoted literal that is \", so the backslash terminates rather
-			// than escapes. Skipping it as an escape runs the context past the element.
-			$terminator = $matches[1][$i][0] . $matches[2][$i][0];
-			$end = strpos($literal, $terminator, $start);
-			$end = $end === FALSE ? strlen($literal) : $end;
+			$end = strpos($literal, $matches[1][$i][0] . $matches[2][$i][0], $start);
+			$spans[] = [$start, $end === FALSE ? strlen($literal) : $end];
+		}
+		return $spans;
+	}
+
+	/** The style attribute containing $rel, when the background sits inside one. */
+	private static function styleAttribute(string $literal, int $rel): ?string
+	{
+		foreach (self::styleAttributeSpans($literal) as [$start, $end]) {
 			if ($rel >= $start && $rel < $end) {
 				return substr($literal, $start, $end - $start);
 			}
 		}
 		return NULL;
+	}
+
+	/**
+	 * The literal with every style attribute's value blanked.
+	 *
+	 * A PHP string is routinely a whole HTML fragment. When the background is not itself
+	 * inside an attribute, the other elements' attributes are still theirs -- handing back
+	 * the whole literal lets a neighbouring span's colour pair it, which is the defect this
+	 * guard exists to catch, one scope further out again.
+	 */
+	private static function withoutOtherAttributes(string $literal): string
+	{
+		$out = $literal;
+		foreach (array_reverse(self::styleAttributeSpans($literal)) as [$start, $end]) {
+			$out = substr($out, 0, $start) . substr($out, $end);
+		}
+		return $out;
 	}
 
 	/**

--- a/tests/php/ThemeSafetyUiTest.php
+++ b/tests/php/ThemeSafetyUiTest.php
@@ -124,6 +124,12 @@ final class ThemeSafetyUiTest extends TestCase
 			// A brace group before an attribute: the cuts interleave, so they must be
 			// ordered before they are applied back to front.
 			'group then attribute'      => ['$s = "foo({color:\'red\'}) background-color: #123456; <b style=\"color:blue\"></b>";', FALSE],
+			// A literal nests exactly as a rule does, so it is scoped the same way.
+			'nested inside a literal'   => ['$s = "foo({outer: {background-color: \'#123456\'}, color: \'red\'})";', FALSE],
+			'nested three deep'         => ['$s = "foo({a: {b: {background-color: \'#123456\'}}, color: \'red\'})";', FALSE],
+			'same level in that group'  => ['$s = "foo({background-color: \'#123456\', color: \'red\'})";', TRUE],
+			'subgroup of that group'    => ['$s = "foo({background-color: \'#123456\', sub: {color: \'red\'}})";', FALSE],
+			'stylesheet is an attribute'=> ['$s = "<div stylesheet=\"color: red;\"></div> background-color: #123456;";', FALSE],
 			// The two fallbacks, each pinned by a pairing further away than the window.
 			'no scope at all'           => ['background-color: #123456;' . str_repeat(' ', 200) . 'color: red;', FALSE],
 			'unclosed block pairs'      => ['.a { background-color: #123456;' . str_repeat(' ', 200) . 'color: red;', TRUE],
@@ -405,7 +411,7 @@ final class ThemeSafetyUiTest extends TestCase
 	 */
 	private static function styleAttributeSpans(string $literal): array
 	{
-		if (preg_match_all('/[-\w]*style\s*=\s*(\\\\?)(["\'])/i', $literal, $matches, PREG_OFFSET_CAPTURE) < 1) {
+		if (preg_match_all('/[-\w]*style[-\w]*\s*=\s*(\\\\?)(["\'])/i', $literal, $matches, PREG_OFFSET_CAPTURE) < 1) {
 			return [];
 		}
 		$spans = [];
@@ -434,13 +440,54 @@ final class ThemeSafetyUiTest extends TestCase
 				return substr($literal, $start, $end - $start);
 			}
 		}
-		$out = $literal;
-		$cuts = array_merge($spans, self::foreignBraceGroups($literal, $rel));
+
+		// Scope to the group the background is actually in, then drop that group's own
+		// nested groups. A literal carries the same nesting a rule does, so it gets the
+		// same treatment: a colour one level out is not the background's.
+		$group = self::enclosingBlock($literal, $rel);
+		if ($group !== NULL) {
+			$out = substr($literal, $group[0], $group[1] - $group[0] + 1);
+			$rel -= $group[0];
+			$cuts = array_merge(self::styleAttributeSpans($out), self::nestedGroupSpans($out));
+		} else {
+			$out = $literal;
+			$cuts = array_merge($spans, self::foreignBraceGroups($literal, $rel));
+		}
+
 		usort($cuts, static fn (array $a, array $b): int => $a[0] <=> $b[0]);
 		foreach (array_reverse($cuts) as [$start, $end]) {
 			$out = substr($out, 0, $start) . substr($out, $end);
 		}
 		return $out;
+	}
+
+	/**
+	 * Spans of a block's immediate subgroups, so its own declarations are what remain.
+	 *
+	 * @return list<array{0: int, 1: int}>
+	 */
+	private static function nestedGroupSpans(string $block): array
+	{
+		$groups = [];
+		$depth = 0;
+		$start = 0;
+		$length = strlen($block);
+		for ($i = 0; $i < $length; $i++) {
+			if ($block[$i] === '{') {
+				$depth++;
+				if ($depth === 2) {
+					$start = $i;
+				}
+				continue;
+			}
+			if ($block[$i] === '}' && $depth > 0) {
+				$depth--;
+				if ($depth === 1) {
+					$groups[] = [$start, $i + 1];
+				}
+			}
+		}
+		return $groups;
 	}
 
 	/**

--- a/tests/php/ThemeSafetyUiTest.php
+++ b/tests/php/ThemeSafetyUiTest.php
@@ -446,9 +446,8 @@ final class ThemeSafetyUiTest extends TestCase
 		// same treatment: a colour one level out is not the background's.
 		$group = self::enclosingBlock($literal, $rel);
 		if ($group !== NULL) {
-			$out = substr($literal, $group[0], $group[1] - $group[0] + 1);
-			$rel -= $group[0];
-			$cuts = array_merge(self::styleAttributeSpans($out), self::nestedGroupSpans($out));
+			$out = self::withoutNestedBlocks(substr($literal, $group[0], $group[1] - $group[0] + 1));
+			$cuts = self::styleAttributeSpans($out);
 		} else {
 			$out = $literal;
 			$cuts = array_merge($spans, self::foreignBraceGroups($literal, $rel));
@@ -459,35 +458,6 @@ final class ThemeSafetyUiTest extends TestCase
 			$out = substr($out, 0, $start) . substr($out, $end);
 		}
 		return $out;
-	}
-
-	/**
-	 * Spans of a block's immediate subgroups, so its own declarations are what remain.
-	 *
-	 * @return list<array{0: int, 1: int}>
-	 */
-	private static function nestedGroupSpans(string $block): array
-	{
-		$groups = [];
-		$depth = 0;
-		$start = 0;
-		$length = strlen($block);
-		for ($i = 0; $i < $length; $i++) {
-			if ($block[$i] === '{') {
-				$depth++;
-				if ($depth === 2) {
-					$start = $i;
-				}
-				continue;
-			}
-			if ($block[$i] === '}' && $depth > 0) {
-				$depth--;
-				if ($depth === 1) {
-					$groups[] = [$start, $i + 1];
-				}
-			}
-		}
-		return $groups;
 	}
 
 	/**

--- a/tests/php/ThemeSafetyUiTest.php
+++ b/tests/php/ThemeSafetyUiTest.php
@@ -130,6 +130,9 @@ final class ThemeSafetyUiTest extends TestCase
 			'same level in that group'  => ['$s = "foo({background-color: \'#123456\', color: \'red\'})";', TRUE],
 			'subgroup of that group'    => ['$s = "foo({background-color: \'#123456\', sub: {color: \'red\'}})";', FALSE],
 			'stylesheet is an attribute'=> ['$s = "<div stylesheet=\"color: red;\"></div> background-color: #123456;";', FALSE],
+			// A quoted brace desynchronises the depth count; the surviving cuts must still
+			// leave the background's own scope standing.
+			'quoted brace desync'       => ['$s = "foo({background-color: \'#123456\', n1: \'{\', n2: \'{\', sub: {color: \'red\'}})";', FALSE],
 			// The two fallbacks, each pinned by a pairing further away than the window.
 			'no scope at all'           => ['background-color: #123456;' . str_repeat(' ', 200) . 'color: red;', FALSE],
 			'unclosed block pairs'      => ['.a { background-color: #123456;' . str_repeat(' ', 200) . 'color: red;', TRUE],

--- a/tests/php/ThemeSafetyUiTest.php
+++ b/tests/php/ThemeSafetyUiTest.php
@@ -133,6 +133,9 @@ final class ThemeSafetyUiTest extends TestCase
 			// A quoted brace desynchronises the depth count; the surviving cuts must still
 			// leave the background's own scope standing.
 			'quoted brace desync'       => ['$s = "foo({background-color: \'#123456\', n1: \'{\', n2: \'{\', sub: {color: \'red\'}})";', FALSE],
+			// An attribute inside a foreign group puts one cut inside another; removing the
+			// inner one first must not invalidate the outer one's end.
+			'attribute inside a group'  => ['$s = "foo({a: \'<div style=\"color: red; xxxxxxxxxxxxxxxxxxxxxxxx\">\'}) background-color: #123456; color: blue;";', TRUE],
 			// The two fallbacks, each pinned by a pairing further away than the window.
 			'no scope at all'           => ['background-color: #123456;' . str_repeat(' ', 200) . 'color: red;', FALSE],
 			'unclosed block pairs'      => ['.a { background-color: #123456;' . str_repeat(' ', 200) . 'color: red;', TRUE],
@@ -456,11 +459,36 @@ final class ThemeSafetyUiTest extends TestCase
 			$cuts = array_merge($spans, self::foreignBraceGroups($literal, $rel));
 		}
 
-		usort($cuts, static fn (array $a, array $b): int => $a[0] <=> $b[0]);
-		foreach (array_reverse($cuts) as [$start, $end]) {
+		foreach (array_reverse(self::mergedCuts($cuts)) as [$start, $end]) {
 			$out = substr($out, 0, $start) . substr($out, $end);
 		}
 		return $out;
+	}
+
+	/**
+	 * Cuts ordered and merged, so no cut sits inside another.
+	 *
+	 * An attribute can live inside a brace group, which puts one span inside the other.
+	 * Removing the inner one first leaves the outer one's end offset pointing past where
+	 * its text now ends, and the removal eats whatever followed -- including the pairing
+	 * the background actually had.
+	 *
+	 * @param list<array{0: int, 1: int}> $cuts
+	 * @return list<array{0: int, 1: int}>
+	 */
+	private static function mergedCuts(array $cuts): array
+	{
+		usort($cuts, static fn (array $a, array $b): int => [$a[0], $b[1]] <=> [$b[0], $a[1]]);
+		$merged = [];
+		foreach ($cuts as [$start, $end]) {
+			$last = count($merged) - 1;
+			if ($last >= 0 && $start <= $merged[$last][1]) {
+				$merged[$last][1] = max($merged[$last][1], $end);
+				continue;
+			}
+			$merged[] = [$start, $end];
+		}
+		return $merged;
 	}
 
 	/**

--- a/tests/php/ThemeSafetyUiTest.php
+++ b/tests/php/ThemeSafetyUiTest.php
@@ -114,6 +114,16 @@ final class ThemeSafetyUiTest extends TestCase
 			'unrelated attribute'       => ['$s = ".a { background-color: #123456; } <span style=\"color: black;\"></span>";', FALSE],
 			'unrelated attr, no braces' => ['$s = \'background-color: #123456; <span style="color:black;"></span>\';', FALSE],
 			'own attribute pairs it'    => ['$s = "<input style=\"color: black; background-color: #123456;\">";', TRUE],
+			// Only a real style attribute opens a span: data-style and chart_style do not.
+			'decoy carries a colour'    => ['$s = "<div data-style=\"color: red\"></div> background-color: #123456;";', FALSE],
+			'decoy attribute name'      => ['$s = "<div data-style=\"dark\">x</div> background-color: #123456; foo({color: \'red\'})";', FALSE],
+			'real attribute still pairs'=> ['$s = "<div data-style=\"dark\" style=\"color: red; background-color: #123456;\">";', TRUE],
+			// A background flanked by two attributes: both values go, and the later span's
+			// offsets must still be valid when the earlier one is removed.
+			'flanked by two attributes' => ['$s = "<a style=\"color:red\"></a> background-color: #123456; <b style=\"color:blue\"></b>";', FALSE],
+			// A brace group before an attribute: the cuts interleave, so they must be
+			// ordered before they are applied back to front.
+			'group then attribute'      => ['$s = "foo({color:\'red\'}) background-color: #123456; <b style=\"color:blue\"></b>";', FALSE],
 			// The two fallbacks, each pinned by a pairing further away than the window.
 			'no scope at all'           => ['background-color: #123456;' . str_repeat(' ', 200) . 'color: red;', FALSE],
 			'unclosed block pairs'      => ['.a { background-color: #123456;' . str_repeat(' ', 200) . 'color: red;', TRUE],
@@ -372,8 +382,7 @@ final class ThemeSafetyUiTest extends TestCase
 			}
 			if ($source[$i] === $quote) {
 				$literal = substr($source, $open, $i - $open + 1);
-				return self::styleAttribute($literal, $offset - $open)
-					?? self::withoutOtherAttributes($literal);
+				return self::styleContext($literal, $offset - $open);
 			}
 		}
 		// The quote never closed on this line, so it was an apostrophe in prose, not a
@@ -389,11 +398,14 @@ final class ThemeSafetyUiTest extends TestCase
 	 * literal that is \", so the backslash terminates rather than escapes. Skipping it as
 	 * an escape runs the span past the element it belongs to.
 	 *
+	 * data-style and chart_style count too: whatever the attribute is named, its value
+	 * belongs to its own element and cannot pair a background somewhere else.
+	 *
 	 * @return list<array{0: int, 1: int}>
 	 */
 	private static function styleAttributeSpans(string $literal): array
 	{
-		if (preg_match_all('/style\s*=\s*(\\\\?)(["\'])/i', $literal, $matches, PREG_OFFSET_CAPTURE) < 1) {
+		if (preg_match_all('/[-\w]*style\s*=\s*(\\\\?)(["\'])/i', $literal, $matches, PREG_OFFSET_CAPTURE) < 1) {
 			return [];
 		}
 		$spans = [];
@@ -406,32 +418,63 @@ final class ThemeSafetyUiTest extends TestCase
 		return $spans;
 	}
 
-	/** The style attribute containing $rel, when the background sits inside one. */
-	private static function styleAttribute(string $literal, int $rel): ?string
+	/**
+	 * The declarations that share an element with a background inside a literal.
+	 *
+	 * A PHP string is routinely a whole HTML fragment. If the background sits in a style
+	 * attribute, only that attribute can pair it; otherwise the other elements' attributes
+	 * are still theirs, so their values are removed rather than read as neighbours. Spans
+	 * are excised back to front, or an earlier removal shifts the offsets of a later one.
+	 */
+	private static function styleContext(string $literal, int $rel): string
 	{
-		foreach (self::styleAttributeSpans($literal) as [$start, $end]) {
+		$spans = self::styleAttributeSpans($literal);
+		foreach ($spans as [$start, $end]) {
 			if ($rel >= $start && $rel < $end) {
 				return substr($literal, $start, $end - $start);
 			}
 		}
-		return NULL;
-	}
-
-	/**
-	 * The literal with every style attribute's value blanked.
-	 *
-	 * A PHP string is routinely a whole HTML fragment. When the background is not itself
-	 * inside an attribute, the other elements' attributes are still theirs -- handing back
-	 * the whole literal lets a neighbouring span's colour pair it, which is the defect this
-	 * guard exists to catch, one scope further out again.
-	 */
-	private static function withoutOtherAttributes(string $literal): string
-	{
 		$out = $literal;
-		foreach (array_reverse(self::styleAttributeSpans($literal)) as [$start, $end]) {
+		$cuts = array_merge($spans, self::foreignBraceGroups($literal, $rel));
+		usort($cuts, static fn (array $a, array $b): int => $a[0] <=> $b[0]);
+		foreach (array_reverse($cuts) as [$start, $end]) {
 			$out = substr($out, 0, $start) . substr($out, $end);
 		}
 		return $out;
+	}
+
+	/**
+	 * Spans of the brace groups inside a literal that do not contain $rel.
+	 *
+	 * The same rule blocks already follow: a colour one scope in never pairs a background
+	 * one scope out. A literal can carry both -- an object argument beside a declaration --
+	 * so the groups the background is not in are dropped with the other elements'
+	 * attributes.
+	 *
+	 * @return list<array{0: int, 1: int}>
+	 */
+	private static function foreignBraceGroups(string $text, int $rel): array
+	{
+		$groups = [];
+		$depth = 0;
+		$start = 0;
+		$length = strlen($text);
+		for ($i = 0; $i < $length; $i++) {
+			if ($text[$i] === '{') {
+				if ($depth === 0) {
+					$start = $i;
+				}
+				$depth++;
+				continue;
+			}
+			if ($text[$i] === '}' && $depth > 0) {
+				$depth--;
+				if ($depth === 0 && ($rel < $start || $rel > $i)) {
+					$groups[] = [$start, $i + 1];
+				}
+			}
+		}
+		return $groups;
 	}
 
 	/**

--- a/tests/php/ThemeSafetyUiTest.php
+++ b/tests/php/ThemeSafetyUiTest.php
@@ -81,6 +81,37 @@ final class ThemeSafetyUiTest extends TestCase
 	}
 
 	/**
+	 * Backgrounds a neighbouring colour used to launder, and the pairings that are real.
+	 *
+	 * The window that decides "is this background paired" is the whole guard. Both defects
+	 * it had were a colour belonging to a different element landing inside that window:
+	 * a nested object's (issue #2892) and an adjacent statement's (issue #2866). Each row
+	 * states the shape and whether it is genuinely paired.
+	 *
+	 * @return array<string, array{0: string, 1: bool}>
+	 */
+	public static function pairingWindows(): array
+	{
+		return [
+			'nested object colour'     => ['$(x).css({"background-color": "#123456", extra: {color: "nope"}});', FALSE],
+			'nested rule colour'       => ['.a { background-color: #123456; nested: { color: red; } }', FALSE],
+			'sibling statement colour' => ["\$bg = 'background-color: #FFFF00;';\n\$s = 'color: black;';", FALSE],
+			'inline style, unpaired'   => ['$bg = \'background-color: #FFFF00;\';', FALSE],
+			'inline style, paired'     => ['$bg = \'background-color: #FFFF00; color: black;\';', TRUE],
+			'same object colour'       => ['$(x).css({"background-color": "#123456", color: "red"});', TRUE],
+			'same rule colour'         => ['.a { background-color: #123456; color: red; }', TRUE],
+			'outer rule pairs nested'  => ['.a { color: red; background-color: #123456; nested: { top: 0; } }', TRUE],
+		];
+	}
+
+	#[DataProvider('pairingWindows')]
+	public function testOnlyAColourOnTheSameElementPairsABackground(string $source, bool $paired): void
+	{
+		$this->assertSame($paired, self::scan($source) === [],
+			($paired ? 'wrongly reported unpaired: ' : 'a neighbouring colour laundered: ') . $source);
+	}
+
+	/**
 	 * Every syntax scan() detects, in its unpaired and paired form.
 	 *
 	 * @return array<string, array{0: string, 1: string}>
@@ -264,29 +295,130 @@ final class ThemeSafetyUiTest extends TestCase
 		return $found;
 	}
 
+	/**
+	 * The declarations that actually share an element with the background at $offset.
+	 *
+	 * Three shapes, most specific first. A background written inside a string literal is an
+	 * inline style attribute, so only that string can pair it -- the enclosing PHP or JS
+	 * block is code, not a rule, and its neighbours belong to other elements (issue #2866).
+	 * A background in a real block is paired only by that block's own declarations, so
+	 * nested blocks are removed rather than read as siblings (issue #2892).
+	 */
 	private static function declarationContext(string $source, int $offset): string
 	{
-		$before = substr($source, 0, $offset);
-		$brace = strrpos($before, '{');
-		if ($brace !== FALSE) {
-			$end = strpos($source, '}', $brace);
-			if ($end !== FALSE && $end >= $offset) {
-				return substr($source, $brace, $end - $brace + 1);
+		$inline = self::enclosingString($source, $offset);
+		if ($inline !== NULL) {
+			return $inline;
+		}
+		$block = self::enclosingBlock($source, $offset);
+		if ($block !== NULL) {
+			return self::withoutNestedBlocks(substr($source, $block[0], $block[1] - $block[0] + 1));
+		}
+		return substr($source, max(0, $offset - 80), 160);
+	}
+
+	/** The string literal containing $offset, or NULL when it is not inside one. */
+	private static function enclosingString(string $source, int $offset): ?string
+	{
+		$lineStart = strrpos(substr($source, 0, $offset), "\n");
+		$lineStart = $lineStart === FALSE ? 0 : $lineStart + 1;
+
+		$quote = NULL;
+		$open = 0;
+		for ($i = $lineStart; $i < $offset; $i++) {
+			if ($source[$i] === '\\') {
+				$i++;
+				continue;
+			}
+			if ($source[$i] !== "'" && $source[$i] !== '"') {
+				continue;
+			}
+			if ($quote === NULL) {
+				$quote = $source[$i];
+				$open = $i;
+			} elseif ($quote === $source[$i]) {
+				$quote = NULL;
 			}
 		}
-		$sq = strrpos($before, "'");
-		$dq = strrpos($before, '"');
-		if ($sq !== FALSE && ($dq === FALSE || $sq > $dq)) {
-			$start = $sq;
-			$quote = "'";
-		} elseif ($dq !== FALSE) {
-			$start = $dq;
-			$quote = '"';
-		} else {
-			return substr($source, max(0, $offset - 80), 160);
+		if ($quote === NULL) {
+			return NULL;
 		}
-		$end = strpos($source, $quote, $start + 1);
-		return $end === FALSE ? substr($source, $start) : substr($source, $start, $end - $start + 1);
+
+		$lineEnd = strpos($source, "\n", $offset);
+		$lineEnd = $lineEnd === FALSE ? strlen($source) : $lineEnd;
+		for ($i = $offset; $i < $lineEnd; $i++) {
+			if ($source[$i] === '\\') {
+				$i++;
+				continue;
+			}
+			if ($source[$i] === $quote) {
+				return substr($source, $open, $i - $open + 1);
+			}
+		}
+		return substr($source, $open, $lineEnd - $open);
+	}
+
+	/**
+	 * Offsets of the innermost brace block containing $offset, or NULL at top level.
+	 *
+	 * @return array{0: int, 1: int}|null
+	 */
+	private static function enclosingBlock(string $source, int $offset): ?array
+	{
+		$stack = [];
+		for ($i = 0; $i < $offset; $i++) {
+			if ($source[$i] === '{') {
+				$stack[] = $i;
+			} elseif ($source[$i] === '}') {
+				array_pop($stack);
+			}
+		}
+		if ($stack === []) {
+			return NULL;
+		}
+
+		$start = (int)end($stack);
+		$depth = 0;
+		$length = strlen($source);
+		for ($i = $start; $i < $length; $i++) {
+			if ($source[$i] === '{') {
+				$depth++;
+			} elseif ($source[$i] === '}') {
+				$depth--;
+				if ($depth === 0) {
+					return [$start, $i];
+				}
+			}
+		}
+		return [$start, $length - 1];
+	}
+
+	/** The block's own declarations, with every nested block's contents dropped. */
+	private static function withoutNestedBlocks(string $block): string
+	{
+		$out = '';
+		$depth = 0;
+		$length = strlen($block);
+		for ($i = 0; $i < $length; $i++) {
+			if ($block[$i] === '{') {
+				$depth++;
+				if ($depth === 1) {
+					$out .= $block[$i];
+				}
+				continue;
+			}
+			if ($block[$i] === '}') {
+				$depth--;
+				if ($depth === 0) {
+					$out .= $block[$i];
+				}
+				continue;
+			}
+			if ($depth <= 1) {
+				$out .= $block[$i];
+			}
+		}
+		return $out;
 	}
 
 	private static function contextHasForeground(string $ctx): bool

--- a/tests/php/ThemeSafetyUiTest.php
+++ b/tests/php/ThemeSafetyUiTest.php
@@ -93,14 +93,29 @@ final class ThemeSafetyUiTest extends TestCase
 	public static function pairingWindows(): array
 	{
 		return [
-			'nested object colour'     => ['$(x).css({"background-color": "#123456", extra: {color: "nope"}});', FALSE],
-			'nested rule colour'       => ['.a { background-color: #123456; nested: { color: red; } }', FALSE],
-			'sibling statement colour' => ["\$bg = 'background-color: #FFFF00;';\n\$s = 'color: black;';", FALSE],
-			'inline style, unpaired'   => ['$bg = \'background-color: #FFFF00;\';', FALSE],
-			'inline style, paired'     => ['$bg = \'background-color: #FFFF00; color: black;\';', TRUE],
-			'same object colour'       => ['$(x).css({"background-color": "#123456", color: "red"});', TRUE],
-			'same rule colour'         => ['.a { background-color: #123456; color: red; }', TRUE],
-			'outer rule pairs nested'  => ['.a { color: red; background-color: #123456; nested: { top: 0; } }', TRUE],
+			// Nested scopes: a colour one level in never pairs a background one level out.
+			'nested object colour'      => ['$(x).css({"background-color": "#123456", extra: {color: "nope"}});', FALSE],
+			'nested rule colour'        => ['.a { background-color: #123456; nested: { color: red; } }', FALSE],
+			'nested block before it'    => ['.a { nested: { color: red; } background-color: #123456; }', FALSE],
+			'pairing after that block'  => ['.a { background-color: #123456; nested: { top: 0; } color: red; }', TRUE],
+			'outer rule pairs nested'   => ['.a { color: red; background-color: #123456; nested: { top: 0; } }', TRUE],
+			// Issue #2866: a code block is not a rule, so a sibling statement cannot pair.
+			'sibling statement colour'  => ["if (\$x) {\n\t\$bg = 'background-color: #FFFF00;';\n\t\$f = \"<span style=\\\"color: black; background-color: #FFFF00;\\\">x</span>\";\n}", FALSE],
+			'inline style, unpaired'    => ['$bg = \'background-color: #FFFF00;\';', FALSE],
+			'inline style, paired'      => ['$bg = \'background-color: #FFFF00; color: black;\';', TRUE],
+			// A literal is often a whole fragment: one element must not pair another's.
+			'sibling element colour'    => ['$s = "<span style=\"color: black;\"></span><input style=\"background-color: #123456;\">";', FALSE],
+			'same element colour'       => ['$s = "<span style=\"color: black; background-color: #FFFF00;\">x</span>";', TRUE],
+			'single-quoted attribute'   => ['$s = \'<input style="background-color: #123456;">\';', FALSE],
+			// An apostrophe in prose is not a string opener.
+			'apostrophe in prose'       => ["/* don't */ .a { background-color: #123456; } .b { color: red; }", FALSE],
+			'apostrophe, pair below'    => ["/* it's fine */ .a { background-color: #123456;\n color: red; }", TRUE],
+			// The two fallbacks, each pinned by a pairing further away than the window.
+			'no scope at all'           => ['background-color: #123456;' . str_repeat(' ', 200) . 'color: red;', FALSE],
+			'unclosed block pairs'      => ['.a { background-color: #123456;' . str_repeat(' ', 200) . 'color: red;', TRUE],
+			// Same-scope pairings that must keep working.
+			'same object colour'        => ['$(x).css({"background-color": "#123456", color: "red"});', TRUE],
+			'same rule colour'          => ['.a { background-color: #123456; color: red; }', TRUE],
 		];
 	}
 
@@ -352,10 +367,44 @@ final class ThemeSafetyUiTest extends TestCase
 				continue;
 			}
 			if ($source[$i] === $quote) {
-				return substr($source, $open, $i - $open + 1);
+				return self::styleAttribute($source, $open, $i, $offset)
+					?? substr($source, $open, $i - $open + 1);
 			}
 		}
-		return substr($source, $open, $lineEnd - $open);
+		// The quote never closed on this line, so it was an apostrophe in prose, not a
+		// string opener. Truncating a context at end-of-line hides a pairing on the next
+		// one; let the block resolver answer instead.
+		return NULL;
+	}
+
+	/**
+	 * The innermost style="..." attribute inside a literal, when the background is in one.
+	 *
+	 * A PHP string is routinely a whole HTML fragment, not one attribute -- several sites
+	 * build a <span> and an <input> in the same literal. Resolving to the literal lets one
+	 * element's colour pair another's background, which is the #2866 defect one scope out.
+	 */
+	private static function styleAttribute(string $source, int $open, int $close, int $offset): ?string
+	{
+		$literal = substr($source, $open, $close - $open + 1);
+		$rel = $offset - $open;
+		if (preg_match_all('/style\s*=\s*(\\\\?)(["\'])/i', $literal, $matches, PREG_OFFSET_CAPTURE) < 1) {
+			return NULL;
+		}
+		$count = count($matches[0]);
+		for ($i = 0; $i < $count; $i++) {
+			$start = $matches[0][$i][1] + strlen($matches[0][$i][0]);
+			// The attribute's closing delimiter is written exactly as its opener was: in a
+			// PHP double-quoted literal that is \", so the backslash terminates rather
+			// than escapes. Skipping it as an escape runs the context past the element.
+			$terminator = $matches[1][$i][0] . $matches[2][$i][0];
+			$end = strpos($literal, $terminator, $start);
+			$end = $end === FALSE ? strlen($literal) : $end;
+			if ($rel >= $start && $rel < $end) {
+				return substr($literal, $start, $end - $start);
+			}
+		}
+		return NULL;
 	}
 
 	/**

--- a/tests/smoke/ui/test_theme_legibility_render.py
+++ b/tests/smoke/ui/test_theme_legibility_render.py
@@ -6,6 +6,7 @@ is the tier that sees a loaded page.
 
 from __future__ import annotations
 
+import re
 from typing import TYPE_CHECKING
 
 import pytest
@@ -46,6 +47,35 @@ def test_list_textareas_do_not_force_unpaired_fafafa(webui: WebUI) -> None:
         assert resp.status_code == 200, path
         assert marker in resp.text, path
         assert "background:#fafafa" not in resp.text, path
+
+
+_INLINE_STYLE = re.compile(r'style\s*=\s*"([^"]*)"')
+_OPAQUE_BACKGROUND = re.compile(r"background(?:-color)?\s*:\s*(#[0-9a-fA-F]{3,8}|[a-zA-Z]+)")
+_FOREGROUND = re.compile(r"(?<![-\w])color\s*:")
+
+
+def test_no_inline_style_paints_an_unpaired_background(webui: WebUI) -> None:
+    """An opaque inline background must carry its own foreground.
+
+    ThemeSafetyUiTest holds this over the source; this holds it over what the page
+    actually emits, which is where issue #2866 lived -- a style attribute built from a
+    variable, correct in every branch the source scan could see.
+
+    The failed-download row itself needs a .fail sidecar to render, so it is not
+    reachable from a clean box; the source-side inventory covers that one.
+    """
+    for path, marker in _LIST_PAGES.items():
+        resp = webui.get(path)
+        assert resp.status_code == 200, path
+        assert marker in resp.text, path
+        for style in _INLINE_STYLE.findall(resp.text):
+            if not _OPAQUE_BACKGROUND.search(style):
+                continue
+            if "rgba(" in style or "transparent" in style:
+                continue
+            assert _FOREGROUND.search(style), (
+                f"{path}: inline style paints an opaque background with no foreground: {style}"
+            )
 
 
 def test_alerts_page_ships_both_unified_palette_groups(webui: WebUI) -> None:

--- a/tests/smoke/ui/test_theme_legibility_render.py
+++ b/tests/smoke/ui/test_theme_legibility_render.py
@@ -49,7 +49,9 @@ def test_list_textareas_do_not_force_unpaired_fafafa(webui: WebUI) -> None:
         assert "background:#fafafa" not in resp.text, path
 
 
-_INLINE_STYLE = re.compile(r'style\s*=\s*"([^"]*)"')
+# A boundary before "style", or data-style="…" is read as a style attribute and its
+# value judged as one. Both quote delimiters, or a single-quoted style slips the check.
+_INLINE_STYLE = re.compile(r"""(?<![-\w])style\s*=\s*(?P<q>["'])(?P<value>[^"']*)(?P=q)""", re.IGNORECASE)
 _OPAQUE_BACKGROUND = re.compile(r"background(?:-color)?\s*:\s*(#[0-9a-fA-F]{3,8}|[a-zA-Z]+)")
 _FOREGROUND = re.compile(r"(?<![-\w])color\s*:")
 
@@ -69,7 +71,8 @@ def test_no_inline_style_paints_an_unpaired_background(webui: WebUI) -> None:
         resp = webui.get(path)
         assert resp.status_code == 200, path
         assert marker in resp.text, path
-        for style in _INLINE_STYLE.findall(resp.text):
+        for match in _INLINE_STYLE.finditer(resp.text):
+            style = match.group("value")
             if not _OPAQUE_BACKGROUND.search(style):
                 continue
             if "rgba(" in style or "transparent" in style:

--- a/tests/smoke/ui/test_theme_legibility_render.py
+++ b/tests/smoke/ui/test_theme_legibility_render.py
@@ -61,8 +61,9 @@ def test_no_inline_style_paints_an_unpaired_background(webui: WebUI) -> None:
     actually emits, which is where issue #2866 lived -- a style attribute built from a
     variable, correct in every branch the source scan could see.
 
-    The failed-download row itself needs a .fail sidecar to render, so it is not
-    reachable from a clean box; the source-side inventory covers that one.
+    The failed-download row itself needs a .fail sidecar to render, so it is not reachable
+    from a clean box and this assertion cannot go red for it -- issue #2931 tracks seeding
+    it at the functional tier. The source-side inventory covers that one line meanwhile.
     """
     for path, marker in _LIST_PAGES.items():
         resp = webui.get(path)


### PR DESCRIPTION
Closes #2866. Closes #2892.

Two issues, one bug. Both are the same false negative in `ThemeSafetyUiTest`: a `color`
belonging to a **different element** landing inside the window that decides whether a background
is paired. #2866 is the adjacent-statement variant, #2892 the nested-object one. They are fixed
together because a fix for either alone leaves the other reachable through the same helper.

## The shipped defect (#2866)

`pfblockerng_category_edit.php` set the failed-download row's fill with no foreground:

```php
$failed_bg = 'background-color: #FFFF00;';
```

The text inherited the page colour, which on the dark themes is near-white — **1.07:1** against
`#ffffff`, where WCAG AA wants 4.5:1. The neighbouring span at the next line already did this
correctly, pinning `color: black` beside its own `#FFFF00`. Only the variable path was unpaired.

Fixed by pairing it, matching what the span beside it already did.

## Why the guard passed it

`declarationContext()` found the nearest `{` before the background and the **first** `}` after it.
In a PHP file that brace is an `if` block, not a rule — so the span's `color: black` on the next
line fell inside the window and laundered the background one line above it. The same
non-depth-aware walk let a nested object's colour pair an outer background (#2892):

```js
$(x).css({'background-color': '#123456', extra: {color: 'nope'}});   // passed; genuinely unpaired
```

The context now resolves three ways, most specific first:

1. **Inside a string literal** → that string is the whole context. A background written in a
   string is an inline `style` attribute, so only that attribute can pair it. The surrounding PHP
   or JS is code, and its neighbours belong to other elements.
2. **Inside a real block** → the block's own declarations, with nested blocks removed rather than
   read as siblings.
3. Otherwise the previous ±80-character window.

## Verification

Applying the scanner fix alone turned the tree red on exactly one file — the #2866 defect, found
by the guard rather than asserted separately:

```text
src/usr/local/www/pfblockerng/pfblockerng_category_edit.php: new opaque-without-foreground
site -- do not allowlist it, fix it or get an owner ruling: background-color: #FFFF00
```

Pairing the shipped code turned it green. No other file in the tree changed verdict, so the
stricter window found the one real defect and invented none.

Three mutations, each failing the assertion that should catch it:

| Mutation | Fails |
|---|---|
| drop the string-literal rule | `sibling statement colour` / `inline style, unpaired` |
| drop nested-block stripping | `nested object colour` / `nested rule colour` |
| revert the shipped pairing | the tree inventory, naming `category_edit.php` |

A `pairingWindows` provider now states each shape and whether it is genuinely paired, including
the pairings that must keep working — a colour in the same object, the same rule, and an outer
rule pairing a background that sits above a nested block.

`ThemeSafety` suite: 24 tests / 47 assertions green at this commit.

**Correction (round 1).** This section originally claimed the full suite went 62 errors/16
failures → 61/15. That is wrong and I have re-measured it: base and PR are both **62/16**. The
apparent improvement was two git-dependent tests (`LogNowTokenRetiredTest`,
`SrcPhpDeprecationLintTest`) that fail in a `.git`-less `git archive` snapshot and pass in a real
checkout — an artifact of how I built the comparison tree, not an effect of this change. The
mutation row claiming the string rule was pinned by both `sibling statement colour` and
`inline style, unpaired` was also only half true; see round 1 below.


## Review round 1 — four blocking findings, fixed in `0ec493c2`

Round 1 was right on every count. Two of my verification claims were not reproducible, and the
guard rewrite was a net regression in two shapes the old scanner caught.

### The string rule moved the laundering rather than removing it

A PHP literal is routinely a whole HTML fragment, not one `style` attribute — 28 sites in this
tree build markup with escaped `style=\"` inside one string. Resolving the context to the literal
let one element's colour pair another's background:

```php
$s = "<span style=\"color: black;\"></span><input style=\"background-color: #123456;\">";
// devel: 1 hit (correct) · round-1 head: 0 hits · now: 1 hit
```

That is #2866 one scope out. The context is now the innermost `style` attribute inside the
literal, falling back to the literal only when the background is not inside one — so the shipped
`$failed` span, which is genuinely paired, stays green.

The attribute's closing delimiter is written exactly as its opener, `\"` inside a double-quoted
PHP string. Treating that backslash as an escape to skip ran the context straight past the
element, which is what my first attempt at this fix did.

### An apostrophe in prose is not a string opener

```text
/* don't */ .a { background-color: #123456; } .b { color: red; }   devel: hit · round 1: MISSED
/* it's fine */ .a { background-color: #123456;
 color: red; }                                                     devel: clean · round 1: FALSE HIT
```

Both came from truncating the context at end-of-line when the quote never closed. An unterminated
quote now falls through to the block resolver.

### The provider was pinning less than it claimed

Run against the **devel** scanner, only 2 of 8 rows were red-first. Worst of all, the row the body
presented as #2866's pin was already green on devel: with no enclosing block, the old quote
fallback happened to answer correctly. The real shape needs the `if` block that made the defect
reachable, and that row is now in the provider.

The set is now 20 rows, 7 of them red on devel — see the round-2 correction below; the numbers I
first wrote here were stale. The rest are regression guards, and they earn their place: the false
negatives above were shapes devel got right and my change broke.

### The resolution order was constrained by nothing

Round 1's most useful finding: swapping the string and block resolution — the PR's central design
claim, "most specific first" — left the entire suite green. Seven other mutants survived too,
including the depth-aware brace scan that #2892's own suggested fix asked for.

All eight are now killed:

| Mutant | Killed by |
|---|---|
| resolution order swapped | `sibling statement colour` |
| block scan not depth-aware | `pairing after that block` |
| brace stack → `strrpos('{')` | `nested block before it` |
| backslash-escape skip removed | `sibling element colour` |
| `styleAttribute` narrowing removed | `sibling element colour` |
| unterminated string → truncate at EOL | `apostrophe in prose`, `apostrophe, pair below` |
| ±80 fallback → whole source | `no scope at all` |
| unclosed block → `NULL` | `unclosed block pairs` |

The last two needed rows whose pairing sits **further away than the window**, or the two fallbacks
give the same answer either way and nothing discriminates them.

### Verified

`ThemeSafety`: 33 tests / 56 assertions green. Tree inventory byte-identical to the round-1 head —
still exactly one file changed verdict, and pairing it turns that green. `phpcs` and `phpstan`
clean on the changed file. 13 hostile shapes checked directly against both scanners.

### Left open

Round 1 also noted, and I agree: JS template literals (backticks) are invisible to this scanner on
devel and still are — pre-existing, its own issue, not widened into this PR. And
`enclosingBlock()` rescans from offset 0 per hit, which is O(n·hits); irrelevant at 0.19s for this
tree but a poor shape if `scanTree()` ever meets a minified asset. Recording both rather than
quietly fixing them here.


## Review round 2 — two blocking findings, fixed in `e2cdfd68`

### The fix opened a third laundering scope

`styleAttribute()` returned NULL in two different situations — the literal has no style attribute
at all, and the literal has one that simply isn't this background's — and the caller widened to the
whole literal in both. So an unrelated element's colour paired a background declared outside any
attribute:

```php
$s = ".a { background-color: #123456; } <span style=\"color: black;\">";
// devel: 1 hit (correct) · round-1 head: 0 hits · now: 1 hit
```

This is the same defect class as #2866 and #2892, one scope further out again, and I introduced it
while fixing them. The two cases are now distinct: a background inside an attribute resolves to
that attribute, and otherwise the context is the literal with every attribute's value removed — so
the background keeps its own surroundings and loses everyone else's.

Round 2 also noted `style-x="..."` is not matched by `style\s*=`, which is correct behaviour and
now has a row.

### The row counts were wrong again

The body said "15 rows, 5 red on devel". It was 17 and 6 when round 2 measured it. I wrote those
numbers before adding the two fallback rows and never re-measured — the same failure round 1
caught in the suite-delta claim, repeated one round later in the paragraph that was supposed to be
the correction.

Both numbers are now produced by execution rather than written from memory. At this head:

```text
20 rows, 7 red-before-fix
  nested object colour · nested rule colour · nested block before it
  pairing after that block · sibling statement colour
  unrelated attr, no braces · unclosed block pairs
```

Note `unrelated attribute` (the braced form) is **not** in that list — devel catches it. Only the
brace-less variant is a shape devel misses too.

### Mutants

All ten now killed, each by a named row, re-run at this head:

| Mutant | Killed by |
|---|---|
| `withoutOtherAttributes` → whole literal | `unrelated attribute`, `unrelated attr, no braces` |
| `styleAttribute` narrowing removed | `sibling element colour` |
| resolution order swapped | `sibling statement colour` |
| block scan not depth-aware | `pairing after that block` |
| brace stack → `strrpos('{')` | `nested block before it` |
| backslash-escape skip removed | `sibling element colour` |
| `withoutNestedBlocks` disabled | the three nested rows |
| unterminated string → truncate at EOL | `apostrophe in prose`, `apostrophe, pair below` |
| ±80 fallback → whole source | `no scope at all` |
| unclosed block → `NULL` | `unclosed block pairs` |

One correction to round 1's table above: the resolution-order swap is killed by
`sibling statement colour` alone. `sibling element colour` has no brace, so the swap cannot reach
it — I listed it without checking.

`ThemeSafety`: 36 tests / 59 assertions. `phpcs` and `phpstan` clean. Tree inventory still shows
exactly the one file, and pairing it turns it green.


## Review round 3 — two blocking findings, fixed in `891d1a80`

### A fourth laundering scope, and my first fix for it was wrong

The span regex had no boundary before `style`, so any attribute name *ending* in it opened a
phantom span — and `chart_style = "<?=$pfbchartstyle;?>"` exists verbatim at
`pfblockerng_alerts.php:5275`, so this was reachable in the shipped tree rather than theoretical.

My first correction was a word boundary, excluding `data-style` and `chart_style`. Testing it
showed that is **backwards**. Excluding a decoy leaves its value *in* the context, so this
launders:

```php
$s = "<div data-style=\"color: red\"></div> background-color: #123456;";
```

Whatever an attribute is named, its value belongs to its own element and cannot pair someone
else's background. So every `*style=` attribute is excised, and the boundary is gone. The mutation
that reintroduces it is killed by `decoy carries a colour`.

I briefly had a third variant that kept the decoys but only let a *real* `style` attribute be the
containing context. No test could distinguish it, so it is deleted rather than carried — the same
rule that produced the two fixes above.

### Brace groups inside literals

A literal can carry an object argument beside a declaration, and that group's colour is no more
the background's than an attribute's is:

```php
$s = "<div data-style=\"dark\">x</div> background-color: #123456; foo({color: 'red'})";
```

Groups the background is not inside are now dropped along with the attributes — the same
nested-scope rule `withoutNestedBlocks()` already applies to blocks, applied inside literals.

### The splice order was unpinned

Round 3's other blocking finding: dropping `array_reverse()` passed the whole suite. With two or
more cuts and the background outside them, forward-order splicing uses stale offsets against an
already-shortened string. `flanked by two attributes` pins it.

Cuts from two sources also interleave, so they are sorted before being applied. That was unpinned
too until `group then attribute` was added — I found it by mutating, not by reasoning.

### Counts, measured

```text
25 rows, 9 red-before-fix
```

Both figures produced by execution against the devel scanner, not written from memory. Round 2's
finding was that I had done exactly that twice.

### Mutants

Superseded — round 4 re-ran this table and found it wrong on three rows; the corrected,
executed table is in the round-4 section below.

`ThemeSafety`: 41 tests / 64 assertions. `phpcs` and `phpstan` clean. Tree inventory unchanged —
still exactly the one file, green once paired.

Round 3's over-engineering nitpick is taken: the two consumers of the span list are now one
function, so the regex runs once per literal instead of twice.


## Review round 4 — the fourth instance, and its cause

Round 4 asked a different question than rounds 1–3: instead of checking the latest fix, it
enumerated every scope a colour can live in and tested a paired and an unpaired case in each
against both scanners. That found the fourth instance immediately, and named why there kept being
another one.

### One operation, implemented twice, drifted

The source path scoped to the innermost enclosing brace group and dropped that group's nested ones.
The literal path dropped only top-level groups and never scoped at all. So a colour one level
*above* a nested background, both inside the same literal, paired it:

```php
$s = "foo({outer: {background-color: '#123456'}, color: 'red'})";   // devel: unpaired · this PR: paired
```

The literal path now calls `enclosingBlock()` exactly as the source path does, then removes the
scoped group's own subgroups. **Three of the four laundering scopes in this PR were this one
operation disagreeing with itself** — which is the finding, more than any individual case.

### `stylesheet=` was not an attribute

The decoy match only caught names *ending* in `style`, so `stylesheet="color: red"` stayed in the
context and laundered. It now matches any name containing it, which is what the docblock already
claimed. Not live in the tree today.

### The mutation table, re-measured

Round 4 found round 3's table wrong on three of six rows — including silently reverting the
"7 rows" figure that round 2 had already corrected to one. That is the third count error in this
PR, and the first where I re-broke a number someone had already fixed. Every figure below is now
the output of a run, not a recollection:

Superseded — round 5 found the `resolution order swapped` row measured a different mutation
than its label described. The corrected table is in the round-5 section.

`nestedGroupSpans` survived until a row was added for it: the nesting rows all scope to an
innermost group that has no subgroups, so the stripping never ran. `subgroup of that group` covers
it.

```text
30 rows, 10 red-before-fix
```

`ThemeSafety`: 46 tests / 69 assertions. `phpcs` and `phpstan` clean. Tree inventory unchanged.

### Still open, disclosed

Heredoc and nowdoc bodies share the backtick blind spot — no quote characters to track — and the
earlier "Left open" note named only template literals. Neither carries a background in the tree
today. Round 4 also found `foreignBraceGroups`' bound is unreachable in practice, since the offset
is always the word `background`, never a brace.


## Review round 5 — two blocking findings, fixed in `85668f72`

### The unification was half-done

Round 4 diagnosed the recurring defect as one operation implemented twice. The fix closed half of
it: both paths found the group with `enclosingBlock()`, but the **stripping** stayed duplicated —
the rule path in `withoutNestedBlocks()`, the literal path in `nestedGroupSpans()` plus a splice.
Round 5 built the consolidation and proved it before reporting it.

The literal path now calls `withoutNestedBlocks()` too, and the second implementation is deleted.
Thirty net lines removed, and it closes a case the shipped head still laundered:

```php
$s = "foo({background-color: '#123456', n1: '{', n2: '{', sub: {color: 'red'}})";
```

A single left-to-right pass survives a brace count desynchronised by a quoted `{`; pre-computed
spans are measured against an offset space that the bad depth has already invalidated. devel and
every earlier head of this branch launder that input. This one does not.

That is the fifth instance of the same class, and the first found by looking for a *divergence
between two implementations* rather than for a bad case. Since there is now one implementation,
that particular search is exhausted.

### The mutation table, corrected

Round 5 could not reproduce `resolution order swapped | 8` and measured 1. Both numbers are right;
my **label** was wrong. My mutation deleted the string branch outright, which is "the string path
removed" and kills 8. The true order swap keeps both and reorders them, and kills 1 — the same row
rounds 1–3 named. Two different mutations under one name.

| Mutant | Rows that fail |
|---|---|
| string path removed entirely | 8 |
| resolution order swapped (both kept, reordered) | 1 — `sibling statement colour` |
| `styleContext` containment removed | 3 (+ the tree inventory) |
| literal not scoped to its group | 4 |
| `withoutNestedBlocks` disabled | 5 |
| decoy regex narrowed to names *ending* in style | 1 |
| `array_reverse` dropped | 2 |
| `usort` dropped | 1 |
| `foreignBraceGroups` disabled | 2 |

This is the fourth count problem in this PR, and the least excusable kind: not a stale figure but a
figure attached to the wrong experiment. Every row above names the mutation precisely enough to
re-run.

### Coverage pairing

The `Coverage pairing` check had been failing since this PR opened — the `www/` change shipped no
Tier-A test. Round 1 raised it as advisory and I twice noted it without acting. There is now a
`tests/smoke/ui/` assertion that no inline style on these pages paints an opaque background with no
foreground, verified against the pre-fix and post-fix markup. It also covers something the source
scan structurally cannot: #2866's defect was a style attribute assembled from a variable, correct in
every branch the source could see.

### Still open, disclosed

Round 5 confirmed the brace counting is not quote-aware, so a quoted `{` in CSS `content:` can
desynchronise it. The consolidation above fixes the case it found, but the class remains and is
**pre-existing** — identical on devel and on every head of this branch. It belongs in its own issue
rather than widening this one, alongside the heredoc/backtick blind spot already noted.

`ThemeSafety`: 46 tests / 69 assertions. `phpcs` and `phpstan` clean.


## Review round 6 — a sixth instance, and four deferrals finally filed

### The count, once more

Round 6 measured `styleContext containment removed` at 3 rows where the body claimed 4. Both
numbers are real: 4 **tests** fail, but only 3 are provider rows — the fourth is
`testCurrentTreeInventoryMatchesTheDatedTodo`. My column is headed "rows that fail", so 3 is the
right number under that header and I have corrected it. That is the fifth count problem in this PR,
and the second caused by a label not matching the measurement.

### The sixth instance — filed, not fixed here

`enclosingString()` scans back only to the start of the offset's own line, so a genuine multi-line
string literal is read as "unterminated quote, therefore prose", falls through to the brace path,
and re-launders the exact #2866 shape. `token_get_all` finds **192 multi-line literals** under
`src/usr/local/www/pfblockerng/`, including in a file already on the TODO list.

I am not fixing it in this PR, and the reasoning matters rather than the conclusion. It is
**pre-existing** — round 6 confirms `devel` gets the same input wrong and that a devel-vs-PR scan
diff over the real tree is empty, so nothing regresses. `landing.md` says a confirmed pre-existing
defect belongs in its own tracking issue rather than widening a PR under review, which is exactly
how #2866 and #2892 were split out of #2857 in the first place. Six rounds in, widening again
would be the wrong call.

It is also not a trivial fix: the line scoping is not arbitrary, it is what stops an apostrophe in
prose from desynchronising the whole file — the defect round 3 found. A naive whole-file quote scan
reintroduces it. That belongs in a change that can be reviewed on its own terms.

Filed as **#2928**.

### The deferrals that were never filed

Round 6's sharpest process finding: I have written "belongs in its own issue" in this body since
round 4 and never opened one. Under `landing.md`'s DEFER rule that is not optional. Now filed:

| Issue | |
|---|---|
| **#2928** | multi-line string literal launders (the sixth instance above) |
| **#2929** | brace counting is not quote-aware — `content: "{"` desynchronises scope |
| **#2930** | heredoc/nowdoc and template-literal bodies cannot be scoped |
| **#2931** | the failed-download row is not reachable from the hermetic Tier-A harness |

On #2929 specifically: round 6 confirmed this PR makes one case *better* than devel — the
consolidation in `85668f72` handles the quoted-brace desync that devel and every earlier head of
this branch get wrong — and no case worse.

### The Tier-A claim, corrected

Round 6 is right that I implied Tier-A coverage I did not deliver. The assertion is a real guard
over every other inline background on those pages, but `$failed_bg` is empty without a `.fail`
sidecar, so it can never go red for the row this PR fixes. The docstring now says that and names
#2931, which proposes seeding the sidecar at the functional tier, where `smoke_vm` exists.
`EXCLUDED_FROM_TIER_A` is the wrong shape for it — that table records whole pages kept out of the
sweep, and this page is *in* the sweep; it is one row's state that is unreachable.

### A behaviour change with no row

`85668f72` fixed the quoted-brace desync and shipped no test for it, which `testing.md` principle 1
requires. `quoted brace desync` now covers it: reverting that commit's diff fails exactly that row.

```text
31 rows, 11 red-before-fix
```

`ThemeSafety`: 47 tests / 70 assertions.


## Review round 7 — converged

No blocking findings. Round 7 verified the round-6 deferral on its merits rather than accepting it:
it rebuilt devel's scanner and confirmed both claims the deferral rests on — devel launders the
multi-line repro identically, and a devel-vs-PR `scanTree()` diff over the whole tree is empty. The
defer stands as a `landing.md` DEFER, tracked in #2928, not a silent drop.

Four nitpicks, all taken:

**The SHAs in this body were stale.** The branch was rebased onto current devel, renaming every
commit. All references above now point at the commits that exist.

**`subgroup of that group` was not killed by that revert.** I claimed reverting the consolidation
fails both it and `quoted brace desync`. Applying the commit's *actual* diff in reverse fails only
`quoted brace desync`. My earlier reconstruction restored `foreignBraceGroups` as well, which is a
larger change than the commit made — the same mistake as the "resolution order swapped" mislabel,
measuring a neighbouring mutation and reporting it under this one's name. That is the sixth count
problem here and the third of exactly this kind.

**Two counts had gone stale** when `quoted brace desync` was added: `literal not scoped to its
group` is 4, not 3, and `withoutNestedBlocks disabled` is 5, not 4. Corrected above.

**#2929's example did not reproduce.** Round 7 ran `content: "{"` against both scanners and both
correctly flag it — the desync happens but coincidentally resolves a valid scope. The issue has
been corrected to `content: "}"`, which does reproduce on both. An issue filed to discharge a review
obligation but describing something false is worse than no issue, so this mattered.

Round 7 also probed a genuinely new axis — token gluing when `withoutNestedBlocks()` splices out a
nested group without a separator, so `c{n}olor: red` becomes a phantom `color:`. It reproduces, and
it is in the shared primitive, hitting both paths. But no valid PHP, JS or CSS can split a keyword
across a brace pair, so it has no demonstrated reach. Filed as **#2934** with that framing rather
than left in a transcript.

```text
31 rows, 11 red-before-fix · 47 tests / 70 assertions
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved readability when feed downloads fail by ensuring highlighted Header/Label text remains clearly visible against the yellow background.

- **Tests**
  - Expanded theme-safety checks to better detect conflicting colors across nested styles and markup.
  - Added UI smoke coverage to identify inline backgrounds without a matching foreground color, helping prevent illegible rendered pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->