### PR TITLE
smoke: stop reading the due ledger while Run Now is still writing it

### DIFF
--- a/tests/php/DueLedgerTest.php
+++ b/tests/php/DueLedgerTest.php
@@ -832,20 +832,22 @@ final class DueLedgerTest extends TestCase
 	}
 
 	/**
-	 * set_pending records a deferral without touching anything the tick owns.
+	 * Neither branch of set_pending advances last_run.
 	 *
-	 * The live smoke test (test_update_runnow_does_not_publish_schedule_cache) compares
-	 * the ledger across a Run Now and tolerates exactly this one key, because a deferred
-	 * pass legitimately writes it. That tolerance is only safe if set_pending really does
-	 * leave the cache identity and every schedule field alone.
+	 * The live smoke test (test_update_runnow_does_not_publish_schedule_cache) holds one
+	 * fact across a Run Now: cron.last_run never advances. Everything else in the ledger
+	 * is rewritten by the pass tail's own pfb_schedule_cache_refresh_locked(), so it is
+	 * not the tick's to own. set_pending is on the deferral path a Run Now can reach, and
+	 * it has two branches -- marking an existing entry, and creating a placeholder when
+	 * the job has none. Both must leave last_run where it was.
 	 *
 	 * Scenario:
-	 *   Given a published cache with a _meta identity and a cron entry with a schedule.
+	 *   Given a published cache with a cron entry, and separately one without.
 	 *   When  set_pending marks the job deferred.
-	 *   Then  only pending_apply appears -- _meta, last_run, next_due and jitter are
-	 *         byte-for-byte what they were, and no job is added or removed.
+	 *   Then  last_run is unchanged in the first case and 0 in the second, the cache
+	 *         identity is untouched, and only the deferral marker was added.
 	 */
-	public function testSetPendingLeavesTheCacheIdentityAndScheduleUntouched(): void
+	public function testSetPendingNeverAdvancesLastRun(): void
 	{
 		$hash    = str_repeat('a', 64);
 		$entries = [
@@ -861,13 +863,31 @@ final class DueLedgerTest extends TestCase
 		$after = json_decode((string)file_get_contents($this->dir . '/pfb_due_ledger.json'), TRUE);
 
 		$this->assertTrue($after['cron']['pending_apply'], 'the deferral marker must be recorded');
-		$this->assertSame(array_keys($before), array_keys($after),
-			'set_pending must not add or remove a job');
+		$this->assertSame($before['cron']['last_run'], $after['cron']['last_run'],
+			'set_pending must not advance the last_run the tick owns');
 		$this->assertSame($before['_meta'], $after['_meta'],
-			'set_pending must not republish the cache identity the tick owns');
+			'set_pending must not republish the cache identity');
 		unset($after['cron']['pending_apply']);
-		$this->assertSame($before, $after,
-			'set_pending must change nothing but the deferral marker');
+		$this->assertSame($before, $after, 'set_pending must change nothing but the marker');
+	}
+
+	/**
+	 * The placeholder branch starts last_run at 0, so it cannot advance one either.
+	 *
+	 * set_pending creates {last_run: 0, next_due: 0, jitter: 0} when the job has no entry.
+	 * A ledger with no cron row is reachable on a box that has never completed a pass, and
+	 * the smoke oracle must not read that placeholder as the tick having run.
+	 */
+	public function testSetPendingPlaceholderStartsLastRunAtZero(): void
+	{
+		$this->assertTrue(pfb_due_ledger_set_pending('cron', $this->dir),
+			'set_pending must publish a placeholder when the job has no entry');
+
+		$entry = pfb_due_ledger_read_entry('cron', $this->dir);
+		$this->assertNotNull($entry, 'the placeholder entry must exist');
+		$this->assertSame(0, $entry['last_run'],
+			'a placeholder must not invent a last_run the tick never recorded');
+		$this->assertTrue($entry['pending_apply'], 'the deferral marker must be recorded');
 	}
 
 	/**

--- a/tests/php/DueLedgerTest.php
+++ b/tests/php/DueLedgerTest.php
@@ -832,6 +832,45 @@ final class DueLedgerTest extends TestCase
 	}
 
 	/**
+	 * set_pending records a deferral without touching anything the tick owns.
+	 *
+	 * The live smoke test (test_update_runnow_does_not_publish_schedule_cache) compares
+	 * the ledger across a Run Now and tolerates exactly this one key, because a deferred
+	 * pass legitimately writes it. That tolerance is only safe if set_pending really does
+	 * leave the cache identity and every schedule field alone.
+	 *
+	 * Scenario:
+	 *   Given a published cache with a _meta identity and a cron entry with a schedule.
+	 *   When  set_pending marks the job deferred.
+	 *   Then  only pending_apply appears -- _meta, last_run, next_due and jitter are
+	 *         byte-for-byte what they were, and no job is added or removed.
+	 */
+	public function testSetPendingLeavesTheCacheIdentityAndScheduleUntouched(): void
+	{
+		$hash    = str_repeat('a', 64);
+		$entries = [
+			'cron'      => ['last_run' => 1000, 'next_due' => 2000, 'jitter' => 7],
+			'extra:dcc' => ['last_run' => 3000, 'next_due' => 4000, 'jitter' => 11],
+		];
+		$this->assertTrue(pfb_due_ledger_write_cache($entries, $hash, $this->dir),
+			'the fixture cache must publish');
+		$before = json_decode((string)file_get_contents($this->dir . '/pfb_due_ledger.json'), TRUE);
+
+		$this->assertTrue(pfb_due_ledger_set_pending('cron', $this->dir),
+			'set_pending must publish its marker');
+		$after = json_decode((string)file_get_contents($this->dir . '/pfb_due_ledger.json'), TRUE);
+
+		$this->assertTrue($after['cron']['pending_apply'], 'the deferral marker must be recorded');
+		$this->assertSame(array_keys($before), array_keys($after),
+			'set_pending must not add or remove a job');
+		$this->assertSame($before['_meta'], $after['_meta'],
+			'set_pending must not republish the cache identity the tick owns');
+		unset($after['cron']['pending_apply']);
+		$this->assertSame($before, $after,
+			'set_pending must change nothing but the deferral marker');
+	}
+
+	/**
 	 * A set_pending placeholder (next_due=0, no real prior schedule) has nothing
 	 * meaningful to anchor to — behaves exactly like plain mark_ran (base = now).
 	 *

--- a/tests/smoke/ui/test_functional.py
+++ b/tests/smoke/ui/test_functional.py
@@ -29,6 +29,7 @@ the output filter per render -- it must be re-extracted, never cached).
 
 from __future__ import annotations
 
+import json
 import subprocess
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
@@ -1891,6 +1892,29 @@ _ENABLE_CB_CFG = "installedpackages/pfblockerng/config/0/enable_cb"
 _LEDGER_PATH = f"{helpers.PFB_DBDIR}/pfb_due_ledger.json"
 
 
+def _ledger_ownership(vm: helpers.SmokeVM) -> tuple[int, object]:
+    """The whole ledger minus the one marker a Run Now is allowed to write.
+
+    Byte-identity is the wrong oracle on a live box. The page process never writes this
+    file -- that is pinned off-appliance by UpdateRunNowScheduleOwnershipTest, where the
+    dispatch is stubbed -- but the detached run does: a deferred pass records
+    ``pending_apply`` on its entry, which advances no schedule and republishes no cache.
+    Everything else, including ``_meta``, every job's timestamps and the set of jobs
+    present, must survive the run untouched.
+    """
+    result = vm.ssh("/bin/cat", _LEDGER_PATH, timeout=30.0)
+    if result.returncode != 0:
+        return (result.returncode, None)
+    try:
+        document = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:  # a corrupt ledger is a failure, not a comparison
+        raise AssertionError(f"{_LEDGER_PATH} is not valid JSON: {exc}") from exc
+    for entry in document.values():
+        if isinstance(entry, dict):
+            entry.pop("pending_apply", None)
+    return (result.returncode, document)
+
+
 def test_update_runnow_does_not_publish_schedule_cache(
     webui: WebUI,
     smoke_vm: helpers.SmokeVM,
@@ -1902,7 +1926,8 @@ def test_update_runnow_does_not_publish_schedule_cache(
 
     Given pfBlockerNG is enabled,
     When Run Now is submitted for partial and full scopes,
-    Then ``pfb_due_ledger.json`` remains byte-identical after each POST.
+    Then the tick-owned facts in ``pfb_due_ledger.json`` -- the derived cache
+    identity and the cron job's own schedule -- are unchanged once each run settles.
 
     The next locked tick owns cache regeneration from config and durable state.
     """
@@ -1913,31 +1938,7 @@ def test_update_runnow_does_not_publish_schedule_cache(
         helpers.set_package_enabled(vm, True)
 
     try:
-        pre = vm.ssh("/bin/cat", _LEDGER_PATH)
-        pre_snapshot = (pre.returncode, pre.stdout)
 
-        # ACT 1: POST scope=ip — a partial run; the cron ledger must NOT advance.
-        # pfb_runnow() dispatches a detached process and returns immediately (the live log is
-        # AJAX-polled since #671); mark_ran('cron') still runs synchronously in the page process,
-        # so the ledger assertions below read the intended state regardless of the run's progress.
-        resp = webui.post(
-            UPDATE_PAGE,
-            overrides={"pfb_scope": "ip"},
-            submit=("run", "Run Now"),
-            timeout=SAVE_TIMEOUT,
-        )
-        assert not looks_like_login_page(resp.text), "scope=ip POST returned the login form (session lost)"
-
-        result = vm.ssh("/bin/cat", _LEDGER_PATH, timeout=30.0)
-        assert (result.returncode, result.stdout) == pre_snapshot, (
-            "scope=ip Run Now replaced the tick-owned schedule cache"
-        )
-
-        # Run Now no longer blocks (the live log is AJAX-polled, #671), so the scope=ip dispatched
-        # process may still be alive. Wait for it to exit before the next POST — otherwise
-        # pfb_active_task_running() would refuse the scope=both dispatch and the cron ledger would
-        # not advance (a race the old blocking pfb_livetail() masked). Mirrors isvalidpid: read the
-        # pidfile daemon(8) self-clears on exit and probe the pid with kill -0.
         def _runnow_idle() -> bool:
             probe = vm.ssh(
                 "/bin/sh",
@@ -1947,14 +1948,31 @@ def test_update_runnow_does_not_publish_schedule_cache(
             )
             return probe.stdout.strip() == "down"
 
+        pre_snapshot = _ledger_ownership(vm)
+
+        # ACT 1: POST scope=ip — a partial run; the cron ledger must NOT advance.
+        # pfb_runnow() dispatches a detached process and returns immediately (#671), so each
+        # act waits for that process to exit before reading. Reading mid-flight compares a
+        # settled snapshot against a run still in progress, which is what made this flaky.
+        resp = webui.post(
+            UPDATE_PAGE,
+            overrides={"pfb_scope": "ip"},
+            submit=("run", "Run Now"),
+            timeout=SAVE_TIMEOUT,
+        )
+        assert not looks_like_login_page(resp.text), "scope=ip POST returned the login form (session lost)"
+
         assert helpers.wait_until(_runnow_idle, timeout=25.0), (
-            "scope=ip Run Now process did not exit before the scope=both POST — "
-            "pfb_active_task_running() would refuse the next dispatch"
+            "scope=ip Run Now process did not exit before the ledger was read"
+        )
+        assert _ledger_ownership(vm) == pre_snapshot, (
+            "scope=ip Run Now republished the tick-owned cache or advanced the cron schedule"
         )
 
-        # ACT 2: a full pass must leave the same ownership boundary intact.
-        before_both = vm.ssh("/bin/cat", _LEDGER_PATH)
-        before_both_snapshot = (before_both.returncode, before_both.stdout)
+        # ACT 2: a full pass must leave the same ownership boundary intact. The idle wait
+        # above also gates the dispatch: pfb_active_task_running() would refuse this POST
+        # while the scope=ip process is alive.
+        before_both_snapshot = _ledger_ownership(vm)
         resp2 = webui.post(
             UPDATE_PAGE,
             overrides={"pfb_scope": "both"},
@@ -1963,9 +1981,11 @@ def test_update_runnow_does_not_publish_schedule_cache(
         )
         assert not looks_like_login_page(resp2.text), "scope=both POST returned the login form (session lost)"
 
-        result2 = vm.ssh("/bin/cat", _LEDGER_PATH, timeout=30.0)
-        assert (result2.returncode, result2.stdout) == before_both_snapshot, (
-            "scope=both Run Now replaced the tick-owned schedule cache"
+        assert helpers.wait_until(_runnow_idle, timeout=25.0), (
+            "scope=both Run Now process did not exit before the ledger was read"
+        )
+        assert _ledger_ownership(vm) == before_both_snapshot, (
+            "scope=both Run Now republished the tick-owned cache or advanced the cron schedule"
         )
 
         # Re-render the Update page and confirm the Schedule section is present.

--- a/tests/smoke/ui/test_functional.py
+++ b/tests/smoke/ui/test_functional.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 
 import json
 import subprocess
+import time
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -1892,27 +1893,61 @@ _ENABLE_CB_CFG = "installedpackages/pfblockerng/config/0/enable_cb"
 _LEDGER_PATH = f"{helpers.PFB_DBDIR}/pfb_due_ledger.json"
 
 
-def _ledger_ownership(vm: helpers.SmokeVM) -> tuple[int, object]:
-    """The whole ledger minus the one marker a Run Now is allowed to write.
+def _cron_last_run(vm: helpers.SmokeVM) -> int:
+    """The one ledger field a Run Now must never advance.
 
-    Byte-identity is the wrong oracle on a live box. The page process never writes this
-    file -- that is pinned off-appliance by UpdateRunNowScheduleOwnershipTest, where the
-    dispatch is stubbed -- but the detached run does: a deferred pass records
-    ``pending_apply`` on its entry, which advances no schedule and republishes no cache.
-    Everything else, including ``_meta``, every job's timestamps and the set of jobs
-    present, must survive the run untouched.
+    Not byte-identity, and not the whole document. Every pass ends in
+    pfb_schedule_cache_refresh_locked() (pfblockerng_apply.inc), which rewrites
+    pfb_due_ledger.json in full -- _meta, the cron row, every extra row -- and sets
+    next_due to wall-clock time whenever the plan is due. That republication is the
+    pass's own, so comparing it is comparing something Run Now is entitled to change.
+
+    last_run is different: it moves only through pfb_schedule_state_record_outcome(),
+    whose two call sites are both gated on scheduled_runtime_cron, which a manual Run
+    Now never sets. That is the ownership boundary this test exists to hold.
     """
     result = vm.ssh("/bin/cat", _LEDGER_PATH, timeout=30.0)
-    if result.returncode != 0:
-        return (result.returncode, None)
+    assert result.returncode == 0, (
+        f"{_LEDGER_PATH} is missing, so this test would assert nothing -- "
+        "pfBlockerNG must be enabled and have published a ledger before Run Now is exercised"
+    )
     try:
         document = json.loads(result.stdout)
-    except json.JSONDecodeError as exc:  # a corrupt ledger is a failure, not a comparison
+    except json.JSONDecodeError as exc:
         raise AssertionError(f"{_LEDGER_PATH} is not valid JSON: {exc}") from exc
-    for entry in document.values():
-        if isinstance(entry, dict):
-            entry.pop("pending_apply", None)
-    return (result.returncode, document)
+    cron = document.get("cron")
+    assert isinstance(cron, dict), (
+        f"{_LEDGER_PATH} has no cron entry, so an unchanged last_run would prove nothing: {document!r}"
+    )
+    return int(cron.get("last_run", 0))
+
+
+def _settle_runnow(vm: helpers.SmokeVM, timeout: float = 25.0) -> None:
+    """Best-effort wait for a dispatched Run Now to finish.
+
+    pfb_runnow() unlinks the pidfile and calls mwexec_bg, and daemon(8) writes the
+    pidfile only once it has started -- so "no live pid" is true before the run exists
+    as well as after it ends. Waiting for the up edge first distinguishes them; a run
+    that finishes before it is ever observed up is not an error, so neither poll is
+    allowed to fail the test. This gates the next dispatch, which
+    pfb_active_task_running() would otherwise refuse; the assertions do not depend on
+    it, because last_run is unchanged at every instant of the run.
+    """
+
+    def _up() -> bool:
+        probe = vm.ssh(
+            "/bin/sh",
+            "-c",
+            "p=$(cat /var/run/pfb_runnow.pid 2>/dev/null); "
+            'if [ -n "$p" ] && kill -0 "$p" 2>/dev/null; then echo up; else echo down; fi',
+        )
+        return probe.stdout.strip() == "up"
+
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline and not _up():
+        time.sleep(0.5)
+    while time.monotonic() < deadline and _up():
+        time.sleep(0.5)
 
 
 def test_update_runnow_does_not_publish_schedule_cache(
@@ -1926,8 +1961,7 @@ def test_update_runnow_does_not_publish_schedule_cache(
 
     Given pfBlockerNG is enabled,
     When Run Now is submitted for partial and full scopes,
-    Then the tick-owned facts in ``pfb_due_ledger.json`` -- the derived cache
-    identity and the cron job's own schedule -- are unchanged once each run settles.
+    Then ``cron.last_run`` in ``pfb_due_ledger.json`` never advances.
 
     The next locked tick owns cache regeneration from config and durable state.
     """
@@ -1938,22 +1972,12 @@ def test_update_runnow_does_not_publish_schedule_cache(
         helpers.set_package_enabled(vm, True)
 
     try:
+        before_ip = _cron_last_run(vm)
 
-        def _runnow_idle() -> bool:
-            probe = vm.ssh(
-                "/bin/sh",
-                "-c",
-                "p=$(cat /var/run/pfb_runnow.pid 2>/dev/null); "
-                'if [ -n "$p" ] && kill -0 "$p" 2>/dev/null; then echo up; else echo down; fi',
-            )
-            return probe.stdout.strip() == "down"
-
-        pre_snapshot = _ledger_ownership(vm)
-
-        # ACT 1: POST scope=ip — a partial run; the cron ledger must NOT advance.
-        # pfb_runnow() dispatches a detached process and returns immediately (#671), so each
-        # act waits for that process to exit before reading. Reading mid-flight compares a
-        # settled snapshot against a run still in progress, which is what made this flaky.
+        # ACT 1: POST scope=ip — a partial run must not claim the tick's run.
+        # pfb_runnow() dispatches a detached process (#671), so the read below may land at
+        # any point of the run. That is fine for last_run, which is unchanged throughout;
+        # it was not fine for the whole document, which the pass tail rewrites.
         resp = webui.post(
             UPDATE_PAGE,
             overrides={"pfb_scope": "ip"},
@@ -1962,17 +1986,15 @@ def test_update_runnow_does_not_publish_schedule_cache(
         )
         assert not looks_like_login_page(resp.text), "scope=ip POST returned the login form (session lost)"
 
-        assert helpers.wait_until(_runnow_idle, timeout=25.0), (
-            "scope=ip Run Now process did not exit before the ledger was read"
+        assert _cron_last_run(vm) <= before_ip, (
+            "scope=ip Run Now advanced cron.last_run -- a partial scope must not claim the tick's run"
         )
-        assert _ledger_ownership(vm) == pre_snapshot, (
-            "scope=ip Run Now republished the tick-owned cache or advanced the cron schedule"
-        )
+        _settle_runnow(vm)
 
-        # ACT 2: a full pass must leave the same ownership boundary intact. The idle wait
-        # above also gates the dispatch: pfb_active_task_running() would refuse this POST
-        # while the scope=ip process is alive.
-        before_both_snapshot = _ledger_ownership(vm)
+        # ACT 2: a full pass must leave the same ownership boundary intact. The settle
+        # above gates this dispatch, which pfb_active_task_running() would otherwise
+        # refuse while the scope=ip process is alive.
+        before_both = _cron_last_run(vm)
         resp2 = webui.post(
             UPDATE_PAGE,
             overrides={"pfb_scope": "both"},
@@ -1981,12 +2003,10 @@ def test_update_runnow_does_not_publish_schedule_cache(
         )
         assert not looks_like_login_page(resp2.text), "scope=both POST returned the login form (session lost)"
 
-        assert helpers.wait_until(_runnow_idle, timeout=25.0), (
-            "scope=both Run Now process did not exit before the ledger was read"
+        assert _cron_last_run(vm) <= before_both, (
+            "scope=both Run Now advanced cron.last_run -- the next locked tick owns that"
         )
-        assert _ledger_ownership(vm) == before_both_snapshot, (
-            "scope=both Run Now republished the tick-owned cache or advanced the cron schedule"
-        )
+        _settle_runnow(vm)
 
         # Re-render the Update page and confirm the Schedule section is present.
         page_resp = webui.get(UPDATE_PAGE)

--- a/tests/smoke/ui/test_functional.py
+++ b/tests/smoke/ui/test_functional.py
@@ -1931,9 +1931,15 @@ def _assert_tick_run_not_claimed(before: int | None, after: int | None, scope: s
     does exist, last_run must not move. The off-appliance
     UpdateRunNowScheduleOwnershipTest holds the stronger byte-identity version, and
     DueLedgerTest pins both branches of the deferral write.
+
+    Removal is treated as a failure because no actor in this harness turns the schedule
+    off mid-test -- each lane boots its own VM and runs one test stream, and a General
+    save never reaches the pass tail that rewrites this file. In production a concurrent
+    admin disabling the schedule would drop the row legitimately, so this is a fact about
+    the harness rather than a product invariant.
     """
     assert not (after is None and before is not None), (
-        f"{scope} Run Now removed the cron entry -- the configuration it derives from did not change"
+        f"{scope} Run Now removed the cron entry, and nothing in this test disables the schedule"
     )
     if after is None:
         return

--- a/tests/smoke/ui/test_functional.py
+++ b/tests/smoke/ui/test_functional.py
@@ -1893,7 +1893,7 @@ _ENABLE_CB_CFG = "installedpackages/pfblockerng/config/0/enable_cb"
 _LEDGER_PATH = f"{helpers.PFB_DBDIR}/pfb_due_ledger.json"
 
 
-def _cron_last_run(vm: helpers.SmokeVM) -> int:
+def _cron_last_run(vm: helpers.SmokeVM) -> int | None:
     """The one ledger field a Run Now must never advance.
 
     Not byte-identity, and not the whole document. Every pass ends in
@@ -1916,10 +1916,36 @@ def _cron_last_run(vm: helpers.SmokeVM) -> int:
     except json.JSONDecodeError as exc:
         raise AssertionError(f"{_LEDGER_PATH} is not valid JSON: {exc}") from exc
     cron = document.get("cron")
-    assert isinstance(cron, dict), (
-        f"{_LEDGER_PATH} has no cron entry, so an unchanged last_run would prove nothing: {document!r}"
-    )
+    if not isinstance(cron, dict):
+        # No cron row: the box has no schedule configured, so the tick has never recorded a
+        # run. That is a state to hold, not an error -- a Run Now must not create one.
+        return None
     return int(cron.get("last_run", 0))
+
+
+def _assert_tick_run_not_claimed(before: int | None, after: int | None, scope: str) -> None:
+    """A Run Now must not record the tick's run, whether or not one exists yet.
+
+    On a box with no schedule configured the ledger carries no cron row at all, so the
+    strongest available statement is that a manual pass does not invent one. Where a row
+    does exist, last_run must not move. The off-appliance
+    UpdateRunNowScheduleOwnershipTest holds the stronger byte-identity version, and
+    DueLedgerTest pins both branches of the deferral write.
+    """
+    assert not (after is None and before is not None), (
+        f"{scope} Run Now removed the cron entry -- the configuration it derives from did not change"
+    )
+    if after is None:
+        return
+    if before is None:
+        assert after == 0, (
+            f"{scope} Run Now created a cron entry claiming last_run={after} -- "
+            "the next locked tick owns recording its own run"
+        )
+        return
+    assert after <= before, (
+        f"{scope} Run Now advanced cron.last_run from {before} to {after} -- the next locked tick owns that"
+    )
 
 
 def _settle_runnow(vm: helpers.SmokeVM, timeout: float = 25.0) -> None:
@@ -1986,9 +2012,7 @@ def test_update_runnow_does_not_publish_schedule_cache(
         )
         assert not looks_like_login_page(resp.text), "scope=ip POST returned the login form (session lost)"
 
-        assert _cron_last_run(vm) <= before_ip, (
-            "scope=ip Run Now advanced cron.last_run -- a partial scope must not claim the tick's run"
-        )
+        _assert_tick_run_not_claimed(before_ip, _cron_last_run(vm), "scope=ip")
         _settle_runnow(vm)
 
         # ACT 2: a full pass must leave the same ownership boundary intact. The settle
@@ -2003,9 +2027,7 @@ def test_update_runnow_does_not_publish_schedule_cache(
         )
         assert not looks_like_login_page(resp2.text), "scope=both POST returned the login form (session lost)"
 
-        assert _cron_last_run(vm) <= before_both, (
-            "scope=both Run Now advanced cron.last_run -- the next locked tick owns that"
-        )
+        _assert_tick_run_not_claimed(before_both, _cron_last_run(vm), "scope=both")
         _settle_runnow(vm)
 
         # Re-render the Update page and confirm the Schedule section is present.


### PR DESCRIPTION
Closes #2919.

## The failure

```text
FAILED tests/smoke/ui/test_update_runnow_does_not_publish_schedule_cache
AssertionError: scope=both Run Now replaced the tick-owned schedule cache
```

Intermittent, one live-VM leg at a time, on unrelated PRs and different platforms. It sits behind
the `All UI legs passed (AND gate)`, so one unlucky leg blocks a whole PR's UI gate.

## What is actually wrong

The test required `pfb_due_ledger.json` to be **byte-identical** across a Run Now. The product does
not promise that. Every non-save pass ends here:

```php
// pfblockerng_apply.inc — tail of every pass
if ($pfb['enable'] === PfbToggle::On) {
    pfb_schedule_cache_refresh_locked();
}
```

That republishes the whole document — `_meta`, the `cron` row and every `extra:*` row — and
`pfb_schedule_cache_refresh()` sets `$next_due = $due ? $now : $plan['next_due']`, so `next_due`
becomes wall-clock time whenever the plan is due. A Run Now therefore *does* republish the derived
cache, every time. It normally reproduces identical content, which is why byte-identity passed most
of the time and failed on the runs where it did not.

## What the tick actually owns

`cron.last_run`. It moves only through `pfb_schedule_state_record_outcome()`, and both of its call
sites are gated on `$pfb['scheduled_runtime_cron']`, which a manual Run Now never sets. That is
precisely the guard the test's own scenario line has always stated:

```text
Scenario: scope-guard — partial scope=ip must NOT advance cron.last_run.
```

So the oracle is now that one field, and the docstring says why the rest is not the tick's to own.
Because `last_run` is unchanged at *every instant* of the run, the read no longer needs the run to
settle.

## The wait did not wait

```python
p=$(cat /var/run/pfb_runnow.pid); if [ -n "$p" ] && kill -0 "$p"; then echo up; else echo down; fi
```

`pfb_runnow()` unlinks the pidfile and then calls `mwexec_bg`; `daemon(8)` writes it asynchronously;
and `helpers.wait_until` evaluates its predicate *before* the first sleep. So "no live pid" is true
before the run exists as well as after it ends, and the first poll could return immediately. The
probe now waits for the **up edge** first. It cannot fail the test — a fast run that is never
observed up is not an error — because it only gates the next dispatch, which
`pfb_active_task_running()` would otherwise refuse.

## No longer able to pass while asserting nothing

The previous oracle returned `(returncode, None)` when the ledger was absent, so both snapshots
compared equal and every assertion passed vacuously. A missing, unparseable, or `cron`-less ledger
now fails with a message naming the file:

| ledger state | result |
|---|---|
| missing | asserts — "would assert nothing" |
| not valid JSON | asserts, naming the parse error |
| no `cron` row | asserts — "an unchanged last_run would prove nothing" |
| pass tail rewrote `_meta` and `next_due` | tolerated, `last_run` still read |
| `set_pending` placeholder | reads `0`, does not advance |

## Pinned off-appliance

`set_pending` is on a deferral path a Run Now can reach, and it has two branches. Both are covered,
and both mutations are executed:

| Mutation | Killed by |
|---|---|
| existing branch bumps `last_run` | `set_pending must not advance the last_run the tick owns` |
| placeholder invents `last_run: 9999` | `a placeholder must not invent a last_run the tick never recorded` |

`DueLedger` suites: 47 tests / 164 assertions green. `ruff`, `ruff format`, `mypy` clean; the smoke
module still collects 73 tests.

`UpdateRunNowScheduleOwnershipTest` is untouched and still asserts byte-identity — correctly, because
there `mwexec_bg` is stubbed, so only the page process runs and nothing writes the file. Copying that
assertion into an environment where the detached pass actually runs is how this started.

## What this does not do

It does not prove which leg failed for which reason — I have no live VM here and those runs are gone.
It also does not address a `*/15` `cron-tick` landing inside the assertion window, which would write
the ledger through no fault of Run Now; that is rarer than what this fixes and is left unaddressed
rather than quietly assumed away.

## History

The first version of this PR blamed `pending_apply`, written by `set_pending` on a deferral, and
waited for the run to settle before comparing the whole document. Round 1 disproved it: the two
`set_pending` call sites need a lost feed-pass lock race or a MaxMind failure, neither reachable on
a box with no feeds and no MaxMind key, while the pass-tail republish above runs unconditionally and
was not named at all. Waiting made it strictly worse by guaranteeing the republish landed before the
read — CI then failed deterministically on `scope=ip`, which is the evidence that settled it.


## What CI answered — the test was vacuous on this box all along

The previous head asserted the ledger must have a `cron` entry. Every live leg failed:

```text
AssertionError: /var/db/pfblockerng/pfb_due_ledger.json has no cron entry, so an unchanged
last_run would prove nothing: {'_meta': {'schema': 1, 'config_hash': 'e97f78f5...'}, ...}
```

The smoke box's ledger has `_meta` and the extra rows and **no `cron` row at all** —
`pfb_schedule_cache_refresh()` writes one only when the model is scheduled and a `next_due`
exists, and this box has no schedule configured.

That is the whole story. This test has never asserted its own scenario here. Byte-identity was
comparing `_meta` and the `extra:*` rows — exactly what the pass tail rewrites — and never
`cron.last_run`, which does not exist on this box. It is also why the failure message named a
schedule-cache republication: the thing it compared and the thing it claimed to protect were
different things, and the message described the latter.

So the flake was never about the tick's run being stolen. It was `_meta`/`next_due` moving under an
oracle that had no business reading them.

## The correction

Requiring the row was wrong — it fails a legitimate state on every leg. What the scenario demands
holds either way: a manual pass must never record the tick's run.

| before → after | verdict |
|---|---|
| no row → no row | pass |
| no row → row claiming `last_run > 0` | **fail** |
| no row → row with `last_run == 0` | pass (the deferral placeholder) |
| row → same `last_run` | pass |
| row → advanced `last_run` | **fail** |
| row → row removed | **fail** (the configuration it derives from does not change mid-run) |

Verified by driving the helper and the assertion against fabricated documents, including the exact
shape CI reported.

## Coverage, stated plainly

This is weaker than the assertion it replaces. On this box only the absent-row case can be
exercised, so the "must not advance an existing `last_run`" arm is unreached here. It is not
unreached everywhere: `UpdateRunNowScheduleOwnershipTest` holds byte-identity off-appliance, where
`mwexec_bg` is stubbed and only the page process runs, and `DueLedgerTest` pins both branches of
the deferral write. Recording that rather than presenting the live test as stronger than it is.

Configuring a schedule so the box grows a real `cron` row would give genuine coverage, and would be
a larger change than this fix — worth its own issue rather than smuggling setup into a flake repair.


## Review round 3 — converged, with one thing stated more precisely

No blocking findings. Round 3 traced `pfb_schedule_cache_refresh()`'s write condition
independently and reproduced the before/after table by execution, including against the exact
document shape CI reported.

**The overclaim, fixed in `e6dcd3e6`.** The removal assertion said "the configuration it derives
from did not change", which reads as a product invariant. It is not: in production a concurrent
admin disabling the schedule drops the cron row legitimately. It holds *here* because each smoke
lane boots its own VM and runs one serial test stream, and a General-page save never reaches the
pass tail that rewrites this file (`if (!$pfb['save'])`). That is now said where the assertion
lives, so reuse against a less isolated environment does not inherit the assumption.

**On vacuity, plainly.** Round 3 confirmed by execution what this PR already disclosed, and it is
worth stating without softening: on this box `before` is always `None` and `after` is always
`None`, so the assertion takes the trivial path every time. A regression that reintroduced #2919
would not be caught here, because the write only reaches the ledger's `cron` key when
`model['scheduled']` is true, which this box never sets.

So this PR does not restore live coverage of the invariant — it stops a test from failing for a
reason unrelated to what it claims to check, and says so. The invariant itself is held by
`UpdateRunNowScheduleOwnershipTest` (43 tests / 138 assertions, byte-identity, seeded cron row,
dispatch stubbed) and by `DueLedgerTest`'s two `set_pending` branch cases. Giving the smoke box a
real schedule is the way to get genuine coverage back, and it belongs in its own issue.

Round 3 also identified that the earlier run's `error: 2 skip(s) not on tests/skip-allowlist.txt`
is unrelated to this PR — it is the skip-allowlist gate's own red-canary self-test printing its
expected failure, immediately checked by `[ "$canary_status" -eq 1 ]`.
