### PR TITLE
pfblockerng: mask ASN IPinfo token

### DIFF
--- a/graphify-out/memory/query_20260830_160233_how_does_pfblockerng_ip_php_render_and_persist_asn.md
+++ b/graphify-out/memory/query_20260830_160233_how_does_pfblockerng_ip_php_render_and_persist_asn.md
@@ -1,0 +1,17 @@
+---
+type: "query"
+date: "2026-08-30T16:02:33.176126+00:00"
+question: "How does pfblockerng_ip.php render and persist asn_token compared with maxmind_key, and where are equivalent live UI tests?"
+contributor: "graphify"
+outcome: "useful"
+---
+
+# Q: How does pfblockerng_ip.php render and persist asn_token compared with maxmind_key, and where are equivalent live UI tests?
+
+## Answer
+
+Graph oriented the investigation to pfblockerng_ip.php, pfb_filter, Form_Input, and the live WebUI harness. Exact source inspection then showed asn_token was loaded from stored iconfig, rendered as text, and unconditionally overwritten on blank POST, while maxmind_key was write-only/password/blank-preserving. Coverage belongs in test_render_smoke.py and test_functional.py.
+
+## Outcome
+
+- Signal: useful

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -2299,11 +2299,10 @@ function pfb_filter($input, $type, $reference='Unknown', $default='', $escape=FA
 	if (!empty($input) && empty($result) &&
 	    !in_array($type, array(PFB_FILTER_URL, PFB_FILTER_FILE_MIME_COMPARE, PFB_FILTER_FILE_MIME, PFB_FILTER_FILE_MIME_COMPRESSED, PFB_FILTER_ON_OFF, PFB_FILTER_NUM))) {
 
-		// Exceptions -- callers whose rejected input must never be logged, even at
-		// debug level: 'DNSBL_Download' (parsed feed lines -- volume); 'top1m_token'
-		// (ADR-59 -- the secret itself, not merely its download URL); 'maxmind_key'
-		// (issue #924 -- same masked/write-only treatment for the MaxMind license key).
-		if (in_array($reference, array('DNSBL_Download', 'top1m_token', 'maxmind_key'))) {
+		// Exceptions: parsed feed-line volume, plus write-only credentials whose rejected
+		// values must never be logged: top1m_token (ADR-59), maxmind_key (#924),
+		// and asn_token (#2922).
+		if (in_array($reference, array('DNSBL_Download', 'top1m_token', 'maxmind_key', 'asn_token'))) {
 			//
 		} else {
 			pfb_logger("{$header} Failed validation [ " . htmlspecialchars($input) . " ]", 6);

--- a/src/usr/local/www/pfblockerng/pfblockerng_ip.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_ip.php
@@ -67,7 +67,8 @@ $pconfig['enable_rdns']		= PfbConfig::read('ip/enable_rdns');
 $pconfig['ip_placeholder']	= $pfb['iconfig']['ip_placeholder']			?: '127.1.7.7';
 $pconfig['maxmind_locale']	= $pfb['iconfig']['maxmind_locale']			?: 'en';
 $pconfig['asn_reporting']	= $pfb['iconfig']['asn_reporting']			?: 'disabled';
-$pconfig['asn_token']		= $pfb['iconfig']['asn_token']				?: '';
+// issue #2922: asn_token is masked/write-only; never load the stored token into the form.
+$pconfig['asn_token']		= $_POST['asn_token'] ?? '';
 $pconfig['database_cc']		= PfbConfig::read('ip/database_cc');
 $pconfig['maxmind_account']	= $pfb['iconfig']['maxmind_account']			?: '';
 // issue #924: maxmind_key is masked/write-only -- never populate it from the stored value.
@@ -191,7 +192,8 @@ if ($_POST) {
 			$input_errors[] = 'MaxMind License key Invalid';
 		}
 
-		if (!empty($_POST['asn_token']) && empty(pfb_filter($_POST['asn_token'], PFB_FILTER_WORD, 'ip'))) {
+		$pfb_asn_token_post = (string) ($_POST['asn_token'] ?? '');
+		if ($pfb_asn_token_post !== '' && empty(pfb_filter($pfb_asn_token_post, PFB_FILTER_WORD, 'ip'))) {
 			$input_errors[] = 'IPinfo Token Invalid';
 		}
 
@@ -270,7 +272,9 @@ if ($_POST) {
 				$pfb['iconfig']['maxmind_key'] = pfb_filter($pfb_maxmind_key_post, PFB_FILTER_WORD, 'maxmind_key') ?: '';
 			}
 			$pfb['iconfig']['asn_reporting']	= $_POST['asn_reporting']					?: 'disabled';
-			$pfb['iconfig']['asn_token']		= $_POST['asn_token']					?: '';
+			if ($pfb_asn_token_post !== '') {
+				$pfb['iconfig']['asn_token'] = $pfb_asn_token_post;
+			}
 			$pfb['iconfig']['inbound_interface']	= implode(',', (array)$_POST['inbound_interface'])		?: '';
 			$pfb['iconfig']['inbound_deny_action']	= $_POST['inbound_deny_action']					?: '';
 			$pfb['iconfig']['outbound_interface']	= implode(',', (array)$_POST['outbound_interface'])		?: '';
@@ -529,14 +533,15 @@ $section->addInput(new Form_Select(
   ->setAttribute('style', 'width: auto');
 
 $section->addInput(new Form_Input(
-        'asn_token',
-        gettext('ASN IPinfo Token'),
-        'text',
-        $pconfig['asn_token'],
-        ['placeholder' => 'Enter your IPinfo Token']
+	'asn_token',
+	gettext('ASN IPinfo Token'),
+	'password',
+	$pconfig['asn_token'] ?? '',
+	['placeholder' => 'Enter your IPinfo Token -- leave blank to keep the current token']
 ))->setHelp('To utilize the free IPinfo ASN functionality, you must first register for a free IPinfo user account. Visit the following '
-        . '<a href="https://ipinfo.io/signup" target="_blank" rel="noopener noreferrer">Link to Register</a> for a free IPinfo user account. '
-        . '<strong>NOTE: If you use Snort/Suricata, check for IPinfo blocked events!</strong>')
+	. '<a href="https://ipinfo.io/signup" target="_blank" rel="noopener noreferrer">Link to Register</a> for a free IPinfo user account. '
+	. '<strong>NOTE: If you use Snort/Suricata, check for IPinfo blocked events!</strong>'
+	. ' The stored token is never displayed here; leaving this field blank on Save keeps the existing token unchanged.')
   ->setAttribute('autocomplete', 'off');
 
 $form->add($section);

--- a/src/usr/local/www/pfblockerng/pfblockerng_ip.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_ip.php
@@ -193,7 +193,7 @@ if ($_POST) {
 		}
 
 		$pfb_asn_token_post = (string) ($_POST['asn_token'] ?? '');
-		if ($pfb_asn_token_post !== '' && empty(pfb_filter($pfb_asn_token_post, PFB_FILTER_WORD, 'ip'))) {
+		if ($pfb_asn_token_post !== '' && empty(pfb_filter($pfb_asn_token_post, PFB_FILTER_WORD, 'asn_token'))) {
 			$input_errors[] = 'IPinfo Token Invalid';
 		}
 

--- a/tests/php/PfbFilterTest.php
+++ b/tests/php/PfbFilterTest.php
@@ -271,43 +271,38 @@ final class PfbFilterTest extends TestCase
 	}
 
 	/**
-	 * issue #924 (security): a MaxMind license key rejected by PFB_FILTER_WORD must NEVER be
-	 * logged -- the same reference-scoped suppression proven above for top1m_token, extended
-	 * to the 'maxmind_key' reference (added to the pfb_filter() exceptions list at
-	 * pfblockerng.inc ~1658). Every maxmind_key call site passes this reference -- the UI
-	 * validate/store (pfblockerng_ip.php) AND the pfb_global() consumer read
-	 * (pfblockerng.inc ~2361) -- so a rejected stored key never reaches the log on any path.
-	 * A DIFFERENT reference still logs the reject, proving the suppression is reference-scoped
-	 * and not a side effect of PFB_FILTER_WORD itself.
+	 * Secret credentials rejected by PFB_FILTER_WORD must never reach the error log.
+	 * An ordinary reference still logs the same rejected input, proving suppression
+	 * remains reference-scoped rather than filter-wide.
 	 */
-	public function testWordFilterRejectionNeverLogsForMaxmindKeyReferenceButOtherReferencesStillDo(): void
+	public function testWordFilterRejectionNeverLogsForSecretReferencesButOtherReferencesStillDo(): void
 	{
-		$errlog = tempnam(sys_get_temp_dir(), 'pfb_filter_maxmind_errlog_');
+		$errlog = tempnam(sys_get_temp_dir(), 'pfb_filter_secret_errlog_');
 		$this->assertNotFalse($errlog, 'could not create temp errlog');
 		$saved = array_key_exists('errlog', $GLOBALS['pfb'] ?? []) ? $GLOBALS['pfb']['errlog'] : false;
 		$GLOBALS['pfb']['errlog'] = $errlog;
 
 		try {
-			// A key with non-word chars ('-'/'!') that PFB_FILTER_WORD rejects.
-			$secret = 'REJECTED-MAXMIND-KEY-should-never-be-logged!!!';
+			$cases = [
+				'maxmind_key' => 'REJECTED-MAXMIND-KEY-should-never-be-logged!!!',
+				'asn_token' => 'REJECTED-ASN-TOKEN-should-never-be-logged!!!',
+			];
+			foreach ($cases as $reference => $secret) {
+				file_put_contents($errlog, '');
+				$this->assertSame('', pfb_filter($secret, PFB_FILTER_WORD, $reference));
+				$this->assertStringNotContainsString(
+					$secret,
+					(string) file_get_contents($errlog),
+					"a key rejected via the {$reference} reference must never be logged"
+				);
 
-			// Given/When: reference 'maxmind_key' -- the issue #924 exception.
-			$this->assertSame('', pfb_filter($secret, PFB_FILTER_WORD, 'maxmind_key'));
-			// Then: the rejected key never reaches the error log.
-			$this->assertStringNotContainsString(
-				$secret,
-				(string) file_get_contents($errlog),
-				'a key rejected via the maxmind_key reference must never be logged'
-			);
-
-			// Given/When: a DIFFERENT (ordinary) reference for the same rejected input.
-			$this->assertSame('', pfb_filter($secret, PFB_FILTER_WORD, 'some_other_caller'));
-			// Then: the suppression is reference-scoped -- an ordinary caller still logs.
-			$this->assertStringContainsString(
-				$secret,
-				(string) file_get_contents($errlog),
-				'a non-maxmind_key reference must still log its rejected input as before'
-			);
+				$this->assertSame('', pfb_filter($secret, PFB_FILTER_WORD, 'some_other_caller'));
+				$this->assertStringContainsString(
+					$secret,
+					(string) file_get_contents($errlog),
+					"an ordinary reference must still log rejected {$reference} input"
+				);
+			}
 		} finally {
 			if ($saved === false) {
 				unset($GLOBALS['pfb']['errlog']);

--- a/tests/smoke/ui/test_functional.py
+++ b/tests/smoke/ui/test_functional.py
@@ -717,43 +717,50 @@ def test_ip_maxmind_key_masked_field_persists_and_is_never_echoed(
 
 
 ASN_TOKEN_CFG = "installedpackages/pfblockerngipsettings/config/0/asn_token"
+AUTORULE_SUFFIX_CFG = "installedpackages/pfblockerngipsettings/config/0/autorule_suffix"
 
 
-def test_ip_asn_token_blank_preserves_and_new_value_replaces(
+def test_ip_asn_token_blank_preserves_new_value_replaces_and_bogus_rejects(
     webui: WebUI,
     smoke_vm: helpers.SmokeVM,
 ) -> None:
-    """ASN IPinfo token is write-only: blank preserves it and a new value replaces it."""
+    """ASN token blank Save succeeds and preserves; valid replaces; bogus aborts."""
     seed_token = "PFBASNTESTTOKEN0001"
     new_token = "PFBASNTESTTOKEN0002"
-    original = helpers.config_get(smoke_vm, ASN_TOKEN_CFG)
+    original_token = helpers.config_get_state(smoke_vm, ASN_TOKEN_CFG)
+    original_suffix = helpers.config_get_state(smoke_vm, AUTORULE_SUFFIX_CFG)
+    sentinel_suffix = "standard" if original_suffix[1] != "standard" else "autorule"
     try:
-        seed = helpers.php_eval(
-            smoke_vm,
-            f"config_set_path({helpers._php_str(ASN_TOKEN_CFG)}, {helpers._php_str(seed_token)});\n"
-            "write_config('#2922 smoke: seed asn_token');\necho 'OK';",
-        )
-        assert "OK" in seed.stdout, f"failed to seed asn_token: {seed.stdout!r}"
+        helpers.config_set(smoke_vm, ASN_TOKEN_CFG, seed_token)
         assert helpers.config_get(smoke_vm, ASN_TOKEN_CFG) == seed_token, (
             "seed did not take before ASN token save assertions"
         )
 
-        got_after_blank = _post_and_get(webui, smoke_vm, IP_PAGE, {"asn_token": ""}, ASN_TOKEN_CFG)
-        assert got_after_blank == seed_token, (
-            f"a blank asn_token POST must preserve the existing token: expected {seed_token!r}, got {got_after_blank!r}"
+        blank = webui.post(
+            IP_PAGE,
+            {"asn_token": "", "autorule_suffix": sentinel_suffix},
+            timeout=SAVE_TIMEOUT,
+        )
+        assert not looks_like_login_page(blank.text), "blank ASN token Save lost its authenticated session"
+        assert helpers.config_get(smoke_vm, ASN_TOKEN_CFG) == seed_token, (
+            "a blank asn_token POST must preserve the existing token"
+        )
+        assert helpers.config_get(smoke_vm, AUTORULE_SUFFIX_CFG) == sentinel_suffix, (
+            "blank asn_token must not abort the rest of the IP settings Save"
         )
 
         got_after_new = _post_and_get(webui, smoke_vm, IP_PAGE, {"asn_token": new_token}, ASN_TOKEN_CFG)
         assert got_after_new == new_token, (
             f"asn_token should persist a new posted value: expected {new_token!r}, got {got_after_new!r}"
         )
-    finally:
-        restore = helpers.php_eval(
-            smoke_vm,
-            f"config_set_path({helpers._php_str(ASN_TOKEN_CFG)}, {helpers._php_str(original)});\n"
-            "write_config('#2922 smoke: restore asn_token');\necho 'OK';",
+
+        got_after_bogus = _post_and_get(webui, smoke_vm, IP_PAGE, {"asn_token": "bad/token"}, ASN_TOKEN_CFG)
+        assert got_after_bogus == new_token, (
+            f"a non-word asn_token must abort the save: expected {new_token!r}, got {got_after_bogus!r}"
         )
-        assert "OK" in restore.stdout, f"failed to restore asn_token: {restore.stdout!r}"
+    finally:
+        helpers.config_restore_state(smoke_vm, AUTORULE_SUFFIX_CFG, original_suffix)
+        helpers.config_restore_state(smoke_vm, ASN_TOKEN_CFG, original_token)
 
 
 # --------------------------------------------------------------------------- #
@@ -1042,13 +1049,10 @@ def _post_and_confirm_general(
 # multiselects are unvalidated (implode comma-join). No test overrides
 # maxmind_locale, so the ugc conversion never fires -- every flow is hermetic.
 #
-# maxmind_key (issue #924) is a HARD-ABORT validator too (a non-word bogus value
-# still aborts the whole save), but it is NOT in the parametrized WORD-filter flow
-# below alongside maxmind_account/asn_token: it is now masked/write-only, so an
-# EMPTY POST means "keep the stored key" rather than "overwrite with empty" --
-# incompatible with that flow's shared "restore via a blank/original POST" idiom.
-# Its own valid/blank-keeps/reject coverage lives in
-# test_ip_maxmind_key_masked_field_persists_and_is_never_echoed above.
+# maxmind_key and asn_token are masked/write-only HARD-ABORT fields: blank means
+# "keep the stored credential", while a non-word value aborts the whole save.
+# Their dedicated tests above cover valid replacement, blank preservation, and
+# rejection. maxmind_account retains the ordinary blank-clears word-field contract.
 # --------------------------------------------------------------------------- #
 
 IP_PLACEHOLDER_CFG = "installedpackages/pfblockerngipsettings/config/0/ip_placeholder"
@@ -1089,46 +1093,21 @@ def test_ip_placeholder_valid_isolated_ipv4_and_reject_unchanged(
         webui.post(IP_PAGE, {"ip_placeholder": original or "127.1.7.7"}, timeout=SAVE_TIMEOUT)
 
 
-@pytest.mark.parametrize(
-    ("field", "valid", "bogus"),
-    [
-        ("maxmind_account", "Test_123", "bad-chars!"),
-        ("asn_token", "Tok_789", "tok@en"),
-    ],
-    ids=["maxmind_account", "asn_token"],
-)
-def test_ip_word_filter_field_valid_and_reject_unchanged(
-    field: str,
-    valid: str,
-    bogus: str,
+def test_ip_maxmind_account_valid_and_reject_unchanged(
     webui: WebUI,
     smoke_vm: helpers.SmokeVM,
 ) -> None:
-    """A ``PFB_FILTER_WORD`` field stores a clean word; a non-word value aborts the save.
-
-    ``PFB_FILTER_WORD`` = no non-word char (``/\\W/``): only ``[A-Za-z0-9_]`` passes.
-    Save guard: ``!empty($_POST[field]) && empty(pfb_filter($_POST[field],
-    PFB_FILTER_WORD, 'ip'))`` -> a field-specific input error -> the WHOLE save
-    aborts -> config UNCHANGED. A valid word ('Test_123' / 'Tok_789') passes and is
-    stored verbatim; a value with a non-word char ('bad-chars!', 'tok@en') is
-    REJECTED -> config unchanged (NOT the bogus value, NOT empty). Empty input is
-    allowed (the ``!empty`` guard) and stores ''. Pure regex validation, NO egress
-    (these tokens only drive update/reload lookups, not this save). Same mechanism
-    for both fields -> parametrized. (``maxmind_key`` shares the same
-    ``PFB_FILTER_WORD`` reject branch but NOT this "blank stores empty" contract --
-    see the masked-field test above.)
-    """
-    vm = smoke_vm
+    """MaxMind account stores a clean word; a non-word value aborts the save."""
+    field = "maxmind_account"
+    valid = "Test_123"
+    bogus = "bad-chars!"
     cfg = f"installedpackages/pfblockerngipsettings/config/0/{field}"
-    original = helpers.config_get(vm, cfg)
+    original = helpers.config_get(smoke_vm, cfg)
     try:
         assert original != valid, f"{field} already {valid!r} before the valid POST"
-        # VALID clean word -> stored verbatim.
-        assert _post_and_get(webui, vm, IP_PAGE, {field: valid}, cfg) == valid
-        # Restore the original (typically '' -- empty is allowed and stores '').
-        assert _post_and_get(webui, vm, IP_PAGE, {field: original}, cfg) == original
-        # REJECT: a non-word char aborts the save -> config UNCHANGED.
-        got = _post_and_get(webui, vm, IP_PAGE, {field: bogus}, cfg)
+        assert _post_and_get(webui, smoke_vm, IP_PAGE, {field: valid}, cfg) == valid
+        assert _post_and_get(webui, smoke_vm, IP_PAGE, {field: original}, cfg) == original
+        got = _post_and_get(webui, smoke_vm, IP_PAGE, {field: bogus}, cfg)
         assert got == original, f"bogus {field} must leave config unchanged at {original!r}, got {got!r}"
     finally:
         webui.post(IP_PAGE, {field: original}, timeout=SAVE_TIMEOUT)

--- a/tests/smoke/ui/test_functional.py
+++ b/tests/smoke/ui/test_functional.py
@@ -716,6 +716,46 @@ def test_ip_maxmind_key_masked_field_persists_and_is_never_echoed(
         assert "OK" in restore.stdout, f"failed to restore maxmind_key: {restore.stdout!r}"
 
 
+ASN_TOKEN_CFG = "installedpackages/pfblockerngipsettings/config/0/asn_token"
+
+
+def test_ip_asn_token_blank_preserves_and_new_value_replaces(
+    webui: WebUI,
+    smoke_vm: helpers.SmokeVM,
+) -> None:
+    """ASN IPinfo token is write-only: blank preserves it and a new value replaces it."""
+    seed_token = "PFBASNTESTTOKEN0001"
+    new_token = "PFBASNTESTTOKEN0002"
+    original = helpers.config_get(smoke_vm, ASN_TOKEN_CFG)
+    try:
+        seed = helpers.php_eval(
+            smoke_vm,
+            f"config_set_path({helpers._php_str(ASN_TOKEN_CFG)}, {helpers._php_str(seed_token)});\n"
+            "write_config('#2922 smoke: seed asn_token');\necho 'OK';",
+        )
+        assert "OK" in seed.stdout, f"failed to seed asn_token: {seed.stdout!r}"
+        assert helpers.config_get(smoke_vm, ASN_TOKEN_CFG) == seed_token, (
+            "seed did not take before ASN token save assertions"
+        )
+
+        got_after_blank = _post_and_get(webui, smoke_vm, IP_PAGE, {"asn_token": ""}, ASN_TOKEN_CFG)
+        assert got_after_blank == seed_token, (
+            f"a blank asn_token POST must preserve the existing token: expected {seed_token!r}, got {got_after_blank!r}"
+        )
+
+        got_after_new = _post_and_get(webui, smoke_vm, IP_PAGE, {"asn_token": new_token}, ASN_TOKEN_CFG)
+        assert got_after_new == new_token, (
+            f"asn_token should persist a new posted value: expected {new_token!r}, got {got_after_new!r}"
+        )
+    finally:
+        restore = helpers.php_eval(
+            smoke_vm,
+            f"config_set_path({helpers._php_str(ASN_TOKEN_CFG)}, {helpers._php_str(original)});\n"
+            "write_config('#2922 smoke: restore asn_token');\necho 'OK';",
+        )
+        assert "OK" in restore.stdout, f"failed to restore asn_token: {restore.stdout!r}"
+
+
 # --------------------------------------------------------------------------- #
 # General settings (installedpackages/pfblockerng/config/0)
 # --------------------------------------------------------------------------- #

--- a/tests/smoke/ui/test_render_smoke.py
+++ b/tests/smoke/ui/test_render_smoke.py
@@ -704,6 +704,46 @@ def test_ip_page_never_leaks_maxmind_key(
         assert "OK" in restore.stdout, f"failed to restore maxmind_key: {restore.stdout!r}"
 
 
+_CFG_ASN_TOKEN = "installedpackages/pfblockerngipsettings/config/0/asn_token"
+
+
+@pytest.mark.ui_e2e
+def test_ip_page_never_leaks_asn_ipinfo_token(
+    smoke_vm: SmokeVM, webui: WebUI, php_error_log_guard: PhpErrorLogGuard
+) -> None:  # noqa: ARG001
+    """Stored ASN IPinfo token stays absent from HTML and its input is password-masked."""
+    seed_token = "PFBASNTESTTOKEN0001"
+    original = helpers.config_get(smoke_vm, _CFG_ASN_TOKEN)
+    seed = helpers.php_eval(
+        smoke_vm,
+        f"config_set_path({helpers._php_str(_CFG_ASN_TOKEN)}, {helpers._php_str(seed_token)});\n"
+        "write_config('#2922 smoke: seed asn_token for never-leak render check');\n"
+        "echo 'OK';",
+    )
+    assert "OK" in seed.stdout, f"failed to seed asn_token: {seed.stdout!r}"
+    assert helpers.config_get(smoke_vm, _CFG_ASN_TOKEN) == seed_token, (
+        "seed did not take before ASN token render assertions"
+    )
+    try:
+        resp = webui.get(_IP_PAGE)
+        assert resp.status_code == 200, f"GET {_IP_PAGE} -> HTTP {resp.status_code} (expected 200)"
+        body = resp.text
+        assert seed_token not in body, f"asn_token leaked into the IP page body: expected {seed_token!r} to be absent"
+        tag = re.search(r'<input[^>]*\bname="asn_token"[^>]*>', body)
+        assert tag, "asn_token input not present on the IP page"
+        assert 'type="password"' in tag.group(0), (
+            f'asn_token input must be masked (type="password"): got {tag.group(0)!r}'
+        )
+    finally:
+        restore = helpers.php_eval(
+            smoke_vm,
+            f"config_set_path({helpers._php_str(_CFG_ASN_TOKEN)}, {helpers._php_str(original)});\n"
+            "write_config('#2922 smoke: restore asn_token');\n"
+            "echo 'OK';",
+        )
+        assert "OK" in restore.stdout, f"failed to restore asn_token: {restore.stdout!r}"
+
+
 _UPDATE_PAGE = "/pfblockerng/pfblockerng_update.php"
 _HOOKS_PAGE = "/pfblockerng/pfblockerng_hooks.php"
 _LOG_PAGE = "/pfblockerng/pfblockerng_log.php"

--- a/tests/smoke/ui/test_render_smoke.py
+++ b/tests/smoke/ui/test_render_smoke.py
@@ -642,106 +642,54 @@ def test_ip_page_renders_v6_suppression_section(webui: WebUI) -> None:
     )
 
 
-_CFG_MAXMIND_KEY = "installedpackages/pfblockerngipsettings/config/0/maxmind_key"
+_IP_WRITE_ONLY_CREDENTIALS = (
+    pytest.param(
+        "maxmind_key",
+        "installedpackages/pfblockerngipsettings/config/0/maxmind_key",
+        "PFBTESTKEY000001",
+        id="maxmind-key",
+    ),
+    pytest.param(
+        "asn_token",
+        "installedpackages/pfblockerngipsettings/config/0/asn_token",
+        "PFBASNTESTTOKEN0001",
+        id="asn-token",
+    ),
+)
 
 
-# Dual-marked ui_e2e (issue #810): this test MUTATES config.xml (seeds maxmind_key) as
-# setup, so it must ride the per-test isolation probe (_ui_pfb_isolation gates on the
-# ui_e2e/ui_browser markers); the module-level ui_render marker keeps it in the Tier-A gate.
+# Dual-marked ui_e2e because this test mutates config.xml; the module-level
+# ui_render marker keeps both parameter rows in the Tier-A render gate.
 @pytest.mark.ui_e2e
-def test_ip_page_never_leaks_maxmind_key(
-    smoke_vm: SmokeVM, webui: WebUI, php_error_log_guard: PhpErrorLogGuard
+@pytest.mark.parametrize(("field", "config_path", "seed_token"), _IP_WRITE_ONLY_CREDENTIALS)
+def test_ip_page_never_leaks_write_only_credential(
+    field: str,
+    config_path: str,
+    seed_token: str,
+    smoke_vm: SmokeVM,
+    webui: WebUI,
+    php_error_log_guard: PhpErrorLogGuard,
 ) -> None:  # noqa: ARG001
-    """The masked ``maxmind_key`` field (issue #924) never echoes the stored MaxMind
-    license key back into the rendered HTML, and is masked (``type="password"``).
-
-    Before this fix the field was a plain ``text`` input pre-filled with the stored
-    key verbatim (``$pconfig['maxmind_key'] = $pfb['iconfig']['maxmind_key']``), so a
-    GET leaked the secret straight into the page source and into any screen-share /
-    browser autofill. Seed an inert key directly (independent of the save path Tier
-    B covers), GET the page, and assert (1) the exact stored key string is ABSENT
-    from the body -- this is the never-leak assertion PRE-change would FAIL on, since
-    the old code echoed it verbatim into the ``value`` attribute -- and (2) the
-    ``maxmind_key`` input renders ``type="password"`` (masked), not ``type="text"``.
-    """
-    seed_token = "PFBTESTKEY000001"
-    original = helpers.config_get(smoke_vm, _CFG_MAXMIND_KEY)
-    seed = helpers.php_eval(
-        smoke_vm,
-        f"config_set_path({helpers._php_str(_CFG_MAXMIND_KEY)}, {helpers._php_str(seed_token)});\n"
-        "write_config('#924 smoke: seed maxmind_key for the never-leak render check');\n"
-        "echo 'OK';",
-    )
-    assert "OK" in seed.stdout, f"failed to seed maxmind_key: {seed.stdout!r}"
-    # Confirm the seed actually persisted BEFORE the never-leak GET -- else "OK" (which
-    # prints even if config_set_path silently no-opped) would let the `not in body`
-    # assertion pass vacuously, with the leakable fixture it must fail on absent.
-    seeded = helpers.config_get(smoke_vm, _CFG_MAXMIND_KEY)
-    assert seeded == seed_token, f"seed did not take: expected {seed_token!r}, got {seeded!r}"
+    """Stored IP-page credentials stay absent; inputs render blank and password-masked."""
+    original = helpers.config_get_state(smoke_vm, config_path)
     try:
+        helpers.config_set(smoke_vm, config_path, seed_token)
+        assert helpers.config_get(smoke_vm, config_path) == seed_token, (
+            f"{field} seed did not take before render assertions"
+        )
+
         resp = webui.get(_IP_PAGE)
         assert resp.status_code == 200, f"GET {_IP_PAGE} -> HTTP {resp.status_code} (expected 200)"
         body = resp.text
-        assert seed_token not in body, (
-            f"maxmind_key leaked into the IP page body: expected {seed_token!r} to be ABSENT, "
-            f"but it was found in the response (write-only masked field must never echo the stored key)"
-        )
-        # Bind type="password" to the maxmind_key input tag ITSELF -- a bare page-level
-        # 'type="password"' substring could be satisfied by any other element, so match the
-        # maxmind_key <input> tag and assert the mask attribute lives inside it.
-        tag = re.search(r'<input[^>]*\bname="maxmind_key"[^>]*>', body)
-        assert tag, "maxmind_key input not present on the IP page"
+        assert seed_token not in body, f"{field} leaked into the IP page body: expected {seed_token!r} to be absent"
+        tag = re.search(rf'<input[^>]*\bname="{re.escape(field)}"[^>]*>', body)
+        assert tag, f"{field} input not present on the IP page"
         assert 'type="password"' in tag.group(0), (
-            f'maxmind_key input must be masked (type="password"), not a plain text field: got {tag.group(0)!r}'
+            f'{field} input must be masked (type="password"): got {tag.group(0)!r}'
         )
+        assert scrape_form_fields(body).get(field) == "", f"{field} input must render blank"
     finally:
-        restore = helpers.php_eval(
-            smoke_vm,
-            f"config_set_path({helpers._php_str(_CFG_MAXMIND_KEY)}, {helpers._php_str(original)});\n"
-            "write_config('#924 smoke: restore maxmind_key');\n"
-            "echo 'OK';",
-        )
-        assert "OK" in restore.stdout, f"failed to restore maxmind_key: {restore.stdout!r}"
-
-
-_CFG_ASN_TOKEN = "installedpackages/pfblockerngipsettings/config/0/asn_token"
-
-
-@pytest.mark.ui_e2e
-def test_ip_page_never_leaks_asn_ipinfo_token(
-    smoke_vm: SmokeVM, webui: WebUI, php_error_log_guard: PhpErrorLogGuard
-) -> None:  # noqa: ARG001
-    """Stored ASN IPinfo token stays absent from HTML and its input is password-masked."""
-    seed_token = "PFBASNTESTTOKEN0001"
-    original = helpers.config_get(smoke_vm, _CFG_ASN_TOKEN)
-    seed = helpers.php_eval(
-        smoke_vm,
-        f"config_set_path({helpers._php_str(_CFG_ASN_TOKEN)}, {helpers._php_str(seed_token)});\n"
-        "write_config('#2922 smoke: seed asn_token for never-leak render check');\n"
-        "echo 'OK';",
-    )
-    assert "OK" in seed.stdout, f"failed to seed asn_token: {seed.stdout!r}"
-    assert helpers.config_get(smoke_vm, _CFG_ASN_TOKEN) == seed_token, (
-        "seed did not take before ASN token render assertions"
-    )
-    try:
-        resp = webui.get(_IP_PAGE)
-        assert resp.status_code == 200, f"GET {_IP_PAGE} -> HTTP {resp.status_code} (expected 200)"
-        body = resp.text
-        assert seed_token not in body, f"asn_token leaked into the IP page body: expected {seed_token!r} to be absent"
-        tag = re.search(r'<input[^>]*\bname="asn_token"[^>]*>', body)
-        assert tag, "asn_token input not present on the IP page"
-        assert 'type="password"' in tag.group(0), (
-            f'asn_token input must be masked (type="password"): got {tag.group(0)!r}'
-        )
-    finally:
-        restore = helpers.php_eval(
-            smoke_vm,
-            f"config_set_path({helpers._php_str(_CFG_ASN_TOKEN)}, {helpers._php_str(original)});\n"
-            "write_config('#2922 smoke: restore asn_token');\n"
-            "echo 'OK';",
-        )
-        assert "OK" in restore.stdout, f"failed to restore asn_token: {restore.stdout!r}"
+        helpers.config_restore_state(smoke_vm, config_path, original)
 
 
 _UPDATE_PAGE = "/pfblockerng/pfblockerng_update.php"


### PR DESCRIPTION
## Summary

- render the ASN IPinfo token as a blank password field
- preserve the stored token when Save submits a blank field; replace it on a valid non-empty submission
- reject invalid ASN tokens without overwriting configuration or logging the rejected secret
- add Tier A/Tier B live-UI coverage and focused filter-log coverage

Fixes #2922

## Final red-to-green evidence

Frozen test blob IDs, identical before RED and after GREEN:

- `tests/php/PfbFilterTest.php`: `448a9f360154c764ab3500ac8ed867cd26d4059c`
- `tests/smoke/ui/test_functional.py`: `9e5657f037953ff0bf998638431eda6c278b0478`
- `tests/smoke/ui/test_render_smoke.py`: `c3eb0aedba9f5473e962daac3e6c4e6d6852dd60`

UI RED (`RUN_ID=local-100038-1788107337-80b2947a4089e10c`): 2 failed, 1 passed, 657 deselected. ASN persistence and ASN rendering failed against base production; MaxMind rendering passed as control.

UI GREEN (`RUN_ID=local-100035-1788107528-a911ca2feadaa089`): 4 passed, 656 deselected. ASN persistence, repaired MaxMind-account sibling, MaxMind rendering, and ASN rendering passed.

Focused PHPUnit: RED `1 test, 7 assertions, 1 failure` because the rejected ASN token reached the log; GREEN `OK (1 test, 9 assertions)`.

## Verification

- `scripts/agent/run-gates.sh --diff origin/devel` — PASS
- focused live pfSense UI smoke — 4 passed
- required CI checks at `d53fd8db051d941c72f6b2009d63d4574e82a9b4` — PASS
- four adversarial review legs and re-review — PASS
- CodeRabbit review — no actionable comments

🤖 Generated by Oh My Pi and posted on behalf of @andrebrait.
