### PR TITLE
www: constrain IP rule order select

### DIFF
--- a/src/usr/local/www/pfblockerng/pfblockerng_ip.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_ip.php
@@ -502,7 +502,7 @@ $section->addInput(new Form_Select(
 		. 'Select the \'<strong>Order</strong>\' of the Rules<br /><br />'
 		. '&emsp;Selecting \'original format\', sets pfBlockerNG rules at the top of the Firewall TAB.<br />'
 		. '&emsp;Selecting any other \'Order\' will re-order <strong>all the rules to the format indicated!</strong></div>')
-  ->setAttribute('style', 'width: auto');
+  ->setAttribute('style', 'width: auto; max-width: 100%');
 
 $section->addInput(new Form_Select(
 	'autorule_suffix',

--- a/tests/php/IpRuleOrderLayoutUiTest.php
+++ b/tests/php/IpRuleOrderLayoutUiTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/** Firewall Auto Rule Order keeps its choices while fitting narrow viewports (issue #2898). */
+final class IpRuleOrderLayoutUiTest extends TestCase
+{
+	private const PAGE = __DIR__ . '/../../src/usr/local/www/pfblockerng/pfblockerng_ip.php';
+
+	private static function source(): string
+	{
+		$source = file_get_contents(self::PAGE);
+		self::assertIsString($source, 'the IP page must be readable');
+		return $source;
+	}
+
+	public function testRuleOrderKeepsFiveDistinctValuesAndOrderZeroDefault(): void
+	{
+		$source = self::source();
+		$this->assertMatchesRegularExpression(
+			'/\$pconfig\[\'pass_order\'\]\s*=.*\?:\s*\'order_0\';/',
+			$source,
+			'Firewall Auto Rule Order must keep order_0 as its fallback default'
+		);
+		$this->assertSame(1, preg_match('/\\$options_pass_order\\s*=\\s*\\[(.*?)\\];/s', $source, $block),
+			'could not locate the Firewall Auto Rule Order options');
+		preg_match_all("/'(order_\\d+)'\\s*=>\\s*'([^']+)'/", $block[1], $options, PREG_SET_ORDER);
+
+		$values = array_column($options, 1);
+		$labels = array_column($options, 2);
+		$this->assertSame(['order_0', 'order_1', 'order_2', 'order_3', 'order_4'], $values);
+		$this->assertCount(5, array_unique($labels), 'all five rule orderings must remain distinguishable');
+	}
+
+	public function testRuleOrderKeepsIntrinsicDesktopWidthButCapsAtItsContainer(): void
+	{
+		$source = self::source();
+		$this->assertSame(1, preg_match("/new Form_Select\\(\\s*'pass_order'.*?;\\n/s", $source, $control),
+			'could not locate the Firewall Auto Rule Order control');
+		$this->assertStringContainsString(
+			"->setAttribute('style', 'width: auto; max-width: 100%')",
+			$control[0],
+			'width:auto must preserve native desktop sizing while max-width caps narrow rendering'
+		);
+	}
+}

--- a/tests/smoke/ui/test_browser_ip.py
+++ b/tests/smoke/ui/test_browser_ip.py
@@ -141,6 +141,17 @@ def test_firewall_auto_rule_order_stays_inside_its_container(
         (control) => {
           const column = control.closest('div[class*="col-sm-"]');
           if (!column) throw new Error('pass_order has no Bootstrap control column');
+          const reference = control.cloneNode(true);
+          reference.removeAttribute('id');
+          reference.removeAttribute('name');
+          reference.setAttribute('aria-hidden', 'true');
+          reference.style.cssText +=
+            '; position: absolute !important; visibility: hidden !important;' +
+            ' pointer-events: none !important; width: auto !important; max-width: none !important';
+          column.append(reference);
+          const nativeAutoWidth = reference.getBoundingClientRect().width;
+          reference.remove();
+
           const box = control.getBoundingClientRect();
           const container = column.getBoundingClientRect();
           const root = document.documentElement;
@@ -148,6 +159,7 @@ def test_firewall_auto_rule_order_stays_inside_its_container(
             left: box.left,
             right: box.right,
             width: box.width,
+            nativeAutoWidth,
             containerLeft: container.left,
             containerRight: container.right,
             containerWidth: container.width,
@@ -172,8 +184,8 @@ def test_firewall_auto_rule_order_stays_inside_its_container(
         f"[{label} {viewport['width']}px] IP page gained horizontal document scroll: {metrics!r}"
     )
     if label == "desktop":
-        assert metrics["width"] < metrics["containerWidth"], (
-            f"desktop select must keep its intrinsic native width rather than fill the column: {metrics!r}"
+        assert abs(metrics["width"] - metrics["nativeAutoWidth"]) <= 1, (
+            f"desktop select must keep the native auto width of its identical options: {metrics!r}"
         )
 
     for value in RULE_ORDER_VALUES:

--- a/tests/smoke/ui/test_browser_ip.py
+++ b/tests/smoke/ui/test_browser_ip.py
@@ -33,13 +33,16 @@ sync_api = pytest.importorskip("playwright.sync_api", reason="playwright not ins
 expect = sync_api.expect
 
 if TYPE_CHECKING:
-    from playwright.sync_api import Locator, Page
+    from playwright.sync_api import Locator, Page, ViewportSize
 
     from .webui import WebUI
 
 pytestmark = pytest.mark.ui_browser
 
 IP_PAGE = "/pfblockerng/pfblockerng_ip.php"
+RULE_ORDER_VALUES = tuple(f"order_{index}" for index in range(5))
+PHONE: ViewportSize = {"width": 414, "height": 896}
+DESKTOP: ViewportSize = {"width": 1440, "height": 900}
 # The ADR-11 multi-select's four option VALUES (the action-type labels the GUI action
 # dropdown / Logs page already use). Order is the canonical type order. Each names the
 # destination folder/class an aggregate unions (its Alias variant folds in).
@@ -108,6 +111,74 @@ def _shot_field(locator: Locator, screenshot_dir: Path, name: str) -> None:
 def _selected_values(select: Locator) -> list[str]:
     """The currently-selected option values of the multi-select, in DOM order."""
     return select.evaluate("el => Array.from(el.selectedOptions).map(o => o.value)")
+
+
+@pytest.mark.parametrize(("label", "viewport"), [("desktop", DESKTOP), ("phone", PHONE)])
+def test_firewall_auto_rule_order_stays_inside_its_container(
+    browser_page: Page,
+    webui: WebUI,
+    screenshot_dir: Path,
+    label: str,
+    viewport: ViewportSize,
+) -> None:
+    """All five native choices remain usable without overflowing either viewport."""
+    page = browser_page
+    page.set_viewport_size(viewport)
+    _open(page, webui, IP_PAGE)
+
+    select = page.locator("#pass_order")
+    expect(select).to_be_visible(timeout=JS_TIMEOUT_MS)
+    rendered_options = select.locator("option").evaluate_all(
+        "(options) => options.map((option) => ({value: option.value, label: option.textContent.trim()}))"
+    )
+    assert [option["value"] for option in rendered_options] == list(RULE_ORDER_VALUES)
+    assert len({option["label"] for option in rendered_options}) == len(RULE_ORDER_VALUES), (
+        f"the five Firewall Auto Rule Order labels must remain distinguishable: {rendered_options!r}"
+    )
+
+    metrics = select.evaluate(
+        """
+        (control) => {
+          const column = control.closest('div[class*="col-sm-"]');
+          if (!column) throw new Error('pass_order has no Bootstrap control column');
+          const box = control.getBoundingClientRect();
+          const container = column.getBoundingClientRect();
+          const root = document.documentElement;
+          return {
+            left: box.left,
+            right: box.right,
+            width: box.width,
+            containerLeft: container.left,
+            containerRight: container.right,
+            containerWidth: container.width,
+            viewportWidth: root.clientWidth,
+            documentOverflow: root.scrollWidth - root.clientWidth,
+          };
+        }
+        """
+    )
+    _shot(page, screenshot_dir, f"ip_rule_order_{label}")
+
+    assert metrics["left"] >= metrics["containerLeft"] - 1, (
+        f"[{label} {viewport['width']}px] select starts outside its container: {metrics!r}"
+    )
+    assert metrics["right"] <= metrics["containerRight"] + 1, (
+        f"[{label} {viewport['width']}px] select exceeds its container: {metrics!r}"
+    )
+    assert metrics["right"] <= metrics["viewportWidth"] + 1, (
+        f"[{label} {viewport['width']}px] select exceeds the viewport: {metrics!r}"
+    )
+    assert metrics["documentOverflow"] == 0, (
+        f"[{label} {viewport['width']}px] IP page gained horizontal document scroll: {metrics!r}"
+    )
+    if label == "desktop":
+        assert metrics["width"] < metrics["containerWidth"], (
+            f"desktop select must keep its intrinsic native width rather than fill the column: {metrics!r}"
+        )
+
+    for value in RULE_ORDER_VALUES:
+        select.select_option(value)
+        assert select.input_value() == value, f"native selection did not accept {value}"
 
 
 def test_ip_aggregate_types_multiselect(


### PR DESCRIPTION
## Summary

- keep the Firewall Auto Rule Order select's intrinsic desktop width
- cap it at its Bootstrap control column on narrow viewports
- preserve the five ordered values, labels, and `order_0` default
- add focused PHP contract coverage and live-browser coverage at 1440×900 and 414×896

Fixes #2898

## Scope and exact identity

Exactly three paths differ from `devel`:

- `src/usr/local/www/pfblockerng/pfblockerng_ip.php`
- `tests/php/IpRuleOrderLayoutUiTest.php`
- `tests/smoke/ui/test_browser_ip.py`

The four adversarial reviews and CodeRabbit completed on reviewed head `f9fbfc74d8bf62683b0aafc05e4576d749d286fb`. The landing rebase reproduced the byte-identical three-file patch onto `devel` at `fd974d1df553c663cba75e6dcb8d0d26c0fce0ae`; exact PR head is now `c64c106ceb9ae6486a46cbfd36e93176f4fe1077`.

Final head blobs:

- production: `93a501d8bebb0bf91a247f9e0d3c23a4a646e128`
- PHP test: `8a58831925f8730e260799c5b12ccd7ef2fc0a5c`
- browser test: `6526878804607f2dc6d3ada11e3d3f0415743595`

The honesty follow-up changed only the browser test: the production and focused PHP-test blobs stayed unchanged. The live test now compares the desktop control width with a hidden native `width:auto` reference cloned with the same options, rather than merely requiring the control to be narrower than its container.

## Test-first evidence

Frozen PHP test blob: `8a58831925f8730e260799c5b12ccd7ef2fc0a5c`.

- RED against untouched base production: `vendor/bin/phpunit tests/php/IpRuleOrderLayoutUiTest.php` → exit 1; 2 tests, 8 assertions, 1 failure because the control had `width: auto` without the container cap.
- GREEN against the implementation: same command and frozen test → exit 0; 2 tests, 8 assertions.
- Focused PHP mutations killed: removed cap, `101%` cap, changed default to `order_1`, and changed final value to `order_5` all failed.

### Desktop-width honesty mutation

[UI mutant run 33324217853](https://github.com/pfBlockerNG/pfBlockerNG/actions/runs/33324217853) exercised mutant commit `43a03ffac28b2de96b13cfa28bfcf4ab27d1fbc5`, which changed the shipped select to `width: 50%` while retaining the narrow cap.

- desktop 1440×900: **RED** — actual width `467.5px` differed from the identical-options native-auto reference `545px`
- phone 414×896: passed the narrow container/viewport/no-scroll contract
- focused result: **1 failed, 1 passed, 660 deselected**

This kills the previously surviving `width:50%` mutant while proving the narrow cap is independently preserved.

## Verification

### Exact-head required CI

[Tests run 33324174344](https://github.com/pfBlockerNG/pfBlockerNG/actions/runs/33324174344) → success on reviewed head `f9fbfc74d8bf62683b0aafc05e4576d749d286fb`.

After the landing rebase, [Tests run 33342426549](https://github.com/pfBlockerNG/pfBlockerNG/actions/runs/33342426549) → success on exact head `c64c106ceb9ae6486a46cbfd36e93176f4fe1077`. All 23 jobs reached terminal state: every required job and the `All tests passed` gate succeeded; the benchmark and unlabeled full UI fan-out jobs were the two expected skips.

### Focused live pfSense browser proof

[UI tests run 33324547319](https://github.com/pfBlockerNG/pfBlockerNG/actions/runs/33324547319) → success on reviewed head `f9fbfc74d8bf62683b0aafc05e4576d749d286fb`. After the landing rebase, [UI tests run 33342456683](https://github.com/pfBlockerNG/pfBlockerNG/actions/runs/33342456683) → success on exact head `c64c106ceb9ae6486a46cbfd36e93176f4fe1077`.

Dispatch: `ui-tests.yml`, `tier=browser`, `scope=impacted`, `pytest_filter=test_firewall_auto_rule_order_stays_inside_its_container`.

- supported live row: `browser / CE-2.8 (live pfSense VM)` → success
- reviewed-head exact test: **2 passed, 660 deselected**; landing exact-head rerun: **2 passed, 661 deselected**
- desktop 1440×900: control width matched the native-auto identical-options reference within 1px, stayed inside its container/viewport, and introduced no document overflow
- phone 414×896: control stayed inside its container and viewport and introduced no document overflow
- both rows retain exact ordered `order_0`…`order_4` values, five distinguishable labels, and native selection/read-back of every value
- reviewed-head diagnostics/screenshots artifact: `9735894379`; landing exact-head artifact: `9741013927`

Independent scoped verification passed reviewed head `f9fbfc74d8bf62683b0aafc05e4576d749d286fb`, including the mutation RED, current GREEN, file identities, and clean three-path scope. The landing rebase preserved the complete patch and all three changed-file blobs byte-for-byte; canonical gates, required CI, and focused live UI then passed exact head `c64c106ceb9ae6486a46cbfd36e93176f4fe1077`.

🤖 Generated by Oh My Pi and posted on behalf of @andrebrait.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the Firewall Auto Rule Order selector so it fits within its container on narrow screens while retaining its natural desktop width.
  * Preserved all five available rule-order options and the default selection.
* **Tests**
  * Added coverage to verify rule-order options, responsive sizing, and the absence of horizontal page overflow across desktop and mobile layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->