### PR TITLE
unbound: bound daemon startup wait

### DIFF
--- a/docs/misc/external-process-waits.md
+++ b/docs/misc/external-process-waits.md
@@ -34,6 +34,20 @@ In-tree, exactly that split:
 - **ADR-12 update hooks** (`pfb_run_hooks()` in `pfblockerng.inc`) run under `timeout --foreground` — documented HAProxy recipe restarts daemon *meant* to survive.
 - **`list_scripts` feed pre/post scripts** stay **default** — transform pipelines, hung `curl | jq` must die as whole tree on overrun, not orphaned. Feed script that starts a service is misuse: use **post-update hook** instead, where daemon case handled right.
 
+### Mixed survivor + transient tree: supervise a process group
+
+Unbound startup needs both properties: the resolver that daemonizes successfully must
+survive, but a stuck launcher and its ordinary helpers must all die. Neither timeout mode
+can provide both: default reaper mode captures the daemon too; `--foreground` kills only
+the launcher and orphans helpers.
+
+`pfb_stop_start_unbound()` therefore starts a small PHP supervisor in its own process
+group behind a release barrier. The parent verifies `PGID == launcher PID` before the
+configured command runs. A real daemon's `setsid()` moves it out of that group; ordinary
+helpers remain. Completion or the monotonic deadline sends TERM, then SIGKILL after the
+grace, to the negative PGID and explicitly reaps the supervisor. Stdio still targets
+`/dev/null` plus a regular output file, never a capture pipe.
+
 ## Don't let a daemon hold the capture pipe
 
 PHP `exec()` / `$(command substitution)` read command stdout **to EOF**. Daemon the command spawned inherits command stdout/stderr, and while it lives pipe never reaches EOF — capture **blocks** even though command itself exited. (`timeout` reaper-wait above is *second*, independent way same hook hangs.)

--- a/docs/misc/external-process-waits.md
+++ b/docs/misc/external-process-waits.md
@@ -42,11 +42,13 @@ can provide both: default reaper mode captures the daemon too; `--foreground` ki
 the launcher and orphans helpers.
 
 `pfb_stop_start_unbound()` therefore starts a small PHP supervisor in its own process
-group behind a release barrier. The parent verifies `PGID == launcher PID` before the
-configured command runs. A real daemon's `setsid()` moves it out of that group; ordinary
-helpers remain. Completion or the monotonic deadline sends TERM, then SIGKILL after the
-grace, to the negative PGID and explicitly reaps the supervisor. Stdio still targets
-`/dev/null` plus a regular output file, never a capture pipe.
+group behind a five-second setup barrier. The parent verifies
+`PGID == launcher PID` before release; only that event starts the configured command's
+30-second deadline, so scheduler delay while creating the supervisor cannot become a false
+command expiry. A real daemon's `setsid()` moves it out of that group; ordinary helpers
+remain. Completion or deadline sends TERM, then SIGKILL after the grace, to the negative
+PGID and explicitly reaps the supervisor. Stdio targets `/dev/null` plus a regular output
+file, never a capture pipe.
 
 ## Don't let a daemon hold the capture pipe
 

--- a/docs/misc/external-process-waits.md
+++ b/docs/misc/external-process-waits.md
@@ -42,13 +42,17 @@ can provide both: default reaper mode captures the daemon too; `--foreground` ki
 the launcher and orphans helpers.
 
 `pfb_stop_start_unbound()` therefore starts a small PHP supervisor in its own process
-group behind a five-second setup barrier. The parent verifies
-`PGID == launcher PID` before release; only that event starts the configured command's
-30-second deadline, so scheduler delay while creating the supervisor cannot become a false
-command expiry. A real daemon's `setsid()` moves it out of that group; ordinary helpers
-remain. Completion or deadline sends TERM, then SIGKILL after the grace, to the negative
-PGID and explicitly reaps the supervisor. Stdio targets `/dev/null` plus a regular output
-file, never a capture pipe.
+group behind a five-second setup barrier. The supervisor executable is the package's
+canonical CLI path (`$pfb['php']`, falling back to `PHP_BINDIR . '/php'`), never
+`PHP_BINARY`: under a pfSense web request that constant names `php-cgi`, which rejects
+the CLI-only `-r` option.
+
+The parent verifies `PGID == launcher PID` before release; only the child's subsequent
+start acknowledgement begins the configured command's 30-second deadline, so scheduler
+delay while creating the supervisor cannot become a false command expiry. A real daemon's
+`setsid()` moves it out of that group; ordinary helpers remain. Completion or deadline
+sends TERM, then SIGKILL after the grace, to the negative PGID and explicitly reaps the
+supervisor. Stdio targets `/dev/null` plus a regular output file, never a capture pipe.
 
 ## Don't let a daemon hold the capture pipe
 

--- a/graphify-out/memory/query_20260830_152058_issue_2882__pfb_stop_start_unbound_direct_unbound.md
+++ b/graphify-out/memory/query_20260830_152058_issue_2882__pfb_stop_start_unbound_direct_unbound.md
@@ -1,0 +1,17 @@
+---
+type: "query"
+date: "2026-08-30T15:20:58.071316+00:00"
+question: "Issue 2882: pfb_stop_start_unbound direct Unbound daemon startup spawn, existing bounded-wait process-tree patterns, preserving retry rollback apply-ledger behavior, and focused tests"
+contributor: "graphify"
+outcome: "useful"
+---
+
+# Q: Issue 2882: pfb_stop_start_unbound direct Unbound daemon startup spawn, existing bounded-wait process-tree patterns, preserving retry rollback apply-ledger behavior, and focused tests
+
+## Answer
+
+Located pfb_stop_start_unbound at pfblockerng.inc:11409 and connected pfb_run_hooks as the existing daemon-survivor wait pattern; test impact remained broad/truncated and will be resolved with CodeGraph.
+
+## Outcome
+
+- Signal: useful

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -11450,34 +11450,198 @@ function pfb_stop_start_unbound($type) {
 		return $final;
 	}
 
-	// FreeBSD timeout(1) foreground mode lets a successfully daemonized resolver
-	// survive. File output prevents that survivor from holding exec()'s capture pipe.
-	$timeout = escapeshellarg($pfb['timeout'] ?? '/usr/bin/timeout');
-	$cmd = "{$timeout} --foreground -s TERM -k " . PFB_HOOK_KILL_GRACE . ' ' .
-		PFB_UNBOUND_START_WAIT . ' ' . PFB_UNBOUND_START_CMD . ' > ' .
-		escapeshellarg($outfile) . ' 2>&1 < /dev/null';
-	$discard = array();
-	$retval = 0;
-	$started = hrtime(TRUE);
-	if (exec($cmd, $discard, $retval) === FALSE && $retval === 0) {
+	$ready = "{$outfile}.ready";
+	$release = "{$outfile}.release";
+	$done = "{$outfile}.done";
+	$proc = NULL;
+	$pid = 0;
+	$group_ready = FALSE;
+	$retval = NULL;
+	$failure = '';
+	$expired = FALSE;
+
+	// A successful Unbound daemon creates its own session and leaves this group.
+	// Any ordinary helper stays with the launcher, so expiry can reap the whole tree.
+	$stop_group = static function (&$proc, int $pid, bool $group_ready): void {
+		if (!is_resource($proc) || $pid <= 0) {
+			return;
+		}
+		if ($group_ready) {
+			@posix_kill(-$pid, 15);
+		} else {
+			@proc_terminate($proc, 15);
+		}
+
+		$grace_deadline = hrtime(TRUE) + (PFB_HOOK_KILL_GRACE * 1000000000);
+		while (is_resource($proc) && hrtime(TRUE) < $grace_deadline) {
+			$status = @proc_get_status($proc);
+			if (!is_array($status) || !$status['running']) {
+				@proc_close($proc);
+				$proc = NULL;
+				break;
+			}
+			usleep(10000);
+		}
+		if (is_resource($proc)) {
+			if ($group_ready) {
+				@posix_kill(-$pid, 9);
+			}
+			@proc_terminate($proc, 9);
+			@proc_close($proc);
+			$proc = NULL;
+			return;
+		}
+
+		// Once the group leader is reaped, a still-live group is made solely of
+		// descendants; wait out their TERM grace, then kill any that ignored it.
+		if (!$group_ready || !@posix_kill(-$pid, 0)) {
+			return;
+		}
+		while (hrtime(TRUE) < $grace_deadline) {
+			if (!@posix_kill(-$pid, 0)) {
+				return;
+			}
+			usleep(10000);
+		}
+		@posix_kill(-$pid, 9);
+	};
+
+	try {
+		foreach (array('proc_open', 'proc_get_status', 'posix_setpgid', 'posix_getpgid', 'posix_kill') as $required) {
+			if (!function_exists($required)) {
+				throw new RuntimeException("{$required}() unavailable; Unbound start not run");
+			}
+		}
+
+		// The child establishes its own process group, publishes readiness, then waits
+		// for the parent to verify that group before executing the configured command.
+		$launcher_code =
+			'if (!posix_setpgid(0, 0)) { exit(126); } ' .
+			'$pid = getmypid(); putenv("PFB_UNBOUND_START_PGID={$pid}"); ' .
+			'$ready_tmp = $argv[1] . ".new"; ' .
+			'if (@file_put_contents($ready_tmp, (string) $pid) === FALSE || ' .
+			'!@rename($ready_tmp, $argv[1])) { exit(126); } ' .
+			'$barrier_deadline = hrtime(TRUE) + ((int) $argv[4] * 1000000000); ' .
+			'while (!file_exists($argv[2])) { ' .
+			'if (hrtime(TRUE) >= $barrier_deadline) { exit(125); } usleep(1000); } ' .
+			'passthru($argv[3], $status); ' .
+			'$done_tmp = $argv[5] . ".new"; ' .
+			'if (@file_put_contents($done_tmp, (string) $status) === FALSE || ' .
+			'!@rename($done_tmp, $argv[5])) { exit(126); } ' .
+			'$linger_deadline = hrtime(TRUE) + ((int) $argv[4] * 1000000000); ' .
+			'while (hrtime(TRUE) < $linger_deadline) { usleep(10000); } exit($status);';
+		$descriptors = array(
+			0 => array('file', '/dev/null', 'r'),
+			1 => array('file', $outfile, 'a'),
+			2 => array('file', $outfile, 'a'),
+		);
+		$pipes = array();
+		$started = hrtime(TRUE);
+		$deadline = $started + (PFB_UNBOUND_START_WAIT * 1000000000);
+		$proc = @proc_open(array(
+			PHP_BINARY,
+			'-r',
+			$launcher_code,
+			'--',
+			$ready,
+			$release,
+			PFB_UNBOUND_START_CMD,
+			(string) PFB_UNBOUND_START_WAIT,
+			$done,
+		), $descriptors, $pipes);
+		if (!is_resource($proc)) {
+			throw new RuntimeException('could not launch supervised Unbound start');
+		}
+
+		$status = proc_get_status($proc);
+		$pid = (int) $status['pid'];
+		while (!file_exists($ready)) {
+			$status = proc_get_status($proc);
+			if (!$status['running']) {
+				$retval = (int) $status['exitcode'];
+				break;
+			}
+			if (hrtime(TRUE) >= $deadline) {
+				$expired = TRUE;
+				break;
+			}
+			usleep(1000);
+		}
+
+		if ($retval === NULL && !$expired && file_exists($ready)) {
+			$published_pid = (int) trim((string) @file_get_contents($ready));
+			$group_ready = @posix_getpgid($pid) === $pid;
+			if ($published_pid !== $pid || !$group_ready) {
+				$failure = 'Unbound start process-group barrier verification failed';
+			} elseif (!@touch($release)) {
+				$failure = 'Unbound start process-group barrier release failed';
+			}
+		}
+
+		while ($retval === NULL && !$expired && $failure === '' && !file_exists($done)) {
+			$status = proc_get_status($proc);
+			if (!$status['running']) {
+				$retval = (int) $status['exitcode'];
+				break;
+			}
+			if (hrtime(TRUE) >= $deadline) {
+				$expired = TRUE;
+				break;
+			}
+			usleep(10000);
+		}
+		if ($retval === NULL && !$expired && $failure === '' && file_exists($done)) {
+			$done_status = trim((string) @file_get_contents($done));
+			if (preg_match('/^[0-9]+$/D', $done_status) !== 1) {
+				$failure = 'Unbound start completion status invalid';
+			} else {
+				$retval = (int) $done_status;
+			}
+		}
+
+		if ($expired) {
+			$group_ready = $group_ready || @posix_getpgid($pid) === $pid;
+			$stop_group($proc, $pid, $group_ready);
+			$retval = 124;
+		} elseif ($failure !== '') {
+			$group_ready = $group_ready || @posix_getpgid($pid) === $pid;
+			$stop_group($proc, $pid, $group_ready);
+			$retval = -1;
+		} elseif ($group_ready) {
+			// Reap the supervisor and any completed command's non-daemon helpers.
+			$stop_group($proc, $pid, TRUE);
+		} elseif (is_resource($proc)) {
+			@proc_close($proc);
+			$proc = NULL;
+		}
+	} catch (Throwable $error) {
+		$failure = $error->getMessage();
 		$retval = -1;
-	}
-	// GNU timeout reports 128+SIGKILL when its kill-after grace fires; FreeBSD
-	// reports 124. Only normalize a 137 that actually consumed the wall budget,
-	// preserving an unrelated immediate SIGKILL as its original status.
-	if ($retval === 137 && hrtime(TRUE) - $started >= PFB_UNBOUND_START_WAIT * 1000000000) {
-		$retval = 124;
+	} finally {
+		if (is_resource($proc)) {
+			$group_ready = $group_ready || ($pid > 0 && @posix_getpgid($pid) === $pid);
+			$stop_group($proc, $pid, $group_ready);
+		}
+		$raw = (string) @file_get_contents($outfile);
+		@unlink("{$done}.new");
+		@unlink($done);
+		@unlink($release);
+		@unlink("{$ready}.new");
+		@unlink($ready);
+		@unlink($outfile);
 	}
 
-	$raw = (string) @file_get_contents($outfile);
+	if ($failure !== '') {
+		$raw .= ($raw !== '' && !str_ends_with($raw, "\n") ? "\n" : '') . "{$failure}\n";
+		pfb_logger("\n{$failure}", 2);
+	}
 	$final['result'] = ($raw === '') ? array() : explode("\n", $raw);
 	if (end($final['result']) === '') {
 		array_pop($final['result']);
 	}
-	$final['retval'] = $retval;
-	@unlink($outfile);
+	$final['retval'] = (int) ($retval ?? -1);
 
-	if ($retval === 124) {
+	if ($final['retval'] === 124) {
 		pfb_logger("\nUnbound Resolver start TIMED OUT after " . PFB_UNBOUND_START_WAIT .
 			"s and was killed", 2);
 	}

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -11545,9 +11545,10 @@ function pfb_stop_start_unbound($type) {
 			2 => array('file', $outfile, 'a'),
 		);
 		$pipes = array();
+		$php_cli = (string) ($pfb['php'] ?? (PHP_BINDIR . '/php'));
 		$setup_deadline = hrtime(TRUE) + (PFB_UNBOUND_START_SETUP_WAIT * 1000000000);
 		$proc = @proc_open(array(
-			PHP_BINARY,
+			$php_cli,
 			'-r',
 			$launcher_code,
 			'--',

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -11394,14 +11394,17 @@ function pfb_dnsbl_tld_stats_finalize(array $group_counts): void {
 	dnsbl_save_stats();
 }
 
-// The daemon-start command and the stop-wait budget are named so a harness can
-// override them before this file loads (issue #2613: the unit suite would otherwise
-// start a real resolver on any box carrying Unbound at the shipped path).
+// The daemon-start command and stop/start budgets are named so a harness can override
+// them before this file loads (issue #2613: the unit suite would otherwise start a real
+// resolver or pay the appliance waits).
 if (!defined('PFB_UNBOUND_START_CMD')) {
 	define('PFB_UNBOUND_START_CMD', '/usr/local/sbin/unbound -c /var/unbound/unbound.conf 2>&1');
 }
 if (!defined('PFB_UNBOUND_STOP_WAIT')) {
 	define('PFB_UNBOUND_STOP_WAIT', 30);
+}
+if (!defined('PFB_UNBOUND_START_WAIT')) {
+	define('PFB_UNBOUND_START_WAIT', 30);
 }
 
 // Function to Start Unbound
@@ -11439,7 +11442,45 @@ function pfb_stop_start_unbound($type) {
 	}
 
 	pfb_logger("\nStarting Unbound Resolver", 1);
-	exec(PFB_UNBOUND_START_CMD, $final['result'], $final['retval']);
+	$outfile = @tempnam(sys_get_temp_dir(), 'pfbus');
+	if ($outfile === FALSE) {
+		$final['result'] = array('could not stage Unbound start output');
+		$final['retval'] = -1;
+		pfb_logger("\nUnbound Resolver start could not stage output; not run", 2);
+		return $final;
+	}
+
+	// FreeBSD timeout(1) foreground mode lets a successfully daemonized resolver
+	// survive. File output prevents that survivor from holding exec()'s capture pipe.
+	$timeout = escapeshellarg($pfb['timeout'] ?? '/usr/bin/timeout');
+	$cmd = "{$timeout} --foreground -s TERM -k " . PFB_HOOK_KILL_GRACE . ' ' .
+		PFB_UNBOUND_START_WAIT . ' ' . PFB_UNBOUND_START_CMD . ' > ' .
+		escapeshellarg($outfile) . ' 2>&1 < /dev/null';
+	$discard = array();
+	$retval = 0;
+	$started = hrtime(TRUE);
+	if (exec($cmd, $discard, $retval) === FALSE && $retval === 0) {
+		$retval = -1;
+	}
+	// GNU timeout reports 128+SIGKILL when its kill-after grace fires; FreeBSD
+	// reports 124. Only normalize a 137 that actually consumed the wall budget,
+	// preserving an unrelated immediate SIGKILL as its original status.
+	if ($retval === 137 && hrtime(TRUE) - $started >= PFB_UNBOUND_START_WAIT * 1000000000) {
+		$retval = 124;
+	}
+
+	$raw = (string) @file_get_contents($outfile);
+	$final['result'] = ($raw === '') ? array() : explode("\n", $raw);
+	if (end($final['result']) === '') {
+		array_pop($final['result']);
+	}
+	$final['retval'] = $retval;
+	@unlink($outfile);
+
+	if ($retval === 124) {
+		pfb_logger("\nUnbound Resolver start TIMED OUT after " . PFB_UNBOUND_START_WAIT .
+			"s and was killed", 2);
+	}
 	return $final;
 }
 

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -11406,6 +11406,9 @@ if (!defined('PFB_UNBOUND_STOP_WAIT')) {
 if (!defined('PFB_UNBOUND_START_WAIT')) {
 	define('PFB_UNBOUND_START_WAIT', 30);
 }
+if (!defined('PFB_UNBOUND_START_SETUP_WAIT')) {
+	define('PFB_UNBOUND_START_SETUP_WAIT', 5);
+}
 
 // Function to Start Unbound
 function pfb_stop_start_unbound($type) {
@@ -11452,6 +11455,7 @@ function pfb_stop_start_unbound($type) {
 
 	$ready = "{$outfile}.ready";
 	$release = "{$outfile}.release";
+	$command_started = "{$outfile}.started";
 	$done = "{$outfile}.done";
 	$proc = NULL;
 	$pid = 0;
@@ -11524,10 +11528,13 @@ function pfb_stop_start_unbound($type) {
 			'$barrier_deadline = hrtime(TRUE) + ((int) $argv[4] * 1000000000); ' .
 			'while (!file_exists($argv[2])) { ' .
 			'if (hrtime(TRUE) >= $barrier_deadline) { exit(125); } usleep(1000); } ' .
+			'$started_tmp = $argv[5] . ".new"; ' .
+			'if (@file_put_contents($started_tmp, "1") === FALSE || ' .
+			'!@rename($started_tmp, $argv[5])) { exit(126); } ' .
 			'passthru($argv[3], $status); ' .
-			'$done_tmp = $argv[5] . ".new"; ' .
+			'$done_tmp = $argv[6] . ".new"; ' .
 			'if (@file_put_contents($done_tmp, (string) $status) === FALSE || ' .
-			'!@rename($done_tmp, $argv[5])) { exit(126); } ' .
+			'!@rename($done_tmp, $argv[6])) { exit(126); } ' .
 			'$linger_deadline = hrtime(TRUE) + ((int) $argv[4] * 1000000000); ' .
 			'while (hrtime(TRUE) < $linger_deadline) { usleep(10000); } exit($status);';
 		$descriptors = array(
@@ -11536,8 +11543,7 @@ function pfb_stop_start_unbound($type) {
 			2 => array('file', $outfile, 'a'),
 		);
 		$pipes = array();
-		$started = hrtime(TRUE);
-		$deadline = $started + (PFB_UNBOUND_START_WAIT * 1000000000);
+		$setup_deadline = hrtime(TRUE) + (PFB_UNBOUND_START_SETUP_WAIT * 1000000000);
 		$proc = @proc_open(array(
 			PHP_BINARY,
 			'-r',
@@ -11546,7 +11552,8 @@ function pfb_stop_start_unbound($type) {
 			$ready,
 			$release,
 			PFB_UNBOUND_START_CMD,
-			(string) PFB_UNBOUND_START_WAIT,
+			(string) (PFB_UNBOUND_START_SETUP_WAIT + PFB_HOOK_KILL_GRACE),
+			$command_started,
 			$done,
 		), $descriptors, $pipes);
 		if (!is_resource($proc)) {
@@ -11561,21 +11568,41 @@ function pfb_stop_start_unbound($type) {
 				$retval = (int) $status['exitcode'];
 				break;
 			}
-			if (hrtime(TRUE) >= $deadline) {
-				$expired = TRUE;
+			if (hrtime(TRUE) >= $setup_deadline) {
+				$failure = 'Unbound start process-group setup TIMED OUT after ' .
+					PFB_UNBOUND_START_SETUP_WAIT . 's; not run';
 				break;
 			}
 			usleep(1000);
 		}
 
-		if ($retval === NULL && !$expired && file_exists($ready)) {
+		if ($retval === NULL && $failure === '' && file_exists($ready)) {
 			$published_pid = (int) trim((string) @file_get_contents($ready));
 			$group_ready = @posix_getpgid($pid) === $pid;
 			if ($published_pid !== $pid || !$group_ready) {
 				$failure = 'Unbound start process-group barrier verification failed';
 			} elseif (!@touch($release)) {
 				$failure = 'Unbound start process-group barrier release failed';
+			} else {
+				$start_ack_deadline = hrtime(TRUE) + (PFB_UNBOUND_START_SETUP_WAIT * 1000000000);
 			}
+		}
+
+		while ($retval === NULL && $failure === '' && !file_exists($command_started)) {
+			$status = proc_get_status($proc);
+			if (!$status['running']) {
+				$retval = (int) $status['exitcode'];
+				break;
+			}
+			if (hrtime(TRUE) >= $start_ack_deadline) {
+				$failure = 'Unbound command-start acknowledgement TIMED OUT after ' .
+					PFB_UNBOUND_START_SETUP_WAIT . 's; not run';
+				break;
+			}
+			usleep(1000);
+		}
+		if ($retval === NULL && $failure === '' && file_exists($command_started)) {
+			$deadline = hrtime(TRUE) + (PFB_UNBOUND_START_WAIT * 1000000000);
 		}
 
 		while ($retval === NULL && !$expired && $failure === '' && !file_exists($done)) {
@@ -11626,6 +11653,8 @@ function pfb_stop_start_unbound($type) {
 		@unlink("{$done}.new");
 		@unlink($done);
 		@unlink($release);
+		@unlink("{$command_started}.new");
+		@unlink($command_started);
 		@unlink("{$ready}.new");
 		@unlink($ready);
 		@unlink($outfile);

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -11463,6 +11463,8 @@ function pfb_stop_start_unbound($type) {
 	$retval = NULL;
 	$failure = '';
 	$expired = FALSE;
+	$start_ack_deadline = NULL;
+	$deadline = NULL;
 
 	// A successful Unbound daemon creates its own session and leaves this group.
 	// Any ordinary helper stays with the launcher, so expiry can reap the whole tree.
@@ -11589,6 +11591,10 @@ function pfb_stop_start_unbound($type) {
 		}
 
 		while ($retval === NULL && $failure === '' && !file_exists($command_started)) {
+			if ($start_ack_deadline === NULL) {
+				$failure = 'Unbound command-start acknowledgement deadline not armed';
+				break;
+			}
 			$status = proc_get_status($proc);
 			if (!$status['running']) {
 				$retval = (int) $status['exitcode'];
@@ -11606,6 +11612,10 @@ function pfb_stop_start_unbound($type) {
 		}
 
 		while ($retval === NULL && !$expired && $failure === '' && !file_exists($done)) {
+			if ($deadline === NULL) {
+				$failure = 'Unbound start deadline not armed';
+				break;
+			}
 			$status = proc_get_status($proc);
 			if (!$status['running']) {
 				$retval = (int) $status['exitcode'];

--- a/tests/php/PfbSyncStatusDnsblWritersTest.php
+++ b/tests/php/PfbSyncStatusDnsblWritersTest.php
@@ -402,6 +402,48 @@ final class PfbSyncStatusDnsblWritersTest extends TestCase
 			'a swap-not-confirmed restart-fallback that ultimately converges must not leave a dnsbl apply entry open');
 	}
 
+	/**
+	 * A failed bounded start is still the existing recovery event: restore the
+	 * last-known-good config, retry exactly once, then leave apply explicitly open.
+	 */
+	public function testRestartFailurePreservesRollbackRetryAndApplyLedger(): void
+	{
+		$newConfig = "server:\n\tmodule-config: \"python validator iterator\"\n";
+		$oldConfig = "server:\n\tmodule-config: \"validator iterator\"\n";
+		file_put_contents("{$this->dir}/unbound.conf", $newConfig);
+		file_put_contents("{$this->dir}/unbound.bk", $oldConfig);
+		$GLOBALS['pfb']['dnsbl_file'] = "{$this->dir}/dnsbl_file";
+		$GLOBALS['pfb']['unbound_py_count'] = "{$this->dir}/unbound_py_count";
+		$GLOBALS['pfb']['chroot_cmd'] = '/bin/echo';
+		$GLOBALS['pfb']['dnsbl_python_unmount'] = FALSE;
+		$GLOBALS['g']['varrun_path'] = $this->dir;
+		$GLOBALS['pfb_test_process_running']['unbound'] = FALSE;
+
+		$startLog = (string) $GLOBALS['pfb_test_unbound_start_log'];
+		$before = file_exists($startLog) ? count(file($startLog, FILE_IGNORE_NEW_LINES) ?: []) : 0;
+		$ledgerCalls = 0;
+
+		pfb_reload_unbound('enabled', FALSE, FALSE, FALSE,
+			static function () use (&$ledgerCalls): bool {
+				$ledgerCalls++;
+				return pfb_dnsbl_apply_ledger_update();
+			});
+
+		$after = count(file($startLog, FILE_IGNORE_NEW_LINES) ?: []);
+		$this->assertSame($before + 2, $after,
+			'a non-zero start must still make the original attempt plus exactly one recovery retry');
+		$this->assertSame($oldConfig, file_get_contents("{$this->dir}/unbound.conf"),
+			'the retry must run only after restoring the last-known-good resolver config');
+		$this->assertSame($newConfig, file_get_contents("{$this->dir}/unbound.conf.error"),
+			'the failed candidate config must remain observable for diagnosis');
+		$this->assertSame(1, $ledgerCalls,
+			'the failed retry path must still reach the shared apply-ledger tail exactly once');
+		$open = pfb_sync_status_list_open($this->dir, 'dnsbl');
+		$this->assertCount(1, $open,
+			'a resolver that is still down after retry must leave one explicit apply entry open');
+		$this->assertSame('apply', $open[0]['stage']);
+	}
+
 	// -----------------------------------------------------------------------
 	// pfb_reload_unbound() -- zero-downtime swap SUCCESS early-return (issue #1024)
 	// -----------------------------------------------------------------------

--- a/tests/php/PfbSyncStatusDnsblWritersTest.php
+++ b/tests/php/PfbSyncStatusDnsblWritersTest.php
@@ -45,7 +45,7 @@ final class PfbSyncStatusDnsblWritersTest extends TestCase
 		mkdir($this->dir, 0777, TRUE);
 
 		foreach (['dnsbldir', 'dbdir', 'dnsbl_file', 'unbound_py_count', 'chroot_cmd',
-			  'dnsbl_python_unmount', 'log', 'errlog'] as $k) {
+			  'dnsbl_python_unmount', 'log', 'errlog', 'php'] as $k) {
 			$this->savedPfb[$k] = array_key_exists($k, $GLOBALS['pfb'] ?? []) ? $GLOBALS['pfb'][$k] : false;
 		}
 		foreach (['varrun_path'] as $k) {
@@ -56,6 +56,7 @@ final class PfbSyncStatusDnsblWritersTest extends TestCase
 		$GLOBALS['pfb']['dbdir']    = $this->dir;
 		$GLOBALS['pfb']['log']      = "{$this->dir}/pfblockerng.log";
 		$GLOBALS['pfb']['errlog']   = "{$this->dir}/error.log";
+		$GLOBALS['pfb']['php']      = PHP_BINARY;
 		$GLOBALS['pfb_test_process_running'] = ['unbound' => TRUE];
 	}
 

--- a/tests/php/UnboundRestartSeamTest.php
+++ b/tests/php/UnboundRestartSeamTest.php
@@ -35,7 +35,7 @@ final class UnboundRestartSeamTest extends TestCase
 		// Track key EXISTENCE separately from value: 'dnsbl_python_unmount' is legitimately
 		// boolean FALSE, so a FALSE sentinel would unset a sibling suite's value instead of
 		// restoring it.
-		foreach (['log', 'errlog', 'dnsbl_python_unmount'] as $key) {
+		foreach (['log', 'errlog', 'dnsbl_python_unmount', 'php'] as $key) {
 			$this->savedPfb[$key] = [
 				array_key_exists($key, $GLOBALS['pfb'] ?? []),
 				$GLOBALS['pfb'][$key] ?? NULL,
@@ -52,6 +52,7 @@ final class UnboundRestartSeamTest extends TestCase
 			'log'                  => "{$this->dir}/pfblockerng.log",
 			'errlog'               => "{$this->dir}/error.log",
 			'dnsbl_python_unmount' => FALSE,
+			'php'                  => PHP_BINARY,
 		]);
 		$GLOBALS['g']['varrun_path'] = $this->dir;
 	}

--- a/tests/php/UnboundRestartSeamTest.php
+++ b/tests/php/UnboundRestartSeamTest.php
@@ -212,12 +212,16 @@ final class UnboundRestartSeamTest extends TestCase
 	public function testDaemonizedStartSurvivesTheBoundedWrapper(): void
 	{
 		$pidfile = "{$this->dir}/daemon.pid";
+		$daemonCode = '$sid = posix_setsid(); if ($sid === -1) { exit(126); } '
+			. 'file_put_contents($argv[1], (string) getmypid()); sleep(30);';
 		$script = $this->makeStartScript('daemonize.sh',
-			'sleep 30 </dev/null >/dev/null 2>&1 &' . "\n"
-			. 'printf \'%s\\n\' "$!" > "$1"' . "\n"
+			'"$2" -r ' . escapeshellarg($daemonCode) . ' "$1" </dev/null >/dev/null 2>&1 &' . "\n"
+			. 'i=0; while [ ! -s "$1" ] && [ "$i" -lt 100 ]; do i=$((i + 1)); sleep 0.01; done' . "\n"
+			. '[ -s "$1" ] || exit 126' . "\n"
 			. 'exit 0');
 
-		$run = $this->runIsolatedStart(escapeshellarg($script) . ' ' . escapeshellarg($pidfile));
+		$run = $this->runIsolatedStart(escapeshellarg($script) . ' ' .
+			escapeshellarg($pidfile) . ' ' . escapeshellarg(PHP_BINARY));
 		$pid = (int) trim((string) @file_get_contents($pidfile));
 		try {
 			$this->assertSame(0, $run['status'],
@@ -227,12 +231,36 @@ final class UnboundRestartSeamTest extends TestCase
 			$this->assertSame(0, $run['payload']['final']['retval'],
 				'a successfully daemonized start must remain a successful start');
 			$this->assertTrue($this->pidIsAlive($pid),
-				'--foreground must let the successfully daemonized resolver survive its launcher');
+				'a successfully daemonized resolver must escape the supervised launcher group and survive');
 		} finally {
 			$this->terminatePid($pid);
 		}
 		$this->assertFalse($this->pidIsAlive($pid),
 			'the daemon-survival row must reap its controlled survivor before returning');
+	}
+
+	public function testStartCommandRunsOnlyAfterItsProcessGroupExists(): void
+	{
+		$expectedFile = "{$this->dir}/expected.pgid";
+		$actualFile = "{$this->dir}/actual.pgid";
+		$script = $this->makeStartScript('record-pgid.sh',
+			'printf \'%s\\n\' "$PFB_UNBOUND_START_PGID" > "$1"' . "\n"
+			. 'ps -o pgid= -p "$$" | tr -d \' \' > "$2"' . "\n"
+			. 'exit 0');
+
+		$run = $this->runIsolatedStart(escapeshellarg($script) . ' '
+			. escapeshellarg($expectedFile) . ' ' . escapeshellarg($actualFile));
+		$expected = trim((string) @file_get_contents($expectedFile));
+		$actual = trim((string) @file_get_contents($actualFile));
+
+		$this->assertSame(0, $run['status'],
+			'the process-group runner must complete inside its salvage cap: ' . implode("\n", $run['output']));
+		$this->assertIsArray($run['payload']);
+		$this->assertSame(0, $run['payload']['final']['retval']);
+		$this->assertMatchesRegularExpression('/^[1-9][0-9]*$/', $expected,
+			'RED issue #2882: the launcher must publish its group only after setpgid succeeds');
+		$this->assertSame($expected, $actual,
+			'the start command must not execute until it is inside the launcher process group');
 	}
 
 	public function testTermIgnoringStartExpiresObservablyAndLeavesNoProcess(): void
@@ -263,6 +291,45 @@ final class UnboundRestartSeamTest extends TestCase
 			$run['payload']['errlog'], 'expiry must be explicit in the error log');
 		$this->assertFalse($alive,
 			'the SIGKILL grace must leave no TERM-ignoring transient start process behind');
+	}
+
+	public function testExpiryReapsTermIgnoringLauncherAndDescendant(): void
+	{
+		$launcherFile = "{$this->dir}/launcher.pid";
+		$helperFile = "{$this->dir}/helper.pid";
+		$script = $this->makeStartScript('term-ignoring-tree.sh',
+			'trap \'\' TERM' . "\n"
+			. 'printf \'%s\\n\' "$$" > "$1"' . "\n"
+			. '(' . "\n"
+			. "\ttrap '' TERM\n"
+			. "\texec sleep 30\n"
+			. ') &' . "\n"
+			. 'helper=$!' . "\n"
+			. 'printf \'%s\\n\' "$helper" > "$2"' . "\n"
+			. 'wait "$helper"');
+
+		$run = $this->runIsolatedStart(escapeshellarg($script) . ' '
+			. escapeshellarg($launcherFile) . ' ' . escapeshellarg($helperFile));
+		$launcher = (int) trim((string) @file_get_contents($launcherFile));
+		$helper = (int) trim((string) @file_get_contents($helperFile));
+		$launcherAlive = $this->pidIsAlive($launcher);
+		$helperAlive = $this->pidIsAlive($helper);
+		if ($launcherAlive) {
+			$this->terminatePid($launcher);
+		}
+		if ($helperAlive) {
+			$this->terminatePid($helper);
+		}
+
+		$this->assertSame(0, $run['status'],
+			'the process-tree expiry runner must complete inside its salvage cap: ' . implode("\n", $run['output']));
+		$this->assertIsArray($run['payload']);
+		$this->assertSame(124, $run['payload']['final']['retval'],
+			'the process-tree expiry must preserve the retry-triggering timeout status');
+		$this->assertFalse($launcherAlive,
+			'the direct TERM-ignoring launcher must be absent after kill grace');
+		$this->assertFalse($helperAlive,
+			'RED issue #2882: expiry must kill the launcher process group, not orphan its TERM-ignoring helper');
 	}
 
 	public function testImmediateNonZeroStartPreservesStatusAndOutput(): void
@@ -329,11 +396,15 @@ final class UnboundRestartSeamTest extends TestCase
 			'no branch may reach the daemon binary except through PFB_UNBOUND_START_CMD');
 		$this->assertStringContainsString('$i <= PFB_UNBOUND_STOP_WAIT;', $body,
 			'the stop-wait budget must come from the constant, not a literal');
-		$this->assertStringContainsString('--foreground -s TERM -k ', $body,
-			'the start wait must let a daemonized resolver survive and still kill a stuck launcher');
+		$this->assertStringContainsString('posix_setpgid(0, 0)', $body,
+			'the start command must enter its own process group before the release barrier opens');
+		$this->assertStringContainsString('posix_kill(-$pid', $body,
+			'expiry must signal the whole launcher group, not only its direct process');
 		$this->assertStringContainsString('PFB_UNBOUND_START_WAIT', $body,
 			'the start wait must consume its configured finite budget');
-		$this->assertStringContainsString(' 2>&1 < /dev/null', $body,
-			'a daemon must inherit a regular output file, never exec() capture pipes');
+		$this->assertStringContainsString("0 => array('file', '/dev/null', 'r')", $body,
+			'the supervised launcher must read from /dev/null');
+		$this->assertStringContainsString("1 => array('file', \$outfile, 'a')", $body,
+			'a daemon must inherit a regular output file, never proc_open() pipes');
 	}
 }

--- a/tests/php/UnboundRestartSeamTest.php
+++ b/tests/php/UnboundRestartSeamTest.php
@@ -105,8 +105,13 @@ final class UnboundRestartSeamTest extends TestCase
 	 *
 	 * @return array{status: int, output: list<string>, payload: array<string, mixed>|null}
 	 */
-	private function runIsolatedStart(string $startCommand, int $budget = 5): array
+	private function runIsolatedStart(
+		string $startCommand,
+		int $budget = 5,
+		?string $phpCli = NULL
+	): array
 	{
+		$phpCli ??= PHP_BINARY;
 		$id = bin2hex(random_bytes(4));
 		$runner = "{$this->dir}/runner_{$id}.php";
 		$log = "{$this->dir}/isolated_{$id}.log";
@@ -120,6 +125,7 @@ final class UnboundRestartSeamTest extends TestCase
 			. "define('PFB_HOOK_KILL_GRACE', 1);\n"
 			. 'require ' . var_export($bootstrap, TRUE) . ";\n"
 			. '$GLOBALS[\'pfb\'][\'timeout\'] = ' . var_export($timeout, TRUE) . ";\n"
+			. '$GLOBALS[\'pfb\'][\'php\'] = ' . var_export($phpCli, TRUE) . ";\n"
 			. '$GLOBALS[\'pfb\'][\'log\'] = ' . var_export($log, TRUE) . ";\n"
 			. '$GLOBALS[\'pfb\'][\'errlog\'] = ' . var_export($errlog, TRUE) . ";\n"
 			. "\$GLOBALS['pfb']['dnsbl_python_unmount'] = FALSE;\n"
@@ -262,6 +268,28 @@ final class UnboundRestartSeamTest extends TestCase
 			'RED issue #2882: the launcher must publish its group only after setpgid succeeds');
 		$this->assertSame($expected, $actual,
 			'the start command must not execute until it is inside the launcher process group');
+	}
+
+	public function testSupervisorUsesConfiguredCliPhpInsteadOfCurrentSapiBinary(): void
+	{
+		$argvLog = "{$this->dir}/php-cli.argv";
+		$phpCli = $this->makeStartScript('php-cli',
+			'printf \'%s\\n\' "$@" > ' . escapeshellarg($argvLog) . "\n"
+			. 'exec ' . escapeshellarg(PHP_BINARY) . ' "$@"');
+		$start = $this->makeStartScript('cli-start.sh', 'exit 0');
+
+		$run = $this->runIsolatedStart(escapeshellarg($start), 5, $phpCli);
+		$argv = file_exists($argvLog) ? (file($argvLog, FILE_IGNORE_NEW_LINES) ?: []) : [];
+
+		$this->assertSame(0, $run['status'],
+			'the configured-CLI runner must complete inside its salvage cap: ' . implode("\n", $run['output']));
+		$this->assertIsArray($run['payload']);
+		$this->assertSame(0, $run['payload']['final']['retval'],
+			'the configured CLI executable must run the supervisor and preserve child success');
+		$this->assertSame('-r', $argv[0] ?? NULL,
+			'RED issue #2882: the supervisor must invoke the configured CLI PHP, not PHP_BINARY/php-cgi');
+		$this->assertContains('--', $argv,
+			'the CLI supervisor arguments must retain the option terminator before runtime values');
 	}
 
 	public function testTermIgnoringStartExpiresObservablyAndLeavesNoProcess(): void
@@ -420,6 +448,13 @@ final class UnboundRestartSeamTest extends TestCase
 		$this->assertGreaterThan($acknowledged, $deadline,
 			'the start-command deadline must begin after the child start event, not during supervisor setup');
 
+		$this->assertStringContainsString(
+			"\$php_cli = (string) (\$pfb['php'] ?? (PHP_BINDIR . '/php'));",
+			$body,
+			'the appliance must select the canonical CLI executable without a version hardcode'
+		);
+		$this->assertStringNotContainsString('PHP_BINARY', $body,
+			'the web php-cgi SAPI binary must never launch the CLI-only -r supervisor');
 		$this->assertStringContainsString('PFB_UNBOUND_START_CMD', $body,
 			'the daemon start must run through the constant so a harness can neuter it');
 		$this->assertStringNotContainsString('/usr/local/sbin/unbound', $body,

--- a/tests/php/UnboundRestartSeamTest.php
+++ b/tests/php/UnboundRestartSeamTest.php
@@ -403,6 +403,14 @@ final class UnboundRestartSeamTest extends TestCase
 		$end = strpos($src, "\n}\n", $start);
 		$this->assertNotFalse($end, 'could not find the end of pfb_stop_start_unbound()');
 		$body = substr($src, $start, $end - $start);
+		$this->assertStringContainsString('$start_ack_deadline = NULL;', $body,
+			'the start-ack deadline must have an explicit unarmed sentinel');
+		$this->assertStringContainsString('$deadline = NULL;', $body,
+			'the command deadline must have an explicit unarmed sentinel');
+		$this->assertStringContainsString('if ($start_ack_deadline === NULL) {', $body,
+			'the start-ack loop must fail closed before reading an unarmed deadline');
+		$this->assertStringContainsString('if ($deadline === NULL) {', $body,
+			'the command loop must fail closed before reading an unarmed deadline');
 		$release = strpos($body, '@touch($release)');
 		$acknowledged = strpos($body, 'file_exists($command_started)');
 		$deadline = strpos($body, '$deadline = hrtime(TRUE) + (PFB_UNBOUND_START_WAIT');

--- a/tests/php/UnboundRestartSeamTest.php
+++ b/tests/php/UnboundRestartSeamTest.php
@@ -105,7 +105,7 @@ final class UnboundRestartSeamTest extends TestCase
 	 *
 	 * @return array{status: int, output: list<string>, payload: array<string, mixed>|null}
 	 */
-	private function runIsolatedStart(string $startCommand): array
+	private function runIsolatedStart(string $startCommand, int $budget = 5): array
 	{
 		$id = bin2hex(random_bytes(4));
 		$runner = "{$this->dir}/runner_{$id}.php";
@@ -116,7 +116,7 @@ final class UnboundRestartSeamTest extends TestCase
 		file_put_contents($runner, "<?php\n"
 			. "define('PFB_UNBOUND_START_CMD', " . var_export($startCommand, TRUE) . ");\n"
 			. "define('PFB_UNBOUND_STOP_WAIT', 1);\n"
-			. "define('PFB_UNBOUND_START_WAIT', 1);\n"
+			. "define('PFB_UNBOUND_START_WAIT', " . var_export($budget, TRUE) . ");\n"
 			. "define('PFB_HOOK_KILL_GRACE', 1);\n"
 			. 'require ' . var_export($bootstrap, TRUE) . ";\n"
 			. '$GLOBALS[\'pfb\'][\'timeout\'] = ' . var_export($timeout, TRUE) . ";\n"
@@ -132,8 +132,9 @@ final class UnboundRestartSeamTest extends TestCase
 
 		$output = [];
 		$status = 0;
-		$cmd = escapeshellarg($timeout) . ' -s TERM -k 2 ' . self::SALVAGE_SECONDS
-			. ' ' . escapeshellarg(PHP_BINARY) . ' ' . escapeshellarg($runner) . ' 2>&1';
+		$cmd = 'TMPDIR=' . escapeshellarg($this->dir) . ' ' .
+			escapeshellarg($timeout) . ' -s TERM -k 2 ' . self::SALVAGE_SECONDS .
+			' ' . escapeshellarg(PHP_BINARY) . ' ' . escapeshellarg($runner) . ' 2>&1';
 		exec($cmd, $output, $status);
 
 		$payload = NULL;
@@ -271,12 +272,17 @@ final class UnboundRestartSeamTest extends TestCase
 			. 'trap \'\' TERM' . "\n"
 			. 'exec sleep 30');
 
-		$run = $this->runIsolatedStart(escapeshellarg($script) . ' ' . escapeshellarg($pidfile));
+		$run = $this->runIsolatedStart(
+			escapeshellarg($script) . ' ' . escapeshellarg($pidfile),
+			2
+		);
 		$pid = (int) trim((string) @file_get_contents($pidfile));
 		$alive = $this->pidIsAlive($pid);
 		if ($alive) {
 			$this->terminatePid($pid);
 		}
+		$this->assertGreaterThan(0, $pid,
+			'the timeout row must observe the command-start event before evaluating cleanup');
 
 		$this->assertSame(0, $run['status'],
 			'RED issue #2882: the production start wait exceeded the 8s salvage cap; '
@@ -285,9 +291,9 @@ final class UnboundRestartSeamTest extends TestCase
 		$this->assertIsArray($run['payload'], 'the bounded start must return its JSON result');
 		$this->assertSame(124, $run['payload']['final']['retval'],
 			'an expired start must surface timeout(1) status 124 so retry/recovery still runs');
-		$this->assertStringContainsString('Unbound Resolver start TIMED OUT after 1s and was killed',
+		$this->assertStringContainsString('Unbound Resolver start TIMED OUT after 2s and was killed',
 			$run['payload']['log'], 'expiry must be explicit in the main log');
-		$this->assertStringContainsString('Unbound Resolver start TIMED OUT after 1s and was killed',
+		$this->assertStringContainsString('Unbound Resolver start TIMED OUT after 2s and was killed',
 			$run['payload']['errlog'], 'expiry must be explicit in the error log');
 		$this->assertFalse($alive,
 			'the SIGKILL grace must leave no TERM-ignoring transient start process behind');
@@ -308,8 +314,10 @@ final class UnboundRestartSeamTest extends TestCase
 			. 'printf \'%s\\n\' "$helper" > "$2"' . "\n"
 			. 'wait "$helper"');
 
-		$run = $this->runIsolatedStart(escapeshellarg($script) . ' '
-			. escapeshellarg($launcherFile) . ' ' . escapeshellarg($helperFile));
+		$run = $this->runIsolatedStart(
+			escapeshellarg($script) . ' ' . escapeshellarg($launcherFile) . ' ' . escapeshellarg($helperFile),
+			2
+		);
 		$launcher = (int) trim((string) @file_get_contents($launcherFile));
 		$helper = (int) trim((string) @file_get_contents($helperFile));
 		$launcherAlive = $this->pidIsAlive($launcher);
@@ -320,6 +328,10 @@ final class UnboundRestartSeamTest extends TestCase
 		if ($helperAlive) {
 			$this->terminatePid($helper);
 		}
+		$this->assertGreaterThan(0, $launcher,
+			'the process-tree row must observe its direct launcher before evaluating cleanup');
+		$this->assertGreaterThan(0, $helper,
+			'the process-tree row must observe its helper before evaluating cleanup');
 
 		$this->assertSame(0, $run['status'],
 			'the process-tree expiry runner must complete inside its salvage cap: ' . implode("\n", $run['output']));
@@ -383,12 +395,22 @@ final class UnboundRestartSeamTest extends TestCase
 			'the appliance must still wait up to 30 seconds for the outgoing daemon');
 		$this->assertNotFalse(strpos($src, "define('PFB_UNBOUND_START_WAIT', 30);"),
 			'the appliance start child must have an explicit finite 30-second budget');
+		$this->assertNotFalse(strpos($src, "define('PFB_UNBOUND_START_SETUP_WAIT', 5);"),
+			'the process-group setup barrier must have its own finite five-second budget');
 
 		$start = strpos($src, 'function pfb_stop_start_unbound(');
 		$this->assertNotFalse($start, 'pfb_stop_start_unbound() must still exist');
 		$end = strpos($src, "\n}\n", $start);
 		$this->assertNotFalse($end, 'could not find the end of pfb_stop_start_unbound()');
 		$body = substr($src, $start, $end - $start);
+		$release = strpos($body, '@touch($release)');
+		$acknowledged = strpos($body, 'file_exists($command_started)');
+		$deadline = strpos($body, '$deadline = hrtime(TRUE) + (PFB_UNBOUND_START_WAIT');
+		$this->assertNotFalse($release, 'the parent must explicitly release the verified process group');
+		$this->assertNotFalse($acknowledged, 'the child must acknowledge command start after release');
+		$this->assertNotFalse($deadline, 'the configured command deadline must be explicit');
+		$this->assertGreaterThan($acknowledged, $deadline,
+			'the start-command deadline must begin after the child start event, not during supervisor setup');
 
 		$this->assertStringContainsString('PFB_UNBOUND_START_CMD', $body,
 			'the daemon start must run through the constant so a harness can neuter it');

--- a/tests/php/UnboundRestartSeamTest.php
+++ b/tests/php/UnboundRestartSeamTest.php
@@ -19,6 +19,8 @@ use PHPUnit\Framework\TestCase;
 #[CoversFunction('pfb_stop_start_unbound')]
 final class UnboundRestartSeamTest extends TestCase
 {
+	private const SALVAGE_SECONDS = 8;
+
 	private string $dir;
 	/** @var array<string, array{0: bool, 1: mixed}> key => [existed, value] */
 	private array $savedPfb = [];
@@ -87,6 +89,78 @@ final class UnboundRestartSeamTest extends TestCase
 			'the harness must publish the path of its daemon-start double log');
 		return file_exists($log) ? (file($log, FILE_IGNORE_NEW_LINES) ?: []) : [];
 	}
+	private function makeStartScript(string $name, string $body): string
+	{
+		$path = "{$this->dir}/{$name}";
+		file_put_contents($path, "#!/bin/sh\n{$body}\n");
+		chmod($path, 0755);
+		return $path;
+	}
+
+	/**
+	 * Run the production function in a fresh PHP process so each row can set the
+	 * existing PFB_UNBOUND_START_CMD seam. The outer timeout is salvage only:
+	 * default mode reaps the whole runner tree if production regresses to an
+	 * unbounded wait.
+	 *
+	 * @return array{status: int, output: list<string>, payload: array<string, mixed>|null}
+	 */
+	private function runIsolatedStart(string $startCommand): array
+	{
+		$id = bin2hex(random_bytes(4));
+		$runner = "{$this->dir}/runner_{$id}.php";
+		$log = "{$this->dir}/isolated_{$id}.log";
+		$errlog = "{$this->dir}/isolated_{$id}.err";
+		$timeout = (string) $GLOBALS['pfb']['timeout'];
+		$bootstrap = __DIR__ . '/bootstrap.php';
+		file_put_contents($runner, "<?php\n"
+			. "define('PFB_UNBOUND_START_CMD', " . var_export($startCommand, TRUE) . ");\n"
+			. "define('PFB_UNBOUND_STOP_WAIT', 1);\n"
+			. "define('PFB_UNBOUND_START_WAIT', 1);\n"
+			. "define('PFB_HOOK_KILL_GRACE', 1);\n"
+			. 'require ' . var_export($bootstrap, TRUE) . ";\n"
+			. '$GLOBALS[\'pfb\'][\'timeout\'] = ' . var_export($timeout, TRUE) . ";\n"
+			. '$GLOBALS[\'pfb\'][\'log\'] = ' . var_export($log, TRUE) . ";\n"
+			. '$GLOBALS[\'pfb\'][\'errlog\'] = ' . var_export($errlog, TRUE) . ";\n"
+			. "\$GLOBALS['pfb']['dnsbl_python_unmount'] = FALSE;\n"
+			. '$GLOBALS[\'g\'][\'varrun_path\'] = ' . var_export($this->dir, TRUE) . ";\n"
+			. "\$GLOBALS['pfb_test_process_running']['unbound'] = FALSE;\n"
+			. "\$final = pfb_stop_start_unbound('');\n"
+			. 'echo json_encode([\'final\' => $final, \'log\' => (string) @file_get_contents('
+			. var_export($log, TRUE) . '), \'errlog\' => (string) @file_get_contents('
+			. var_export($errlog, TRUE) . ")]), \"\\n\";\n");
+
+		$output = [];
+		$status = 0;
+		$cmd = escapeshellarg($timeout) . ' -s TERM -k 2 ' . self::SALVAGE_SECONDS
+			. ' ' . escapeshellarg(PHP_BINARY) . ' ' . escapeshellarg($runner) . ' 2>&1';
+		exec($cmd, $output, $status);
+
+		$payload = NULL;
+		if ($status === 0 && $output !== []) {
+			$decoded = json_decode((string) end($output), TRUE);
+			$payload = is_array($decoded) ? $decoded : NULL;
+		}
+		return ['status' => $status, 'output' => $output, 'payload' => $payload];
+	}
+
+	private function pidIsAlive(int $pid): bool
+	{
+		return $pid > 0 && posix_kill($pid, 0);
+	}
+
+	private function terminatePid(int $pid): void
+	{
+		if (!$this->pidIsAlive($pid)) {
+			return;
+		}
+		posix_kill($pid, 9);
+		$deadline = microtime(TRUE) + 2.0;
+		while ($this->pidIsAlive($pid) && microtime(TRUE) < $deadline) {
+			usleep(10000);
+		}
+	}
+
 
 	/**
 	 * Scenario: a restart under the unit harness must not reach the real daemon.
@@ -135,11 +209,97 @@ final class UnboundRestartSeamTest extends TestCase
 		$this->assertSame(PFB_UNBOUND_STOP_WAIT, $polls,
 			'the wait loop must poll exactly its configured budget when the daemon never exits');
 	}
+	public function testDaemonizedStartSurvivesTheBoundedWrapper(): void
+	{
+		$pidfile = "{$this->dir}/daemon.pid";
+		$script = $this->makeStartScript('daemonize.sh',
+			'sleep 30 </dev/null >/dev/null 2>&1 &' . "\n"
+			. 'printf \'%s\\n\' "$!" > "$1"' . "\n"
+			. 'exit 0');
+
+		$run = $this->runIsolatedStart(escapeshellarg($script) . ' ' . escapeshellarg($pidfile));
+		$pid = (int) trim((string) @file_get_contents($pidfile));
+		try {
+			$this->assertSame(0, $run['status'],
+				'stuck/environment: the daemonized start runner exceeded its salvage cap: '
+				. implode("\n", $run['output']));
+			$this->assertIsArray($run['payload'], 'the isolated start runner must return its JSON result');
+			$this->assertSame(0, $run['payload']['final']['retval'],
+				'a successfully daemonized start must remain a successful start');
+			$this->assertTrue($this->pidIsAlive($pid),
+				'--foreground must let the successfully daemonized resolver survive its launcher');
+		} finally {
+			$this->terminatePid($pid);
+		}
+		$this->assertFalse($this->pidIsAlive($pid),
+			'the daemon-survival row must reap its controlled survivor before returning');
+	}
+
+	public function testTermIgnoringStartExpiresObservablyAndLeavesNoProcess(): void
+	{
+		$pidfile = "{$this->dir}/stuck.pid";
+		$script = $this->makeStartScript('term-ignoring.sh',
+			'printf \'%s\\n\' "$$" > "$1"' . "\n"
+			. 'trap \'\' TERM' . "\n"
+			. 'exec sleep 30');
+
+		$run = $this->runIsolatedStart(escapeshellarg($script) . ' ' . escapeshellarg($pidfile));
+		$pid = (int) trim((string) @file_get_contents($pidfile));
+		$alive = $this->pidIsAlive($pid);
+		if ($alive) {
+			$this->terminatePid($pid);
+		}
+
+		$this->assertSame(0, $run['status'],
+			'RED issue #2882: the production start wait exceeded the 8s salvage cap; '
+			. 'the direct PFB_UNBOUND_START_CMD child is still unbounded. Output: '
+			. implode("\n", $run['output']));
+		$this->assertIsArray($run['payload'], 'the bounded start must return its JSON result');
+		$this->assertSame(124, $run['payload']['final']['retval'],
+			'an expired start must surface timeout(1) status 124 so retry/recovery still runs');
+		$this->assertStringContainsString('Unbound Resolver start TIMED OUT after 1s and was killed',
+			$run['payload']['log'], 'expiry must be explicit in the main log');
+		$this->assertStringContainsString('Unbound Resolver start TIMED OUT after 1s and was killed',
+			$run['payload']['errlog'], 'expiry must be explicit in the error log');
+		$this->assertFalse($alive,
+			'the SIGKILL grace must leave no TERM-ignoring transient start process behind');
+	}
+
+	public function testImmediateNonZeroStartPreservesStatusAndOutput(): void
+	{
+		$script = $this->makeStartScript('nonzero.sh', "echo 'start failed'\nexit 7");
+
+		$run = $this->runIsolatedStart(escapeshellarg($script));
+
+		$this->assertSame(0, $run['status'],
+			'the immediate-failure runner must complete inside its salvage cap: ' . implode("\n", $run['output']));
+		$this->assertIsArray($run['payload']);
+		$this->assertSame(7, $run['payload']['final']['retval'],
+			'a quick non-zero start must retain its status for the existing retry branch');
+		$this->assertSame(['start failed'], $run['payload']['final']['result'],
+			'a quick non-zero start must retain diagnostics for the existing recovery log');
+		$this->assertStringNotContainsString('TIMED OUT', $run['payload']['log'],
+			'a quick non-zero exit is a launch failure, not an expiry');
+	}
+
+	public function testMissingStartCommandRemainsAnExplicitLaunchFailure(): void
+	{
+		$run = $this->runIsolatedStart(escapeshellarg("{$this->dir}/missing-unbound") . ' 2>&1');
+
+		$this->assertSame(0, $run['status'],
+			'the missing-command runner must complete inside its salvage cap: ' . implode("\n", $run['output']));
+		$this->assertIsArray($run['payload']);
+		$this->assertSame(127, $run['payload']['final']['retval'],
+			'a start command that cannot launch must remain non-zero for retry/recovery');
+		$this->assertNotEmpty($run['payload']['final']['result'],
+			'the launch failure must retain timeout/shell diagnostics');
+	}
+
 
 	/**
 	 * The appliance keeps starting the shipped daemon against the shipped config, and
-	 * keeps waiting the full 30 seconds for the old one -- asserted against the source
-	 * because the harness replaces both constants at load time in this process.
+	 * keeps both stop and start waits at 30 seconds -- asserted against the source
+	 * because the harness replaces those constants at load time in this process.
 	 */
 	public function testShippedDefaultsStillStartTheApplianceDaemon(): void
 	{
@@ -154,6 +314,8 @@ final class UnboundRestartSeamTest extends TestCase
 			'the appliance must still start the shipped daemon against the shipped config');
 		$this->assertNotFalse(strpos($src, "define('PFB_UNBOUND_STOP_WAIT', 30);"),
 			'the appliance must still wait up to 30 seconds for the outgoing daemon');
+		$this->assertNotFalse(strpos($src, "define('PFB_UNBOUND_START_WAIT', 30);"),
+			'the appliance start child must have an explicit finite 30-second budget');
 
 		$start = strpos($src, 'function pfb_stop_start_unbound(');
 		$this->assertNotFalse($start, 'pfb_stop_start_unbound() must still exist');
@@ -161,11 +323,17 @@ final class UnboundRestartSeamTest extends TestCase
 		$this->assertNotFalse($end, 'could not find the end of pfb_stop_start_unbound()');
 		$body = substr($src, $start, $end - $start);
 
-		$this->assertStringContainsString('exec(PFB_UNBOUND_START_CMD,', $body,
+		$this->assertStringContainsString('PFB_UNBOUND_START_CMD', $body,
 			'the daemon start must run through the constant so a harness can neuter it');
 		$this->assertStringNotContainsString('/usr/local/sbin/unbound', $body,
 			'no branch may reach the daemon binary except through PFB_UNBOUND_START_CMD');
 		$this->assertStringContainsString('$i <= PFB_UNBOUND_STOP_WAIT;', $body,
 			'the stop-wait budget must come from the constant, not a literal');
+		$this->assertStringContainsString('--foreground -s TERM -k ', $body,
+			'the start wait must let a daemonized resolver survive and still kill a stuck launcher');
+		$this->assertStringContainsString('PFB_UNBOUND_START_WAIT', $body,
+			'the start wait must consume its configured finite budget');
+		$this->assertStringContainsString(' 2>&1 < /dev/null', $body,
+			'a daemon must inherit a regular output file, never exec() capture pipes');
 	}
 }

--- a/tests/php/bootstrap.php
+++ b/tests/php/bootstrap.php
@@ -61,17 +61,29 @@ $GLOBALS['argv'] = ['pfblockerng.inc'];
 $GLOBALS['argc'] = 1;
 
 // 4b. Keep the resolver start dormant too, the sibling of step 4: no unit test may
-//     start Unbound (issue #2613) or pay its 30-poll stop-wait. The double exits 127
-//     because an absent binary returns exactly that off-appliance, which is what keeps
-//     the caller's retval != 0 retry branch exercised. Guarded: a re-load stays silent.
+//     start Unbound (issue #2613) or pay either appliance wait. The executable double
+//     exits 127 because an absent binary returns exactly that off-appliance, which keeps
+//     the caller's retval != 0 retry branch exercised without a shell compound escaping
+//     the timeout wrapper. Guarded: a re-load stays silent.
 $GLOBALS['pfb_test_unbound_start_log'] = "{$pfb_test_tmp}/unbound_start.log";
+$pfb_test_unbound_start_cmd = "{$pfb_test_tmp}/unbound-start-double";
+file_put_contents($pfb_test_unbound_start_cmd, <<<'SH'
+	#!/bin/sh
+	printf '%s\n' 'unit-test double: Unbound start suppressed' | tee -a "$1"
+	exit 127
+	SH);
+chmod($pfb_test_unbound_start_cmd, 0755);
 if (!defined('PFB_UNBOUND_START_CMD')) {
-	define('PFB_UNBOUND_START_CMD', 'echo "unit-test double: Unbound start suppressed" | tee -a '
-		. escapeshellarg($GLOBALS['pfb_test_unbound_start_log']) . ' 2>&1; exit 127');
+	define('PFB_UNBOUND_START_CMD', escapeshellarg($pfb_test_unbound_start_cmd) . ' '
+		. escapeshellarg($GLOBALS['pfb_test_unbound_start_log']));
 }
 if (!defined('PFB_UNBOUND_STOP_WAIT')) {
 	define('PFB_UNBOUND_STOP_WAIT', 2);
 }
+if (!defined('PFB_UNBOUND_START_WAIT')) {
+	define('PFB_UNBOUND_START_WAIT', 2);
+}
+unset($pfb_test_unbound_start_cmd);
 
 // 2 + load. Define the production functions by including the real source.
 // pfblockerng.inc is legacy code that emits some load-time E_DEPRECATED/E_WARNING
@@ -82,6 +94,15 @@ $pfb_prev_er = error_reporting();
 error_reporting($pfb_prev_er & ~E_DEPRECATED & ~E_WARNING);
 require_once dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng.inc';
 error_reporting($pfb_prev_er);
+$pfb_test_timeout_out = [];
+$pfb_test_timeout_rc = 0;
+exec('command -v timeout 2>/dev/null', $pfb_test_timeout_out, $pfb_test_timeout_rc);
+$pfb_test_timeout = trim((string) ($pfb_test_timeout_out[0] ?? ''));
+if ($pfb_test_timeout_rc !== 0 || !is_executable($pfb_test_timeout)) {
+	throw new RuntimeException('PHPUnit requires a real timeout(1) on PATH for bounded process tests.');
+}
+$GLOBALS['pfb']['timeout'] = $pfb_test_timeout;
+unset($pfb_test_timeout_out, $pfb_test_timeout_rc, $pfb_test_timeout);
 
 // Snapshot the SHIPPED $pfb['mime_types'] allow-list exactly as the just-loaded
 // production source defines it, before any test mutates/unsets $GLOBALS['pfb']

--- a/tests/php/bootstrap.php
+++ b/tests/php/bootstrap.php
@@ -102,6 +102,8 @@ if ($pfb_test_timeout_rc !== 0 || !is_executable($pfb_test_timeout)) {
 	throw new RuntimeException('PHPUnit requires a real timeout(1) on PATH for bounded process tests.');
 }
 $GLOBALS['pfb']['timeout'] = $pfb_test_timeout;
+// Unit tests run under CLI; never inherit the appliance-only /usr/local path on a developer host.
+$GLOBALS['pfb']['php'] = PHP_BINARY;
 unset($pfb_test_timeout_out, $pfb_test_timeout_rc, $pfb_test_timeout);
 
 // Snapshot the SHIPPED $pfb['mime_types'] allow-list exactly as the just-loaded

--- a/tests/php/bootstrap.php
+++ b/tests/php/bootstrap.php
@@ -102,8 +102,6 @@ if ($pfb_test_timeout_rc !== 0 || !is_executable($pfb_test_timeout)) {
 	throw new RuntimeException('PHPUnit requires a real timeout(1) on PATH for bounded process tests.');
 }
 $GLOBALS['pfb']['timeout'] = $pfb_test_timeout;
-// Unit tests run under CLI; never inherit the appliance-only /usr/local path on a developer host.
-$GLOBALS['pfb']['php'] = PHP_BINARY;
 unset($pfb_test_timeout_out, $pfb_test_timeout_rc, $pfb_test_timeout);
 
 // Snapshot the SHIPPED $pfb['mime_types'] allow-list exactly as the just-loaded


### PR DESCRIPTION
## Summary

- Bound the direct Unbound start with separate 5-second process-group setup and child-start acknowledgement budgets; the 30-second command deadline starts only after the atomic start acknowledgement.
- Let a successfully daemonized resolver escape the transient process group while TERM/KILL cleanup reaps the whole stalled launcher tree, including nested TERM-ignoring descendants.
- Use the pfSense CLI PHP executable for the supervisor (`$pfb['php']`, falling back to `PHP_BINDIR . '/php'`) rather than the web SAPI's `PHP_BINARY` (`php-cgi`).
- Preserve the 30-second stop poll, mount ordering, one retry, failed-candidate retention, rollback to last-known-good configuration, timeout observability, and DNSBL apply-ledger convergence.

## Frozen RED → GREEN provenance

Each behavior-changing wave had its own frozen test blob. These historical hashes are not conflated with the final rebased file identity:

| Wave | Frozen test blob | Executed provenance |
| --- | --- | --- |
| Original bounded start | `fcb17585805f5ff5dfaa737135c6dcf0aac80d24` | RED against base `9569ca7d`: 27 tests / 87 assertions / 2 failures; GREEN at `d1fdf3ac`: 27 / 100. |
| Process-group descendant cleanup | `aba82b826ff945d2059b39d273715c97beba6a7c` | Nested TERM-ignoring descendant row was RED before the `0e243547` process-group correction and GREEN after it. |
| Post-ack deadline correction | `43585daa03b5a46590007808733ac9c7f2381a6a` | RED on `0e243547`: 29 tests / 106 assertions / 1 failure (`missing finite five-second setup barrier contract`); GREEN at `aca0b8fe`: 29 / 120. |
| Deadline sentinels | `089dc0af7a71b38ba4c0b44fa0d366317aa2c759` | RED required explicit NULL sentinels and fail-closed guards; removing either guard is RED; GREEN at `0bfad0fe`. |
| CLI PHP launcher | `3023642d89c37ab19a0b11ecc44f0a24bd3eadf4` | RED when the injected CLI wrapper was not invoked; GREEN records `-r` / `--` argv and child status; the `PHP_BINARY` mutant is RED at `847b9aa8`. |
| Current exact-head identity only | `1ccaaeefbecaebe7ab2cdb5c8a3a0622e0a521e5` | Current rebased `tests/php/UnboundRestartSeamTest.php` blob at `d17fa0c5`; this is not presented as a historical RED-time hash. |

Final focused proof: Tick + restart/ledger tests 36 / 149, explicit post-fixture cleanup oracle 31 / 132, targeted PHPStan clean, CLI-inclusive stress 16/16 (4 tests / 20 assertions each).

## Rebase and exact-head identity

- Base: `ee8db18fb9e72dc31470b79fc0872b265a748874`
- Head: `d17fa0c53030ca32673cc98543a8bca7a6b49a48`
- Tree: `e8daa3ae3498e3a87a8f140b02473d603b1d1e27`
- Seven tracked paths; full binary diff SHA-256 `a377d91ff036efa0b8d1325a5b9b5e8502cc9bae9df7ed51767a01e61cdb1f7e`; six human-semantic paths SHA-256 `6b491ba6853c05f84b0c75ab0ee6995424fb12c5e3fc888e9406ef0a175245a0`.
- `git range-diff` reports all six commits `=` across the live-base rebase, and all six stable patch IDs are unchanged. The three original human-semantic stable patch IDs remain byte-identical: `0b63fae9ae5b570674d459bfea2333defeb00e11`, `69a4ae212c8e1090ace79c1415a1425c5dce5c54`, `7969540bc64117f0c7feb2235370d9bad9a44450`.
- Live base added feed-lock handling in the same production file at lines 18738+, with no overlap with the Unbound restart function at lines 11414+; the rebased exact tree was re-gated and re-run live.

| Tracked path | Exact-head blob |
| --- | --- |
| `docs/misc/external-process-waits.md` | `770568edc3aeada294073ce34aef1825d4f30c77` |
| `graphify-out/graph.json` | `1dfdaab2ad6a571675b789b58e602da7b0fae7ba` |
| `graphify-out/memory/query_20260830_152058_issue_2882__pfb_stop_start_unbound_direct_unbound.md` | `e2a43e9088f08ee545d03d6d79b550bea208bbb2` |
| `src/usr/local/pkg/pfblockerng/pfblockerng.inc` | `8221c07ece8019bb37366a5334074367e35672f5` |
| `tests/php/PfbSyncStatusDnsblWritersTest.php` | `87c28fa68adb30bd919a61e8f84f16d37a50b0c2` |
| `tests/php/UnboundRestartSeamTest.php` | `1ccaaeefbecaebe7ab2cdb5c8a3a0622e0a521e5` |
| `tests/php/bootstrap.php` | `be833cc54add6b7bb533303f8f94b22558589ac3` |

## Canonical and CI

- Canonical: `scripts/agent/run-gates.sh --diff ee8db18fb9e72dc31470b79fc0872b265a748874` — 12/12 gates, `GATES: PASS`, 4m11s. Log SHA-256 `03cfec05652a68f958a127b9be16a6cef7e81ab6aa24ca4cd0d917c750f03013`.
- Exact-head CI: PASS, 22 successful checks / 2 intentional skips / 0 failures. Tests run `33336163885`; context-budget run `33336163649`; aggregate job `99323845814`.

## Live pfSense proof

Exact head ran through the supported local smoke harness on pfSense CE 2.8.1 with 1 vCPU and 2,088,214,528 bytes RAM:

- Run `local-100037-1788125088-e586ac12fed30b7b` on `root@10.0.0.37`; pytest 1 passed / 1063 deselected in 149.51s; whole leased run 175.78s.
- Normal restart: retval 0 in 1.251905s; resolver PID/PGID/SID changed from `14608/14608/14608` to `35494/35494/35494`, remained alive after return, DNSBL still answered the sinkhole VIP, and neither log contained a false timeout.
- Nested stalled start: launcher/helper/grandchild PIDs `45924/46475/46800`, all in transient PGID `45911`. TERM arrived at 29.965173s / 29.966065s / 29.966707s; retry followed after 5.153303s. All three PIDs and the entire process group were absent after return without harness-forced cleanup.
- Recovery: exact timeout line appeared in both main and error logs; failed candidate was retained, last-known-good configuration restored, attempts were `45924 first` then `79026 second`, retry daemon `79855/79855/79855` survived, and apply-ledger rows converged to empty.
- Cleanup: final daemon `79855` remained healthy, transient pattern/group residue was empty, and the box lease was released.

Persisted live evidence: `root@10.0.0.37:/root/pfBlockerNG/smoke-diag/issue2882-live-evidence-final.json`.

Fixes #2882

🤖 Generated by Oh My Pi and posted on behalf of @andrebrait.
