### PR TITLE
geoip: fix bare-text <ul> help markup and make long paths/URL wrap (#2897)

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng_geoip.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_geoip.inc
@@ -615,10 +615,10 @@ $action_txt = "Default: <strong>Disabled</strong>
 					<li>'Alias Permit' and 'Alias Match' will be saved in the Same folder as the other Permit/Match Auto-Rules</li>
 					<li>'Alias Native' lists are kept in their Native format without any modifications.</li></ul>
 
-			<span class=\"text-danger\">Note: </span><ul>
+			<span class=\"text-danger\">Note: </span><ul><li>
 				When manually creating 'Alias' type firewall rules; <strong>Do not add</strong> (pfB_) to the
 				start of the rule description, use (pfb_) (Lowercase prefix). Manually created 'Alias' rules with 'pfB_' in the
-				description will be auto-removed by package when 'Auto' rules are defined.</ul>
+				description will be auto-removed by package when 'Auto' rules are defined.</li></ul>
 		</div>";
 
 $section->addInput(new Form_Select(
@@ -1052,8 +1052,8 @@ $section->addInput(new Form_StaticText(
 	'Why Reputation Matters',
 	'By enabling <strong>Reputation</strong>, each Blocklist will be analyzed for repeat offenders in each IP range.'
 	. '<div class="infoblock">'
-	. '<ul>Example: &emsp;x.x.x.1, x.x.x.2, x.x.x.3, x.x.x.4, x.x.x.5<br />'
-	. 'No. of <strong> repeat offending IPs </strong> [ &nbsp;<strong>5</strong>&nbsp; ], in a Blocklist within the same IP range.</ul>'
+	. '<ul><li>Example: &emsp;x.x.x.1, x.x.x.2, x.x.x.3, x.x.x.4, x.x.x.5<br />'
+	. 'No. of <strong> repeat offending IPs </strong> [ &nbsp;<strong>5</strong>&nbsp; ], in a Blocklist within the same IP range.</li></ul>'
 	. 'With <strong>Reputation</strong> enabled, these 5 IPs will be removed and a single<strong>x.x.x.0/24</strong> Block is used.<br />'
 	. 'This will completely Block/Reject this particular range from your Firewall.<br /><br />'
 	. 'Selecting Blocklists from various Threat Sources will help to highlight repeat offending IP ranges,<br />'
@@ -1089,11 +1089,11 @@ $section->addInput(new Form_StaticText(
 	'Once all Blocklists are downloaded, these two additional processes <strong>[ pMax and dMax ]</strong><br />'
 	. 'Can be used to further analyze for repeat offenders.'
 	. '<div class="infoblock">'
-	. '<ul>Analyzing all Blocklists as a whole:</ul>'
-	. '<ul><strong>[ pMax ]</strong> will analyze for repeat offenders in each IP range but will not use the Country Exclusion.<br />'
-	. 'Default is 50 IPs in any range. Having 50 repeat offenders IPs in any range will Block the entire range.<br /><br /></ul>'
-	. '<ul><strong>[ dMax ]</strong> will analyze for repeat offenders in each IP range. Country Exclusions will be applied.<br />'
-	. 'Default is 5 IPs in any range.</ul>'
+	. '<ul><li>Analyzing all Blocklists as a whole:</li></ul>'
+	. '<ul><li><strong>[ pMax ]</strong> will analyze for repeat offenders in each IP range but will not use the Country Exclusion.<br />'
+	. 'Default is 50 IPs in any range. Having 50 repeat offenders IPs in any range will Block the entire range.<br /><br /></li></ul>'
+	. '<ul><li><strong>[ dMax ]</strong> will analyze for repeat offenders in each IP range. Country Exclusions will be applied.<br />'
+	. 'Default is 5 IPs in any range.</li></ul>'
 	. 'Note: <strong>MAX</strong> performs on individual Blocklists, while <strong>pMAX / dMAX</strong>'
 	. 'perform on all Lists together.'
 	. '</div>'
@@ -1144,15 +1144,15 @@ $section->addInput(new Form_StaticText(
 	. 'Countries. The original blocklisted IPs remain intact. All other repeat offending Country ranges will be processed.'
 	. '<div class="infoblock">'
 	. 'Define repeat offending ranges [ <strong>Action</strong> ] Available settings are:<br />'
-	. '<ul><strong>Ignore</strong>: Repeat offenders that are in the <strong>ccwhite</strong> category will be <strong>Ignored</strong> (Default)</ul>'
-	. '<ul><strong>Block:</strong> Repeat offenders are set to Block the entire repeat offending range(s)</ul>'
-	. '<ul><strong>Match:</strong> Repeat offenders are added to a <strong>Match</strong> List which can be used in a Floating Match rule<br />'
-	. 'Selecting <strong>Match</strong> will consume more processing time, so only select this option if you enable rules for it.</ul>'
+	. '<ul><li><strong>Ignore</strong>: Repeat offenders that are in the <strong>ccwhite</strong> category will be <strong>Ignored</strong> (Default)</li></ul>'
+	. '<ul><li><strong>Block:</strong> Repeat offenders are set to Block the entire repeat offending range(s)</li></ul>'
+	. '<ul><li><strong>Match:</strong> Repeat offenders are added to a <strong>Match</strong> List which can be used in a Floating Match rule<br />'
+	. 'Selecting <strong>Match</strong> will consume more processing time, so only select this option if you enable rules for it.</li></ul>'
 	. '\'<strong>ccwhite</strong>\' are Countries that are selected to be excluded from the repeat offenders search.<br />'
 	. '\'<strong>ccblack</strong>\' are all other Countries that are not selected.<br /><br />'
 	. 'To use <strong>Match</strong> Lists, Create a new \'Alias\''
 	. 'and select one of the <strong>Action Match</strong> Formats and<br /> enter the <strong>Localfile</strong> as:'
-	. '<ul>/var/db/pfblockerng/match/generated/pfB_Match_Exempt_v4.txt</ul><br />'
+	. '<ul style="overflow-wrap: anywhere;"><li>/var/db/pfblockerng/match/generated/pfB_Match_Exempt_v4.txt</li></ul><br />'
 	. '<strong>These Country Code options are only available when the MaxMind key has been entered and MaxMind database has been downloaded and updated</strong>'
 	. '</div>'
 ));
@@ -1198,15 +1198,15 @@ $section->addInput(new Form_StaticText(
 	'<strong>Proofpoint ET IQRisk</strong> is a subscription based professional Reputation list.<br /><br />'
 	. 'The URL must include the name <strong>iprepdata.txt</strong><br />'
 	. 'ET IQRisk Blocklist URL must be entered in the IPv4 Lists Tab using the following example:'
-	. '<ul>https://rules.emergingthreatspro.com/XXXXXXXXXXXXXXXX/reputation/iprepdata.txt.gz</ul>'
+	. '<ul style="overflow-wrap: anywhere;"><li>https://rules.emergingthreatspro.com/XXXXXXXXXXXXXXXX/reputation/iprepdata.txt.gz</li></ul>'
 	. 'Select the <strong>Auto</strong> format. The URL should use the .gz File type.<br />'
 	. 'Enter your "ETPRO" code in URL. Further information can be found @ '
 	. '<a target="_blank" rel="noopener noreferrer" href="https://www.proofpoint.com/us/solutions/products/threat-intelligence">Proofpoint IQRisk</a><br /><br />'
 	. 'To use <strong>Match</strong> Lists, Create a new Alias and select one of the <strong>'
 	. 'Action Match</strong> Formats and <br />'
-	. 'enter the <strong>Localfile</strong> as: <ul>/var/db/pfblockerng/match/generated/pfB_Match_ET_v4.txt</ul>'
+	. 'enter the <strong>Localfile</strong> as: <ul style="overflow-wrap: anywhere;"><li>/var/db/pfblockerng/match/generated/pfB_Match_ET_v4.txt</li></ul>'
 	. 'ET IQRisk Individual Match Lists can be found in the following folder:<br />'
-	. '<ul>/var/db/pfblockerng/ET</ul>'
+	. '<ul style="overflow-wrap: anywhere;"><li>/var/db/pfblockerng/ET</li></ul>'
 ));
 
 $section->addInput(new Form_Input(

--- a/tests/php/GeoipReputationHelpMarkupTest.php
+++ b/tests/php/GeoipReputationHelpMarkupTest.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Reputation (and sibling List-Action) help in pfblockerng_geoip.inc used a bare
+ * `<ul>` as a plain indentation wrapper — no `<li>` child — which is malformed
+ * list markup and gives the long filesystem paths / feed URL inside no wrapping
+ * affordance, so their tails paint past a narrow viewport (issue #2897: the
+ * pfB_Match_Exempt_v4.txt path was permanently unreachable at 414px because the
+ * Collective List Reputation panel-body is not a scroll container).
+ *
+ * Contract pinned here:
+ *   1. every `<ul>` in the file carries `<li>` content (no bare-text indent hack);
+ *   2. the five fragments the issue names keep their wording byte-for-byte;
+ *   3. the fragments carrying a long unbreakable token sit in a list that
+ *      declares a wrap affordance (overflow-wrap: anywhere), so the token can
+ *      break inside a narrow viewport instead of overflowing it.
+ */
+final class GeoipReputationHelpMarkupTest extends TestCase
+{
+	private const WORDING = [
+		'Analyzing all Blocklists as a whole:',
+		'/var/db/pfblockerng/match/generated/pfB_Match_Exempt_v4.txt',
+		'https://rules.emergingthreatspro.com/XXXXXXXXXXXXXXXX/reputation/iprepdata.txt.gz',
+		'/var/db/pfblockerng/match/generated/pfB_Match_ET_v4.txt',
+		'/var/db/pfblockerng/ET',
+	];
+
+	/** The fragments whose wording is one long unbreakable token. */
+	private const LONG_TOKENS = [
+		'/var/db/pfblockerng/match/generated/pfB_Match_Exempt_v4.txt',
+		'https://rules.emergingthreatspro.com/XXXXXXXXXXXXXXXX/reputation/iprepdata.txt.gz',
+		'/var/db/pfblockerng/match/generated/pfB_Match_ET_v4.txt',
+		'/var/db/pfblockerng/ET',
+	];
+
+	private static function source(): string
+	{
+		$source = file_get_contents(dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng_geoip.inc');
+		if ($source === FALSE) {
+			throw new RuntimeException('failed to read pfblockerng_geoip.inc');
+		}
+		return $source;
+	}
+
+	/** @return array<int, array{string, string}> [open tag (incl. attributes), body] per <ul>...</ul> span */
+	private static function ulSpans(string $source): array
+	{
+		self::assertGreaterThan(
+			0,
+			preg_match_all('/<ul\b([^>]*)>(.*?)<\/ul>/s', $source, $m, PREG_SET_ORDER),
+			'pfblockerng_geoip.inc must still contain <ul> lists to validate'
+		);
+		$spans = [];
+		foreach ($m as $ul) {
+			$spans[] = [$ul[1], $ul[2]];
+		}
+		return $spans;
+	}
+
+	public function testNoListIsABareTextIndentWrapper(): void
+	{
+		foreach (self::ulSpans(self::source()) as [$openTag, $body]) {
+			if (trim(strip_tags($body)) === '') {
+				continue; // an empty <ul></ul> is valid markup, not a text wrapper
+			}
+			$this->assertStringContainsString(
+				'<li',
+				$body,
+				"a <ul> with visible text and no <li> is malformed list markup"
+					. ' (open tag: <ul' . $openTag . '>; body starts: '
+					. substr($body, 0, 60) . '...)'
+			);
+		}
+	}
+
+	public function testIssueWordingIsByteEquivalent(): void
+	{
+		$source = self::source();
+		foreach (self::WORDING as $wording) {
+			$this->assertStringContainsString(
+				$wording,
+				$source,
+				'the #2897 fix is markup/wrapping only; the help wording must survive byte-for-byte'
+			);
+		}
+	}
+
+	public function testLongTokenFragmentsDeclareWrapAffordance(): void
+	{
+		$spans = self::ulSpans(self::source());
+		foreach (self::LONG_TOKENS as $token) {
+			$found = FALSE;
+			foreach ($spans as [$openTag, $body]) {
+				if (str_contains($body, $token)) {
+					$found = TRUE;
+					$this->assertMatchesRegularExpression(
+						'/overflow-wrap\s*:\s*anywhere|word-break\s*:\s*break-all/',
+						$openTag,
+						"the list holding the long token [ {$token} ] must declare a wrap affordance"
+							. ' so the token breaks inside a narrow viewport instead of overflowing it'
+					);
+				}
+			}
+			$this->assertTrue($found, "long token [ {$token} ] must still sit inside a <ul> list");
+		}
+	}
+}

--- a/tests/php/fixtures/geoip_pre_move_golden.json
+++ b/tests/php/fixtures/geoip_pre_move_golden.json
@@ -29,20 +29,21 @@
     "ZZ_v4.txt": "454debca5afcd37addd0dcca05094625dcde6402510f8fc664cd567893ec7096"
   },
   "continent_pages": {
-    "pfblockerng_Africa.php": "c3b683701a22175d2f52396c0a301336b58d462b5dacef657d022c53c8ec790e",
-    "pfblockerng_Antarctica.php": "7bede466a14735a5bf1de676d1834d83ecb026c4004187ccbc927fbfd7061103",
-    "pfblockerng_Asia.php": "f3d8553bb7ce000b69a71933731f48482c70a46b49350507e2403d9b23c79fc4",
-    "pfblockerng_Europe.php": "3f21044142d30512e90112a63fbb6c30a71b9325fe6d830fe7778195347e304e",
-    "pfblockerng_North_America.php": "65bdadba245570b39f7e319ca49c04288335ef19a7bf90c385a0b426d75f64b4",
-    "pfblockerng_Oceania.php": "6ec66b171da5006b790f30dd8bf5631d59b7d5b424bdb96c4f827eda946e9187",
-    "pfblockerng_South_America.php": "2de9a89d5d60ed303e8aed18f1d746d80b5d7235bf0533911e7b3f4997a59df1",
-    "pfblockerng_Proxy_and_Satellite.php": "bb79ace7c7d4325f54a30448ed96f4ff77aa56be1b253c128743e94090c78716",
-    "pfblockerng_Top_Spammers.php": "7e37603b035a82771b50aef8a07b3d689231ff6122a0cbe66f5657bedfcd2fcb"
+    "pfblockerng_Africa.php": "b15c8d777f2bb50a03e7ae14e0ffe47d8174824d353113bb05f9d5d96241e354",
+    "pfblockerng_Antarctica.php": "34a159e8d6df3cb763e1ec3eca544a7572fad6611d60bbb33b39123d9742ccea",
+    "pfblockerng_Asia.php": "3b167df2ea49435f9a9e41ea47a23cf5ac4f647df49c76ea5e0e9cc88ff66889",
+    "pfblockerng_Europe.php": "1b05fdfa9a82cdfc620141d79d6ca10e47633664a78eddb34cc82f7d19bb8594",
+    "pfblockerng_North_America.php": "7b7567a5f2f505c19001c5097170c2a000b28e0de05faa661a6e955ae70a849f",
+    "pfblockerng_Oceania.php": "0977c120be91c347e198241e5fa065f0be0c4f2a3efc68b764cdc2e0eb8146f8",
+    "pfblockerng_South_America.php": "765fc226e398169bd4f78e410e6e4781431e6eb0e5910ababfa1b2cd547fe3f2",
+    "pfblockerng_Proxy_and_Satellite.php": "6c76826113a514602e9d93f2dbf8312cba2807602170837da5839e105d3f2e57",
+    "pfblockerng_Top_Spammers.php": "1781c867e7acdf6f0f7f749286293f62a9c74acf6ddd5fb1a8d975234bb5b657"
   },
-  "reputation_empty": "59a4fa81040c5691ddb1b13574dfe3669052530c0947535a74b30bb3af459b4e",
-  "reputation_populated": "dcfe541ef16a5c9c74e8692354351bd9a78b52a17f3f50ea9b1efde42b240568",
+  "reputation_empty": "db362e398b52d23dfdc8221b4dc0fb3f972d992ef7d37582c6c97ab0290b2f97",
+  "reputation_populated": "ebca5913c83c5644f1bc95c07de3e8c1c0f63736dfe16c487865e63c4327b660",
   "continent_pages_amended": "issue #1845: the generated pages now carry the pfBlockerNG.js cache-buster; the pre-move template is otherwise unchanged",
   "reputation_hashes_amended": "issue #1896: the Reputation section's config_get_path/config_set_path calls now route through PfbConfig::readSection()/writeSection(); the pre-move template is otherwise unchanged",
   "continent_behavior_amended": "issue #2103: generated pages route anchor layout and MaxMind documentation rendering through behavior-tested helpers",
-  "continent_copy_amended": "GUI reorg: generated country pages now name 'Force Global IP Logging' on the IP tab and point MaxMind credentials at the IP tab; the pre-move template is otherwise unchanged"
+  "continent_copy_amended": "GUI reorg: generated country pages now name 'Force Global IP Logging' on the IP tab and point MaxMind credentials at the IP tab; the pre-move template is otherwise unchanged",
+  "reputation_markup_amended": "issue #2897: the embedded List-Action help and Reputation help in the generated pages now wrap bare-text <ul> indent wrappers in <li> children and declare overflow-wrap: anywhere on long-token fragments; the pre-move template is otherwise unchanged"
 }


### PR DESCRIPTION
Rebases the pre-existing fix commit for #2897 onto current `devel` (`f21ca0eb`), plus the sanctioned GeoIP pre-move golden refresh its bytes require.

## What changed
- `src/usr/local/pkg/pfblockerng/pfblockerng_geoip.inc` (`bb4ebb0e`): replaces the 12 malformed bare-text `<ul>` indent wrappers in the Reputation / List-Action help with `<ul><li>` markup, and adds `overflow-wrap: anywhere` on the open tags whose content carries long unbreakable path/URL tokens (all four flagged by the issue), so they wrap inside narrow viewports instead of painting past the right edge.
- `tests/php/GeoipReputationHelpMarkupTest.php` (new, `bb4ebb0e`): 3 tests / 31 assertions pinning (1) no `<ul>` in the file carries bare text without an `<li>` child, (2) all five issue wording strings are byte-equivalent, (3) each long-token fragment declares a wrap affordance. Test file byte-identical from RED through GREEN (blob `2b3717b4`).
- `tests/php/fixtures/geoip_pre_move_golden.json` (`797417a2`): the generated country pages embed the List-Action help verbatim and the Reputation page embeds the Reputation help, so the markup fix changes their bytes. Golden refresh follows the `5d421040` precedent: nine continent-page hashes + both reputation hashes recomputed from the actual generation, content diff verified markup-only (nine continent pages = the two embedded help lines only; Reputation page = the twelve markup sites only), recorded as `reputation_markup_amended`.

Help wording is unchanged — markup and wrapping only.

## Acceptance criteria (from the issue)
- [x] No `<ul>` in `pfblockerng_geoip.inc` contains bare text without an `<li>` (test 1, file-wide; live page measured: 0 bare-text `<ul>`, 4 wrap-affordance `<ul>`).
- [x] At 414px, none of the five strings paints past the viewport's right edge — live pfSense measured with `Range.getClientRects()` at 414x896 (see below).
- [x] Visual indentation preserved at desktop width (1440x900: all five single-line, indented, no overflow).
- [x] Help wording unchanged (test 2, byte-equivalence).

## Test plan
- `vendor/bin/phpunit tests/php/GeoipReputationHelpMarkupTest.php` — OK (3 tests, 31 assertions); file byte-identical from RED through GREEN (git blob `2b3717b4`).
- `scripts/agent/run-gates.sh --diff f21ca0eb` — all gates PASS (incl. full 6059-test PHPUnit run) after the golden refresh; RED proof of the unchanged golden oracle on the markup-only state is in the first CI run of this PR (33325154044).
- Live pfSense CE 2.8 VM at this exact head: all five strings measured with `Range.getClientRects()` at 414x896 — 276.4 / 387.7 / 370.5 / 373.5 / 209.3 px right edge, all within the 414px viewport, long tokens wrapping to 2 lines, document horizontal overflow 0 (the `pfB_Match_Exempt_v4.txt` path that was permanently unreachable at 467px is now inside); at 1440x900 all five single-line, indented, no overflow.

Fixes #2897