### PR TITLE
smoke: preserve host diagnostics redaction

### DIFF
--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -5333,40 +5333,62 @@ def redact_pkg_urls(text: str) -> str:
 
 
 def _redact_pkg_tar_filter(member: tarfile.TarInfo, dest_path: str) -> tarfile.TarInfo | None:
-    """Keep the data filter's protections while omitting appliance absolute links."""
+    """Keep data-filter protections and drop links that could alias outside ``pkg/``."""
     try:
-        return tarfile.data_filter(member, dest_path)
+        filtered = tarfile.data_filter(member, dest_path)
     except tarfile.AbsoluteLinkError:
         return None
+    if member.islnk() or member.issym():
+        return None
+    return filtered
 
 
 def redact_pkg_tarball(tgz_path: str) -> None:
     """Host-side second pass over a pulled diag tarball's ``pkg/`` files.
 
     The guest sed has no case-insensitive flag; this IGNORECASE pass is the
-    belt. No-op when the archive is missing or has no pkg dump.
+    belt. Missing archives and incomplete pkg-file processing raise.
     """
-    if not os.path.isfile(tgz_path):
-        return
     with tempfile.TemporaryDirectory() as tmp:
         with tarfile.open(tgz_path, "r:gz") as tar:
             tar.extractall(tmp, filter=_redact_pkg_tar_filter)
         pkg_root = os.path.join(tmp, "pfb_smoke_diag", "pkg")
+        failures: list[str] = []
         if os.path.isdir(pkg_root):
             for dirpath, _, files in os.walk(pkg_root):
                 for name in files:
                     path = os.path.join(dirpath, name)
+                    relative = os.path.relpath(path, pkg_root)
                     try:
                         raw = Path(path).read_text(encoding="utf-8", errors="surrogateescape")
-                    except OSError:
+                    except OSError as exc:
+                        failures.append(f"{relative}: read failed: {exc!r}")
                         continue
                     new = redact_pkg_urls(raw)
                     if new != raw:
-                        Path(path).write_text(new, encoding="utf-8", errors="surrogateescape")
-        tmp_out = tgz_path + ".redact"
-        with tarfile.open(tmp_out, "w:gz") as tar:
-            tar.add(os.path.join(tmp, "pfb_smoke_diag"), arcname="pfb_smoke_diag")
-        os.replace(tmp_out, tgz_path)
+                        try:
+                            Path(path).write_text(new, encoding="utf-8", errors="surrogateescape")
+                        except OSError as exc:
+                            failures.append(f"{relative}: write failed: {exc!r}")
+        if failures:
+            raise RuntimeError("host-side pkg redaction incomplete: " + "; ".join(failures))
+
+        output_dir = os.path.dirname(os.path.abspath(tgz_path))
+        output_fd, tmp_out = tempfile.mkstemp(
+            dir=output_dir,
+            prefix=f".{os.path.basename(tgz_path)}.redact-",
+            suffix=".tmp",
+        )
+        os.close(output_fd)
+        try:
+            with tarfile.open(tmp_out, "w:gz") as tar:
+                tar.add(os.path.join(tmp, "pfb_smoke_diag"), arcname="pfb_smoke_diag")
+            os.replace(tmp_out, tgz_path)
+        finally:
+            try:
+                os.unlink(tmp_out)
+            except FileNotFoundError:
+                pass
 
 
 def redact_values(text: str, values: Iterable[str]) -> str:

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -5336,7 +5336,7 @@ def _redact_pkg_tar_filter(member: tarfile.TarInfo, dest_path: str) -> tarfile.T
     """Keep data-filter protections and drop links that could alias outside ``pkg/``."""
     try:
         filtered = tarfile.data_filter(member, dest_path)
-    except tarfile.AbsoluteLinkError:
+    except (tarfile.AbsoluteLinkError, tarfile.LinkOutsideDestinationError):
         return None
     if member.islnk() or member.issym():
         return None
@@ -5354,22 +5354,23 @@ def redact_pkg_tarball(tgz_path: str) -> None:
             tar.extractall(tmp, filter=_redact_pkg_tar_filter)
         pkg_root = os.path.join(tmp, "pfb_smoke_diag", "pkg")
         failures: list[str] = []
-        if os.path.isdir(pkg_root):
-            for dirpath, _, files in os.walk(pkg_root):
-                for name in files:
-                    path = os.path.join(dirpath, name)
-                    relative = os.path.relpath(path, pkg_root)
+        if not os.path.isdir(pkg_root):
+            raise RuntimeError("host-side pkg redaction incomplete: missing pfb_smoke_diag/pkg")
+        for dirpath, _, files in os.walk(pkg_root):
+            for name in files:
+                path = os.path.join(dirpath, name)
+                relative = os.path.relpath(path, pkg_root)
+                try:
+                    raw = Path(path).read_text(encoding="utf-8", errors="surrogateescape")
+                except OSError as exc:
+                    failures.append(f"{relative}: read failed: {exc!r}")
+                    continue
+                new = redact_pkg_urls(raw)
+                if new != raw:
                     try:
-                        raw = Path(path).read_text(encoding="utf-8", errors="surrogateescape")
+                        Path(path).write_text(new, encoding="utf-8", errors="surrogateescape")
                     except OSError as exc:
-                        failures.append(f"{relative}: read failed: {exc!r}")
-                        continue
-                    new = redact_pkg_urls(raw)
-                    if new != raw:
-                        try:
-                            Path(path).write_text(new, encoding="utf-8", errors="surrogateescape")
-                        except OSError as exc:
-                            failures.append(f"{relative}: write failed: {exc!r}")
+                        failures.append(f"{relative}: write failed: {exc!r}")
         if failures:
             raise RuntimeError("host-side pkg redaction incomplete: " + "; ".join(failures))
 

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -5332,6 +5332,14 @@ def redact_pkg_urls(text: str) -> str:
     return _PKG_TOKEN_QUERY_RE.sub(r"\1REDACTED", out)
 
 
+def _redact_pkg_tar_filter(member: tarfile.TarInfo, dest_path: str) -> tarfile.TarInfo | None:
+    """Keep the data filter's protections while omitting appliance absolute links."""
+    try:
+        return tarfile.data_filter(member, dest_path)
+    except tarfile.AbsoluteLinkError:
+        return None
+
+
 def redact_pkg_tarball(tgz_path: str) -> None:
     """Host-side second pass over a pulled diag tarball's ``pkg/`` files.
 
@@ -5342,7 +5350,7 @@ def redact_pkg_tarball(tgz_path: str) -> None:
         return
     with tempfile.TemporaryDirectory() as tmp:
         with tarfile.open(tgz_path, "r:gz") as tar:
-            tar.extractall(tmp, filter="data")
+            tar.extractall(tmp, filter=_redact_pkg_tar_filter)
         pkg_root = os.path.join(tmp, "pfb_smoke_diag", "pkg")
         if os.path.isdir(pkg_root):
             for dirpath, _, files in os.walk(pkg_root):
@@ -5532,8 +5540,16 @@ def collect_host_diagnostics(vm: SmokeVM, dest_dir: str = "smoke-diag", *, timeo
         ]
         result = subprocess.run(scp_argv, capture_output=True, text=True, timeout=timeout, check=False)
         if result.returncode == 0:
-            print(f"[smoke] collected full guest diagnostics -> {dest_dir}/pfb_smoke_diag.tgz")
-            redact_pkg_tarball(os.path.join(dest_dir, "pfb_smoke_diag.tgz"))
+            tgz_path = os.path.join(dest_dir, "pfb_smoke_diag.tgz")
+            try:
+                redact_pkg_tarball(tgz_path)
+            except Exception as exc:  # noqa: BLE001
+                print(
+                    "[smoke] host-side diagnostics redaction failed; "
+                    f"archive has guest-side redaction only -> {tgz_path}: {exc!r}"
+                )
+            else:
+                print(f"[smoke] collected and redacted full guest diagnostics -> {tgz_path}")
         else:
             print(f"[smoke] guest-diagnostics scp failed (non-fatal): {result.stderr!r}")
         # Surface the VM SERIAL CONSOLE in the uploaded artifact. boot_vm.sh runs

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -5379,12 +5379,19 @@ def redact_pkg_tarball(tgz_path: str) -> None:
             prefix=f".{os.path.basename(tgz_path)}.redact-",
             suffix=".tmp",
         )
-        os.close(output_fd)
+        output_closed = False
         try:
+            os.close(output_fd)
+            output_closed = True
             with tarfile.open(tmp_out, "w:gz") as tar:
                 tar.add(os.path.join(tmp, "pfb_smoke_diag"), arcname="pfb_smoke_diag")
             os.replace(tmp_out, tgz_path)
         finally:
+            if not output_closed:
+                try:
+                    os.close(output_fd)
+                except OSError:
+                    pass
             try:
                 os.unlink(tmp_out)
             except FileNotFoundError:

--- a/tests/test_smoke_diag_pkg_abi.py
+++ b/tests/test_smoke_diag_pkg_abi.py
@@ -24,6 +24,13 @@ import pytest
 from tests.smoke import helpers
 
 
+def _add_text_member(archive: tarfile.TarFile, name: str, text: str) -> None:
+    payload = text.encode("utf-8")
+    member = tarfile.TarInfo(name)
+    member.size = len(payload)
+    archive.addfile(member, io.BytesIO(payload))
+
+
 def test_collect_host_diagnostics_captures_pkg_abi_and_uname() -> None:
     """Given collect_host_diagnostics
     When it builds the guest snapshot script
@@ -195,8 +202,148 @@ def test_collect_host_diagnostics_reports_host_redaction_failure(
     helpers.collect_host_diagnostics(cast(helpers.SmokeVM, vm), str(dest))
 
     output = capsys.readouterr().out
-    assert "[smoke] collected full guest diagnostics" not in output
-    assert "[smoke] host-side diagnostics redaction failed" in output
-    assert "archive has guest-side redaction only" in output
-    assert "ReadError" in output
+    success_prefix = "[smoke] collected and redacted full guest diagnostics ->"
+    failure_prefix = "[smoke] host-side diagnostics redaction failed;"
+    terminal_prefixes = (
+        success_prefix,
+        failure_prefix,
+        "[smoke] guest-diagnostics scp failed",
+        "[smoke] collect_host_diagnostics failed",
+    )
+    terminal_lines = [line for line in output.splitlines() if line.startswith(terminal_prefixes)]
+    assert success_prefix not in output
+    assert len(terminal_lines) == 1
+    assert terminal_lines[0].startswith(failure_prefix)
+    assert "archive has guest-side redaction only" in terminal_lines[0]
+    assert "ReadError" in terminal_lines[0]
     assert (dest / "pfb_smoke_diag.tgz").exists()
+
+
+def test_redact_pkg_tarball_missing_archive_is_failure(tmp_path: Path) -> None:
+    """A missing pulled archive cannot be reported as a completed host pass."""
+    with pytest.raises(FileNotFoundError):
+        helpers.redact_pkg_tarball(str(tmp_path / "missing.tgz"))
+
+
+def test_redact_pkg_tarball_read_failure_is_terminal_after_all_pkg_files(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Every intended pkg file is attempted, then any read failure rejects the pass."""
+    tgz = tmp_path / "pfb_smoke_diag.tgz"
+    with tarfile.open(tgz, "w:gz") as archive:
+        _add_text_member(archive, "pfb_smoke_diag/pkg/a-fail.conf", "unreadable")
+        _add_text_member(
+            archive,
+            "pfb_smoke_diag/pkg/z-ok.conf",
+            "url: https://pkg.example/repo?TOKEN=SECOND_FILE_SECRET\n",
+        )
+
+    original_read_text = Path.read_text
+    attempted: list[str] = []
+
+    def injected_read_text(path: Path, encoding: str | None = None, errors: str | None = None) -> str:
+        attempted.append(path.name)
+        if path.name == "a-fail.conf":
+            raise OSError("injected regular-file read failure")
+        return original_read_text(path, encoding=encoding, errors=errors)
+
+    monkeypatch.setattr(Path, "read_text", injected_read_text)
+    with pytest.raises(RuntimeError, match="a-fail.conf"):
+        helpers.redact_pkg_tarball(str(tgz))
+
+    assert set(attempted) == {"a-fail.conf", "z-ok.conf"}
+    with tarfile.open(tgz, "r:gz") as archive:
+        data = archive.extractfile("pfb_smoke_diag/pkg/z-ok.conf")
+        assert data is not None
+        assert "SECOND_FILE_SECRET" in data.read().decode("utf-8")
+
+
+def test_redact_pkg_tarball_preserves_preexisting_fixed_sidecar(tmp_path: Path) -> None:
+    """The old predictable .redact path is unrelated data, never scratch space."""
+    tgz = tmp_path / "pfb_smoke_diag.tgz"
+    with tarfile.open(tgz, "w:gz") as archive:
+        _add_text_member(archive, "pfb_smoke_diag/pkg/repos.conf", "clean\n")
+    fixed_sidecar = Path(f"{tgz}.redact")
+    fixed_sidecar.write_bytes(b"preexisting unrelated artifact")
+
+    helpers.redact_pkg_tarball(str(tgz))
+
+    assert fixed_sidecar.read_bytes() == b"preexisting unrelated artifact"
+
+
+@pytest.mark.parametrize("failure_phase", ["add", "close", "replace"])
+def test_redact_pkg_tarball_removes_partial_temp_on_repack_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, failure_phase: str
+) -> None:
+    """Every repack failure removes its unique temporary archive."""
+    tgz = tmp_path / "pfb_smoke_diag.tgz"
+    with tarfile.open(tgz, "w:gz") as archive:
+        _add_text_member(archive, "pfb_smoke_diag/pkg/repos.conf", "clean\n")
+    before = {path.name for path in tmp_path.iterdir()}
+
+    if failure_phase == "add":
+
+        def fail_add(*_args: object, **_kwargs: object) -> None:
+            raise OSError("injected tar.add failure")
+
+        monkeypatch.setattr(tarfile.TarFile, "add", fail_add)
+    elif failure_phase == "close":
+        original_close = tarfile.TarFile.close
+        close_failed = False
+
+        def fail_close(archive: tarfile.TarFile) -> None:
+            nonlocal close_failed
+            fail_now = archive.mode == "w" and not close_failed
+            original_close(archive)
+            if fail_now:
+                close_failed = True
+                raise OSError("injected tar.close failure")
+
+        monkeypatch.setattr(tarfile.TarFile, "close", fail_close)
+    else:
+
+        def fail_replace(*_args: object, **_kwargs: object) -> None:
+            raise OSError("injected os.replace failure")
+
+        monkeypatch.setattr(helpers.os, "replace", fail_replace)
+
+    with pytest.raises(OSError, match=f"injected .*{failure_phase} failure"):
+        helpers.redact_pkg_tarball(str(tgz))
+
+    assert {path.name for path in tmp_path.iterdir()} == before
+
+
+def test_redact_pkg_tarball_drops_internal_link_aliases_without_rewriting_non_pkg(
+    tmp_path: Path,
+) -> None:
+    """Pkg symlink and hardlink aliases cannot rewrite a non-pkg archive member."""
+    tgz = tmp_path / "pfb_smoke_diag.tgz"
+    non_pkg_secret = "url: https://outside.example/repo?TOKEN=NON_PKG_SECRET\n"
+    pkg_secret = "url: https://pkg.example/repo?TOKEN=PKG_SECRET\n"
+    with tarfile.open(tgz, "w:gz") as archive:
+        _add_text_member(archive, "pfb_smoke_diag/outside.conf", non_pkg_secret)
+        _add_text_member(archive, "pfb_smoke_diag/pkg/repos.conf", pkg_secret)
+        symlink = tarfile.TarInfo("pfb_smoke_diag/pkg/symlink.conf")
+        symlink.type = tarfile.SYMTYPE
+        symlink.linkname = "../outside.conf"
+        archive.addfile(symlink)
+        hardlink = tarfile.TarInfo("pfb_smoke_diag/pkg/hardlink.conf")
+        hardlink.type = tarfile.LNKTYPE
+        hardlink.linkname = "pfb_smoke_diag/outside.conf"
+        archive.addfile(hardlink)
+
+    helpers.redact_pkg_tarball(str(tgz))
+
+    with tarfile.open(tgz, "r:gz") as archive:
+        names = archive.getnames()
+        outside = archive.extractfile("pfb_smoke_diag/outside.conf")
+        pkg = archive.extractfile("pfb_smoke_diag/pkg/repos.conf")
+        assert outside is not None
+        assert pkg is not None
+        outside_text = outside.read().decode("utf-8")
+        pkg_text = pkg.read().decode("utf-8")
+    assert "pfb_smoke_diag/pkg/symlink.conf" not in names
+    assert "pfb_smoke_diag/pkg/hardlink.conf" not in names
+    assert outside_text == non_pkg_secret
+    assert "PKG_SECRET" not in pkg_text
+    assert "TOKEN=REDACTED" in pkg_text

--- a/tests/test_smoke_diag_pkg_abi.py
+++ b/tests/test_smoke_diag_pkg_abi.py
@@ -11,6 +11,14 @@ query parameters at capture time.
 from __future__ import annotations
 
 import inspect
+import io
+import subprocess
+import tarfile
+import tempfile
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
 
 from tests.smoke import helpers
 
@@ -117,28 +125,73 @@ def test_collect_host_diagnostics_redacts_pkg_urls_at_capture() -> None:
     assert "redact_pkg_tarball(" in src
 
 
-def test_redact_pkg_tarball_strips_uppercase_token() -> None:
-    """Given a pulled diag tarball whose pkg dump still has ?TOKEN=
-    When the host second pass runs
-    Then the secret is gone from the retarred bundle.
-    """
-    import tarfile
-    import tempfile
-    from pathlib import Path
+def test_redact_pkg_tarball_drops_absolute_symlink_and_strips_residual_token(tmp_path: Path) -> None:
+    """The host pass skips appliance absolute links without losing pkg redaction."""
+    outside = tmp_path / "outside.conf"
+    outside_text = "url: https://outside.example/repo?TOKEN=OUTSIDE_SECRET\n"
+    outside.write_text(outside_text, encoding="utf-8")
+    tgz = tmp_path / "pfb_smoke_diag.tgz"
+    secret = b"url: https://pkg.example.com/repo?ToKeN=HOST_PASS_SECRET\n"
+    with tarfile.open(tgz, "w:gz") as tar:
+        member = tarfile.TarInfo("pfb_smoke_diag/pkg/pkg_vv.txt")
+        member.size = len(secret)
+        tar.addfile(member, io.BytesIO(secret))
+        absolute_link = tarfile.TarInfo("pfb_smoke_diag/pkg/repos/pfSense.conf")
+        absolute_link.type = tarfile.SYMTYPE
+        absolute_link.linkname = str(outside)
+        tar.addfile(absolute_link)
 
-    secret = "url: https://pkg.example.com/repo?TOKEN=SEKRIT\n"
-    with tempfile.TemporaryDirectory() as tmp:
-        inner = Path(tmp) / "pkg"
-        inner.mkdir()
-        (inner / "repos.conf").write_text(secret, encoding="utf-8")
-        tgz = Path(tmp) / "pfb_smoke_diag.tgz"
-        with tarfile.open(tgz, "w:gz") as tar:
-            tar.add(inner, arcname="pfb_smoke_diag/pkg")
+    helpers.redact_pkg_tarball(str(tgz))
+
+    with tarfile.open(tgz, "r:gz") as tar:
+        assert "pfb_smoke_diag/pkg/repos/pfSense.conf" not in tar.getnames()
+        data = tar.extractfile("pfb_smoke_diag/pkg/pkg_vv.txt")
+        assert data is not None
+        out = data.read().decode("utf-8")
+    assert "HOST_PASS_SECRET" not in out
+    assert "ToKeN=REDACTED" in out
+    assert outside.read_text(encoding="utf-8") == outside_text
+
+
+def test_redact_pkg_tarball_rejects_traversal(tmp_path: Path, monkeypatch) -> None:
+    """A traversal member remains fatal and cannot write outside extraction."""
+    monkeypatch.setattr(tempfile, "tempdir", str(tmp_path))
+    tgz = tmp_path / "pfb_smoke_diag.tgz"
+    escaped = tmp_path / "escaped.txt"
+    payload = b"must not escape"
+    with tarfile.open(tgz, "w:gz") as tar:
+        member = tarfile.TarInfo("../escaped.txt")
+        member.size = len(payload)
+        tar.addfile(member, io.BytesIO(payload))
+
+    with pytest.raises(tarfile.OutsideDestinationError):
         helpers.redact_pkg_tarball(str(tgz))
-        with tarfile.open(tgz, "r:gz") as tar:
-            member = tar.getmember("pfb_smoke_diag/pkg/repos.conf")
-            data = tar.extractfile(member)
-            assert data is not None
-            out = data.read().decode("utf-8")
-        assert "SEKRIT" not in out
-        assert "TOKEN=REDACTED" in out
+
+    assert not escaped.exists()
+
+
+def test_collect_host_diagnostics_reports_host_redaction_failure(tmp_path: Path, monkeypatch, capsys) -> None:
+    """A pulled archive is not reported as fully collected when host redaction fails."""
+    dest = tmp_path / "diag"
+
+    def fake_scp(argv, **_kwargs):
+        Path(argv[-1]).write_bytes(b"not a tar archive")
+        return subprocess.CompletedProcess(argv, 0, "", "")
+
+    monkeypatch.setattr(helpers.subprocess, "run", fake_scp)
+    vm = SimpleNamespace(
+        ssh=lambda *_args, **_kwargs: None,
+        ssh_key_path="unused",
+        ssh_port=22,
+        ssh_target="root@unused",
+        log_path=None,
+    )
+
+    helpers.collect_host_diagnostics(vm, str(dest))
+
+    output = capsys.readouterr().out
+    assert "[smoke] collected full guest diagnostics" not in output
+    assert "[smoke] host-side diagnostics redaction failed" in output
+    assert "archive has guest-side redaction only" in output
+    assert "ReadError" in output
+    assert (dest / "pfb_smoke_diag.tgz").exists()

--- a/tests/test_smoke_diag_pkg_abi.py
+++ b/tests/test_smoke_diag_pkg_abi.py
@@ -17,6 +17,7 @@ import tarfile
 import tempfile
 from pathlib import Path
 from types import SimpleNamespace
+from typing import cast
 
 import pytest
 
@@ -153,7 +154,7 @@ def test_redact_pkg_tarball_drops_absolute_symlink_and_strips_residual_token(tmp
     assert outside.read_text(encoding="utf-8") == outside_text
 
 
-def test_redact_pkg_tarball_rejects_traversal(tmp_path: Path, monkeypatch) -> None:
+def test_redact_pkg_tarball_rejects_traversal(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """A traversal member remains fatal and cannot write outside extraction."""
     monkeypatch.setattr(tempfile, "tempdir", str(tmp_path))
     tgz = tmp_path / "pfb_smoke_diag.tgz"
@@ -170,11 +171,15 @@ def test_redact_pkg_tarball_rejects_traversal(tmp_path: Path, monkeypatch) -> No
     assert not escaped.exists()
 
 
-def test_collect_host_diagnostics_reports_host_redaction_failure(tmp_path: Path, monkeypatch, capsys) -> None:
+def test_collect_host_diagnostics_reports_host_redaction_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
     """A pulled archive is not reported as fully collected when host redaction fails."""
     dest = tmp_path / "diag"
 
-    def fake_scp(argv, **_kwargs):
+    def fake_scp(argv: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
         Path(argv[-1]).write_bytes(b"not a tar archive")
         return subprocess.CompletedProcess(argv, 0, "", "")
 
@@ -187,7 +192,7 @@ def test_collect_host_diagnostics_reports_host_redaction_failure(tmp_path: Path,
         log_path=None,
     )
 
-    helpers.collect_host_diagnostics(vm, str(dest))
+    helpers.collect_host_diagnostics(cast(helpers.SmokeVM, vm), str(dest))
 
     output = capsys.readouterr().out
     assert "[smoke] collected full guest diagnostics" not in output

--- a/tests/test_smoke_diag_pkg_abi.py
+++ b/tests/test_smoke_diag_pkg_abi.py
@@ -162,6 +162,31 @@ def test_redact_pkg_tarball_drops_absolute_symlink_and_strips_residual_token(tmp
     assert outside.read_text(encoding="utf-8") == outside_text
 
 
+def test_redact_pkg_tarball_drops_relative_link_outside_destination(tmp_path: Path) -> None:
+    """A relative external link is omitted without aborting the host pass."""
+    tgz = tmp_path / "pfb_smoke_diag.tgz"
+    with tarfile.open(tgz, "w:gz") as archive:
+        _add_text_member(
+            archive,
+            "pfb_smoke_diag/pkg/repos.conf",
+            "url: https://pkg.example/repo?TOKEN=RELATIVE_LINK_SECRET\n",
+        )
+        link = tarfile.TarInfo("pfb_smoke_diag/pkg/external.conf")
+        link.type = tarfile.SYMTYPE
+        link.linkname = "../../../outside.conf"
+        archive.addfile(link)
+
+    helpers.redact_pkg_tarball(str(tgz))
+
+    with tarfile.open(tgz, "r:gz") as archive:
+        assert "pfb_smoke_diag/pkg/external.conf" not in archive.getnames()
+        data = archive.extractfile("pfb_smoke_diag/pkg/repos.conf")
+        assert data is not None
+        redacted = data.read().decode("utf-8")
+    assert "RELATIVE_LINK_SECRET" not in redacted
+    assert "TOKEN=REDACTED" in redacted
+
+
 def test_redact_pkg_tarball_rejects_traversal(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """A traversal member remains fatal and cannot write outside extraction."""
     monkeypatch.setattr(tempfile, "tempdir", str(tmp_path))
@@ -179,16 +204,30 @@ def test_redact_pkg_tarball_rejects_traversal(tmp_path: Path, monkeypatch: pytes
     assert not escaped.exists()
 
 
+@pytest.mark.parametrize(
+    ("archive_kind", "expected_error"),
+    [
+        pytest.param("invalid", "ReadError", id="invalid-tar"),
+        pytest.param("missing-pkg", "RuntimeError", id="missing-pkg"),
+    ],
+)
 def test_collect_host_diagnostics_reports_host_redaction_failure(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
+    archive_kind: str,
+    expected_error: str,
 ) -> None:
-    """A pulled archive is not reported as fully collected when host redaction fails."""
+    """An invalid or incomplete archive cannot be reported as fully redacted."""
     dest = tmp_path / "diag"
 
     def fake_scp(argv: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
-        Path(argv[-1]).write_bytes(b"not a tar archive")
+        tgz = Path(argv[-1])
+        if archive_kind == "invalid":
+            tgz.write_bytes(b"not a tar archive")
+        else:
+            with tarfile.open(tgz, "w:gz") as archive:
+                _add_text_member(archive, "pfb_smoke_diag/unrelated.txt", "no package tree")
         return subprocess.CompletedProcess(argv, 0, "", "")
 
     monkeypatch.setattr(helpers.subprocess, "run", fake_scp)
@@ -216,7 +255,7 @@ def test_collect_host_diagnostics_reports_host_redaction_failure(
     assert len(terminal_lines) == 1
     assert terminal_lines[0].startswith(failure_prefix)
     assert "archive has guest-side redaction only" in terminal_lines[0]
-    assert "ReadError" in terminal_lines[0]
+    assert expected_error in terminal_lines[0]
     assert (dest / "pfb_smoke_diag.tgz").exists()
 
 

--- a/tests/test_smoke_diag_pkg_abi.py
+++ b/tests/test_smoke_diag_pkg_abi.py
@@ -313,6 +313,25 @@ def test_redact_pkg_tarball_removes_partial_temp_on_repack_failure(
     assert {path.name for path in tmp_path.iterdir()} == before
 
 
+def test_redact_pkg_tarball_removes_temp_when_fd_close_fails(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A close failure after mkstemp cannot strand its partial archive."""
+    tgz = tmp_path / "pfb_smoke_diag.tgz"
+    with tarfile.open(tgz, "w:gz") as archive:
+        _add_text_member(archive, "pfb_smoke_diag/pkg/repos.conf", "clean\n")
+    before = {path.name for path in tmp_path.iterdir()}
+    original_close = helpers.os.close
+
+    def fail_close(fd: int) -> None:
+        original_close(fd)
+        raise OSError("injected os.close failure")
+
+    monkeypatch.setattr(helpers.os, "close", fail_close)
+    with pytest.raises(OSError, match="injected os.close failure"):
+        helpers.redact_pkg_tarball(str(tgz))
+
+    assert {path.name for path in tmp_path.iterdir()} == before
+
+
 def test_redact_pkg_tarball_drops_internal_link_aliases_without_rewriting_non_pkg(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_smoke_diag_pkg_abi.py
+++ b/tests/test_smoke_diag_pkg_abi.py
@@ -10,6 +10,7 @@ query parameters at capture time.
 
 from __future__ import annotations
 
+import errno
 import inspect
 import io
 import subprocess
@@ -219,6 +220,53 @@ def test_collect_host_diagnostics_reports_host_redaction_failure(
     assert (dest / "pfb_smoke_diag.tgz").exists()
 
 
+def test_collect_host_diagnostics_reports_one_success_after_real_redaction(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A valid archive emits one success terminal only after its secret is scrubbed."""
+    dest = tmp_path / "diag"
+
+    def fake_scp(argv: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        tgz = Path(argv[-1])
+        with tarfile.open(tgz, "w:gz") as archive:
+            _add_text_member(
+                archive,
+                "pfb_smoke_diag/pkg/repos.conf",
+                "url: https://pkg.example/repo?ToKeN=SUCCESS_SECRET\n",
+            )
+        return subprocess.CompletedProcess(argv, 0, "", "")
+
+    monkeypatch.setattr(helpers.subprocess, "run", fake_scp)
+    vm = SimpleNamespace(
+        ssh=lambda *_args, **_kwargs: None,
+        ssh_key_path="unused",
+        ssh_port=22,
+        ssh_target="root@unused",
+        log_path=None,
+    )
+
+    helpers.collect_host_diagnostics(cast(helpers.SmokeVM, vm), str(dest))
+
+    output = capsys.readouterr().out
+    success_prefix = "[smoke] collected and redacted full guest diagnostics ->"
+    terminal_prefixes = (
+        success_prefix,
+        "[smoke] host-side diagnostics redaction failed;",
+        "[smoke] guest-diagnostics scp failed",
+        "[smoke] collect_host_diagnostics failed",
+    )
+    terminal_lines = [line for line in output.splitlines() if line.startswith(terminal_prefixes)]
+    assert terminal_lines == [f"{success_prefix} {dest / 'pfb_smoke_diag.tgz'}"]
+    with tarfile.open(dest / "pfb_smoke_diag.tgz", "r:gz") as archive:
+        data = archive.extractfile("pfb_smoke_diag/pkg/repos.conf")
+        assert data is not None
+        redacted = data.read().decode("utf-8")
+    assert "SUCCESS_SECRET" not in redacted
+    assert "ToKeN=REDACTED" in redacted
+
+
 def test_redact_pkg_tarball_missing_archive_is_failure(tmp_path: Path) -> None:
     """A missing pulled archive cannot be reported as a completed host pass."""
     with pytest.raises(FileNotFoundError):
@@ -330,6 +378,38 @@ def test_redact_pkg_tarball_removes_temp_when_fd_close_fails(tmp_path: Path, mon
         helpers.redact_pkg_tarball(str(tgz))
 
     assert {path.name for path in tmp_path.iterdir()} == before
+
+
+def test_redact_pkg_tarball_closes_fd_when_initial_close_fails(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A pre-close failure still closes the mkstemp descriptor during cleanup."""
+    tgz = tmp_path / "pfb_smoke_diag.tgz"
+    with tarfile.open(tgz, "w:gz") as archive:
+        _add_text_member(archive, "pfb_smoke_diag/pkg/repos.conf", "clean\n")
+    before = {path.name for path in tmp_path.iterdir()}
+    original_close = helpers.os.close
+    close_calls: list[int] = []
+
+    def fail_first_close(fd: int) -> None:
+        close_calls.append(fd)
+        if len(close_calls) == 1:
+            raise OSError("injected pre-close failure")
+        original_close(fd)
+
+    monkeypatch.setattr(helpers.os, "close", fail_first_close)
+    with pytest.raises(OSError, match="injected pre-close failure"):
+        helpers.redact_pkg_tarball(str(tgz))
+
+    assert {path.name for path in tmp_path.iterdir()} == before
+    assert close_calls[:2] == [close_calls[0], close_calls[0]]
+    try:
+        with pytest.raises(OSError) as closed:
+            helpers.os.fstat(close_calls[0])
+        assert closed.value.errno == errno.EBADF
+    finally:
+        try:
+            original_close(close_calls[0])
+        except OSError:
+            pass
 
 
 def test_redact_pkg_tarball_drops_internal_link_aliases_without_rewriting_non_pkg(


### PR DESCRIPTION
👀 ***#2881***: ***Host-side diagnostics redaction***

## Summary

- preserve `tarfile.data_filter` path-traversal protections while omitting appliance absolute-link members such as `pkg/repos/pfSense.conf`
- run the host-side case-insensitive package URL redaction pass before reporting full diagnostic collection success
- pin the absolute-link, traversal, mixed-case-token, external-target, and truthful-failure contracts with mutation-proven tests

## Verification

### Hermetic and canonical

- `scripts/agent/run-gates.sh --diff origin/devel` — 5/5 gates passed on base `f21ca0eb511edcf3185118fa26ff96f2cb861983` and head `c92c3e0fa82f3eb347db717ae4909da466bfcd49`
- frozen test blob `aea660e20525a9c8d4c1da82717388e1e4f25b78` — base RED: 2 failed, 10 passed; fixed head GREEN: 12 passed
- representative mutations rejected unsafe traversal extraction, retained absolute links, over-broad filter catches, missing `IGNORECASE`, and premature success output

### Live pfSense

- command: `scripts/local-smoke.sh --ref issue/2881-smoke-host-side-diag-redaction --filter test_hook_shim_file_exists_on_deployed_build --no-two-vm`
- lease: `local-100031-1788111333-25edfd036de4276f` on `root@10.0.0.31`; package run: `local-pfbbox1-1788111344-6e24e3f87830feaa`
- exact on-box ref: `c92c3e0fa82f3eb347db717ae4909da466bfcd49`; pfSense image: `sha256:19ea9a833d7601aefecdf2982e8f07301b276c428d258b7ab4c87bbcd1d8a874`
- result: `1 passed, 1061 deselected`; one `[smoke] collected and redacted full guest diagnostics` line; zero guest-only or top-level collection failure lines
- pulled archive: SHA-256 `8a5296acb96964fb5bfaf1ce0bd06accb22394aaf2d18838c7d746a69751bff3`, 610344 bytes, 29 readable members; `pfb_smoke_diag/pkg/repos/pfSense.conf` absent; no link members; no unredacted token-query values
- controlled copy of that live archive: exact absolute-link member plus mixed-case `ToKeN=HOST_PASS_SECRET` payload were added; the production redactor removed the link and secret, emitted `ToKeN=REDACTED`, and preserved the external target byte-for-byte (`0a170ec0330c222fb76cdcab5e8f5564301cc3b8903596449885fd521c07db7b` before and after)
- live log SHA-256: `68ea801aaaf34c9067c241180989c1cd4af6f2974b8b7eef2b763896697f2d83`

### CI

- exact-head workflow: [Tests run 33325636218](https://github.com/pfBlockerNG/pfBlockerNG/actions/runs/33325636218), run 6078 attempt 1 — success; 21 successful and 2 intentionally skipped check runs, no failures

Fixes #2881

🤖 Generated by Oh My Pi and posted on behalf of @andrebrait.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved diagnostic package redaction to prevent unsafe links and path traversal during archive processing.
  * Sensitive URL credentials and token-like query parameters are now more consistently removed, including uppercase variants.
  * Redaction failures are reported clearly while allowing host diagnostic collection to continue where possible.
  * Missing archives and file-processing errors now produce explicit failures instead of being silently ignored.
  * Temporary files are cleaned up reliably after successful or failed archive processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->