### PR TITLE
Route runtime toggles through the config gateway

### DIFF
--- a/docs/misc/config-gateway.md
+++ b/docs/misc/config-gateway.md
@@ -141,6 +141,10 @@ Authorization = property of **write**, not call site (generalises
     keeps its `pfb_filter(…, PFB_FILTER_ON_OFF, …) ?: ''` (transport normalisation of a
     POST-absent checkbox, re-normalised by `writeSection()`); what moved is the READ
     default. Regrowth blocked by `scripts/check_toggle_registry.py` (below).
+    Issue #2817 completed the runtime side: the seven IP consumers and the DNSBL
+    settings-section `auto*` branch use `PfbConfig::read()`. Identically named
+    per-feed-row and per-continent fields remain foreign; their direct reads pass
+    through `pfb_dnsbl_toggle_enabled()` so they share the registered vocabulary.
   - **Ten adapter-bearing toggles default On:** `pfb_keep`, `pfb_software_check`,
     `pfb_feed_internal_filter`, `pfb_syntax_highlight`, `pfb_cache`, `pfb_py_reply`,
     `pfb_hsts`, `pfb_idn_block_malicious`, ip-section `suppression`, and (since #2123)
@@ -489,9 +493,9 @@ registered path set). Each annotation committed in relevant source file.
 | `pfblockerngdnsblsettings/config/0/dnsbl_webpage` | Out-of-scope foreign key (ADR-29 §2.5); written directly by `pfblockerng_dnsbl.php`, read via `pfb_dnsbl_webpage()` (issue #713 removed the never-written `dnsblwebpage` registry mis-spelling) |
 | `pfblockerngdnsbl` / `pfblockernglistsv4/v6` (section-level reads) | Dynamic list sections |
 | `aliases/alias`, `filter/rule`, `system/*`, `interfaces`, `unbound/*` | pfSense core sections |
-| `pfblockernglistsv4/v6/config/{row}/auto{addrnot,ports,addr,not}_{in,out}` | Dynamic per-row keys (issue #2123: same bare names as the registered `dnsbl/auto*` scalars; `pfblockerng_category_edit.php` writes them at `installedpackages/{$conf_type}/config/{$rowid}/…`, a path no exact-path registry entry can address) |
+| `pfblockernglistsv4/v6/config/{row}/auto{addrnot,ports,addr,not}_{in,out}` | Dynamic per-row keys (issue #2123: same bare names as the registered `dnsbl/auto*` scalars; `pfblockerng_category_edit.php` writes them at `installedpackages/{$conf_type}/config/{$rowid}/…`, a path no exact-path registry entry can address). Runtime reads stay direct and normalize through `pfb_dnsbl_toggle_enabled()` (#2817). |
 | `pfblockernglistsv4/v6/config/{row}/whois_convert` + `filter_top1m` | Dynamic per-row `PFB_FILTER_ON_OFF` keys, same reason |
-| `pfblockerng{continent}/config/0/auto*` | Dynamic per-continent structure (issue #2123: `pfblockerng_geoip.inc` writes the same bare names per continent) |
+| `pfblockerng{continent}/config/0/auto*` | Dynamic per-continent structure (issue #2123: `pfblockerng_geoip.inc` writes the same bare names per continent). Runtime reads stay direct and normalize through `pfb_dnsbl_toggle_enabled()` (#2817). |
 | `pfblockerngsync/config/0/{varsynconchanges,varsynctimeout}` | Foreign siblings of the registered `sync/syncinterfaces` |
 | `pfblockerngglobal/*` except `alertrefresh` | Foreign siblings of the registered `global/alertrefresh` (display prefs, `pfbextdns`, and the dynamic `feed_*`/`widget-*` keys) |
 

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -3283,11 +3283,11 @@ function pfb_global() {
 					array_filter(explode(',', PfbConfig::read('gen/pfb_agg_types')))));
 
 	$pfb['supp']		= PfbConfig::read('ip/suppression');					// Enable Suppression (default on, issue #1907)
-	$pfb['cc']		= $pfb['ipconfig']['database_cc'] ?? '';		// Disable Country database CRON updates
+	$pfb['cc']		= PfbConfig::read('ip/database_cc') === PfbToggle::On;	// Disable Country database CRON updates
 	$pfb['maxmind_locale']	= $pfb['ipconfig']['maxmind_locale']	?: 'en';	// MaxMind Localized Language setting
 	$pfb['asn_reporting']	= $pfb['ipconfig']['asn_reporting']	?: 'disabled';	// ASN Reporting
 	$pfb['asn_token']	= $pfb['ipconfig']['asn_token']		?: '';		// ASN Token (IPinfo)
-	$pfb['rdns']		= pfb_resolve_enabled($pfb['ipconfig']);			// Reverse-DNS lookup for block-log entries (issue #336)
+	$pfb['rdns']		= pfb_resolve_enabled();					// Reverse-DNS lookup for block-log entries (issue #336)
 
 	$pfb['maxmind_account']	= pfb_filter($pfb['ipconfig']['maxmind_account'], PFB_FILTER_WORD, 'pfb_global')	?: '';		// Maxmind Account ID
 	$pfb['maxmind_key']	= pfb_filter($pfb['ipconfig']['maxmind_key'], PFB_FILTER_WORD, 'maxmind_key')		?: '';		// Maxmind License Key (issue #924: log-safe reference -- a rejected key is never logged on this consumer path either)
@@ -7110,20 +7110,28 @@ function pfb_determine_list_detail($list='', $header='', $confconfig='', $key=''
 	}
 
 	// Configure autoports/protocol and auto destination if required.
-	if (!empty($confconfig) && is_array(config_get_path("installedpackages/{$confconfig}/config/{$key}"))) {
+	$conf_path = "installedpackages/{$confconfig}/config/{$key}";
+	if (!empty($confconfig) && is_array(config_get_path($conf_path))) {
 
-		$conf_config	= config_get_path("installedpackages/{$confconfig}/config/{$key}");
+		$conf_config	= config_get_path($conf_path);
+		$registered	= $confconfig === 'pfblockerngdnsblsettings' && (string) $key === '0';
+		$toggle_enabled = static function (string $field) use ($conf_config, $registered): bool {
+			if ($registered) {
+				return PfbConfig::read("dnsbl/{$field}") === PfbToggle::On;
+			}
+			return pfb_dnsbl_toggle_enabled($conf_config[$field] ?? '');
+		};
 		$autotype	= array( 'autoports' => 'aliasports', 'autoaddr' => 'aliasaddr');
 
 		foreach (array('_out', '_in') as $dir) {
 
 			$pfbarr['aproto' . $dir]	= $conf_config['autoproto' . $dir];
-			$pfbarr['anot' . $dir]		= $conf_config['autonot' . $dir];
-			$pfbarr['aaddrnot' . $dir]	= $conf_config['autoaddrnot' . $dir];
+			$pfbarr['anot' . $dir]		= $toggle_enabled('autonot' . $dir) ? 'on' : '';
+			$pfbarr['aaddrnot' . $dir]	= $toggle_enabled('autoaddrnot' . $dir) ? 'on' : '';
 			$pfbarr['agateway' . $dir]	= $conf_config['agateway' . $dir];
 
 			foreach ($autotype as $akey => $atype) {
-				if ($conf_config[$akey . $dir] == 'on') {
+				if ($toggle_enabled($akey . $dir)) {
 					foreach (config_get_path('aliases/alias', []) as $palias) {
 						if ($palias['name'] == $conf_config[$atype . $dir]) {
 							if (!empty($palias['address'])) {
@@ -7148,7 +7156,7 @@ function pfb_determine_list_detail($list='', $header='', $confconfig='', $key=''
 
 	// Force 'Alias Native' setting to any Alias with 'Advanced Inbound/Outbound -Invert src/dst' settings.
 	// This will bypass Deduplication and Reputation features.
-	if ($pfbarr['aaddrnot_in'] == 'on' || $pfbarr['aaddrnot_out'] == 'on') {
+	if ($pfbarr['aaddrnot_in'] === 'on' || $pfbarr['aaddrnot_out'] === 'on') {
 		$pfbarr['adv'] = FALSE;
 		$pfbarr['folder'] = "{$pfb['nativedir']}";
 	}
@@ -17266,12 +17274,8 @@ function pfb_resolve_tracker(
 // Reverse-DNS (PTR) lookup for block-log entries (issue #336). Defaults OFF for
 // new installs; existing installs are seeded 'on' at upgrade (see
 // pfb_rdns_seed_value() + pfblockerng_install.inc) to preserve prior behaviour.
-// Returns FALSE when the key is absent (new install) or explicitly unchecked.
-function pfb_resolve_enabled(array $ipconfig): bool {
-	if (!array_key_exists('enable_rdns', $ipconfig)) {
-		return FALSE;
-	}
-	return pfb_cfg_toggle_read($ipconfig['enable_rdns']) === PfbToggle::On;
+function pfb_resolve_enabled(): bool {
+	return PfbConfig::read('ip/enable_rdns') === PfbToggle::On;
 }
 
 // Decide the one-time upgrade seed for enable_rdns (issue #336). An EXISTING

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
@@ -974,13 +974,13 @@ function sync_package_pfblockerng($cron='', ?string &$deferred_by = NULL): bool 
 	$pfb['deny_action_inbound']  = $pfb['ipconfig']['inbound_deny_action']	?: 'block';
 	$pfb['deny_action_outbound'] = $pfb['ipconfig']['outbound_deny_action']	?: 'reject';
 
-	$pfb['float']		= pfb_cfg_toggle_read($pfb['ipconfig']['enable_float']);				// Enable/Disable floating autorules
-	$pfb['dup']		= pfb_cfg_toggle_read($pfb['ipconfig']['enable_dup']);				// Enable remove of duplicate IPs utilizing grepcidr
-	$pfb['agg']		= pfb_cfg_toggle_read($pfb['ipconfig']['enable_agg']);				// Enable aggregation of CIDRs
+	$pfb['float']		= PfbConfig::read('ip/enable_float');				// Enable/Disable floating autorules
+	$pfb['dup']		= PfbConfig::read('ip/enable_dup');				// Enable remove of duplicate IPs utilizing grepcidr
+	$pfb['agg']		= PfbConfig::read('ip/enable_agg');				// Enable aggregation of CIDRs
 	$pfb['order']		= $pfb['ipconfig']['pass_order'] ?: 'order_0';			// Order of the autorules (default order_0, matching the IP-settings UI; an empty value drops user pass-rules on a managed interface — issue #532)
-	$pfb['global_log']	= pfb_cfg_toggle_read($pfb['ipconfig']['enable_log']);				// Enable Global IP logging
+	$pfb['global_log']	= PfbConfig::read('ip/enable_log');				// Enable Global IP logging
 	$pfb['suffix']		= $pfb['ipconfig']['autorule_suffix'];				// Suffix used for autorules
-	$pfb['kstates'] 	= $pfb['ipconfig']['killstates'];				// Firewall states removal
+	$pfb['kstates'] 	= PfbConfig::read('ip/killstates');				// Firewall states removal
 
 	$pfb['ip_ph']		= pfb_filter($pfb['ipconfig']['ip_placeholder'], PFB_FILTER_IPV4, 'Placeholder IP Address', '127.1.7.7');	// Placeholder IP Address
 
@@ -1210,8 +1210,8 @@ function sync_package_pfblockerng($cron='', ?string &$deferred_by = NULL): bool 
 
 							// Force 'Alias Native' setting to any Alias with 'Advanced Inbound/Outbound -Invert src/dst' settings.
 							// This will bypass Deduplication and Reputation features.
-							if ($continent_config['autoaddrnot_in'] == 'on' ||
-							    $continent_config['autoaddrnot_out'] == 'on') {
+							if (pfb_dnsbl_toggle_enabled($continent_config['autoaddrnot_in'] ?? '') ||
+							    pfb_dnsbl_toggle_enabled($continent_config['autoaddrnot_out'] ?? '')) {
 								$pfb['existing']['native'][]		= "{$pfb_alias}{$vtype}";
 							}
 							else {
@@ -1293,8 +1293,8 @@ function sync_package_pfblockerng($cron='', ?string &$deferred_by = NULL): bool 
 
 						// Force 'Alias Native' setting to any Alias with 'Advanced Inbound/Outbound -Invert src/dst' settings.
 						// This will bypass Deduplication and Reputation features.
-						if ($list['action'] != 'unbound' && ($list['autoaddrnot_in'] == 'on' ||
-						    $list['autoaddrnot_out'] == 'on')) {
+						if ($list['action'] != 'unbound' && (pfb_dnsbl_toggle_enabled($list['autoaddrnot_in'] ?? '') ||
+						    pfb_dnsbl_toggle_enabled($list['autoaddrnot_out'] ?? ''))) {
 							$list['action'] = 'Alias_Native';
 						}
 
@@ -4979,7 +4979,7 @@ function sync_package_pfblockerng($cron='', ?string &$deferred_by = NULL): bool 
 	#	KILL STATES		#
 	#################################
 
-	if (!$pfb['save'] && $pfb['kstates'] && !$pfb['filter_configure']) {
+	if (!$pfb['save'] && $pfb['kstates'] === PfbToggle::On && !$pfb['filter_configure']) {
 		pfb_remove_states();
 	}
 

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -1728,8 +1728,9 @@ function pfb_cfg_registry(): array
 		// per-feed-row and per-continent keys of the same bare name (those live under
 		// dynamic config paths and stay on the foreign-key exclusion list). All eight
 		// were off-by-default in pfblockerng_dnsbl.php's own `?: ''`, so the registered
-		// '' reproduces the page exactly. pfb_determine_list_detail() reads them off the
-		// section blob through a dynamic path, which registration leaves untouched.
+		// '' reproduces the page exactly. The registered settings singleton reads through
+		// PfbConfig; only per-feed-row and per-continent namesakes remain foreign, with
+		// pfb_dnsbl_toggle_enabled() providing the shared runtime vocabulary (#2817).
 		'dnsbl/autoaddrnot_in' => [
 			'default'       => '',
 			'read_adapter'  => 'pfb_cfg_toggle_read',

--- a/tests/php/ApplyDynamicToggleConsumersTest.php
+++ b/tests/php/ApplyDynamicToggleConsumersTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class ApplyDynamicToggleConsumersTest extends TestCase
+{
+	private const APPLY = __DIR__ . '/../../src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc';
+
+	public static function invertStates(): iterable
+	{
+		yield 'inbound mixed-case On' => ['On', '', TRUE];
+		yield 'outbound mixed-case On' => ['', 'On', TRUE];
+		yield 'mixed-case OFF' => ['OFF', 'OFF', FALSE];
+		yield 'legacy off' => ['off', 'off', FALSE];
+		yield 'absent' => [NULL, NULL, FALSE];
+	}
+
+	#[DataProvider('invertStates')]
+	public function testContinentAndPerRowBranchesUseTheSharedToggleVocabulary(
+		mixed $inbound,
+		mixed $outbound,
+		bool $expected
+	): void {
+		$source = file_get_contents(self::APPLY);
+		if (!is_string($source)) {
+			throw new RuntimeException('test bootstrap: failed to read pfblockerng_apply.inc');
+		}
+		[$continentCondition, $rowCondition] = self::nativeOverrideConditions($source);
+
+		$continent_config = [];
+		$list = ['action' => 'Deny_Both'];
+		if ($inbound !== NULL) {
+			$continent_config['autoaddrnot_in'] = $inbound;
+			$list['autoaddrnot_in'] = $inbound;
+		}
+		if ($outbound !== NULL) {
+			$continent_config['autoaddrnot_out'] = $outbound;
+			$list['autoaddrnot_out'] = $outbound;
+		}
+
+		set_error_handler(static function (int $severity, string $message): never {
+			throw new ErrorException($message, 0, $severity);
+		});
+		try {
+			$continent = eval('return ' . $continentCondition . ';');
+			$row = eval('return ' . $rowCondition . ';');
+		} finally {
+			restore_error_handler();
+		}
+
+		$this->assertSame($expected, $continent, 'per-continent Native override verdict');
+		$this->assertSame($expected, $row, 'per-row Native override verdict');
+	}
+
+	/** @return array{string,string} */
+	private static function nativeOverrideConditions(string $source): array
+	{
+		$marker = "// Force 'Alias Native' setting to any Alias with 'Advanced Inbound/Outbound -Invert src/dst' settings.";
+		$conditions = [];
+		$offset = 0;
+		for ($occurrence = 0; $occurrence < 2; $occurrence++) {
+			$markerStart = strpos($source, $marker, $offset);
+			$ifStart = $markerStart === FALSE ? FALSE : strpos($source, 'if (', $markerStart);
+			if ($markerStart === FALSE || $ifStart === FALSE) {
+				throw new RuntimeException('test bootstrap: failed to find dynamic Native override');
+			}
+			$conditionStart = $ifStart + strlen('if (');
+			$depth = 1;
+			$length = strlen($source);
+			for ($cursor = $conditionStart; $cursor < $length; $cursor++) {
+				if ($source[$cursor] === '(') {
+					$depth++;
+				} elseif ($source[$cursor] === ')') {
+					$depth--;
+					if ($depth === 0) {
+						$conditions[] = substr($source, $conditionStart, $cursor - $conditionStart);
+						$offset = $cursor + 1;
+						break;
+					}
+				}
+			}
+		}
+		if (count($conditions) !== 2) {
+			throw new RuntimeException('test bootstrap: failed to extract both dynamic Native overrides');
+		}
+		return $conditions;
+	}
+}

--- a/tests/php/ResolveEnabledTest.php
+++ b/tests/php/ResolveEnabledTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -15,10 +16,10 @@ use PHPUnit\Framework\TestCase;
  * (see pfblockerng_install.inc) to preserve the historical always-resolving
  * behaviour.
  *
- * pfb_resolve_enabled() branches:
- *   - key absent     → FALSE  (new-install default OFF)
- *   - key = 'on'     → TRUE   (user has the checkbox checked)
- *   - key = ''       → FALSE  (user unchecked the checkbox)
+ * pfb_resolve_enabled() gateway states:
+ *   - key absent     → FALSE  (registered default OFF)
+ *   - key = 'on'/'On' → TRUE  (user has the checkbox checked)
+ *   - key = ''/'off'/'OFF' → FALSE  (user unchecked the checkbox)
  *
  * Scenario: pfb_rdns_seed_value() grandfather logic
  *   Background: the key 'enable_rdns' did not exist before issue #336.
@@ -45,31 +46,23 @@ use PHPUnit\Framework\TestCase;
 #[CoversFunction('pfb_rdns_seed_value')]
 final class ResolveEnabledTest extends TestCase
 {
-	// -------------------------------------------------------------------------
-	// pfb_resolve_enabled()
-	// -------------------------------------------------------------------------
-
-	public function testDefaultsOffWhenKeyAbsent(): void
+	public static function resolveStates(): iterable
 	{
-		// New install: enable_rdns key does not exist yet.
-		// Must return FALSE — reverse-DNS is off by default for new installs.
-		$this->assertFalse(pfb_resolve_enabled([]));
+		yield 'mixed-case On' => ['On', TRUE];
+		yield 'mixed-case OFF' => ['OFF', FALSE];
+		yield 'legacy off' => ['off', FALSE];
+		yield 'absent' => [NULL, FALSE];
 	}
 
-	public function testExplicitOnReturnsTrue(): void
+	#[DataProvider('resolveStates')]
+	public function testReadsRegisteredGatewayVocabulary(mixed $raw, bool $expected): void
 	{
-		// Before: absent key → FALSE (new-install default).
-		$this->assertFalse(pfb_resolve_enabled([]));
-		// After: stored 'on' (checkbox checked) → TRUE.
-		$this->assertTrue(pfb_resolve_enabled(['enable_rdns' => 'on']));
-	}
+		$GLOBALS['config'] = [];
+		if ($raw !== NULL) {
+			config_set_path('installedpackages/pfblockerngipsettings/config/0/enable_rdns', $raw);
+		}
 
-	public function testExplicitOffReturnsFalse(): void
-	{
-		// Before: stored 'on' (checkbox checked) → TRUE; proves the flip is real.
-		$this->assertTrue(pfb_resolve_enabled(['enable_rdns' => 'on']));
-		// After: stored '' (unchecked save) → FALSE — reverse-DNS disabled.
-		$this->assertFalse(pfb_resolve_enabled(['enable_rdns' => '']));
+		$this->assertSame($expected, pfb_resolve_enabled());
 	}
 
 	// -------------------------------------------------------------------------

--- a/tests/php/RuntimeToggleConsumersTest.php
+++ b/tests/php/RuntimeToggleConsumersTest.php
@@ -1,0 +1,222 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+#[CoversFunction('pfb_determine_list_detail')]
+final class RuntimeToggleConsumersTest extends TestCase
+{
+	private const APPLY = __DIR__ . '/../../src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc';
+	private const INC = __DIR__ . '/../../src/usr/local/pkg/pfblockerng/pfblockerng.inc';
+
+	/** @var array<string,array{bool,mixed}> */
+	private array $saved = [];
+
+	protected function setUp(): void
+	{
+		foreach (['config', 'pfb', 'pfbarr'] as $name) {
+			$this->saved[$name] = [array_key_exists($name, $GLOBALS), $GLOBALS[$name] ?? NULL];
+		}
+		$GLOBALS['config'] = [];
+		$GLOBALS['pfb'] = [
+			'denydir' => '/tmp/pfb_deny',
+			'nativedir' => '/tmp/pfb_native',
+			'origdir' => '/tmp/pfb_orig',
+			'reuse' => '',
+		];
+	}
+
+	protected function tearDown(): void
+	{
+		foreach ($this->saved as $name => [$existed, $value]) {
+			if ($existed) {
+				$GLOBALS[$name] = $value;
+			} else {
+				unset($GLOBALS[$name]);
+			}
+		}
+	}
+
+	public static function rawToggleStates(): iterable
+	{
+		yield 'mixed-case On' => ['On', TRUE];
+		yield 'mixed-case OFF' => ['OFF', FALSE];
+		yield 'legacy off' => ['off', FALSE];
+		yield 'absent' => [NULL, FALSE];
+	}
+
+	#[DataProvider('rawToggleStates')]
+	public function testApplyIpMirrorsUseRegisteredToggleVocabulary(mixed $raw, bool $enabled): void
+	{
+		$fields = [
+			'enable_float' => 'float',
+			'enable_dup' => 'dup',
+			'enable_agg' => 'agg',
+			'enable_log' => 'global_log',
+			'killstates' => 'kstates',
+		];
+		$ipconfig = ['pass_order' => 'order_0', 'autorule_suffix' => ''];
+		if ($raw !== NULL) {
+			foreach (array_keys($fields) as $field) {
+				$ipconfig[$field] = $raw;
+			}
+		}
+		config_set_path('installedpackages/pfblockerngipsettings/config/0', $ipconfig);
+
+		$pfb = ['ipconfig' => $ipconfig];
+		$source = self::readSource(self::APPLY);
+		$block = self::sourceRange($source, "\$pfb['float']", "\$pfb['kstates']");
+		set_error_handler(static function (int $severity, string $message): never {
+			throw new ErrorException($message, 0, $severity);
+		});
+		try {
+			eval($block);
+		} finally {
+			restore_error_handler();
+		}
+
+		$expected = $enabled ? PfbToggle::On : PfbToggle::Off;
+		foreach ($fields as $field => $mirror) {
+			$this->assertSame($expected, $pfb[$mirror], "{$field}: runtime mirror");
+		}
+	}
+
+	public function testKillstatesBranchRequiresTheOnEnum(): void
+	{
+		$source = self::readSource(self::APPLY);
+		$this->assertSame(1, preg_match(
+			'/if \((?<condition>[^\r\n]*\$pfb\[\'kstates\'\][^\r\n]*)\) \{/',
+			$source,
+			$match
+		), 'the live killstates condition must be extractable');
+
+		foreach ([[PfbToggle::On, TRUE], [PfbToggle::Off, FALSE]] as [$toggle, $expected]) {
+			$pfb = ['save' => FALSE, 'filter_configure' => FALSE, 'kstates' => $toggle];
+			$actual = eval('return ' . $match['condition'] . ';');
+			$this->assertSame($expected, $actual, "killstates {$toggle->value} verdict");
+		}
+	}
+
+	#[DataProvider('rawToggleStates')]
+	public function testDatabaseCountryConsumerUsesGatewayVerdict(mixed $raw, bool $enabled): void
+	{
+		$ipconfig = [];
+		if ($raw !== NULL) {
+			$ipconfig['database_cc'] = $raw;
+		}
+		config_set_path('installedpackages/pfblockerngipsettings/config/0', $ipconfig);
+
+		$pfb = ['ipconfig' => $ipconfig];
+		$source = self::readSource(self::INC);
+		eval(self::sourceRange($source, "\$pfb['cc']", "\$pfb['cc']"));
+
+		$this->assertSame($enabled, $pfb['cc'], 'database_cc runtime verdict');
+	}
+
+	public static function advancedToggleMatrix(): iterable
+	{
+		$homes = [
+			'static registered settings' => ['pfblockerngdnsblsettings', '0'],
+			'dynamic per-row IPv4 list' => ['pfblockernglistsv4', '3'],
+			'dynamic per-continent list' => ['pfblockerngafrica', '0'],
+		];
+		$fields = [
+			'autoaddrnot_in', 'autoports_in', 'autoaddr_in', 'autonot_in',
+			'autoaddrnot_out', 'autoports_out', 'autoaddr_out', 'autonot_out',
+		];
+		foreach ($homes as $home => [$section, $key]) {
+			foreach ($fields as $field) {
+				foreach (self::rawToggleStates() as $state => [$raw, $enabled]) {
+					yield "{$home}: {$field} [{$state}]" => [$section, $key, $field, $raw, $enabled];
+				}
+			}
+		}
+	}
+
+	#[DataProvider('advancedToggleMatrix')]
+	public function testAdvancedRuleTogglesShareVocabularyAcrossStaticAndDynamicHomes(
+		string $section,
+		string $key,
+		string $field,
+		mixed $raw,
+		bool $enabled
+	): void {
+		$row = self::advancedRow();
+		if ($raw === NULL) {
+			unset($row[$field]);
+		} else {
+			$row[$field] = $raw;
+		}
+		config_set_path("installedpackages/{$section}/config/{$key}", $row);
+		config_set_path('aliases/alias', self::aliases());
+
+		$result = pfb_determine_list_detail('Deny_Both', 'runtime-toggle', $section, $key);
+		$direction = str_ends_with($field, '_in') ? '_in' : '_out';
+
+		if (str_starts_with($field, 'autoaddrnot')) {
+			$this->assertSame($enabled ? 'on' : '', $result['aaddrnot' . $direction]);
+			$this->assertSame(
+				$enabled ? $GLOBALS['pfb']['nativedir'] : $GLOBALS['pfb']['denydir'],
+				$result['folder'],
+				'Invert source/destination must control the Native override'
+			);
+		} elseif (str_starts_with($field, 'autonot')) {
+			$this->assertSame($enabled ? 'on' : '', $result['anot' . $direction]);
+		} elseif (str_starts_with($field, 'autoports')) {
+			$this->assertSame($enabled ? 'ports' . $direction : NULL, $result['aports' . $direction] ?? NULL);
+		} else {
+			$this->assertSame($enabled ? 'address' . $direction : NULL, $result['aaddr' . $direction] ?? NULL);
+		}
+	}
+
+	/** @return array<string,mixed> */
+	private static function advancedRow(): array
+	{
+		$row = [];
+		foreach (['_in', '_out'] as $direction) {
+			$row['autoproto' . $direction] = '';
+			$row['autonot' . $direction] = '';
+			$row['autoaddrnot' . $direction] = '';
+			$row['agateway' . $direction] = 'default';
+			$row['autoports' . $direction] = '';
+			$row['autoaddr' . $direction] = '';
+			$row['aliasports' . $direction] = 'ports' . $direction;
+			$row['aliasaddr' . $direction] = 'address' . $direction;
+		}
+		return $row;
+	}
+
+	/** @return list<array{name:string,address:string}> */
+	private static function aliases(): array
+	{
+		return [
+			['name' => 'ports_in', 'address' => '443'],
+			['name' => 'ports_out', 'address' => '443'],
+			['name' => 'address_in', 'address' => '192.0.2.1'],
+			['name' => 'address_out', 'address' => '192.0.2.2'],
+		];
+	}
+
+	private static function readSource(string $path): string
+	{
+		$source = file_get_contents($path);
+		if (!is_string($source)) {
+			throw new RuntimeException("test bootstrap: failed to read {$path}");
+		}
+		return $source;
+	}
+
+	private static function sourceRange(string $source, string $first, string $last): string
+	{
+		$start = strpos($source, $first);
+		$lastStart = strpos($source, $last, $start === FALSE ? 0 : $start);
+		$end = $lastStart === FALSE ? FALSE : strpos($source, "\n", $lastStart);
+		if ($start === FALSE || $lastStart === FALSE || $end === FALSE) {
+			throw new RuntimeException("test bootstrap: failed to extract {$first} through {$last}");
+		}
+		return substr($source, $start, $end - $start + 1);
+	}
+}

--- a/tests/php/RuntimeToggleOwnershipExecutionTest.php
+++ b/tests/php/RuntimeToggleOwnershipExecutionTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace PfbRuntimeToggleOwnershipSpy;
 
-use PHPUnit\Framework\Attributes\Depends;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 
@@ -57,16 +57,11 @@ final class RuntimeToggleOwnershipExecutionTest extends TestCase
 		'autonot_in', 'autoaddrnot_in', 'autoports_in', 'autoaddr_in',
 	];
 	/** @var array<string,array{bool,mixed}> */
-	private static array $originalGlobals = [];
-	/** @var array<string,array{bool,mixed}> */
 	private array $savedGlobals = [];
 
 
 	public static function setUpBeforeClass(): void
 	{
-		foreach (['pfb', 'pfbarr'] as $name) {
-			self::$originalGlobals[$name] = [array_key_exists($name, $GLOBALS), $GLOBALS[$name] ?? NULL];
-		}
 
 		$reflection = new \ReflectionFunction('pfb_determine_list_detail');
 		$lines = file($reflection->getFileName());
@@ -95,46 +90,45 @@ final class RuntimeToggleOwnershipExecutionTest extends TestCase
 			} else {
 				unset($GLOBALS[$name]);
 			}
-		}
-	}
-
-
-	public function testStaticAndDynamicHomesInvokeOnlyTheirOwner(): void
-	{
-		$homes = [
-			'static settings singleton' => ['pfblockerngdnsblsettings', '0', TRUE],
-			'dynamic feed row' => ['pfblockernglistsv4', '3', FALSE],
-			'dynamic continent' => ['pfblockerngafrica', '0', FALSE],
-		];
-		foreach ($homes as $label => [$section, $key, $registered]) {
-			$this->seed($section, $key);
-
-			$result = pfb_determine_list_detail('Deny_Both', 'ownership-spy', $section, $key);
-
-			$this->assertSame('/native', $result['folder'], "{$label}: enabled invert must force Native");
-			$this->assertSame('on', $result['aaddrnot_in'], "{$label}: enabled invert verdict");
-			if ($registered) {
-				$this->assertSame(
-					array_map(static fn (string $field): string => "dnsbl/{$field}", self::EXPECTED_FIELDS),
-					SpyState::$gatewayKeys,
-					"{$label}: exact registered gateway keys"
-				);
-				$this->assertSame([], SpyState::$dynamicKeys, "{$label}: foreign-key adapter must not run");
-			} else {
-				$this->assertSame([], SpyState::$gatewayKeys, "{$label}: singleton gateway must not run");
-				$this->assertSame(self::EXPECTED_FIELDS, SpyState::$dynamicKeys,
-					"{$label}: exact dynamic foreign-key adapter fields");
-			}
-		}
-	}
-	#[Depends('testStaticAndDynamicHomesInvokeOnlyTheirOwner')]
-	public function testGlobalStateIsRestoredForDependentTests(): void
-	{
-		foreach (self::$originalGlobals as $name => [$existed, $value]) {
 			$this->assertSame($existed, array_key_exists($name, $GLOBALS), "{$name}: existence must be restored");
 			if ($existed) {
 				$this->assertSame($value, $GLOBALS[$name], "{$name}: value must be restored");
 			}
+		}
+	}
+
+
+	public static function homes(): iterable
+	{
+		yield 'static settings singleton' => ['static settings singleton', 'pfblockerngdnsblsettings', '0', TRUE];
+		yield 'dynamic feed row' => ['dynamic feed row', 'pfblockernglistsv4', '3', FALSE];
+		yield 'dynamic continent' => ['dynamic continent', 'pfblockerngafrica', '0', FALSE];
+	}
+
+	#[DataProvider('homes')]
+	public function testStaticAndDynamicHomesInvokeOnlyTheirOwner(
+		string $label,
+		string $section,
+		string $key,
+		bool $registered
+	): void {
+		$this->seed($section, $key);
+
+		$result = pfb_determine_list_detail('Deny_Both', 'ownership-spy', $section, $key);
+
+		$this->assertSame('/native', $result['folder'], "{$label}: enabled invert must force Native");
+		$this->assertSame('on', $result['aaddrnot_in'], "{$label}: enabled invert verdict");
+		if ($registered) {
+			$this->assertSame(
+				array_map(static fn (string $field): string => "dnsbl/{$field}", self::EXPECTED_FIELDS),
+				SpyState::$gatewayKeys,
+				"{$label}: exact registered gateway keys"
+			);
+			$this->assertSame([], SpyState::$dynamicKeys, "{$label}: foreign-key adapter must not run");
+		} else {
+			$this->assertSame([], SpyState::$gatewayKeys, "{$label}: singleton gateway must not run");
+			$this->assertSame(self::EXPECTED_FIELDS, SpyState::$dynamicKeys,
+				"{$label}: exact dynamic foreign-key adapter fields");
 		}
 	}
 

--- a/tests/php/RuntimeToggleOwnershipExecutionTest.php
+++ b/tests/php/RuntimeToggleOwnershipExecutionTest.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PfbRuntimeToggleOwnershipSpy;
+
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+final class SpyState
+{
+	/** @var array<string,mixed> */
+	public static array $paths = [];
+	/** @var array<string,bool> */
+	public static array $registered = [];
+	/** @var list<string> */
+	public static array $gatewayKeys = [];
+	/** @var list<string> */
+	public static array $dynamicKeys = [];
+}
+
+enum PfbToggle
+{
+	case On;
+	case Off;
+}
+
+final class PfbConfig
+{
+	public static function read(string $key): PfbToggle
+	{
+		SpyState::$gatewayKeys[] = $key;
+		$field = substr($key, strpos($key, '/') + 1);
+		return (SpyState::$registered[$field] ?? FALSE) ? PfbToggle::On : PfbToggle::Off;
+	}
+}
+
+function config_get_path(string $path, mixed $default = NULL): mixed
+{
+	return SpyState::$paths[$path] ?? $default;
+}
+
+function pfb_dnsbl_toggle_enabled(mixed $stored): bool
+{
+	if (!is_array($stored) || !is_string($stored['field'] ?? NULL) || !is_bool($stored['enabled'] ?? NULL)) {
+		throw new RuntimeException('dynamic toggle spy received an unlabelled value');
+	}
+	SpyState::$dynamicKeys[] = $stored['field'];
+	return $stored['enabled'];
+}
+
+final class RuntimeToggleOwnershipExecutionTest extends TestCase
+{
+	private const EXPECTED_FIELDS = [
+		'autonot_out', 'autoaddrnot_out', 'autoports_out', 'autoaddr_out',
+		'autonot_in', 'autoaddrnot_in', 'autoports_in', 'autoaddr_in',
+	];
+
+	public static function setUpBeforeClass(): void
+	{
+		$reflection = new \ReflectionFunction('pfb_determine_list_detail');
+		$lines = file($reflection->getFileName());
+		if (!is_array($lines)) {
+			throw new RuntimeException('test bootstrap: failed to read pfb_determine_list_detail source');
+		}
+		$source = implode('', array_slice(
+			$lines,
+			$reflection->getStartLine() - 1,
+			$reflection->getEndLine() - $reflection->getStartLine() + 1
+		));
+		eval('namespace ' . __NAMESPACE__ . '; ' . $source);
+	}
+
+	public function testStaticAndDynamicHomesInvokeOnlyTheirOwner(): void
+	{
+		$homes = [
+			'static settings singleton' => ['pfblockerngdnsblsettings', '0', TRUE],
+			'dynamic feed row' => ['pfblockernglistsv4', '3', FALSE],
+			'dynamic continent' => ['pfblockerngafrica', '0', FALSE],
+		];
+		foreach ($homes as $label => [$section, $key, $registered]) {
+			$this->seed($section, $key);
+
+			$result = pfb_determine_list_detail('Deny_Both', 'ownership-spy', $section, $key);
+
+			$this->assertSame('/native', $result['folder'], "{$label}: enabled invert must force Native");
+			$this->assertSame('on', $result['aaddrnot_in'], "{$label}: enabled invert verdict");
+			if ($registered) {
+				$this->assertSame(
+					array_map(static fn (string $field): string => "dnsbl/{$field}", self::EXPECTED_FIELDS),
+					SpyState::$gatewayKeys,
+					"{$label}: exact registered gateway keys"
+				);
+				$this->assertSame([], SpyState::$dynamicKeys, "{$label}: foreign-key adapter must not run");
+			} else {
+				$this->assertSame([], SpyState::$gatewayKeys, "{$label}: singleton gateway must not run");
+				$this->assertSame(self::EXPECTED_FIELDS, SpyState::$dynamicKeys,
+					"{$label}: exact dynamic foreign-key adapter fields");
+			}
+		}
+	}
+
+	private function seed(string $section, string $key): void
+	{
+		SpyState::$paths = [];
+		SpyState::$registered = [];
+		SpyState::$gatewayKeys = [];
+		SpyState::$dynamicKeys = [];
+		$row = [];
+		foreach (['_out', '_in'] as $direction) {
+			$row['autoproto' . $direction] = '';
+			$row['agateway' . $direction] = 'default';
+			$row['aliasports' . $direction] = '';
+			$row['aliasaddr' . $direction] = '';
+			foreach (['autonot', 'autoaddrnot', 'autoports', 'autoaddr'] as $prefix) {
+				$field = $prefix . $direction;
+				$enabled = $field === 'autoaddrnot_in';
+				$row[$field] = ['field' => $field, 'enabled' => $enabled];
+				SpyState::$registered[$field] = $enabled;
+			}
+		}
+		SpyState::$paths["installedpackages/{$section}/config/{$key}"] = $row;
+		SpyState::$paths['aliases/alias'] = [];
+
+		$GLOBALS['pfb'] = [
+			'denydir' => '/deny',
+			'nativedir' => '/native',
+			'origdir' => '/orig',
+			'reuse' => '',
+		];
+		$GLOBALS['pfbarr'] = [];
+	}
+}

--- a/tests/php/RuntimeToggleOwnershipExecutionTest.php
+++ b/tests/php/RuntimeToggleOwnershipExecutionTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PfbRuntimeToggleOwnershipSpy;
 
+use PHPUnit\Framework\Attributes\Depends;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 
@@ -55,9 +56,18 @@ final class RuntimeToggleOwnershipExecutionTest extends TestCase
 		'autonot_out', 'autoaddrnot_out', 'autoports_out', 'autoaddr_out',
 		'autonot_in', 'autoaddrnot_in', 'autoports_in', 'autoaddr_in',
 	];
+	/** @var array<string,array{bool,mixed}> */
+	private static array $originalGlobals = [];
+	/** @var array<string,array{bool,mixed}> */
+	private array $savedGlobals = [];
+
 
 	public static function setUpBeforeClass(): void
 	{
+		foreach (['pfb', 'pfbarr'] as $name) {
+			self::$originalGlobals[$name] = [array_key_exists($name, $GLOBALS), $GLOBALS[$name] ?? NULL];
+		}
+
 		$reflection = new \ReflectionFunction('pfb_determine_list_detail');
 		$lines = file($reflection->getFileName());
 		if (!is_array($lines)) {
@@ -70,6 +80,24 @@ final class RuntimeToggleOwnershipExecutionTest extends TestCase
 		));
 		eval('namespace ' . __NAMESPACE__ . '; ' . $source);
 	}
+	protected function setUp(): void
+	{
+		foreach (['pfb', 'pfbarr'] as $name) {
+			$this->savedGlobals[$name] = [array_key_exists($name, $GLOBALS), $GLOBALS[$name] ?? NULL];
+		}
+	}
+
+	protected function tearDown(): void
+	{
+		foreach ($this->savedGlobals as $name => [$existed, $value]) {
+			if ($existed) {
+				$GLOBALS[$name] = $value;
+			} else {
+				unset($GLOBALS[$name]);
+			}
+		}
+	}
+
 
 	public function testStaticAndDynamicHomesInvokeOnlyTheirOwner(): void
 	{
@@ -99,6 +127,17 @@ final class RuntimeToggleOwnershipExecutionTest extends TestCase
 			}
 		}
 	}
+	#[Depends('testStaticAndDynamicHomesInvokeOnlyTheirOwner')]
+	public function testGlobalStateIsRestoredForDependentTests(): void
+	{
+		foreach (self::$originalGlobals as $name => [$existed, $value]) {
+			$this->assertSame($existed, array_key_exists($name, $GLOBALS), "{$name}: existence must be restored");
+			if ($existed) {
+				$this->assertSame($value, $GLOBALS[$name], "{$name}: value must be restored");
+			}
+		}
+	}
+
 
 	private function seed(string $section, string $key): void
 	{

--- a/tests/php/RuntimeToggleOwnershipFlowTest.php
+++ b/tests/php/RuntimeToggleOwnershipFlowTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+final class RuntimeToggleOwnershipFlowTest extends TestCase
+{
+	public function testSelectedToggleReaderIsDefinedOnceAndConsumedByEveryFieldLoop(): void
+	{
+		$reflection = new ReflectionFunction('pfb_determine_list_detail');
+		$lines = file($reflection->getFileName());
+		if (!is_array($lines)) {
+			throw new RuntimeException('test bootstrap: failed to read pfb_determine_list_detail source');
+		}
+		$source = implode('', array_slice(
+			$lines,
+			$reflection->getStartLine() - 1,
+			$reflection->getEndLine() - $reflection->getStartLine() + 1
+		));
+
+		$tokens = array_values(array_filter(
+			token_get_all("<?php\n{$source}"),
+			static fn (array|string $token): bool => !is_array($token) || !in_array(
+				$token[0],
+				[T_OPEN_TAG, T_WHITESPACE, T_COMMENT, T_DOC_COMMENT],
+				TRUE
+			)
+		));
+		$uses = [];
+		foreach ($tokens as $index => $token) {
+			if (!is_array($token) || $token[0] !== T_VARIABLE || $token[1] !== '$toggle_enabled') {
+				continue;
+			}
+			$next = self::tokenText($tokens[$index + 1] ?? '');
+			if ($next === '=') {
+				$uses[] = 'assign';
+				continue;
+			}
+			if ($next !== '(') {
+				$uses[] = "other:{$next}";
+				continue;
+			}
+
+			$call = '$toggle_enabled';
+			$depth = 0;
+			for ($cursor = $index + 1; isset($tokens[$cursor]); $cursor++) {
+				$text = self::tokenText($tokens[$cursor]);
+				$call .= $text;
+				if ($text === '(') {
+					$depth++;
+				} elseif ($text === ')' && --$depth === 0) {
+					break;
+				}
+			}
+			$uses[] = "call:{$call}";
+		}
+
+		$this->assertSame([
+			'assign',
+			"call:\$toggle_enabled('autonot'.\$dir)",
+			"call:\$toggle_enabled('autoaddrnot'.\$dir)",
+			"call:\$toggle_enabled(\$akey.\$dir)",
+		], $uses, 'the ownership-selected reader must not be replaced or bypassed before its three field-loop calls');
+	}
+
+	private static function tokenText(array|string $token): string
+	{
+		return is_array($token) ? $token[1] : $token;
+	}
+}

--- a/tests/php/RuntimeToggleOwnershipStructureTest.php
+++ b/tests/php/RuntimeToggleOwnershipStructureTest.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+use PhpParser\Node;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Stmt;
+use PhpParser\NodeFinder;
+use PhpParser\ParserFactory;
+use PHPUnit\Framework\TestCase;
+
+final class RuntimeToggleOwnershipStructureTest extends TestCase
+{
+	private const INC = __DIR__ . '/../../src/usr/local/pkg/pfblockerng/pfblockerng.inc';
+
+	public function testAdvancedToggleOwnershipControlsEveryConsumer(): void
+	{
+		$parser = (new ParserFactory())->createForNewestSupportedVersion();
+		$source = file_get_contents(self::INC);
+		if (!is_string($source)) {
+			throw new RuntimeException('test bootstrap: failed to read pfblockerng.inc');
+		}
+		$ast = $parser->parse($source);
+		if (!is_array($ast)) {
+			throw new RuntimeException('test bootstrap: failed to parse pfblockerng.inc');
+		}
+
+		$finder = new NodeFinder();
+		$function = $finder->findFirst($ast, static fn (Node $node): bool =>
+			$node instanceof Stmt\Function_ && $node->name->toString() === 'pfb_determine_list_detail');
+		$this->assertInstanceOf(Stmt\Function_::class, $function);
+
+		$expected = $parser->parse(<<<'PHP'
+<?php
+$registered = $confconfig === 'pfblockerngdnsblsettings' && (string) $key === '0';
+$toggle_enabled = static function (string $field) use ($conf_config, $registered): bool {
+	if ($registered) {
+		return PfbConfig::read("dnsbl/{$field}") === PfbToggle::On;
+	}
+	return pfb_dnsbl_toggle_enabled($conf_config[$field] ?? '');
+};
+$pfbarr['anot' . $dir] = $toggle_enabled('autonot' . $dir) ? 'on' : '';
+$pfbarr['aaddrnot' . $dir] = $toggle_enabled('autoaddrnot' . $dir) ? 'on' : '';
+if ($toggle_enabled($akey . $dir)) {}
+PHP
+		);
+		$this->assertIsArray($expected);
+
+		$toggleAssignments = $finder->find($function->stmts, static fn (Node $node): bool =>
+			$node instanceof Expr\Assign && self::isVariable($node->var, 'toggle_enabled'));
+		$this->assertCount(1, $toggleAssignments, 'the selected reader must have exactly one definition and no reassignment');
+
+		$registeredAssignments = $finder->find($function->stmts, static fn (Node $node): bool =>
+			$node instanceof Expr\Assign && self::isVariable($node->var, 'registered'));
+		$this->assertCount(1, $registeredAssignments, 'the static-home predicate must have exactly one definition');
+
+		$expressions = $finder->findInstanceOf($function->stmts, Stmt\Expression::class);
+		self::assertOneMatchingNode($expressions, $expected[0], 'the static settings singleton predicate');
+		self::assertOneMatchingNode($expressions, $expected[1], 'the complete selected-reader closure');
+		self::assertOneMatchingNode($expressions, $expected[2], 'the complete autonot consumer expression');
+		self::assertOneMatchingNode($expressions, $expected[3], 'the complete autoaddrnot consumer expression');
+
+		$expectedCondition = $expected[4] instanceof Stmt\If_ ? $expected[4]->cond : NULL;
+		$this->assertInstanceOf(Expr::class, $expectedCondition);
+		$conditions = $finder->find($function->stmts, static fn (Node $node): bool =>
+			$node instanceof Stmt\If_ && self::canonical($node->cond) === self::canonical($expectedCondition));
+		$this->assertCount(1, $conditions, 'the autoports/autoaddr condition must be exactly the selected-reader call');
+
+		$toggleCalls = $finder->find($function->stmts, static fn (Node $node): bool =>
+			$node instanceof Expr\FuncCall && self::isVariable($node->name, 'toggle_enabled'));
+		$this->assertCount(3, $toggleCalls, 'the selected reader must feed exactly the three advanced-field consumers');
+
+		$gatewayCalls = $finder->find($function->stmts, static fn (Node $node): bool =>
+			$node instanceof Expr\StaticCall
+			&& $node->class instanceof Node\Name
+			&& $node->class->toString() === 'PfbConfig'
+			&& $node->name instanceof Node\Identifier
+			&& $node->name->toString() === 'read');
+		$this->assertCount(1, $gatewayCalls, 'PfbConfig may appear only in the registered branch of the selected reader');
+
+		$dynamicCalls = $finder->find($function->stmts, static fn (Node $node): bool =>
+			$node instanceof Expr\FuncCall
+			&& $node->name instanceof Node\Name
+			&& $node->name->toString() === 'pfb_dnsbl_toggle_enabled');
+		$this->assertCount(1, $dynamicCalls, 'the foreign-key adapter may appear only in the dynamic branch of the selected reader');
+	}
+
+	/** @param list<Node> $nodes */
+	private static function assertOneMatchingNode(array $nodes, Node $expected, string $label): void
+	{
+		$canonical = self::canonical($expected);
+		$matches = array_filter($nodes, static fn (Node $node): bool => self::canonical($node) === $canonical);
+		self::assertCount(1, $matches, "{$label} must match the complete AST exactly");
+	}
+
+	private static function isVariable(Node $node, string $name): bool
+	{
+		return $node instanceof Expr\Variable && $node->name === $name;
+	}
+
+	private static function canonical(mixed $value): mixed
+	{
+		if ($value instanceof Node) {
+			$result = ['type' => $value->getType()];
+			foreach ($value->getSubNodeNames() as $name) {
+				$result[$name] = self::canonical($value->{$name});
+			}
+			return $result;
+		}
+		if (is_array($value)) {
+			return array_map(self::canonical(...), $value);
+		}
+		return $value;
+	}
+}

--- a/tests/php/RuntimeToggleOwnershipWiringTest.php
+++ b/tests/php/RuntimeToggleOwnershipWiringTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+final class RuntimeToggleOwnershipWiringTest extends TestCase
+{
+	public function testStaticAndDynamicAdvancedTogglesKeepTheirOwners(): void
+	{
+		$reflection = new ReflectionFunction('pfb_determine_list_detail');
+		$lines = file($reflection->getFileName());
+		if (!is_array($lines)) {
+			throw new RuntimeException('test bootstrap: failed to read pfb_determine_list_detail source');
+		}
+		$source = implode('', array_slice(
+			$lines,
+			$reflection->getStartLine() - 1,
+			$reflection->getEndLine() - $reflection->getStartLine() + 1
+		));
+
+		// The behavioral matrix cannot distinguish these owners because both adapters
+		// intentionally share the same vocabulary and Off default.
+		$this->assertStringContainsString(
+			'$registered=$confconfig===\'pfblockerngdnsblsettings\'&&(string)$key===\'0\';'
+			. '$toggle_enabled=staticfunction(string$field)use($conf_config,$registered):bool{'
+			. 'if($registered){returnPfbConfig::read("dnsbl/{$field}")===PfbToggle::On;}'
+			. 'returnpfb_dnsbl_toggle_enabled($conf_config[$field]??\'\');};',
+			self::tokensWithoutTrivia($source),
+			'registered settings must use PfbConfig while dynamic row/continent namesakes use the foreign-key adapter'
+		);
+	}
+
+	private static function tokensWithoutTrivia(string $source): string
+	{
+		$result = '';
+		foreach (token_get_all("<?php\n{$source}") as $token) {
+			if (is_array($token) && in_array($token[0], [T_OPEN_TAG, T_WHITESPACE, T_COMMENT, T_DOC_COMMENT], TRUE)) {
+				continue;
+			}
+			$result .= is_array($token) ? $token[1] : $token;
+		}
+		return $result;
+	}
+}

--- a/tests/php/fixtures/function_inventory.json
+++ b/tests/php/fixtures/function_inventory.json
@@ -10036,15 +10036,7 @@
     "pfb_resolve_enabled": {
         "returnsRef": false,
         "returnType": "bool",
-        "params": [
-            {
-                "name": "ipconfig",
-                "byRef": false,
-                "variadic": false,
-                "type": "array",
-                "default": null
-            }
-        ]
+        "params": []
     },
     "pfb_resolve_list_script": {
         "returnsRef": false,


### PR DESCRIPTION
## Summary

- Route the seven registered IP runtime toggles through `PfbConfig::read()` and use enum-safe boolean decisions for `database_cc` and `killstates`.
- Route the eight registered DNSBL advanced-rule toggles through the gateway while preserving per-row and per-continent foreign keys through the explicit native toggle adapter.
- Remove the obsolete runtime blob argument from `pfb_resolve_enabled()`, update its function-inventory fixture, and document the static/dynamic ownership split.
- Pin the otherwise behavior-equivalent ownership seam with isolated executable spies: settings invoke only `PfbConfig`, row/continent namesakes invoke only the foreign-key adapter, and mutated globals are restored.

## 17-row runtime coverage matrix

| Registered path | Runtime route | Observable states and proof |
| --- | --- | --- |
| `ip/enable_dup` | `PfbConfig` → apply mirror `dup` | `On` → On; `OFF`/`off`/absent → Off; four-state mirror + registry parity |
| `ip/enable_agg` | `PfbConfig` → apply mirror `agg` | `On` → On; `OFF`/`off`/absent → Off; four-state mirror + registry parity |
| `ip/enable_log` | `PfbConfig` → apply mirror `global_log` | `On` → On; `OFF`/`off`/absent → Off; four-state mirror + registry parity |
| `ip/enable_rdns` | zero-argument `pfb_resolve_enabled()` → `PfbConfig` | `On` → true; `OFF`/`off`/absent → false; four vocabulary rows + four retained upgrade-seed rows |
| `ip/database_cc` | `pfb_global()` converts the enum to the existing boolean contract | `On` → true; `OFF`/`off`/absent → false; four verdict rows |
| `ip/enable_float` | `PfbConfig` → apply mirror `float` | `On` → On; `OFF`/`off`/absent → Off; four-state mirror + registry parity |
| `ip/killstates` | `PfbConfig` → `kstates`; removal branch requires `PfbToggle::On` | `On` enables; `OFF`/`off`/absent disable; mirror and branch assertions |
| `dnsbl/autoaddrnot_in` | static gateway; dynamic row/continent helper; direct native overrides helper | all three homes: `On` enabled, `OFF`/`off`/absent disabled; 12 provider rows + direct inbound rows |
| `dnsbl/autoports_in` | static gateway; dynamic row/continent helper | `On` resolves alias; `OFF`/`off`/absent do not; 12 provider rows |
| `dnsbl/autoaddr_in` | static gateway; dynamic row/continent helper | `On` resolves alias; `OFF`/`off`/absent do not; 12 provider rows |
| `dnsbl/autonot_in` | static gateway; dynamic row/continent helper | `On` emits `on`; `OFF`/`off`/absent emit empty; 12 provider rows |
| `dnsbl/autoaddrnot_out` | static gateway; dynamic row/continent helper; direct native overrides helper | all three homes: `On` enabled, `OFF`/`off`/absent disabled; 12 provider rows + direct outbound rows |
| `dnsbl/autoports_out` | static gateway; dynamic row/continent helper | `On` resolves alias; `OFF`/`off`/absent do not; 12 provider rows |
| `dnsbl/autoaddr_out` | static gateway; dynamic row/continent helper | `On` resolves alias; `OFF`/`off`/absent do not; 12 provider rows |
| `dnsbl/autonot_out` | static gateway; dynamic row/continent helper | `On` emits `on`; `OFF`/`off`/absent emit empty; 12 provider rows |
| `sync/syncinterfaces` | existing runtime section calculations already use `PfbConfig` | `On` disables selected sync sections; `OFF`/`off`/absent do not; registry raw matrix + explicit sync verdict |
| `global/alertrefresh` | existing Alerts consumers already compare the gateway enum | `On` enabled; `OFF`/`off` disabled; absent remains On by registered default; registry matrix + default/canonical test |

The aggregate advanced-rule matrix is eight fields × three homes (registered settings, dynamic per-row IPv4, dynamic per-continent) × four states = 96 provider rows. `CfgToggleRegistryPageParityTest` also covers absent, empty, canonical `on`, legacy `off`, mixed-case `On`/`OFF`, and junk for all 17 registered paths.

## Static/dynamic ownership

- Registered `dnsbl/*` settings use `PfbConfig::read()`.
- Per-feed-row and per-continent namesakes remain unregistered foreign keys and use `pfb_dnsbl_toggle_enabled()` with native toggle semantics.
- The direct per-continent and per-row native-rule overrides in `pfblockerng_apply.inc` use the same helper.
- `docs/misc/config-gateway.md` records both foreign-key families and their runtime adapter. No dynamic path was registered.

## Function inventory

`pfb_resolve_enabled(): bool` now has no runtime blob argument. Live reflection returned:

```json
{"returnsRef":false,"returnType":"bool","params":[]}
```

The committed inventory fixture matches that signature. The unchanged parity test failed with the stale one-parameter fixture (`1 test, 6 assertions, 1 failure`) and passed with the new fixture (`1 test, 6 assertions`). Mutations for wrong parameter count, wrong parameter name, and wrong function name each failed the inventory assertion.

## Test and mutation evidence

The three frozen runtime tests retained their verified blob hashes through implementation and rebase. Against base production they failed on the targeted raw-read behavior (`118 tests`: 6 errors, 70 failures, 8 warnings); against the implementation they passed (`118 tests, 165 assertions`).

Focused verification on reviewed pre-rebase head `9ff46d98fdc7fe087a77624902e3832071adcbb1`;
the frozen changed-test blobs are byte-identical at current rebased head
`db5e7eb68b8160e80cf76c52821d4d3a16990e52`:

```text
vendor/bin/phpunit tests/php/RuntimeToggleConsumersTest.php tests/php/ResolveEnabledTest.php tests/php/ApplyDynamicToggleConsumersTest.php tests/php/CfgToggleRegistryPageParityTest.php tests/php/DnsblIpAliasActionTest.php tests/php/ToggleCaseInsensitiveTest.php
OK (281 tests, 634 assertions)

vendor/bin/phpunit tests/php/FunctionInventoryParityTest.php
OK (1 test, 6 assertions)

vendor/bin/phpunit tests/php/RuntimeToggleOwnershipWiringTest.php tests/php/RuntimeToggleOwnershipFlowTest.php tests/php/RuntimeToggleOwnershipStructureTest.php tests/php/RuntimeToggleOwnershipExecutionTest.php
OK (6 tests, 36 assertions)

vendor/bin/phpunit --filter 'testStaticAndDynamicHomesInvokeOnlyTheirOwner@static settings singleton' tests/php/RuntimeToggleOwnershipExecutionTest.php
OK (1 test, 7 assertions)

php -l src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
No syntax errors detected in src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
```

Mutation kills:

| Mutation | Observable failure |
| --- | --- |
| Restore static raw reads and case-sensitive DNSBL comparisons | runtime suite: absent-key error + eight mixed-case static failures |
| Restore raw `database_cc`/`killstates` values and truthy branch | runtime suite: raw-type/absence errors, legacy-Off truthiness, all database verdict rows fail |
| Restore case-sensitive dynamic comparisons in list detail and direct apply branches | 18 failures: eight row `On`, eight continent `On`, and both direct native overrides |
| Restore resolver blob parameter/absence branch | resolver suite: all four zero-argument vocabulary rows error |
| Inventory wrong parameter count/name or function name | each mutant is rejected by `FunctionInventoryParityTest` |
| Force `$registered = FALSE`; route dynamic through `PfbConfig`; reassign the callable; add helper-first/gateway-first bypass; mutate `$key`; remove global restoration actions | each provider row observes owner calls and restores/asserts its own outer globals; all seven mutants RED, including filtered static-row cleanup failure |

Canonical gate on the prior implementation head
`ba49451a90cd169be6590995d6a5bdd2d2d45ab9` against base
`164f4c57e5c666b1b82b1d5633008483e8fdeabe`:

```text
scripts/agent/run-gates.sh --diff 164f4c57e5c666b1b82b1d5633008483e8fdeabe
13 PASS, 0 FAIL, 0 SKIP — GATES: PASS
```

The later exact-head changes reconcile the function-inventory fixture and
registry comment, then add frozen structural and self-contained executable
ownership proofs; the focused parity/consumer commands above were rerun.

Canonical gate on current rebased head
`db5e7eb68b8160e80cf76c52821d4d3a16990e52` against live base
`2971f20af3ca9a2eb1ccd9cea4e7e5be5282d513`:

```text
scripts/agent/run-gates.sh --diff 2971f20af3ca9a2eb1ccd9cea4e7e5be5282d513
19 PASS, 0 FAIL, 0 SKIP — GATES: PASS
```

## Rebase and exact diff

- The reviewed head `9ff46d98fdc7fe087a77624902e3832071adcbb1`
  was rebased without conflicts through `70d4e38d8bd29744d554651c8ed2faf95c6ac559`
  onto live `origin/devel` at
  `2971f20af3ca9a2eb1ccd9cea4e7e5be5282d513`; current head is
  `db5e7eb68b8160e80cf76c52821d4d3a16990e52`.
- The complete #2817 `pfblockerng.inc` patch retained stable patch ID
  `4c60c9f69c2ffe76f7b8b9fd12b189248f34eb2a`; the other eleven issue
  blobs are byte-identical to the reviewed head. The contract-review fix
  remains only the registry comment, and the honesty-review fixes remain
  test-only ownership proofs.
- Exact issue diff: twelve files, 765 insertions, 61 deletions.

| File | Rebased base blob | Head blob |
| --- | --- | --- |
| `docs/misc/config-gateway.md` | `0f104431f91b92fc1631155c6a3328622c8b0e2a` | `9f63e7465cc9e8a9416752cdc9b3d1a22ccadc8b` |
| `src/usr/local/pkg/pfblockerng/pfblockerng.inc` | `8221c07ece8019bb37366a5334074367e35672f5` | `88fec7a616970b03d32e4763560628c690591faf` |
| `src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc` | `614e857f84ee4c0180fb79879577a9566ea6bc7f` | `a50e06f0a703f193cdef7a3aa28afa8b7956d560` |
| `src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc` | `cbba17c5ba91f9cebfc156d13cc61151b17b3bd1` | `405f47b143c26f10b67b74434ed3e9eddfb54e3b` |
| `tests/php/ApplyDynamicToggleConsumersTest.php` | absent | `3fa4bd9af2db319b227f2e295e4632fd373c855b` |
| `tests/php/ResolveEnabledTest.php` | `c6461eedb4466034e3b781921357f41cb3812612` | `9388b7a1639358a9d54d764efba48f8271df5dcb` |
| `tests/php/RuntimeToggleConsumersTest.php` | absent | `a2cdc540a9f1ca7ff6da5a258e3128ae1c50dbce` |
| `tests/php/RuntimeToggleOwnershipWiringTest.php` | absent | `8a5218d8cadef04f5880e82756d8a3ffc899fce9` |
| `tests/php/RuntimeToggleOwnershipFlowTest.php` | absent | `e22a75ff4266381d3bd15771a097842aa2051974` |
| `tests/php/RuntimeToggleOwnershipStructureTest.php` | absent | `146505687a358ba23eb9c34600a80d6df132e07b` |
| `tests/php/RuntimeToggleOwnershipExecutionTest.php` | absent | `ce3bc7c0494ba0f4bb2d0075f7329ce4ce9570b0` |
| `tests/php/fixtures/function_inventory.json` | `e29df2f3670a2e747e45562f916955e49181f148` | `f88c9f78caa0273ab1bbe3c4cb918fc9cf1ff921` |

## CI

`scripts/agent/wait-checks.sh` pinned the PR to
`db5e7eb68b8160e80cf76c52821d4d3a16990e52` and returned `PASS`.
Both exact-head workflow runs completed successfully:

- [Tests](https://github.com/pfBlockerNG/pfBlockerNG/actions/runs/33339474482)
- [Context budget](https://github.com/pfBlockerNG/pfBlockerNG/actions/runs/33339474081)

The exact-head check suite reported 22 passes and two path-conditional skips
(live-VM UI fan-out and benchmark kill-gates). The required
`All tests passed` aggregate check succeeded.

Fixes #2817

🤖 Generated by Oh My Pi and posted on behalf of @andrebrait.
