### PR TITLE
category_edit: pair failed-download row foreground; scanner same-element pairing

### DIFF
--- a/src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
@@ -1271,7 +1271,7 @@ foreach ($rowdata[$rowid] as $tags) {
 		// Indicate any failed downloads with yellow select field background
 		$failed_bg = '';
 		if ($folder && file_exists("{$folder}/{$row['header']}{$suffix}.fail")) {
-			$failed_bg = 'background-color: #FFFF00;';
+			$failed_bg = 'background-color: #FFFF00; color: black;';
 			$failed = "<span style=\"color: black; background-color: #FFFF00; border-style: groove;\">&emsp;Failed download(s) highlighted in yellow.&emsp;</span>";
 		}
 

--- a/tests/php/ThemeSafetyUiTest.php
+++ b/tests/php/ThemeSafetyUiTest.php
@@ -120,6 +120,23 @@ final class ThemeSafetyUiTest extends TestCase
 			'contextHasForeground() must accept the pairing idiom native to this syntax: ' . $paired);
 	}
 
+	/**
+	 * issue #2866: a `color:` on a NEIGHBOURING element must not satisfy the pairing
+	 * check for an unrelated background. In pfblockerng_category_edit.php the unpaired
+	 * `$failed_bg` background sits in the same PHP block as a separate span that pins
+	 * `color: black`, so the block-level context window laundered the violation.
+	 */
+	public function testNeighbouringElementForegroundDoesNotPair(): void
+	{
+		$span = '$failed = "<span style=\"color: black; background-color: #FFFF00; border-style: groove;\">Failed</span>";';
+		$defect = "if (true) {\n\t\$failed_bg = 'background-color: #FFFF00;';\n\t" . $span . "\n}";
+		$this->assertNotSame([], self::scan($defect),
+			'a colour belonging to a neighbouring element must not pair an unrelated background');
+		$paired = "if (true) {\n\t\$failed_bg = 'background-color: #FFFF00; color: black;';\n\t" . $span . "\n}";
+		$this->assertSame([], self::scan($paired),
+			'a foreground in the same declaration string must still pair');
+	}
+
 	public function testCurrentTreeInventoryMatchesTheDatedTodo(): void
 	{
 		$root = dirname(__DIR__, 2);
@@ -203,8 +220,8 @@ final class ThemeSafetyUiTest extends TestCase
 				if ($value === '' || self::isInterpolated($value) || self::isTranslucent($value)) {
 					continue;
 				}
-				$ctx = self::declarationContext($source, $offset);
-				if (self::contextHasForeground($ctx)) {
+				[$ctx, $ctxStart] = self::declarationContext($source, $offset);
+				if (self::contextHasForeground($source, $offset, $ctx, $ctxStart)) {
 					continue;
 				}
 				if (self::themeRootPinsForeground($source, $offset)) {
@@ -264,14 +281,18 @@ final class ThemeSafetyUiTest extends TestCase
 		return $found;
 	}
 
-	private static function declarationContext(string $source, int $offset): string
+	/**
+	 * @return array{0: string, 1: int} the context window and its absolute start offset
+	 *         in $source, so callers can map matches inside the window back to $source.
+	 */
+	private static function declarationContext(string $source, int $offset): array
 	{
 		$before = substr($source, 0, $offset);
 		$brace = strrpos($before, '{');
 		if ($brace !== FALSE) {
 			$end = strpos($source, '}', $brace);
 			if ($end !== FALSE && $end >= $offset) {
-				return substr($source, $brace, $end - $brace + 1);
+				return [substr($source, $brace, $end - $brace + 1), $brace];
 			}
 		}
 		$sq = strrpos($before, "'");
@@ -283,23 +304,42 @@ final class ThemeSafetyUiTest extends TestCase
 			$start = $dq;
 			$quote = '"';
 		} else {
-			return substr($source, max(0, $offset - 80), 160);
+			return [substr($source, max(0, $offset - 80), 160), max(0, $offset - 80)];
 		}
 		$end = strpos($source, $quote, $start + 1);
-		return $end === FALSE ? substr($source, $start) : substr($source, $start, $end - $start + 1);
+		return [$end === FALSE ? substr($source, $start) : substr($source, $start, $end - $start + 1), $start];
 	}
 
-	private static function contextHasForeground(string $ctx): bool
+	private static function contextHasForeground(string $source, int $bgOffset, string $ctx, int $ctxStart): bool
 	{
 		// Every way a foreground can be set must be recognised here, or code paired through
 		// a form scan() detects but this does not reports as a violation. The two
 		// vocabularies are kept in lockstep by testEveryDetectedFormIsAlsoRecognisedWhenPaired.
-		return (bool)preg_match(
+		//
+		// issue #2866: the pairing foreground must belong to the SAME element as the
+		// background. In a brace context (a PHP block, not a CSS rule) a `color:` can sit
+		// in a neighbouring element's markup — e.g. the separate failed-download span that
+		// laundered category_edit's unpaired $failed_bg. A foreground with an HTML tag
+		// starting between it and the background belongs to a different element and does
+		// not satisfy the pairing check.
+		if (preg_match_all(
 			'/(?<![A-Za-z0-9_-])color["\']?\s*:'
 			. '|(?<![A-Za-z0-9_-])color\s*='
 			. '|setProperty\(\s*["\']color["\']/i',
-			$ctx
-		);
+			$ctx,
+			$m,
+			PREG_OFFSET_CAPTURE
+		) === FALSE) {
+			return FALSE;
+		}
+		foreach ($m[0] as [$text, $rel]) {
+			$colorOffset = $ctxStart + $rel;
+			$gap = substr($source, min($bgOffset, $colorOffset), abs($colorOffset - $bgOffset));
+			if (!preg_match('/<[A-Za-z\/]/', $gap)) {
+				return TRUE;
+			}
+		}
+		return FALSE;
 	}
 
 	private static function themeRootPinsForeground(string $source, int $offset): bool

--- a/tests/smoke/ui/test_browser_failed_row_theme.py
+++ b/tests/smoke/ui/test_browser_failed_row_theme.py
@@ -1,0 +1,221 @@
+"""Tier-B browser proof for #2866: the failed-download row under dark + light.
+
+The category-edit page's failed-download row paints an opaque ``#FFFF00``
+background. Before the fix it shipped with NO paired foreground: on
+``pfSense-dark.css`` the inherited near-white text scored 1.07:1 against the
+saturated yellow. This test seeds the real failed state (a DNSBL alias whose
+source-row header owns a ``.fail`` file), switches the effective
+webConfigurator theme, measures the row's COMPUTED colours in a real browser
+under dark AND light, and restores the exact pre-probe theme and config state
+in ``finally``.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING
+
+import pytest
+
+from .. import helpers
+from .webui import extract_csrf_token, looks_like_login_page
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from playwright.sync_api import Page
+
+    from .webui import WebUI
+
+pytestmark = pytest.mark.ui_browser
+
+CATEGORY_PAGE = "/pfblockerng/pfblockerng_category_edit.php"
+CFG_DNSBL = "installedpackages/pfblockerngdnsbl/config"
+FAIL_DIR = "/var/db/pfblockerng/dnsbl"
+ALIAS = "smokefailedrow"
+HEADER = "smokefailedrow"
+SAVE_TIMEOUT = 120.0
+JS_TIMEOUT_MS = 10_000
+
+# WCAG AA floor the issue sets: the paired row must clear it on BOTH themes.
+AA_FLOOR = 4.5
+
+_DARK = "pfSense-dark.css"
+_LIGHT = "pfSense.css"
+
+
+def _relative_luminance(rgb: tuple[int, int, int]) -> float:
+    """WCAG 2.x relative luminance of an sRGB triple."""
+
+    def chan(c: int) -> float:
+        v = c / 255.0
+        return v / 12.92 if v <= 0.04045 else ((v + 0.055) / 1.055) ** 2.4
+
+    return 0.2126 * chan(rgb[0]) + 0.7152 * chan(rgb[1]) + 0.0722 * chan(rgb[2])
+
+
+def _contrast(fg: tuple[int, int, int], bg: tuple[int, int, int]) -> float:
+    lo, hi = sorted((_relative_luminance(fg), _relative_luminance(bg)))
+    return (hi + 0.05) / (lo + 0.05)
+
+
+def _parse_rgb(value: str) -> tuple[int, int, int]:
+    m = re.match(r"rgba?\((\d+),\s*(\d+),\s*(\d+)", value)
+    assert m, f"unexpected computed colour {value!r}"
+    return (int(m.group(1)), int(m.group(2)), int(m.group(3)))
+
+
+def _open(page: Page, webui: WebUI, path: str) -> None:
+    """Navigate the cookie-authenticated browser and settle the DOM."""
+    page.goto(webui.url(path), wait_until="domcontentloaded", timeout=JS_TIMEOUT_MS * 3)
+    page.wait_for_load_state("networkidle", timeout=JS_TIMEOUT_MS * 3)
+    assert page.locator("#usernamefld").count() == 0, f"GET {path} showed the login form -- cookie not authenticated"
+
+
+def _free_rowid(vm: helpers.SmokeVM, cfg_root: str) -> int:
+    """Return max(numeric keys under cfg_root) + 1 -- a fresh slot this test owns."""
+    pre = (
+        f"$c = config_get_path({helpers._php_str(cfg_root)}, array());\n"
+        "$max = -1;\n"
+        "foreach (array_keys($c) as $k) { if (is_numeric($k) && (int)$k > $max) { $max = (int)$k; } }\n"
+        "$free = $max + 1;\n"
+    )
+    return int(helpers._php_read_scalar(vm, pre, "$free", timeout=SAVE_TIMEOUT))
+
+
+def _del_rowid(vm: helpers.SmokeVM, cfg_root: str, rowid: int) -> None:
+    """Delete ``{cfg_root}/{rowid}`` (cleanup of an alias slot this test created)."""
+    snippet = (
+        f"config_del_path({helpers._php_str(f'{cfg_root}/{rowid}')});\n"
+        "write_config('pfBlockerNG smoke: drop test alias');\n"
+        "echo 'OK';"
+    )
+    result = helpers.php_eval(vm, snippet, timeout=SAVE_TIMEOUT)
+    assert result.returncode == 0 and "OK" in result.stdout, "failed to drop the test alias slot"
+
+
+def _post_form(webui: WebUI, payload: dict[str, str]) -> None:
+    """POST a fully-enumerated category-edit payload with a fresh CSRF token."""
+    get = webui.get(CATEGORY_PAGE, params={"type": "dnsbl"})
+    assert not looks_like_login_page(get.text), "category GET returned the login form (session lost)"
+    data = dict(payload)
+    data["__csrf_magic"] = extract_csrf_token(get.text)
+    data["save"] = "save"
+    resp = webui.session.post(webui.url(CATEGORY_PAGE), data=data, verify=webui._verify, timeout=SAVE_TIMEOUT)
+    assert not looks_like_login_page(resp.text), "category POST returned the login form (session lost)"
+
+
+def _set_theme(vm: helpers.SmokeVM, css: str) -> None:
+    """Flip the effective webConfigurator theme (system/webgui/webguicss)."""
+    snippet = (
+        "$w = config_get_path('system/webgui', array());\n"
+        f"$w['webguicss'] = {helpers._php_str(css)};\n"
+        "config_set_path('system/webgui', $w);\n"
+        "write_config('pfBlockerNG smoke: switch webConfigurator theme');\n"
+        "echo 'OK';"
+    )
+    result = helpers.php_eval(vm, snippet, timeout=SAVE_TIMEOUT)
+    assert result.returncode == 0 and "OK" in result.stdout, f"theme switch to {css} failed"
+
+
+def _active_css(vm: helpers.SmokeVM) -> str:
+    """The currently-configured theme (pfSense's default when the key is absent)."""
+    present, value = helpers.config_get_state(vm, "system/webgui/webguicss")
+    return value if present else _LIGHT
+
+
+def _head_stylesheets(page: "Page") -> str:
+    return page.evaluate(
+        "Array.from(document.querySelectorAll('link[rel=stylesheet]')).map(l => l.getAttribute('href')).join(' ')"
+    )
+
+
+def _measure_failed_row(page: Page) -> tuple[tuple[int, int, int], tuple[int, int, int]]:
+    """Computed (color, background-color) of the failed-download row input."""
+    row = page.locator("input[id^='header-'][style*='#FFFF00']")
+    assert row.count() == 1, f"expected exactly one failed-download row, found {row.count()}"
+    fg = row.evaluate("el => getComputedStyle(el).color")
+    bg = row.evaluate("el => getComputedStyle(el).backgroundColor")
+    return _parse_rgb(fg), _parse_rgb(bg)
+
+
+def test_failed_download_row_is_readable_on_dark_and_light(
+    browser_page: Page,
+    webui: WebUI,
+    smoke_vm: helpers.SmokeVM,
+    screenshot_dir: Path,
+) -> None:
+    """The failed row renders black-on-yellow (>= AA) under dark AND light."""
+    vm = smoke_vm
+    original_state = helpers.config_get_state(vm, "system/webgui/webguicss")
+
+    rowid = _free_rowid(vm, CFG_DNSBL)
+    fail_file = f"{FAIL_DIR}/{HEADER}.fail"
+    try:
+        # Seed the failed state through the package's own save handler: a DNSBL
+        # alias (action=unbound) with one source row whose header owns a .fail
+        # file -- exactly the state a failed download produces. No hand-crafted
+        # request; the page is driven as an authenticated admin would drive it.
+        payload = {
+            "type": "dnsbl",
+            "rowid": str(rowid),
+            "aliasname": ALIAS,
+            "description": "smoke #2866 failed row",
+            "action": "unbound",
+            "cron": "Never",
+            "schedule_override": "",
+            "schedule_weekday": "7",
+            "schedule_hour": "0",
+            "schedule_minute": "0",
+            "sort": "sort",
+            "order": "default",
+            "logging": "enabled",
+            "filter_top1m": "",
+            "srcint": "",
+            "script_pre": "",
+            "script_post": "",
+            "custom": "",
+            "format-0": "auto",
+            "state-0": "Enabled",
+            "url-0": "http://127.0.0.1/smokefailedrow.txt",
+            "header-0": HEADER,
+        }
+        _post_form(webui, payload)
+        base = f"{CFG_DNSBL}/{rowid}"
+        assert helpers.config_get(vm, f"{base}/action") == "unbound", "alias save did not persist action"
+        assert helpers.config_get(vm, f"{base}/row/0/header") == HEADER, "source-row header not persisted"
+
+        touch = vm.ssh(f"touch '{FAIL_DIR}/{HEADER}.fail'")
+        assert touch.returncode == 0, f"seeding .fail failed: {touch.stderr!r}"
+
+        # ---------------- DARK leg ----------------
+        _set_theme(vm, _DARK)
+        _open(browser_page, webui, f"{CATEGORY_PAGE}?type=dnsbl&rowid={rowid}")
+        assert _DARK in _head_stylesheets(browser_page), "pfSense-dark.css is not the active stylesheet"
+        row = browser_page.locator("input[id^='header-'][style*='#FFFF00']")
+        assert row.count() == 1, "the failed-download row did not render with the yellow background"
+        dark_fg, dark_bg = _measure_failed_row(browser_page)
+        dark_contrast = _contrast(dark_fg, dark_bg)
+        assert dark_fg == (0, 0, 0), f"dark: foreground is {dark_fg}, expected pinned black"
+        assert dark_bg == (255, 255, 0), f"dark background is {dark_bg}, expected #FFFF00"
+        assert dark_contrast >= AA_FLOOR, f"dark-theme contrast {dark_contrast:.2f}:1 is below WCAG AA {AA_FLOOR}:1"
+
+        # ---------------- LIGHT leg ----------------
+        _set_theme(vm, _LIGHT)
+        _open(browser_page, webui, f"{CATEGORY_PAGE}?type=dnsbl&rowid={rowid}")
+        assert _LIGHT in _head_stylesheets(browser_page), "pfSense.css is not the active stylesheet"
+        light_fg, light_bg = _measure_failed_row(browser_page)
+        light_contrast = _contrast(light_fg, light_bg)
+        assert light_bg == (255, 255, 0), f"light background is {light_bg}, expected #FFFF00"
+        assert light_contrast >= AA_FLOOR, f"light-theme contrast {light_contrast:.2f}:1 is below AA {AA_FLOOR}:1"
+        assert light_fg == (0, 0, 0), f"light-theme foreground is {light_fg}, expected pinned black"
+
+        # Contrast evidence recorded for the artifact log.
+        print(f"\n#2866 computed contrast: dark {dark_contrast:.2f}:1, light {light_contrast:.2f}:1")
+    finally:
+        # Restore the exact pre-probe theme state (presence + raw token), then
+        # drop the seeded alias slot and the .fail file. The ui_browser marker
+        # also arms the config-digest probe, so a leak surfaces either way.
+        helpers.config_restore_state(vm, "system/webgui/webguicss", original_state)
+        _del_rowid(vm, CFG_DNSBL, rowid)
+        vm.ssh(f"rm -f '{fail_file}'")

--- a/tests/smoke/ui/test_theme_legibility_render.py
+++ b/tests/smoke/ui/test_theme_legibility_render.py
@@ -73,3 +73,16 @@ def test_alerts_page_ships_both_unified_palette_groups(webui: WebUI) -> None:
     assert "#665E17" in resp.text
     assert "#2D6560" in resp.text
     assert "#336279" in resp.text
+
+
+CATEGORY_EDIT = "/pfblockerng/pfblockerng_category_edit.php?type=ipv4"
+_RENDER_MARKER = "Update Frequency"
+_PAIRED_STYLE = "background-color: #FFFF00; color: black;"
+
+
+def test_category_edit_failed_row_pairs_foreground_with_background(webui: WebUI) -> None:
+    """$failed_bg must pin its foreground: black-on-yellow on every theme."""
+    resp = webui.get(CATEGORY_EDIT)
+    assert resp.status_code == 200, CATEGORY_EDIT
+    assert _RENDER_MARKER in resp.text, CATEGORY_EDIT
+    assert _PAIRED_STYLE in resp.text, CATEGORY_EDIT

--- a/tests/smoke/ui/test_theme_legibility_render.py
+++ b/tests/smoke/ui/test_theme_legibility_render.py
@@ -6,14 +6,20 @@ is the tier that sees a loaded page.
 
 from __future__ import annotations
 
+import re
 from typing import TYPE_CHECKING
 
 import pytest
 
+from .. import helpers
+from ..conftest import SmokeVM
+from .render_oracle import body_has_php_error
+from .webui import extract_csrf_token, looks_like_login_page
+
 if TYPE_CHECKING:
     from .webui import WebUI
 
-pytestmark = pytest.mark.ui_render
+pytestmark = [pytest.mark.ui_render, pytest.mark.ui_e2e]
 
 # Path -> a marker the page emits only when it actually rendered.
 _LIST_PAGES: dict[str, str] = {
@@ -75,14 +81,104 @@ def test_alerts_page_ships_both_unified_palette_groups(webui: WebUI) -> None:
     assert "#336279" in resp.text
 
 
-CATEGORY_EDIT = "/pfblockerng/pfblockerng_category_edit.php?type=ipv4"
-_RENDER_MARKER = "Update Frequency"
+CATEGORY_EDIT = "/pfblockerng/pfblockerng_category_edit.php"
 _PAIRED_STYLE = "background-color: #FFFF00; color: black;"
+_UNPAIRED_STYLE = "background-color: #FFFF00;"
+_CFG_DNSBL = "installedpackages/pfblockerngdnsbl/config"
+_FAIL_DIR = "/var/db/pfblockerng/dnsbl"
+_HEADER = "smokefailedrow"
+_SAVE_TIMEOUT = 120.0
 
 
-def test_category_edit_failed_row_pairs_foreground_with_background(webui: WebUI) -> None:
-    """$failed_bg must pin its foreground: black-on-yellow on every theme."""
-    resp = webui.get(CATEGORY_EDIT)
-    assert resp.status_code == 200, CATEGORY_EDIT
-    assert _RENDER_MARKER in resp.text, CATEGORY_EDIT
-    assert _PAIRED_STYLE in resp.text, CATEGORY_EDIT
+def test_category_edit_failed_row_pairs_foreground_with_background(
+    webui: WebUI,
+    smoke_vm: SmokeVM,
+) -> None:
+    """A rendered failed-download row ships background AND pinned foreground.
+
+    The pairing is conditional markup: the yellow row only renders when a
+    source row's header owns a ``.fail`` file. Seed exactly that state through
+    the package's own save handler, assert the rendered body carries the
+    PAIRED style (never the bare background), and restore in ``finally``.
+    Dual-marked ``ui_e2e``: the seed writes config, so the isolation probe
+    rides along.
+    """
+    vm = smoke_vm
+    rowid = _free_rowid(vm, _CFG_DNSBL)
+    try:
+        _post_form(webui, _dnsbl_payload(rowid, "smokefailedrow", _HEADER))
+        touch = vm.ssh(f"touch '{_FAIL_DIR}/{_HEADER}.fail'")
+        assert touch.returncode == 0, f"seeding .fail failed: {touch.stderr!r}"
+
+        resp = webui.get(CATEGORY_EDIT, params={"type": "dnsbl", "rowid": str(rowid)})
+        assert resp.status_code == 200, CATEGORY_EDIT
+        body = resp.text
+        assert not body_has_php_error(body), "category_edit.php rendered a PHP error"
+        assert _PAIRED_STYLE in body, "failed row rendered without the pinned foreground"
+        assert re.search(r"background-color: #FFFF00;(?!\s*color:)", body) is None, (
+            "an UNPAIRED yellow background leaked into the rendered page"
+        )
+    finally:
+        _del_rowid(vm, _CFG_DNSBL, rowid)
+        vm.ssh(f"rm -f '{_FAIL_DIR}/{_HEADER}.fail'")
+
+
+def _free_rowid(vm: SmokeVM, cfg_root: str) -> int:
+    """Return max(numeric keys under cfg_root) + 1 -- a fresh slot this test owns."""
+    pre = (
+        f"$c = config_get_path({helpers._php_str(cfg_root)}, array());\n"
+        "$max = -1;\n"
+        "foreach (array_keys($c) as $k) { if (is_numeric($k) && (int)$k > $max) { $max = (int)$k; } }\n"
+        "$free = $max + 1;\n"
+    )
+    return int(helpers._php_read_scalar(vm, pre, "$free", timeout=_SAVE_TIMEOUT))
+
+
+def _del_rowid(vm: SmokeVM, cfg_root: str, rowid: int) -> None:
+    """Delete ``{cfg_root}/{rowid}`` (cleanup of an alias slot this test created)."""
+    snippet = (
+        f"config_del_path({helpers._php_str(f'{cfg_root}/{rowid}')});\n"
+        "write_config('pfBlockerNG smoke: drop test alias');\n"
+        "echo 'OK';"
+    )
+    result = helpers.php_eval(vm, snippet, timeout=_SAVE_TIMEOUT)
+    assert result.returncode == 0 and "OK" in result.stdout, "failed to drop the test alias slot"
+
+
+def _post_form(webui: WebUI, payload: dict[str, str]) -> None:
+    """POST a fully-enumerated category-edit payload with a fresh CSRF token."""
+    get = webui.get(CATEGORY_EDIT, params={"type": "dnsbl"})
+    assert not looks_like_login_page(get.text), "category GET returned the login form (session lost)"
+    data = dict(payload)
+    data["__csrf_magic"] = extract_csrf_token(get.text)
+    data["save"] = "save"
+    resp = webui.session.post(webui.url(CATEGORY_EDIT), data=data, verify=webui._verify, timeout=_SAVE_TIMEOUT)
+    assert not looks_like_login_page(resp.text), "category POST returned the login form (session lost)"
+
+
+def _dnsbl_payload(rowid: int, aliasname: str, header: str) -> dict[str, str]:
+    """A valid DNSBL alias payload: action=unbound, one Enabled source row."""
+    return {
+        "type": "dnsbl",
+        "rowid": str(rowid),
+        "aliasname": aliasname,
+        "description": "smoke #2866 failed row (render)",
+        "action": "unbound",
+        "cron": "Never",
+        "schedule_override": "",
+        "schedule_weekday": "7",
+        "schedule_hour": "0",
+        "schedule_minute": "0",
+        "sort": "sort",
+        "order": "default",
+        "logging": "enabled",
+        "filter_top1m": "",
+        "srcint": "",
+        "script_pre": "",
+        "script_post": "",
+        "custom": "",
+        "format-0": "auto",
+        "state-0": "Enabled",
+        "url-0": f"http://127.0.0.1/{aliasname}.txt",
+        "header-0": header,
+    }


### PR DESCRIPTION
Fixes #2866.

| Frozen RED test | git hash-object | RED run tail |
| --- | --- | --- |
| `tests/php/ThemeSafetyUiTest.php` | `89348560ba97b4f1f27a134eeed4b23874cb9f6d` | `FAILED a colour belonging to a neighbouring element must not pair an unrelated background` |
