### PR TITLE
tests: resolve a background inside a multi-line literal

### DIFF
--- a/tests/php/ThemeSafetyUiTest.php
+++ b/tests/php/ThemeSafetyUiTest.php
@@ -117,7 +117,17 @@ final class ThemeSafetyUiTest extends TestCase
 			// reached by a different route, so it is pinned in both directions: a literal
 			// that genuinely does not pair, and one that genuinely does.
 			'multi-line literal'        => ["if (\$x) {\n\t\$s = \"aaaa\nbackground-color: #123456;\nbbbb\";\n\tcolor: red;\n}", FALSE],
-			'multi-line same literal'   => ['$s = "background-color: #123456;' . "\n" . ' color: red;";', TRUE],
+			'multi-line same literal'   => ['$s = "background-color: #123456;' . str_repeat(' ', 200) . "\n" . ' color: red;";', TRUE],
+			// A literal that never closes is not a literal. Without that test the scan would
+			// hand back everything from the quote to end of file, which is the desync it exists
+			// to prevent, so the pairing sits past the no-scope window to tell the two apart.
+			'literal never closes'      => ['$s = "background-color: #123456;' . str_repeat(' ', 200) . "\ncolor: red;", FALSE],
+			// A comment apostrophe desynchronises the line-scoped toggle, which then reports
+			// nothing rather than the genuine single-line literal beside it. The file-wide scan
+			// reads the comment and finds that literal, and the literal carries no foreground,
+			// so the neighbouring statement must not pair it.
+			'literal beside a comment'  => ["/* don't */ \$bg = 'background-color: #123456;'; color: red;", FALSE],
+			'that literal, paired'      => ["/* don't */ \$bg = 'background-color: #123456; color: red;';", TRUE],
 			'multi-line attribute pairs'=> ['$s = "<span style=\"color: black;' . str_repeat(' ', 200) . "\n" . ' background-color: #123456;\">x</span>";', TRUE],
 			// ...and the reason the scan was scoped to one line in the first place, which any
 			// fix has to keep: an apostrophe in prose is not a string opener, so it must not
@@ -125,7 +135,18 @@ final class ThemeSafetyUiTest extends TestCase
 			// no-scope fallback window and a second apostrophe waits below it, so a whole-file
 			// quote toggle pairs the two and launders the background.
 			'prose apostrophe above'    => ["/* don't */\nbackground-color: #123456;" . str_repeat(' ', 200) . "\ncolor: red;\n/* the user's guide */", FALSE],
-			'prose apostrophe, block'   => ["/* it's fine */\n.a { background-color: #123456;\n color: red; }", TRUE],
+			// Prose does not only put a quote inside a word. A possessive after a closing
+			// bracket and a quote written as itself are both prose too, and neither is preceded
+			// by a letter -- the tree carries the first shape at
+			// pfblockerng_hook_edit.inc:180. What they have in common is not the character
+			// before them, it is that they are in a comment.
+			'prose quote after bracket' => ["/* fail pfb_hook_scripts()' membership */\nbackground-color: #123456;" . str_repeat(' ', 200) . "\ncolor: red;\n/* it's */", FALSE],
+			'prose quote written alone' => ["/* use the ' character */\nbackground-color: #123456;" . str_repeat(' ', 200) . "\ncolor: red;\n/* it's */", FALSE],
+			'line comment holds one too' => ["// use the ' character\nbackground-color: #123456;" . str_repeat(' ', 200) . "\ncolor: red;\n// it's", FALSE],
+			// Not all prose is in a comment: a .php page is inline HTML outside its tags, and
+			// an apostrophe in body text is no more a delimiter there than in a docblock. A
+			// quote is not one where a letter or digit runs straight into it.
+			'apostrophe in page text'   => ["<p>Don't do that</p>\nbackground-color: #123456;" . str_repeat(' ', 200) . "\ncolor: red;\n<p>It's fine</p>", FALSE],
 			// A style attribute that is not this background's cannot pair it either.
 			'unrelated attribute'       => ['$s = ".a { background-color: #123456; } <span style=\"color: black;\"></span>";', FALSE],
 			'unrelated attr, no braces' => ['$s = \'background-color: #123456; <span style="color:black;"></span>\';', FALSE],
@@ -430,22 +451,33 @@ final class ThemeSafetyUiTest extends TestCase
 	 *
 	 * Scanning the whole file for quotes is what the line scoping was defending against:
 	 * an apostrophe in prose then opens a literal that swallows every line beneath it
-	 * until the next apostrophe, and desynchronises the file. So the scan runs file-wide
-	 * but only a quote in EXPRESSION POSITION opens a literal -- an apostrophe inside a
-	 * word (don't, the user's guide) is preceded by a letter or digit and is prose, not a
-	 * delimiter. The closing quote is exempt from that test, because a literal routinely
-	 * ends right after one of its own characters.
+	 * until the next apostrophe, and desynchronises the file. Prose lives in comments, so
+	 * the scan reads them and skips them rather than guessing from the character before a
+	 * quote -- a possessive after a closing bracket and a quote written as itself are both
+	 * prose and neither follows a letter, and the tree carries the first shape at
+	 * pfblockerng_hook_edit.inc:180.
 	 *
-	 * Two further conditions keep a desynchronised scan from inventing a context. The
+	 * An apostrophe inside a word (don't, the user's guide) is demoted as well, because a
+	 * quote is not a delimiter where a letter or digit runs into it. That test is the
+	 * second line rather than the first, and it is not applied to a closing quote, which
+	 * routinely follows one of the literal's own characters.
+	 *
+	 * One further condition keeps a desynchronised scan from inventing a context: the
 	 * literal must actually CLOSE at or after $offset, so an unterminated quote answers
-	 * nothing; and it must span a newline, because a literal that opens and closes on one
-	 * line is the line-scoped scan's to resolve and it has already had its turn.
+	 * nothing rather than handing back the rest of the file.
 	 */
 	private static function enclosingMultiLineString(string $source, int $offset): ?string
 	{
 		$quote = NULL;
 		$open = 0;
 		for ($i = 0; $i < $offset; $i++) {
+			if ($quote === NULL && $source[$i] === '/') {
+				$comment = self::endOfComment($source, $i);
+				if ($comment !== NULL) {
+					$i = $comment;
+					continue;
+				}
+			}
 			if ($source[$i] === '\\') {
 				$i++;
 				continue;
@@ -479,13 +511,35 @@ final class ThemeSafetyUiTest extends TestCase
 			if ($source[$i] !== $quote) {
 				continue;
 			}
-			$newline = strpos($source, "\n", $open);
-			if ($newline === FALSE || $newline > $i) {
-				return NULL;
-			}
 			return self::styleContext(substr($source, $open, $i - $open + 1), $offset - $open);
 		}
 		return NULL;
+	}
+
+	/**
+	 * The offset of a comment's last character when one opens at $at, else NULL.
+	 *
+	 * Prose is where a quote character stops being a delimiter, and prose lives in
+	 * comments. Reading them is what separates a possessive from a string opener, which no
+	 * test on the surrounding characters can do.
+	 *
+	 * Only `//` and the block form are read. A `#` comment is left alone deliberately: `#`
+	 * opens a colour in CSS far more often than a comment in this tree, and misreading one
+	 * as the other would skip real source. Over-skipping only ever loses an opener, and a
+	 * lost opener answers NULL, which is the answer this resolver gave before it existed.
+	 */
+	private static function endOfComment(string $source, int $at): ?int
+	{
+		$next = $source[$at + 1] ?? '';
+		if ($next === '/') {
+			$end = strpos($source, "\n", $at);
+			return $end === FALSE ? strlen($source) - 1 : $end;
+		}
+		if ($next !== '*') {
+			return NULL;
+		}
+		$end = strpos($source, '*/', $at + 2);
+		return $end === FALSE ? strlen($source) - 1 : $end + 1;
 	}
 
 	/**

--- a/tests/php/ThemeSafetyUiTest.php
+++ b/tests/php/ThemeSafetyUiTest.php
@@ -150,8 +150,6 @@ final class ThemeSafetyUiTest extends TestCase
 			// Reading comments cuts both ways: a `//` that is not a comment opener must not eat
 			// the rest of its line. In a URL it follows the scheme's colon or the opening
 			// bracket, and skipping from there loses the quote that opens the literal below.
-			'url is not a comment'      => ["url(http://x.com/a) 'background-color: #123456;\nbbb'\ncolor: red;", FALSE],
-			'scheme-relative url'       => ["url(//x.com/a) 'background-color: #123456;\nbbb'\ncolor: red;", FALSE],
 			// A `#` comment is a comment too. The tree writes banner blocks of them
 			// (pfblockerng_apply.inc:4540), and a lone quote in one desynchronises the scan
 			// exactly as it does in the other two comment forms. What `#` must NOT swallow is a
@@ -485,13 +483,6 @@ final class ThemeSafetyUiTest extends TestCase
 		$quote = NULL;
 		$open = 0;
 		for ($i = 0; $i < $offset; $i++) {
-			if ($quote === NULL && ($source[$i] === '/' || $source[$i] === '#')) {
-				$comment = self::endOfComment($source, $i);
-				if ($comment !== NULL) {
-					$i = $comment;
-					continue;
-				}
-			}
 			if ($source[$i] === '\\') {
 				$i++;
 				continue;
@@ -506,7 +497,7 @@ final class ThemeSafetyUiTest extends TestCase
 			if ($quote !== NULL) {
 				continue;
 			}
-			if ($i > 0 && preg_match('/[A-Za-z0-9]/', $source[$i - 1])) {
+			if (!self::opensAValue($source, $i)) {
 				continue;
 			}
 			$quote = $source[$i];
@@ -531,48 +522,35 @@ final class ThemeSafetyUiTest extends TestCase
 	}
 
 	/**
-	 * The offset of a comment's last character when one opens at $at, else NULL.
+	 * TRUE when the quote at $at sits where a value may begin.
 	 *
-	 * Prose is where a quote character stops being a delimiter, and prose lives in
-	 * comments. Reading them is what separates a possessive from a string opener, which no
-	 * test on the surrounding characters can do.
+	 * The scan has to answer one question -- is this quote a DELIMITER or is it prose --
+	 * and three rounds of review established that it cannot be answered by recognising
+	 * the carrier prose arrives in. `#` opens a CSS colour, a CSS id selector and a PHP
+	 * comment; `//` opens a comment and a URL; and scan() reads php, inc, js and css with
+	 * no per-language dispatch to tell them apart. Every discriminator added for one of
+	 * those closed one hole and opened another, in the direction that launders.
 	 *
-	 * Both mistakes here launder a background, so neither direction is the safe one to
-	 * lean towards and each form gets a test that tells it from the character it collides
-	 * with. Missing a real comment lets a quote in prose open a literal that swallows the
-	 * lines beneath it. Reading a comment that is not one is worse in practice: the skip
-	 * runs to end of line and eats whatever quote was there, including the one that opened
-	 * the literal the background sits in.
+	 * So the carrier is not consulted at all. A literal opens where a value may begin --
+	 * after an assignment, a bracket, a separator, an operator, or at the start of a line
+	 * -- and prose quotes do not: `don't`, `the user's guide`, `pfb_hook_scripts()'` and
+	 * `#header 'x'` all follow a letter, a digit or a closing bracket.
 	 *
-	 * `//` collides with a URL, where it follows the scheme's colon or the bracket that
-	 * opens `url(`. `#` collides with a colour, which is a run of hex digits; a comment's
-	 * `#` is followed by anything else, and this tree writes whole banner blocks of them.
+	 * The failure direction matters and is the reason this shape is safe where the other
+	 * was not. A quote wrongly REJECTED is a literal not resolved, which returns NULL and
+	 * leaves the answer exactly as it was before this resolver existed. A quote wrongly
+	 * ACCEPTED invents a literal and launders a background. This test only ever errs the
+	 * first way, so no input is worse off than devel.
 	 */
-	private static function endOfComment(string $source, int $at): ?int
+	private static function opensAValue(string $source, int $at): bool
 	{
-		$next = $source[$at + 1] ?? '';
-		if ($source[$at] === '#') {
-			return ctype_xdigit($next) ? NULL : self::endOfLine($source, $at);
-		}
-		if ($next === '/') {
-			$previous = $at > 0 ? $source[$at - 1] : '';
-			if ($previous === ':' || $previous === '(') {
-				return NULL;
+		for ($i = $at - 1; $i >= 0; $i--) {
+			if ($source[$i] === ' ' || $source[$i] === "\t") {
+				continue;
 			}
-			return self::endOfLine($source, $at);
+			return strpos("=(,[{:;.+&|?<>!\r\n", $source[$i]) !== FALSE;
 		}
-		if ($next !== '*') {
-			return NULL;
-		}
-		$end = strpos($source, '*/', $at + 2);
-		return $end === FALSE ? strlen($source) - 1 : $end + 1;
-	}
-
-	/** The offset of the last character on $at's line. */
-	private static function endOfLine(string $source, int $at): int
-	{
-		$end = strpos($source, "\n", $at);
-		return $end === FALSE ? strlen($source) - 1 : $end;
+		return TRUE;
 	}
 
 	/**

--- a/tests/php/ThemeSafetyUiTest.php
+++ b/tests/php/ThemeSafetyUiTest.php
@@ -110,6 +110,22 @@ final class ThemeSafetyUiTest extends TestCase
 			// An apostrophe in prose is not a string opener.
 			'apostrophe in prose'       => ["/* don't */ .a { background-color: #123456; } .b { color: red; }", FALSE],
 			'apostrophe, pair below'    => ["/* it's fine */ .a { background-color: #123456;\n color: red; }", TRUE],
+			// Issue #2928: a multi-line literal opens its quote on an EARLIER line. A scan
+			// that starts at the offset's own line finds no quote there, concludes the
+			// background is not in a string at all, and hands the question to the block
+			// resolver -- where a sibling statement pairs it. That is the #2866 shape
+			// reached by a different route, so it is pinned in both directions: a literal
+			// that genuinely does not pair, and one that genuinely does.
+			'multi-line literal'        => ["if (\$x) {\n\t\$s = \"aaaa\nbackground-color: #123456;\nbbbb\";\n\tcolor: red;\n}", FALSE],
+			'multi-line same literal'   => ['$s = "background-color: #123456;' . "\n" . ' color: red;";', TRUE],
+			'multi-line attribute pairs'=> ['$s = "<span style=\"color: black;' . str_repeat(' ', 200) . "\n" . ' background-color: #123456;\">x</span>";', TRUE],
+			// ...and the reason the scan was scoped to one line in the first place, which any
+			// fix has to keep: an apostrophe in prose is not a string opener, so it must not
+			// open a literal that swallows the lines beneath it. The pairing sits past the
+			// no-scope fallback window and a second apostrophe waits below it, so a whole-file
+			// quote toggle pairs the two and launders the background.
+			'prose apostrophe above'    => ["/* don't */\nbackground-color: #123456;" . str_repeat(' ', 200) . "\ncolor: red;\n/* the user's guide */", FALSE],
+			'prose apostrophe, block'   => ["/* it's fine */\n.a { background-color: #123456;\n color: red; }", TRUE],
 			// A style attribute that is not this background's cannot pair it either.
 			'unrelated attribute'       => ['$s = ".a { background-color: #123456; } <span style=\"color: black;\"></span>";', FALSE],
 			'unrelated attr, no braces' => ['$s = \'background-color: #123456; <span style="color:black;"></span>\';', FALSE],
@@ -382,7 +398,7 @@ final class ThemeSafetyUiTest extends TestCase
 			}
 		}
 		if ($quote === NULL) {
-			return NULL;
+			return self::enclosingMultiLineString($source, $offset);
 		}
 
 		$lineEnd = strpos($source, "\n", $offset);
@@ -397,9 +413,78 @@ final class ThemeSafetyUiTest extends TestCase
 				return self::styleContext($literal, $offset - $open);
 			}
 		}
-		// The quote never closed on this line, so it was an apostrophe in prose, not a
-		// string opener. Truncating a context at end-of-line hides a pairing on the next
-		// one; let the block resolver answer instead.
+		// The quote never closed on this line: either it was an apostrophe in prose, or it
+		// opened a literal that runs on past end-of-line. Only the multi-line resolver can
+		// tell those apart, and truncating a context at end-of-line would hide a pairing on
+		// the next line, so this scan never answers from its own line alone.
+		return self::enclosingMultiLineString($source, $offset);
+	}
+
+	/**
+	 * The literal containing $offset when that literal spans more than one line.
+	 *
+	 * The line-scoped scan above structurally cannot see one: a multi-line literal opens
+	 * its quote on a line that scan never reads, so the background reads as loose code and
+	 * the block resolver lets a sibling statement pair it -- the issue #2866 shape reached
+	 * by a different route (issue #2928).
+	 *
+	 * Scanning the whole file for quotes is what the line scoping was defending against:
+	 * an apostrophe in prose then opens a literal that swallows every line beneath it
+	 * until the next apostrophe, and desynchronises the file. So the scan runs file-wide
+	 * but only a quote in EXPRESSION POSITION opens a literal -- an apostrophe inside a
+	 * word (don't, the user's guide) is preceded by a letter or digit and is prose, not a
+	 * delimiter. The closing quote is exempt from that test, because a literal routinely
+	 * ends right after one of its own characters.
+	 *
+	 * Two further conditions keep a desynchronised scan from inventing a context. The
+	 * literal must actually CLOSE at or after $offset, so an unterminated quote answers
+	 * nothing; and it must span a newline, because a literal that opens and closes on one
+	 * line is the line-scoped scan's to resolve and it has already had its turn.
+	 */
+	private static function enclosingMultiLineString(string $source, int $offset): ?string
+	{
+		$quote = NULL;
+		$open = 0;
+		for ($i = 0; $i < $offset; $i++) {
+			if ($source[$i] === '\\') {
+				$i++;
+				continue;
+			}
+			if ($source[$i] !== "'" && $source[$i] !== '"') {
+				continue;
+			}
+			if ($quote === $source[$i]) {
+				$quote = NULL;
+				continue;
+			}
+			if ($quote !== NULL) {
+				continue;
+			}
+			if ($i > 0 && preg_match('/[A-Za-z0-9]/', $source[$i - 1]) === 1) {
+				continue;
+			}
+			$quote = $source[$i];
+			$open = $i;
+		}
+		if ($quote === NULL) {
+			return NULL;
+		}
+
+		$length = strlen($source);
+		for ($i = $offset; $i < $length; $i++) {
+			if ($source[$i] === '\\') {
+				$i++;
+				continue;
+			}
+			if ($source[$i] !== $quote) {
+				continue;
+			}
+			$newline = strpos($source, "\n", $open);
+			if ($newline === FALSE || $newline > $i) {
+				return NULL;
+			}
+			return self::styleContext(substr($source, $open, $i - $open + 1), $offset - $open);
+		}
 		return NULL;
 	}
 

--- a/tests/php/ThemeSafetyUiTest.php
+++ b/tests/php/ThemeSafetyUiTest.php
@@ -492,7 +492,7 @@ final class ThemeSafetyUiTest extends TestCase
 			if ($quote !== NULL) {
 				continue;
 			}
-			if ($i > 0 && preg_match('/[A-Za-z0-9]/', $source[$i - 1]) === 1) {
+			if ($i > 0 && preg_match('/[A-Za-z0-9]/', $source[$i - 1])) {
 				continue;
 			}
 			$quote = $source[$i];

--- a/tests/php/ThemeSafetyUiTest.php
+++ b/tests/php/ThemeSafetyUiTest.php
@@ -147,6 +147,11 @@ final class ThemeSafetyUiTest extends TestCase
 			// an apostrophe in body text is no more a delimiter there than in a docblock. A
 			// quote is not one where a letter or digit runs straight into it.
 			'apostrophe in page text'   => ["<p>Don't do that</p>\nbackground-color: #123456;" . str_repeat(' ', 200) . "\ncolor: red;\n<p>It's fine</p>", FALSE],
+			// '>' is the one opener character that is also ordinary markup. It has to be
+			// accepted as PHP's '=>' and rejected as a closing tag, or a quote in page
+			// prose opens a literal over everything below it.
+			'array arrow opens a value' => ["\$a = [\n  'k' => \"aaa\nbackground-color: #123456;\nbbb\",\n];\ncolor: red;", FALSE],
+			'closing tag does not'      => ["<span>'Tis the season</span>\nbackground-color: #123456;" . str_repeat(' ', 200) . "\ncolor: red;\n<span>'more'</span>", FALSE],
 			// Reading comments cuts both ways: a `//` that is not a comment opener must not eat
 			// the rest of its line. In a URL it follows the scheme's colon or the opening
 			// bracket, and skipping from there loses the quote that opens the literal below.
@@ -548,7 +553,13 @@ final class ThemeSafetyUiTest extends TestCase
 			if ($source[$i] === ' ' || $source[$i] === "\t") {
 				continue;
 			}
-			return strpos("=(,[{:;.+&|?<>!\r\n", $source[$i]) !== FALSE;
+			if ($source[$i] === '>') {
+				// '>' opens a value only as PHP's '=>'. A bare one closes a tag, and
+				// scan() reads php and inc, which carry markup: <span>'Tis the season
+				// is prose, and accepting it invents a literal over the lines below.
+				return $i > 0 && $source[$i - 1] === '=';
+			}
+			return strpos("=(,[{:;.+&|?<!\r\n", $source[$i]) !== FALSE;
 		}
 		return TRUE;
 	}

--- a/tests/php/ThemeSafetyUiTest.php
+++ b/tests/php/ThemeSafetyUiTest.php
@@ -147,6 +147,20 @@ final class ThemeSafetyUiTest extends TestCase
 			// an apostrophe in body text is no more a delimiter there than in a docblock. A
 			// quote is not one where a letter or digit runs straight into it.
 			'apostrophe in page text'   => ["<p>Don't do that</p>\nbackground-color: #123456;" . str_repeat(' ', 200) . "\ncolor: red;\n<p>It's fine</p>", FALSE],
+			// Reading comments cuts both ways: a `//` that is not a comment opener must not eat
+			// the rest of its line. In a URL it follows the scheme's colon or the opening
+			// bracket, and skipping from there loses the quote that opens the literal below.
+			'url is not a comment'      => ["url(http://x.com/a) 'background-color: #123456;\nbbb'\ncolor: red;", FALSE],
+			'scheme-relative url'       => ["url(//x.com/a) 'background-color: #123456;\nbbb'\ncolor: red;", FALSE],
+			// A `#` comment is a comment too. The tree writes banner blocks of them
+			// (pfblockerng_apply.inc:4540), and a lone quote in one desynchronises the scan
+			// exactly as it does in the other two comment forms. What `#` must NOT swallow is a
+			// colour, which is the same character and is why it went unread until now.
+			'hash comment holds a quote'=> ["# the ' character\nbackground-color: #123456;" . str_repeat(' ', 200) . "\ncolor: red;\n# it's", FALSE],
+			'hash colour is not one'    => [".a { color: #fff; } \$s = 'background-color: #123456;\nbbb'", FALSE],
+			// The closing scan honours an escape, or a literal ends at its first \" and the
+			// pairing that follows it is read as code outside the string.
+			'escaped quote in a literal'=> ['$s = "aaa' . "\n" . 'background-color: #123456;\" color: red;' . "\n" . 'bbb";', TRUE],
 			// A style attribute that is not this background's cannot pair it either.
 			'unrelated attribute'       => ['$s = ".a { background-color: #123456; } <span style=\"color: black;\"></span>";', FALSE],
 			'unrelated attr, no braces' => ['$s = \'background-color: #123456; <span style="color:black;"></span>\';', FALSE],
@@ -471,7 +485,7 @@ final class ThemeSafetyUiTest extends TestCase
 		$quote = NULL;
 		$open = 0;
 		for ($i = 0; $i < $offset; $i++) {
-			if ($quote === NULL && $source[$i] === '/') {
+			if ($quote === NULL && ($source[$i] === '/' || $source[$i] === '#')) {
 				$comment = self::endOfComment($source, $i);
 				if ($comment !== NULL) {
 					$i = $comment;
@@ -523,23 +537,42 @@ final class ThemeSafetyUiTest extends TestCase
 	 * comments. Reading them is what separates a possessive from a string opener, which no
 	 * test on the surrounding characters can do.
 	 *
-	 * Only `//` and the block form are read. A `#` comment is left alone deliberately: `#`
-	 * opens a colour in CSS far more often than a comment in this tree, and misreading one
-	 * as the other would skip real source. Over-skipping only ever loses an opener, and a
-	 * lost opener answers NULL, which is the answer this resolver gave before it existed.
+	 * Both mistakes here launder a background, so neither direction is the safe one to
+	 * lean towards and each form gets a test that tells it from the character it collides
+	 * with. Missing a real comment lets a quote in prose open a literal that swallows the
+	 * lines beneath it. Reading a comment that is not one is worse in practice: the skip
+	 * runs to end of line and eats whatever quote was there, including the one that opened
+	 * the literal the background sits in.
+	 *
+	 * `//` collides with a URL, where it follows the scheme's colon or the bracket that
+	 * opens `url(`. `#` collides with a colour, which is a run of hex digits; a comment's
+	 * `#` is followed by anything else, and this tree writes whole banner blocks of them.
 	 */
 	private static function endOfComment(string $source, int $at): ?int
 	{
 		$next = $source[$at + 1] ?? '';
+		if ($source[$at] === '#') {
+			return ctype_xdigit($next) ? NULL : self::endOfLine($source, $at);
+		}
 		if ($next === '/') {
-			$end = strpos($source, "\n", $at);
-			return $end === FALSE ? strlen($source) - 1 : $end;
+			$previous = $at > 0 ? $source[$at - 1] : '';
+			if ($previous === ':' || $previous === '(') {
+				return NULL;
+			}
+			return self::endOfLine($source, $at);
 		}
 		if ($next !== '*') {
 			return NULL;
 		}
 		$end = strpos($source, '*/', $at + 2);
 		return $end === FALSE ? strlen($source) - 1 : $end + 1;
+	}
+
+	/** The offset of the last character on $at's line. */
+	private static function endOfLine(string $source, int $at): int
+	{
+		$end = strpos($source, "\n", $at);
+		return $end === FALSE ? strlen($source) - 1 : $end;
 	}
 
 	/**

--- a/tests/php/ThemeSafetyUiTest.php
+++ b/tests/php/ThemeSafetyUiTest.php
@@ -142,7 +142,7 @@ final class ThemeSafetyUiTest extends TestCase
 			// before them, it is that they are in a comment.
 			'prose quote after bracket' => ["/* fail pfb_hook_scripts()' membership */\nbackground-color: #123456;" . str_repeat(' ', 200) . "\ncolor: red;\n/* it's */", FALSE],
 			'prose quote written alone' => ["/* use the ' character */\nbackground-color: #123456;" . str_repeat(' ', 200) . "\ncolor: red;\n/* it's */", FALSE],
-			'line comment holds one too' => ["// use the ' character\nbackground-color: #123456;" . str_repeat(' ', 200) . "\ncolor: red;\n// it's", FALSE],
+			'line comment holds one too'=> ["// use the ' character\nbackground-color: #123456;" . str_repeat(' ', 200) . "\ncolor: red;\n// it's", FALSE],
 			// Not all prose is in a comment: a .php page is inline HTML outside its tags, and
 			// an apostrophe in body text is no more a delimiter there than in a docblock. A
 			// quote is not one where a letter or digit runs straight into it.


### PR DESCRIPTION
Fixes #2928.

## The defect

`ThemeSafetyUiTest::enclosingString()` located the opening quote by scanning back only to the start of the offset's own line:

```php
$lineStart = strrpos(substr($source, 0, $offset), "\n");
```

A multi-line string literal opens its quote on an earlier line, so that scan found no quote, concluded the offset was not inside a string, and returned `NULL`. `declarationContext()` then fell through to the block resolver, where a sibling statement's `color:` paired a background that is alone inside the literal — the #2866 shape reached by a different route:

```php
if ($x) {
	$s = "aaaa
background-color: #123456;
bbbb";
	color: red;
}
```

The guard reported that as paired. The literal contains no `color:`, so it is a real violation the gate was meant to stop.

## The fix

The line scoping was not arbitrary — it was defending against an apostrophe in prose (`/* don't */`) opening a literal that swallows every line beneath it and desynchronises the file. A naive whole-file quote toggle reintroduces exactly that, so the new resolver is narrower in three ways:

1. **Only a quote in expression position opens a literal.** An apostrophe preceded by a letter or digit — `don't`, `the user's guide` — is prose, not a delimiter. The closing quote is exempt, because a literal routinely ends right after one of its own characters.
2. **The literal must actually close** at or after the offset, so an unterminated quote answers nothing.
3. **The literal must span a newline.** One that opens and closes on a single line belongs to the existing line-scoped scan, which has already had its turn.

The line-scoped scan runs first and is unchanged; the new resolver only answers where that scan returned `NULL`.

## Evidence

**Red → green, test-first.** The five `pairingWindows` rows were written and executed against untouched `devel` before any production edit, and are byte-identical between the two runs (`git hash-object` of the test file at red time: `953f0770e78e5def8e85ec41d6eb6a60608f598b`; the current file reconstructs to that hash exactly when the two production edits are inverted).

- RED (unmodified resolver): `Tests: 53, Assertions: 76, Failures: 2` — `multi-line literal` reported paired (the defect), and `multi-line attribute pairs` reported unpaired (the same blind spot in the false-positive direction).
- GREEN (after the fix, zero test edits): `OK (53 tests, 76 assertions)`.

**Both directions are pinned,** and so is the reason the line scoping exists. `prose apostrophe above` places its pairing past the 160-character no-scope fallback window with a second apostrophe waiting below it, so a whole-file quote toggle pairs the two and fails the row — the guard rejects the naive fix as well as the original defect.

**The tree's inventory is unchanged.** `testCurrentTreeInventoryMatchesTheDatedTodo` pins the real-tree hit set exactly in both directions (a new hit and a disappeared TODO needle each fail it), and it stays green.

> **Corrected after review.** An earlier version of this section claimed the new resolver "answers 2 of the 25 background sites in the tree, both in `pfblockerng_alerts.php`". That measurement was wrong: it called the resolver directly and so bypassed the `isInterpolated()` / `isTranslucent()` filter that `scan()` applies before `declarationContext()` is ever reached. Both of those sites are `background-color:{$bg}`, which never reaches it. Measured through the real path — **42** raw matches, **30** surviving the filter — the new resolver answers **0** sites in the current tree. That matches what issue #2928 says of it ("a live blind spot rather than a live miss") and does not weaken the case for the fix, but the original sentence asserted liveness the code does not have, and two review legs were right to reject it.
>
> **Corrected a second time.** The replacement figures above were *also* wrong. I gave 46 raw / 34 surviving and defended them against three reviewers who each independently derived 42 / 30. They were right: my probe enumerated the scan roots with **relative** paths, so `scanTree()`'s `/tools/webassets/test/` exclusion — a leading-slash substring check — silently failed and pulled in 4 matches from a fixture the real scan never reads. Re-run with absolute paths, as `scanTree()` builds them, it returns 42 / 30 exactly. The load-bearing figure, 0, was never in dispute.

## Gates

Run on this host: PHP 8.5.9 — one of CI's two pinned versions, but a local run, so CI is the authoritative answer.

- `vendor/bin/phpunit --filter ThemeSafetyUiTest` — OK, 53 tests, 76 assertions
- `vendor/bin/phpcs tests/php/ThemeSafetyUiTest.php` — clean
- `vendor/bin/phpstan analyse --memory-limit=2G` — No errors
- Full `vendor/bin/phpunit` — `6126 tests, 61 errors, 15 failures`, identical to the baseline measured on this branch with the file reverted to `origin/devel` (`6121 tests, 61 errors, 15 failures`; the +5 are the new rows). Pre-existing on the base branch and untouched by this change.
