### PR TITLE
tests: grade the failed-download row highlight on a live box

### DIFF
--- a/tests/smoke/ui/test_category_edit_failed_highlight.py
+++ b/tests/smoke/ui/test_category_edit_failed_highlight.py
@@ -6,10 +6,13 @@
     if ($folder && file_exists("{$folder}/{$row['header']}{$suffix}.fail")) {
 
 On the hermetic Tier-A harness no feed has ever failed, so that branch never fires and the
-input renders ``style=""``. ``test_render_smoke.py``'s
+input renders ``style=""``. ``test_theme_legibility_render.py``'s
 ``test_no_inline_style_paints_an_unpaired_background`` is therefore a real guard for every
 OTHER inline background those pages emit, but it cannot go red for this one -- the state it
 would grade is unreachable from a clean box.
+
+The pairing itself is judged with that test's OWN patterns, imported rather than restated,
+so the two tiers cannot drift into disagreeing about what counts as a background.
 
 Seeding the sidecar is a fixture, not a line: the path is
 ``{folder}/{row['header']}{suffix}.fail``, where ``$folder`` follows the alias action and
@@ -22,7 +25,6 @@ the sweep, and this page IS in the sweep -- it is one row's STATE that is unreac
 
 from __future__ import annotations
 
-import re
 from typing import TYPE_CHECKING
 
 import pytest
@@ -38,6 +40,7 @@ from .test_category_edit import (
     _ipv4_payload,
     _post_form,
 )
+from .test_theme_legibility_render import _FOREGROUND, _INLINE_STYLE, _OPAQUE_BACKGROUND
 from .webui import looks_like_login_page
 
 if TYPE_CHECKING:
@@ -49,26 +52,32 @@ if TYPE_CHECKING:
 # case exists so the ONE row state that sweep cannot reach is graded somewhere.
 pytestmark = pytest.mark.ui_e2e
 
-# The IP loop names each on-disk feed file `{row.header}{vtype}` and the page appends the
-# same `$suffix` when it looks for the failure sidecar, so an IPv4 feed's marker carries
+# A `Deny_*` action resolves $folder to $pfb['denydir'] = "{$pfb['dbdir']}/deny", and the IP
+# loop names each on-disk feed file `{row.header}{vtype}`, so an IPv4 feed's marker carries
 # `_v4` (helpers.force_ip_refetch documents the identical naming for `.update`).
-_V4_SUFFIX = "_v4"
-
-# A `Deny_*` action resolves $folder to $pfb['denydir'] = "{$pfb['dbdir']}/deny".
 _DENY_DIR = f"{helpers.PFB_DBDIR}/deny"
 
 # The Header/Label field the page paints. One configured row -> $r_id 0.
 _HEADER_FIELD = "header-0"
 
+# The legend the same branch emits beside the row, at pfblockerng_category_edit.php:1275.
+_LEGEND = "Failed download(s) highlighted in yellow."
+
 
 def _style_of(tag: str) -> str:
-    """Return the ``style`` attribute's value from an HTML tag, '' when absent."""
-    m = re.search(r'\bstyle="([^"]*)"', tag)
-    return m.group(1) if m else ""
+    """The tag's ``style`` value, '' when it has none.
+
+    ``_INLINE_STYLE`` rather than a local pattern: a bare ``\bstyle=`` also fires on the
+    ``-``-to-``s`` transition inside ``data-style=``, so a decoy attribute would be read as
+    this element's own style. That is the trap the imported pattern's negative lookbehind
+    exists to close, and this file has no reason to re-learn it.
+    """
+    m = _INLINE_STYLE.search(tag)
+    return m.group("value") if m else ""
 
 
-def _render_header_input(webui: WebUI, rowid: int) -> str:
-    """GET the IPv4 editor for ``rowid`` and return its Header/Label input tag."""
+def _render_editor(webui: WebUI, rowid: int) -> tuple[str, str]:
+    """GET the IPv4 editor for ``rowid``; return its Header/Label input tag and the body."""
     resp = webui.get(CATEGORY_PAGE, params={"type": "ipv4", "rowid": str(rowid)})
     assert not looks_like_login_page(resp.text), "category GET returned the login form (session lost)"
     diagnostic = body_has_php_error(resp.text)
@@ -78,7 +87,7 @@ def _render_header_input(webui: WebUI, rowid: int) -> str:
         f'the editor for rowid {rowid} rendered no <input name="{_HEADER_FIELD}"> '
         "-- the configured source row is missing, so the highlight cannot be graded"
     )
-    return tag
+    return tag, resp.text
 
 
 def test_failed_download_row_paints_a_paired_highlight(
@@ -94,7 +103,9 @@ def test_failed_download_row_paints_a_paired_highlight(
 
     Then the row's Header/Label input, which carried NO inline style before, now carries one
       that sets BOTH a background and a foreground -- an opaque background with no paired
-      foreground is illegible under a theme that paints its own text colour.
+      foreground is illegible under a theme that paints its own text colour -- and the
+      legend the same branch emits beside it appears too, since it carries a background of
+      its own and is invisible to the sweep for exactly the same reason.
 
     The before-state assertion is what makes green mean something: it proves the sidecar
     CAUSED the paint, rather than the input having been styled all along.
@@ -102,39 +113,43 @@ def test_failed_download_row_paints_a_paired_highlight(
     vm = smoke_vm
     rowid = _free_rowid(vm, CFG_IPV4)
     header = f"Smokefail{rowid}"
-    sidecar = f"{_DENY_DIR}/{header}{_V4_SUFFIX}.fail"
+    sidecar = f"{_DENY_DIR}/{header}_v4.fail"
     try:
         payload = _ipv4_payload(rowid, f"smokefail{rowid}", action="Deny_Both")
         # `state-0` stays Disabled so no feed is ever downloaded: the sidecar is what this
         # case seeds, and a real fetch would make the run non-hermetic.
         payload[_HEADER_FIELD] = header
         _post_form(webui, payload)
-        assert helpers.config_get(vm, f"{CFG_IPV4}/{rowid}/row/0/header") == header, (
-            f"the source row did not persist at {CFG_IPV4}/{rowid}/row/0/header"
+        stored = helpers.config_get(vm, f"{CFG_IPV4}/{rowid}/row/0/header")
+        assert stored == header, (
+            f"the source row did not persist at {CFG_IPV4}/{rowid}/row/0/header: got {stored!r}, expected {header!r}"
         )
 
         # BEFORE: no sidecar -> the branch does not fire -> style=""
         removed = vm.ssh("/bin/rm", "-f", sidecar, timeout=30.0)
         assert removed.returncode == 0, f"could not clear {sidecar}: {removed.stderr!r}"
-        before = _style_of(_render_header_input(webui, rowid))
+        tag, body = _render_editor(webui, rowid)
+        before = _style_of(tag)
         assert before == "", f"expected no inline style on {_HEADER_FIELD} before the sidecar exists, got {before!r}"
+        assert _LEGEND not in body, f"the legend is rendered with no {sidecar} present"
 
         # WHEN: the failure marker the download path writes.
-        made = vm.ssh("/bin/mkdir", "-p", _DENY_DIR, timeout=30.0)
-        assert made.returncode == 0, f"could not create {_DENY_DIR}: {made.stderr!r}"
-        seeded = vm.ssh("/usr/bin/touch", sidecar, timeout=30.0)
+        seeded = vm.ssh(f"/bin/mkdir -p {_DENY_DIR} && /usr/bin/touch {sidecar}", timeout=30.0)
         assert seeded.returncode == 0, f"could not seed {sidecar}: {seeded.stderr!r}"
 
-        # THEN: highlighted, and legibly.
-        after = _style_of(_render_header_input(webui, rowid))
-        assert after != before, f"seeding {sidecar} changed nothing: {_HEADER_FIELD} still renders style={after!r}"
-        assert re.search(r"(?<![-\w])background(-color)?\s*:", after), (
-            f"the failed row must carry a background; got style={after!r}"
-        )
-        assert re.search(r"(?<![-\w])color\s*:", after), (
+        # THEN: highlighted, and legibly. The patterns are the Tier-A sweep's own, so the two
+        # tiers cannot drift into disagreeing about what a background or a foreground is.
+        tag, body = _render_editor(webui, rowid)
+        after = _style_of(tag)
+        assert _OPAQUE_BACKGROUND.search(after), f"the failed row must carry an opaque background; got style={after!r}"
+        assert _FOREGROUND.search(after), (
             "the failed row's background must be paired with a foreground, or the theme's own "
             f"text colour is left to fight it; got style={after!r}"
         )
+        assert _LEGEND in body, f"seeding {sidecar} rendered the highlight but not its legend"
     finally:
-        vm.ssh("/bin/rm", "-f", sidecar, timeout=30.0)
+        # Reported, never asserted: a cleanup failure must not replace the body's own.
+        swept = vm.ssh("/bin/rm", "-f", sidecar, timeout=30.0)
+        if swept.returncode != 0:
+            print(f"WARNING: {sidecar} was left behind: {swept.stderr!r}")
         _del_rowid(vm, CFG_IPV4, rowid)

--- a/tests/smoke/ui/test_category_edit_failed_highlight.py
+++ b/tests/smoke/ui/test_category_edit_failed_highlight.py
@@ -1,0 +1,140 @@
+"""issue #2931 -- the failed-download row's highlight has no live coverage.
+
+``pfblockerng_category_edit.php`` paints the failed row's Header/Label input from
+``$failed_bg``, which is non-empty only inside::
+
+    if ($folder && file_exists("{$folder}/{$row['header']}{$suffix}.fail")) {
+
+On the hermetic Tier-A harness no feed has ever failed, so that branch never fires and the
+input renders ``style=""``. ``test_render_smoke.py``'s
+``test_no_inline_style_paints_an_unpaired_background`` is therefore a real guard for every
+OTHER inline background those pages emit, but it cannot go red for this one -- the state it
+would grade is unreachable from a clean box.
+
+Seeding the sidecar is a fixture, not a line: the path is
+``{folder}/{row['header']}{suffix}.fail``, where ``$folder`` follows the alias action and
+``$row['header']`` comes from a CONFIGURED feed, and a clean smoke box has no feeds. So this
+case creates the alias first, then seeds.
+
+``EXCLUDED_FROM_TIER_A`` is the wrong shape for the gap: it records whole PAGES kept out of
+the sweep, and this page IS in the sweep -- it is one row's STATE that is unreachable.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING
+
+import pytest
+
+from .. import helpers
+from .render_oracle import body_has_php_error
+from .test_category_edit import (
+    CATEGORY_PAGE,
+    CFG_IPV4,
+    _del_rowid,
+    _free_rowid,
+    _input_tag,
+    _ipv4_payload,
+    _post_form,
+)
+from .webui import looks_like_login_page
+
+if TYPE_CHECKING:
+    from .webui import WebUI
+
+# Tier B: the state under test only exists after a mutating save plus an on-box sidecar
+# write, neither of which the hermetic Tier-A render sweep can produce. Tier A coverage of
+# this page stays exactly what it is (test_render_smoke.py / test_category_edit.py) -- this
+# case exists so the ONE row state that sweep cannot reach is graded somewhere.
+pytestmark = pytest.mark.ui_e2e
+
+# The IP loop names each on-disk feed file `{row.header}{vtype}` and the page appends the
+# same `$suffix` when it looks for the failure sidecar, so an IPv4 feed's marker carries
+# `_v4` (helpers.force_ip_refetch documents the identical naming for `.update`).
+_V4_SUFFIX = "_v4"
+
+# A `Deny_*` action resolves $folder to $pfb['denydir'] = "{$pfb['dbdir']}/deny".
+_DENY_DIR = f"{helpers.PFB_DBDIR}/deny"
+
+# The Header/Label field the page paints. One configured row -> $r_id 0.
+_HEADER_FIELD = "header-0"
+
+
+def _style_of(tag: str) -> str:
+    """Return the ``style`` attribute's value from an HTML tag, '' when absent."""
+    m = re.search(r'\bstyle="([^"]*)"', tag)
+    return m.group(1) if m else ""
+
+
+def _render_header_input(webui: WebUI, rowid: int) -> str:
+    """GET the IPv4 editor for ``rowid`` and return its Header/Label input tag."""
+    resp = webui.get(CATEGORY_PAGE, params={"type": "ipv4", "rowid": str(rowid)})
+    assert not looks_like_login_page(resp.text), "category GET returned the login form (session lost)"
+    diagnostic = body_has_php_error(resp.text)
+    assert diagnostic is None, f"the category editor rendered a PHP diagnostic: {diagnostic}"
+    tag = _input_tag(resp.text, _HEADER_FIELD)
+    assert tag, (
+        f'the editor for rowid {rowid} rendered no <input name="{_HEADER_FIELD}"> '
+        "-- the configured source row is missing, so the highlight cannot be graded"
+    )
+    return tag
+
+
+def test_failed_download_row_paints_a_paired_highlight(
+    webui: WebUI,
+    smoke_vm: helpers.SmokeVM,
+) -> None:
+    """Scenario: an IPv4 feed whose last download failed is highlighted legibly.
+
+    Given a saved Deny_Both IPv4 alias carrying one configured source row, and no failure
+      sidecar for that row on the box,
+
+    When ``{denydir}/{header}_v4.fail`` is created and the editor is reloaded,
+
+    Then the row's Header/Label input, which carried NO inline style before, now carries one
+      that sets BOTH a background and a foreground -- an opaque background with no paired
+      foreground is illegible under a theme that paints its own text colour.
+
+    The before-state assertion is what makes green mean something: it proves the sidecar
+    CAUSED the paint, rather than the input having been styled all along.
+    """
+    vm = smoke_vm
+    rowid = _free_rowid(vm, CFG_IPV4)
+    header = f"Smokefail{rowid}"
+    sidecar = f"{_DENY_DIR}/{header}{_V4_SUFFIX}.fail"
+    try:
+        payload = _ipv4_payload(rowid, f"smokefail{rowid}", action="Deny_Both")
+        # `state-0` stays Disabled so no feed is ever downloaded: the sidecar is what this
+        # case seeds, and a real fetch would make the run non-hermetic.
+        payload[_HEADER_FIELD] = header
+        _post_form(webui, payload)
+        assert helpers.config_get(vm, f"{CFG_IPV4}/{rowid}/row/0/header") == header, (
+            f"the source row did not persist at {CFG_IPV4}/{rowid}/row/0/header"
+        )
+
+        # BEFORE: no sidecar -> the branch does not fire -> style=""
+        removed = vm.ssh("/bin/rm", "-f", sidecar, timeout=30.0)
+        assert removed.returncode == 0, f"could not clear {sidecar}: {removed.stderr!r}"
+        before = _style_of(_render_header_input(webui, rowid))
+        assert before == "", f"expected no inline style on {_HEADER_FIELD} before the sidecar exists, got {before!r}"
+
+        # WHEN: the failure marker the download path writes.
+        made = vm.ssh("/bin/mkdir", "-p", _DENY_DIR, timeout=30.0)
+        assert made.returncode == 0, f"could not create {_DENY_DIR}: {made.stderr!r}"
+        seeded = vm.ssh("/usr/bin/touch", sidecar, timeout=30.0)
+        assert seeded.returncode == 0, f"could not seed {sidecar}: {seeded.stderr!r}"
+
+        # THEN: highlighted, and legibly.
+        after = _style_of(_render_header_input(webui, rowid))
+        assert after != before, f"seeding {sidecar} changed nothing: {_HEADER_FIELD} still renders style={after!r}"
+        assert re.search(r"(?<![-\w])background(-color)?\s*:", after), (
+            f"the failed row must carry a background; got style={after!r}"
+        )
+        assert re.search(r"(?<![-\w])color\s*:", after), (
+            "the failed row's background must be paired with a foreground, or the theme's own "
+            f"text colour is left to fight it; got style={after!r}"
+        )
+    finally:
+        vm.ssh("/bin/rm", "-f", sidecar, timeout=30.0)
+        _del_rowid(vm, CFG_IPV4, rowid)

--- a/tests/smoke/ui/test_category_edit_failed_highlight.py
+++ b/tests/smoke/ui/test_category_edit_failed_highlight.py
@@ -48,8 +48,10 @@ if TYPE_CHECKING:
 
 # Tier B: the state under test only exists after a mutating save plus an on-box sidecar
 # write, neither of which the hermetic Tier-A render sweep can produce. Tier A coverage of
-# this page stays exactly what it is (test_render_smoke.py / test_category_edit.py) -- this
-# case exists so the ONE row state that sweep cannot reach is graded somewhere.
+# this page stays exactly what it is -- the page is swept by test_render_smoke.py's
+# PAGE_TABLE, and the inline-style assertion this module extends is in
+# test_theme_legibility_render.py. This case exists so the ONE row state neither can reach
+# is graded somewhere.
 pytestmark = pytest.mark.ui_e2e
 
 # A `Deny_*` action resolves $folder to $pfb['denydir'] = "{$pfb['dbdir']}/deny", and the IP

--- a/tests/smoke/ui/test_category_edit_failed_highlight.py
+++ b/tests/smoke/ui/test_category_edit_failed_highlight.py
@@ -65,7 +65,7 @@ _LEGEND = "Failed download(s) highlighted in yellow."
 
 
 def _style_of(tag: str) -> str:
-    """The tag's ``style`` value, '' when it has none.
+    r"""The tag's ``style`` value, '' when it has none.
 
     ``_INLINE_STYLE`` rather than a local pattern: a bare ``\bstyle=`` also fires on the
     ``-``-to-``s`` transition inside ``data-style=``, so a decoy attribute would be read as

--- a/tests/smoke/ui/test_theme_legibility_render.py
+++ b/tests/smoke/ui/test_theme_legibility_render.py
@@ -64,8 +64,9 @@ def test_no_inline_style_paints_an_unpaired_background(webui: WebUI) -> None:
     variable, correct in every branch the source scan could see.
 
     The failed-download row itself needs a .fail sidecar to render, so it is not reachable
-    from a clean box and this assertion cannot go red for it -- issue #2931 tracks seeding
-    it at the functional tier. The source-side inventory covers that one line meanwhile.
+    from a clean box and this assertion cannot go red for it. That row is graded at the
+    functional tier instead, by test_category_edit_failed_highlight.py, which seeds the
+    sidecar and reuses the patterns above so the two tiers cannot disagree.
     """
     for path, marker in _LIST_PAGES.items():
         resp = webui.get(path)


### PR DESCRIPTION
Fixes #2931.

## The gap

`pfblockerng_category_edit.php` paints the failed-download row's Header/Label input from
`$failed_bg`, which is non-empty only inside:

```php
if ($folder && file_exists("{$folder}/{$row['header']}{$suffix}.fail")) {
```

On the hermetic Tier-A harness no feed has ever been downloaded, let alone failed, so that
branch never fires and the input renders `style=""`. `test_theme_legibility_render.py`'s
`test_no_inline_style_paints_an_unpaired_background` is a real guard for every **other**
inline background those pages emit — but it cannot go red for this one, because the state
it would grade is unreachable from a clean box.

`EXCLUDED_FROM_TIER_A` is the wrong shape for it, as the issue says: that list records whole
**pages** kept out of the sweep, and this page *is* in the sweep. It is one row's **state**
that is unreachable.

## What this adds

One Tier-B case, `tests/smoke/ui/test_category_edit_failed_highlight.py`. Seeding the
sidecar is a fixture, not a line — the path is built from the row's own header and a clean
box has no feeds — so the case creates the alias first:

1. take a free `installedpackages/pfblockernglistsv4/config` slot;
2. POST a `Deny_Both` IPv4 alias carrying one configured source row, `state-0` left
   `Disabled` so **nothing is ever downloaded** and the run stays hermetic;
3. assert the row's input carries **no** inline style;
4. create `{denydir}/{header}_v4.fail`, the marker the download path writes;
5. reload the editor and assert the same input now carries a style setting **both** a
   background and a foreground;
6. assert the legend the same branch emits beside the row is absent before and present after;
7. remove the sidecar and the alias slot in `finally`.

Step 3 is what makes green mean something: it is a true transition test, so green proves the
sidecar **caused** the paint rather than the input having been styled all along.

Every path is derived, not hardcoded: the folder comes from the existing `helpers.PFB_DBDIR`
constant (`force_ip_refetch` already documents the identical `{header}{vtype}` naming for
`.update` markers), and the alias slot from `_free_rowid`.

## Evidence — a live pfSense VM, both directions

**Green**, on the branch, one leased box (re-run at `01551b24` after the review round rewrote
what is asserted — `1 passed, 661 deselected in 156s`; the original run at `7cb109cc` follows):

```
tests/smoke/ui/test_category_edit_failed_highlight.py::test_failed_download_row_paints_a_paired_highlight
boot-to-ready: 42 seconds
================ 1 passed, 661 deselected in 129.10s (0:02:09) =================
```

**Red under mutation.** The case must be able to fail for the reason it exists, so
`$failed_bg` was mutated on a throwaway ref — `'background-color: #FFFF00; color: black;'`
→ `'background-color: #FFFF00;'`, i.e. the background kept and the paired foreground
removed — and the suite re-run on a leased box:

```
>           assert re.search(r"(?<![-\w])color\s*:", after), (
E           AssertionError: the failed row's background must be paired with a foreground,
E           or the theme's own text colour is left to fight it; got style='background-color: #FFFF00;'
E           assert None
================ 1 failed, 661 deselected in 128.03s (0:02:08) =================
```

The background assertion still passed under that mutation, so the failure is precisely the
pairing — not the case collapsing for an unrelated reason. The mutation ref was published
only to the lab's local git mirror, never to this repository, and has been deleted.

## Tier and gates

Tier B (`ui_e2e`), matching `test_category_edit_custom_flag.py`. `testing.md`'s Tier-A
obligation is scoped to changes touching `www/`, and this diff touches none, so no Tier-A
obligation attaches to it at all — the reachability argument explains why the gap exists, not
a waiver of a rule that applied. Tier A coverage of this page is unchanged and stays what it is — this case exists so
that the one row state the sweep cannot reach is graded somewhere.

`ruff check`, `ruff format --check` and `mypy tests/` all clean on the new file, and the
default `pytest` run is unaffected (`tests/smoke` is `--ignore`d there; the new file adds
zero tests to it).

`scripts/agent/run-gates.sh --diff origin/devel` is green except for one pre-existing
environment failure on this driver host, unrelated to the diff: `npm` is not installed, so
`test_check_webassets_vendor::test_build_webassets_reproduces_the_committed_vendor_tree`
skips and trips the skip-allowlist gate. The webassets-vendor CI job is the gate that
actually enforces that, and CI is authoritative.

🤖 Generated by [Claude Code](https://claude.com/claude-code), posted via @BBcan177's account on their behalf.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added UI coverage verifying that failed downloads display a paired foreground and background highlight in the category editor.
  * Confirmed the associated legend text appears when a download failure is detected.
  * Updated theme-legibility test documentation to reflect the new functional coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->