### PR TITLE
tests: leave a space where a nested group was removed

### DIFF
--- a/tests/php/ThemeSafetyUiTest.php
+++ b/tests/php/ThemeSafetyUiTest.php
@@ -185,6 +185,14 @@ final class ThemeSafetyUiTest extends TestCase
 			// this tree has 208 of the second kind in pfblockerng.inc alone. An unbalanced span
 			// must not open a literal that swallows the lines below it.
 			'backtick span in prose'    => ["// see `background-color\nbackground-color: #123456;" . str_repeat(' ', 200) . "\ncolor: red;\n// and `color", FALSE],
+			// Issue #2934: dropping a nested group joins whatever sat either side of it, so two
+			// tokens that were never adjacent can glue into one the source does not contain --
+			// here a phantom `color:`, which pairs a background that has no foreground at all.
+			// Both resolution paths share the primitive, so both are pinned: the brace path
+			// removes the group with withoutNestedBlocks(), the literal path cuts it as a
+			// foreign group.
+			'glued token in a block'    => ['.a { background-color: #123456; c{n}olor: red; }', FALSE],
+			'glued token in a literal'  => ["\$s = 'background-color: #123456; c{n}olor: red;';", FALSE],
 			'multi-line attribute pairs'=> ['$s = "<span style=\"color: black;' . str_repeat(' ', 200) . "\n" . ' background-color: #123456;\">x</span>";', TRUE],
 			// ...and the reason the scan was scoped to one line in the first place, which any
 			// fix has to keep: an apostrophe in prose is not a string opener, so it must not
@@ -839,7 +847,9 @@ final class ThemeSafetyUiTest extends TestCase
 	 * A PHP string is routinely a whole HTML fragment. If the background sits in a style
 	 * attribute, only that attribute can pair it; otherwise the other elements' attributes
 	 * are still theirs, so their values are removed rather than read as neighbours. Spans
-	 * are excised back to front, or an earlier removal shifts the offsets of a later one.
+	 * are excised back to front, or an earlier removal shifts the offsets of a later one,
+	 * and each leaves a space behind so the cut cannot glue its two sides into a token
+	 * that was never there (issue #2934).
 	 */
 	private static function styleContext(string $literal, int $rel): string
 	{
@@ -863,7 +873,7 @@ final class ThemeSafetyUiTest extends TestCase
 		}
 
 		foreach (array_reverse(self::mergedCuts($cuts)) as [$start, $end]) {
-			$out = substr($out, 0, $start) . substr($out, $end);
+			$out = substr($out, 0, $start) . ' ' . substr($out, $end);
 		}
 		return $out;
 	}
@@ -963,7 +973,14 @@ final class ThemeSafetyUiTest extends TestCase
 		return [$start, $length - 1];
 	}
 
-	/** The block's own declarations, with every nested block's contents dropped. */
+	/**
+	 * The block's own declarations, with every nested block's contents dropped.
+	 *
+	 * A dropped group leaves a space behind rather than closing the gap. Joining the text
+	 * either side of it makes characters adjacent that never were, and they can glue into
+	 * a token the source does not contain -- `c{n}olor: red;` becomes a `color:` that
+	 * pairs a background nothing pairs (issue #2934).
+	 */
 	private static function withoutNestedBlocks(string $block): string
 	{
 		$out = '';
@@ -974,6 +991,8 @@ final class ThemeSafetyUiTest extends TestCase
 				$depth++;
 				if ($depth === 1) {
 					$out .= $block[$i];
+				} elseif ($depth === 2) {
+					$out .= ' ';
 				}
 				continue;
 			}


### PR DESCRIPTION
Fixes #2934.

> **Stacked on #2941, which is stacked on #2939.** The base of this PR is `issue/2930-tests-themesafety-cannot-scope`; all three touch `enclosingString()`'s neighbourhood in the same file, so basing this on `devel` would guarantee a conflict. GitHub retargets the base automatically as each lands. Review only this PR's own commit, `6798852f`.

## The defect

`withoutNestedBlocks()` removes a nested brace group by concatenating the text either side of it and inserting nothing at the splice. Characters that were separated by the group become adjacent, and can glue into a token that was never in the source:

```css
.a { background-color: #123456; c{n}olor: red; }
```

Dropping `{n}` joins `c` to `olor: red;` into a phantom `color:`, so `contextHasForeground()` reports a foreground that does not exist and the unpaired background is laundered.

## A second site, which the issue does not name

The issue says "the literal path shares this primitive since #2920's round-5 consolidation, so both paths are affected identically". Enumerating the removal sites from source rather than from the report shows that is right in effect but not in mechanism — the literal path does not reach `withoutNestedBlocks()` for this shape at all. It cuts the foreign brace group itself, in `styleContext()`, through a plain `substr` splice of the same shape:

```php
$out = substr($out, 0, $start) . substr($out, $end);
```

It reproduces independently:

```php
$s = 'background-color: #123456; c{n}olor: red;';
```

Both sites are fixed, and each has its own row. The attribute-value cuts that share that line **cannot** glue a keyword — their spans are bounded by the quote characters that stay behind — but they take the space too, because that line serves both.

> **Corrected after review.** This originally ended "because it is one splice and one rule". That reads tidier than the truth, and my own mutation table disproves it: the two seams are independent, each caught by its own row and neither catching the other's. A parallel PR on this file (#2940) established the same thing from the other direction — applying only the `withoutNestedBlocks()` arm on top of its branch fixes the block row and leaves the literal row broken, because the literal path never reaches that function. #2934 is not one change with two call sites; it is two changes that share a rationale.

## The fix

A single space in place of the removed group, at both sites. It separates the two sides without joining any pair of tokens the source did separate.

> **Corrected after review.** This paragraph originally continued "and neither the background pattern nor the foreground pattern can match across it". That is false, and the correctness leg was right to reject it. Where the removed group sits at a position those patterns already allow whitespace — `color{n}: red`, `color{n}=`, `setProperty({n}"color"` — the inserted space bridges rather than separates, and the phantom foreground still forms:
>
> ```
> group at a \s* position (block)      -> PAIRED (laundered)
> group at a \s* position (literal)    -> PAIRED (laundered)
> token glue (the fixed case)          -> VIOLATION
> genuine spaced pairing must hold     -> PAIRED (laundered)
> ```
>
> That last line is why this is not simply an oversight in the fix: `color : red` is genuinely paired CSS, so the patterns must tolerate whitespace there, and no choice of separator can distinguish the two cases. The verdict is identical before and after this change, so it is not a regression — it is a second, narrower shape of the same defect, with the same "no valid syntax reaches it" status as #2934 itself. It needs its own issue rather than a silent widening of this one. The code comments never made this claim; only the PR body did.

## Evidence

**Red → green, test-first.** Both rows were executed against the unmodified base before any production edit and are byte-identical between the runs (`git hash-object` at red time: `70c80b044a365ae7459091dcbea4c0407f336be0`; the current file reconstructs to exactly that hash when the production edits are inverted).

- RED: both rows failed — `glued token in a block` and `glued token in a literal`, each reporting the background as paired.
- GREEN (after the fix, zero test edits): `OK (74 tests, 97 assertions)`.

**Each row pins its own site**, one-to-one, by executed mutation:

| Mutation | Rows that go red |
|---|---|
| `withoutNestedBlocks()` closes the gap again | `glued token in a block` |
| the `styleContext()` cut closes the gap again | `glued token in a literal` |

**The tree's inventory is unchanged** — `testCurrentTreeInventoryMatchesTheDatedTodo` pins the real-tree hit set exactly in both directions and stays green, so inserting the space moved no real verdict.

## On reach

The issue is honest that it could not construct valid syntax that reaches this, and I did not manage to either — no valid PHP, JS or CSS splits a keyword across a brace pair. Both rows are synthetic. They are worth having anyway for the reason the issue gives: the primitive is now shared by two resolution paths, so the cost of the guard is two spaces and the cost of not having it is paid by whoever next passes less structured text through it.

## Gates

Run on this host: PHP 8.5.9 — one of CI's two pinned versions, but a local run, so CI is the authoritative answer.

- `vendor/bin/phpunit --filter ThemeSafetyUiTest` — OK, 74 tests, 97 assertions
- `vendor/bin/phpcs tests/php/ThemeSafetyUiTest.php` — clean
- `vendor/bin/phpstan analyse --memory-limit=2G` — No errors
- Full `vendor/bin/phpunit` — `6155 tests, 61 errors, 15 failures`, the same 61/15 measured on `origin/devel` with this file reverted. Pre-existing on the base branch and untouched here.
