### PR TITLE
smoke: pin the deferred-pass exit code to EX_TEMPFAIL

### DIFF
--- a/tests/smoke/test_feed_pass_lock.py
+++ b/tests/smoke/test_feed_pass_lock.py
@@ -16,8 +16,8 @@ Dispatch:
     gh workflow run smoke.yml -f pytest_filter="feed_pass_lock"
 
 Tests:
-    test_cron_verb_skips_while_feed_pass_lock_held — second pass skips + logs
-    test_cron_verb_proceeds_when_lock_free         — normal pass unaffected
+    test_cron_verb_skips_while_feed_pass_lock_held — second pass defers (rc=75) + logs
+    test_cron_verb_proceeds_when_lock_free         — normal pass unaffected (rc=0)
 """
 
 from __future__ import annotations
@@ -46,6 +46,15 @@ _STOP = "/tmp/pfb_smoke_lock_stop"
 # and the other absent, so neither negative assertion can pass vacuously.
 _SKIP_LINE = "Feed pass [ cron ] skipped -- another pfBlockerNG feed pass is running"
 _START_LINE = "CRON  PROCESS  START"
+
+# The CLI contract for a deferred pass (5a19a2ef, issue #2945). A deferral is not a
+# failure and not a success: pfb_feed_pass_exit_code() returns PFB_EXIT_LOCKED, which is
+# EX_TEMPFAIL, while a genuine lock ACQUISITION error stays rc=1 and a completed pass
+# stays rc=0. Asserting the exact code rather than "non-zero" is what keeps those three
+# apart here -- a test that accepted any failure would pass on the error path this
+# distinction exists to separate.
+_EX_TEMPFAIL = 75
+_DEFERRAL_MESSAGE = "pfBlockerNG feed pass deferred: feed-pass lock is held"
 
 # Real on-box lock holder: acquires the SAME flock the funnels use, signals
 # readiness, then waits for the stop file. Self-terminating (120 s deadline)
@@ -111,7 +120,8 @@ def test_cron_verb_skips_while_feed_pass_lock_held(deployed_vm: SmokeVM) -> None
 
     Given another on-box process holds pfb_feed_pass.lock,
     When the cron verb is dispatched,
-    Then it logs the skip line and never starts the pass (no CRON START banner).
+    Then it defers with EX_TEMPFAIL and says so on stderr, logs the skip line, and
+    never starts the pass (no CRON START banner).
     """
     vm = deployed_vm
     h.wait_no_active_pfb_task(vm)
@@ -124,7 +134,13 @@ def test_cron_verb_skips_while_feed_pass_lock_held(deployed_vm: SmokeVM) -> None
     try:
         offset = _log_size(vm)
         run = vm.ssh(f"{_PHP} {_PFB_PHP} cron", timeout=120.0)
-        assert run.returncode == 0, f"cron verb must exit cleanly on a skip: rc={run.returncode} {run.stderr!r}"
+        assert run.returncode == _EX_TEMPFAIL, (
+            f"a deferred pass must report EX_TEMPFAIL, not {run.returncode}: "
+            f"expected {_EX_TEMPFAIL}, got rc={run.returncode} stderr={run.stderr!r}"
+        )
+        assert _DEFERRAL_MESSAGE in run.stderr, (
+            f"the deferral must name its reason on stderr: expected {_DEFERRAL_MESSAGE!r}, got {run.stderr!r}"
+        )
         delta = _log_delta(vm, offset)
         assert _SKIP_LINE in delta, f"expected skip line {_SKIP_LINE!r} in log delta, got: {delta!r}"
         assert _START_LINE not in delta, f"pass must NOT start while the lock is held, log delta: {delta!r}"
@@ -144,7 +160,11 @@ def test_cron_verb_proceeds_when_lock_free(deployed_vm: SmokeVM) -> None:
 
     offset = _log_size(vm)
     run = vm.ssh(f"{_PHP} {_PFB_PHP} cron", timeout=240.0)
-    assert run.returncode == 0, f"cron verb failed: rc={run.returncode} {run.stderr!r}"
+    assert run.returncode == 0, (
+        f"a completed pass must report success, not a deferral or a failure: "
+        f"expected 0, got rc={run.returncode} stderr={run.stderr!r}"
+    )
+    assert _DEFERRAL_MESSAGE not in run.stderr, f"a free lock must not report a deferral, stderr: {run.stderr!r}"
     delta = _log_delta(vm, offset)
     assert _START_LINE in delta, f"expected {_START_LINE!r} in log delta, got: {delta!r}"
     assert _SKIP_LINE not in delta, f"a free lock must not produce a skip, log delta: {delta!r}"

--- a/tests/smoke/test_feed_pass_lock.py
+++ b/tests/smoke/test_feed_pass_lock.py
@@ -47,12 +47,9 @@ _STOP = "/tmp/pfb_smoke_lock_stop"
 _SKIP_LINE = "Feed pass [ cron ] skipped -- another pfBlockerNG feed pass is running"
 _START_LINE = "CRON  PROCESS  START"
 
-# The CLI contract for a deferred pass (5a19a2ef, issue #2945). A deferral is not a
-# failure and not a success: pfb_feed_pass_exit_code() returns PFB_EXIT_LOCKED, which is
-# EX_TEMPFAIL, while a genuine lock ACQUISITION error stays rc=1 and a completed pass
-# stays rc=0. Asserting the exact code rather than "non-zero" is what keeps those three
-# apart here -- a test that accepted any failure would pass on the error path this
-# distinction exists to separate.
+# The CLI contract for a deferred pass (5a19a2ef, issue #2945): pfb_feed_pass_exit_code()
+# returns PFB_EXIT_LOCKED for a deferral, 0 for a completed pass and 1 for a failed one.
+# The exact code is asserted, not "non-zero", so the three stay apart.
 _EX_TEMPFAIL = 75
 _DEFERRAL_MESSAGE = "pfBlockerNG feed pass deferred: feed-pass lock is held"
 
@@ -135,8 +132,8 @@ def test_cron_verb_skips_while_feed_pass_lock_held(deployed_vm: SmokeVM) -> None
         offset = _log_size(vm)
         run = vm.ssh(f"{_PHP} {_PFB_PHP} cron", timeout=120.0)
         assert run.returncode == _EX_TEMPFAIL, (
-            f"a deferred pass must report EX_TEMPFAIL, not {run.returncode}: "
-            f"expected {_EX_TEMPFAIL}, got rc={run.returncode} stderr={run.stderr!r}"
+            f"a deferred pass must report EX_TEMPFAIL: expected {_EX_TEMPFAIL}, "
+            f"got rc={run.returncode} stderr={run.stderr!r}"
         )
         assert _DEFERRAL_MESSAGE in run.stderr, (
             f"the deferral must name its reason on stderr: expected {_DEFERRAL_MESSAGE!r}, got {run.stderr!r}"


### PR DESCRIPTION
Fixes #2945.

## The defect

`5a19a2ef` ("trigger: report lock deferral with exit 75") deliberately changed the `cron` verb to exit `75` when a feed pass is deferred because a lock is held. It shipped with eight PHP test files and `tests/smoke/helpers.py` — but not `tests/smoke/test_feed_pass_lock.py`, whose assertion still read `run.returncode == 0`. That line was written on 2026-08-23 (`cc05ba6f`), a week before the contract moved.

`devel`'s live-VM tier has been red since.

## Evidence

**RED, from a live-VM tier 2 run on the lab box** — not this workstation, and not reasoned:

```
ref ee8db18fb9e72dc31470b79fc0872b265a748874
324 passed, 1 failed, 4 skipped, 1 xfailed, 41m12s

FAILED tests/smoke/test_feed_pass_lock.py::test_cron_verb_skips_while_feed_pass_lock_held
  AssertionError: cron verb must exit cleanly on a skip:
    rc=75 'pfBlockerNG feed pass deferred: feed-pass lock is held\n'
  assert 75 == 0
```

(The stderr repr above is reproduced with the trailing newline the real message carries; an earlier version of this body dropped it while reformatting the artifact.)

Trace, verified independently on a fresh checkout: `5a19a2ef` is an ancestor of `devel` at `HEAD~1` from `ee8db18f`, and its 16 changed files include `tests/smoke/helpers.py` but not this test.

## Which side was stale

The code, not the test, is the deliberate side — `src/usr/local/pkg/pfblockerng/pfblockerng.inc`:

```php
// CLI result for a pass deferred before work starts because a feed lock is held.
define('PFB_EXIT_LOCKED', 75);

function pfb_feed_pass_exit_code(bool $completed, ?string $deferred_by): int {
	return $deferred_by !== NULL ? PFB_EXIT_LOCKED : ($completed ? 0 : 1);
}
```

Three outcomes, not two. `CronDeferralExitCodeTest` pins the distinction repeatedly — an open error, a flock error, and an unavailable runtime must each map to `rc=1`, "not lock-deferral rc=75". `75` is `EX_TEMPFAIL`, the conventional "try again later".

## The change

The deferral assertion now expects `PFB_EXIT_LOCKED` **and** the deferral message on stderr. Asserting the exact code rather than "non-zero" is the point: a test that accepted any failure would pass on the `rc=1` acquisition-error path, which is precisely the path `5a19a2ef` exists to separate.

The free-lock test keeps `rc == 0` and now also asserts the deferral message is **absent**, so its success cannot be a deferral misread as a pass.

## What this PR assumes, and how to reverse it

It assumes `75` is the intended contract. That reading is supported by the commit message, the `define`, and the PHP tier — but **the ruling belongs to `5a19a2ef`'s author**, because editing the assertion is both the obvious move and the way to cement the wrong contract if `0` was right. The operator-facing question is in the issue: under `75`, a cron wrapper that checks exit status sees non-zero on an ordinary, expected skip.

If the ruling goes the other way, this PR is the wrong fix and the change belongs in `pfb_feed_pass_exit_code()` instead. The diff is deliberately small so that reversal is cheap.

## Coverage note, stated rather than skipped

The issue suggests also pinning that a genuine acquisition error stays `rc=1`. I did not add that here, and my first statement of why was wrong in its mechanism — corrected after review.

An **unopenable** lock file does not produce `rc=1` at all. `pfb_feed_pass_begin()` logs "open failed … proceeding unlocked" and returns `TRUE` (`pfblockerng.inc:19022-19024`), so that route yields an ordinary pass, not an error. The `rc=1` path is a genuine `flock()` failure that is *not* contention — and there is no way to force one from a guest shell: root bypasses the permission bits, and `chflags schg` defeats root too.

So the conclusion stands and the reasoning behind it did not. That path is covered off-appliance by `CronDeferralExitCodeTest` and `FeedPassCliExitStatusTest` with a `FailingFlockStream`. Asserting the exact `75` here is what keeps this test from silently absorbing it.

## Gates

Not run here: **pfb-dev has no pool and no `/srv/Smoke`, so I cannot execute the live-VM tier.** Verification of the green run is by the lab seat that reported the failure, on a targeted leg against this head; its artifact path will be posted to this PR.

Run on this host:

- `uv run ruff check tests/smoke/` — All checks passed
- `uv run ruff format --check` — already formatted
- `uv run mypy tests/` — Success, 368 source files
- `uv run pytest tests/smoke --collect-only` — 905 tests collected
