### PR TITLE
tests/smoke: name the rejection, not the config path

### DIFF
--- a/tests/smoke/ui/render_oracle.py
+++ b/tests/smoke/ui/render_oracle.py
@@ -98,24 +98,39 @@ def body_has_php_error(body: str) -> str | None:
 # <div class="alert alert-danger input-errors">...</div> per response. Non-greedy
 # because the block is non-nested: a greedy match swallows the rest of the document
 # and buries the reason this exists to surface.
-_INPUT_ERRORS_RE = re.compile(r"<div[^>]*\binput-errors\b[^>]*>.*?</div>", re.DOTALL)
+# `\b` alone matches inside `no-input-errors`, because `-` is a non-word
+# character: the boundary falls between `no-` and `input`, so a class the page
+# may plausibly grow would read as a rejection. The lookbehind requires the
+# name to START here.
+_INPUT_ERRORS_RE = re.compile(r"<div[^>]*(?<![-\w])input-errors\b[^>]*>.*?</div>", re.DOTALL)
 
 
-def input_errors_block(body: str) -> str:
-    """Return pfSense's ``print_input_errors()`` alert from a save-response body.
+NO_INPUT_ERRORS = "<no input-errors block in response>"
+"""Shown in a failure message where no block was rendered, never ``""``.
+
+An empty string reads as though the response came back blank, which points at the
+wrong layer -- the defect :func:`input_errors_block` exists to stop. DISPLAY only:
+nothing branches on it, so editing it cannot change a verdict.
+"""
+
+
+def input_errors_block(body: str) -> str | None:
+    """Return pfSense's ``print_input_errors()`` alert, or ``None`` when absent.
 
     A save the page REJECTS renders its reason here -- a reserved header name, a
-    failed protocol guard, a bad URL -- and a caller that discards it fails later at
-    whatever it asserts next, naming the config path instead of the rejection
-    (issue #2954). Pulling out just the block keeps the diagnostic readable, which
+    failed protocol guard, a bad URL -- and a caller that discards it fails later
+    at whatever it asserts next, naming the config path instead of the rejection
+    (issue #2954). Returning just the block keeps the diagnostic readable, which
     ``.agents/policy/testing.md`` requires of a failing assertion.
 
-    Absent the div -- the save carried no validation error -- returns an explicit
-    marker, never ``""``: an empty string reads in a failure message as though the
-    response came back blank, which points at the wrong layer again.
+    ``None`` rather than a sentinel string is deliberate: callers gate live
+    assertions on presence, and comparing against a marker would make that
+    MARKER TEXT load-bearing -- edit it and every off-appliance check still
+    passes while the guest-side assertions invert. Use :data:`NO_INPUT_ERRORS`
+    for display.
     """
     match = _INPUT_ERRORS_RE.search(body)
-    return match.group(0) if match else "<no input-errors block in response>"
+    return match.group(0) if match else None
 
 
 @dataclass(frozen=True)

--- a/tests/smoke/ui/render_oracle.py
+++ b/tests/smoke/ui/render_oracle.py
@@ -98,11 +98,35 @@ def body_has_php_error(body: str) -> str | None:
 # <div class="alert alert-danger input-errors">...</div> per response. Non-greedy
 # because the block is non-nested: a greedy match swallows the rest of the document
 # and buries the reason this exists to surface.
-# `\b` alone matches inside `no-input-errors`, because `-` is a non-word
-# character: the boundary falls between `no-` and `input`, so a class the page
-# may plausibly grow would read as a rejection. The lookbehind requires the
-# name to START here.
-_INPUT_ERRORS_RE = re.compile(r"<div[^>]*(?<![-\w])input-errors\b[^>]*>.*?</div>", re.DOTALL)
+# The name must be exactly `input-errors`, bounded on BOTH sides. `\b` alone is no
+# help either way, because `-` is a non-word character: it matches inside
+# `no-input-errors` (boundary between `no-` and `input`) and inside
+# `input-errors-template` (boundary between `errors` and `-template`). Either would
+# read as a rejection, so both are excluded explicitly.
+_INPUT_ERRORS_RE = re.compile(r"<div[^>]*(?<![-\w])input-errors(?![-\w])[^>]*>.*?</div>", re.DOTALL)
+
+
+def rejection_verdict(errors: str | None, expect: bool | str) -> str | None:
+    """The failure message for a save's rejection state, or ``None`` when it is right.
+
+    Split out from the POST helper so the decision is reachable without a guest: the
+    helper needs a live session, this needs a string. ``expect`` is ``False`` for a
+    save that must be accepted, ``True`` for one that must be rejected, and the
+    expected reason as a **string** when it must be rejected FOR that reason.
+
+    One parameter rather than two, so "a reason without expecting a rejection" cannot
+    be written: that combination silently asserted nothing when it was two.
+    """
+    if not expect:
+        return None if errors is None else f"the page rejected this save: {errors}"
+    if errors is None:
+        return f"the page ACCEPTED a save this case requires it to reject: {NO_INPUT_ERRORS}"
+    # WHICH rejection, not merely that one happened. Several validators append to
+    # $input_errors on the same page, so a case can go green on a rejection that has
+    # nothing to do with the guard it is testing.
+    if isinstance(expect, str) and expect not in errors:
+        return f"rejected for the wrong reason: expected {expect!r} in {errors!r}"
+    return None
 
 
 NO_INPUT_ERRORS = "<no input-errors block in response>"

--- a/tests/smoke/ui/render_oracle.py
+++ b/tests/smoke/ui/render_oracle.py
@@ -94,6 +94,30 @@ def body_has_php_error(body: str) -> str | None:
     return match.group(0) if match else None
 
 
+# pfSense's print_input_errors() (guiconfig.inc) renders one non-nested
+# <div class="alert alert-danger input-errors">...</div> per response. Non-greedy
+# because the block is non-nested: a greedy match swallows the rest of the document
+# and buries the reason this exists to surface.
+_INPUT_ERRORS_RE = re.compile(r"<div[^>]*\binput-errors\b[^>]*>.*?</div>", re.DOTALL)
+
+
+def input_errors_block(body: str) -> str:
+    """Return pfSense's ``print_input_errors()`` alert from a save-response body.
+
+    A save the page REJECTS renders its reason here -- a reserved header name, a
+    failed protocol guard, a bad URL -- and a caller that discards it fails later at
+    whatever it asserts next, naming the config path instead of the rejection
+    (issue #2954). Pulling out just the block keeps the diagnostic readable, which
+    ``.agents/policy/testing.md`` requires of a failing assertion.
+
+    Absent the div -- the save carried no validation error -- returns an explicit
+    marker, never ``""``: an empty string reads in a failure message as though the
+    response came back blank, which points at the wrong layer again.
+    """
+    match = _INPUT_ERRORS_RE.search(body)
+    return match.group(0) if match else "<no input-errors block in response>"
+
+
 @dataclass(frozen=True)
 class RenderResult:
     """The (a)-(c) verdict for one fetched page (the (d) log check is sweep-level).

--- a/tests/smoke/ui/test_browser_category_edit.py
+++ b/tests/smoke/ui/test_browser_category_edit.py
@@ -62,6 +62,7 @@ import pytest
 
 from .. import helpers
 from .conftest import mask_page_identity
+from .render_oracle import input_errors_block
 from .test_category_edit import (
     CFG_DNSBL,
     CFG_IPV4,
@@ -471,22 +472,6 @@ _CATEGORY_PAGE = "/pfblockerng/pfblockerng_category_edit.php"
 _SAVE_TIMEOUT = 120.0
 _CFG_IPV4 = "installedpackages/pfblockernglistsv4/config"
 
-# pfSense's print_input_errors() (guiconfig.inc) renders one non-nested
-# <div class="alert alert-danger input-errors">...</div> per response.
-_INPUT_ERRORS_RE = re.compile(r"<div[^>]*\binput-errors\b[^>]*>.*?</div>", re.DOTALL)
-
-
-def _input_errors_block(body: str) -> str:
-    """Extract pfSense's ``print_input_errors()`` alert block from a save-response body.
-
-    Pulling just that block out of the full page keeps failure diagnostics readable
-    (CLAUDE.md "On failure, print expected vs actual"). Absent the div -- the save carried
-    no validation error -- returns an explicit marker so a diagnostic never reads as "the
-    response was empty".
-    """
-    match = _INPUT_ERRORS_RE.search(body)
-    return match.group(0) if match else "<no input-errors block in response>"
-
 
 def _post_ipv4_form(webui: WebUI, payload: dict[str, str]) -> str:
     """POST a fully-enumerated IPv4 category-edit payload and return the response body.
@@ -674,7 +659,7 @@ def test_alias_type_port_field_normalizes_network_alias_away(
                 f"expected NO {error!r} error -- the whitelist sanitiser resets a wrong-type "
                 f"alias to '' before pfb_adv_alias_field_errors() ever runs, so this value "
                 f"never reaches validation as an error.\n"
-                f"  response input-errors block: {_input_errors_block(norm_body)}"
+                f"  response input-errors block: {input_errors_block(norm_body)}"
             )
 
         # The save WENT THROUGH -- a rejected save would write nothing at all.
@@ -683,7 +668,7 @@ def test_alias_type_port_field_normalizes_network_alias_away(
             f"expected the save to go through (a rejected save writes nothing)\n"
             f"  expected aliasname: {aliasname!r}\n"
             f"  actual aliasname  : {got_aliasname!r}\n"
-            f"  response input-errors block: {_input_errors_block(norm_body)}"
+            f"  response input-errors block: {input_errors_block(norm_body)}"
         )
 
         # The wrong-type value was dropped -- normalized to '', not saved verbatim.
@@ -710,7 +695,7 @@ def test_alias_type_port_field_normalizes_network_alias_away(
         )
         assert "Must use a Port-type alias" not in accept_body, (
             f"expected no alias-type error when a port alias is used in a port field\n"
-            f"  response input-errors block: {_input_errors_block(accept_body)}"
+            f"  response input-errors block: {input_errors_block(accept_body)}"
         )
         got_accept_ports_in = helpers.config_get(vm, f"{base}/aliasports_in")
         assert got_accept_ports_in == port_alias, (

--- a/tests/smoke/ui/test_browser_category_edit.py
+++ b/tests/smoke/ui/test_browser_category_edit.py
@@ -62,7 +62,7 @@ import pytest
 
 from .. import helpers
 from .conftest import mask_page_identity
-from .render_oracle import input_errors_block
+from .render_oracle import NO_INPUT_ERRORS, input_errors_block
 from .test_category_edit import (
     CFG_DNSBL,
     CFG_IPV4,
@@ -659,7 +659,7 @@ def test_alias_type_port_field_normalizes_network_alias_away(
                 f"expected NO {error!r} error -- the whitelist sanitiser resets a wrong-type "
                 f"alias to '' before pfb_adv_alias_field_errors() ever runs, so this value "
                 f"never reaches validation as an error.\n"
-                f"  response input-errors block: {input_errors_block(norm_body)}"
+                f"  response input-errors block: {input_errors_block(norm_body) or NO_INPUT_ERRORS}"
             )
 
         # The save WENT THROUGH -- a rejected save would write nothing at all.
@@ -668,7 +668,7 @@ def test_alias_type_port_field_normalizes_network_alias_away(
             f"expected the save to go through (a rejected save writes nothing)\n"
             f"  expected aliasname: {aliasname!r}\n"
             f"  actual aliasname  : {got_aliasname!r}\n"
-            f"  response input-errors block: {input_errors_block(norm_body)}"
+            f"  response input-errors block: {input_errors_block(norm_body) or NO_INPUT_ERRORS}"
         )
 
         # The wrong-type value was dropped -- normalized to '', not saved verbatim.
@@ -695,7 +695,7 @@ def test_alias_type_port_field_normalizes_network_alias_away(
         )
         assert "Must use a Port-type alias" not in accept_body, (
             f"expected no alias-type error when a port alias is used in a port field\n"
-            f"  response input-errors block: {input_errors_block(accept_body)}"
+            f"  response input-errors block: {input_errors_block(accept_body) or NO_INPUT_ERRORS}"
         )
         got_accept_ports_in = helpers.config_get(vm, f"{base}/aliasports_in")
         assert got_accept_ports_in == port_alias, (

--- a/tests/smoke/ui/test_category_edit.py
+++ b/tests/smoke/ui/test_category_edit.py
@@ -43,7 +43,7 @@ from typing import TYPE_CHECKING
 import pytest
 
 from .. import helpers
-from .render_oracle import body_has_php_error, input_errors_block
+from .render_oracle import NO_INPUT_ERRORS, body_has_php_error, input_errors_block
 from .webui import extract_csrf_token, looks_like_login_page
 
 if TYPE_CHECKING:
@@ -93,7 +93,13 @@ def _del_rowid(vm: helpers.SmokeVM, cfg_root: str, rowid: int) -> None:
         raise RuntimeError(f"_del_rowid({cfg_root}/{rowid}) failed: rc={result.returncode} {result.stdout!r}")
 
 
-def _post_form(webui: WebUI, payload: dict[str, str], *, expect_rejection: bool = False) -> None:
+def _post_form(
+    webui: WebUI,
+    payload: dict[str, str],
+    *,
+    expect_rejection: bool = False,
+    expect_reason: str | None = None,
+) -> None:
     """POST a fully-enumerated category-edit payload (token harvested fresh).
 
     GETs the page to obtain a current ``__csrf_magic`` (the csrf-magic output
@@ -119,11 +125,16 @@ def _post_form(webui: WebUI, payload: dict[str, str], *, expect_rejection: bool 
     # unrelated no-op write would satisfy just as well. expect_rejection pins the
     # rejection itself, so those cases assert the thing they are actually testing.
     errors = input_errors_block(resp.text)
-    rejected = errors != "<no input-errors block in response>"
-    if expect_rejection:
-        assert rejected, "the page ACCEPTED a save this case requires it to reject: no input-errors block was rendered"
-    else:
-        assert not rejected, f"the page rejected this save: {errors}"
+    if not expect_rejection:
+        assert errors is None, f"the page rejected this save: {errors}"
+        return
+    assert errors is not None, f"the page ACCEPTED a save this case requires it to reject: {NO_INPUT_ERRORS}"
+    # WHICH rejection, not merely that one happened. Several validators append to
+    # $input_errors on the same page -- pfb_maxmind_credential_notice adds one to any
+    # geoip row when seeded credentials are missing -- so a case can go green on a
+    # rejection that has nothing to do with the guard it is testing.
+    if expect_reason is not None:
+        assert expect_reason in errors, f"rejected for the wrong reason: expected {expect_reason!r} in {errors!r}"
 
 
 def _dnsbl_payload(rowid: int, aliasname: str, **overrides: str) -> dict[str, str]:

--- a/tests/smoke/ui/test_category_edit.py
+++ b/tests/smoke/ui/test_category_edit.py
@@ -93,7 +93,7 @@ def _del_rowid(vm: helpers.SmokeVM, cfg_root: str, rowid: int) -> None:
         raise RuntimeError(f"_del_rowid({cfg_root}/{rowid}) failed: rc={result.returncode} {result.stdout!r}")
 
 
-def _post_form(webui: WebUI, payload: dict[str, str]) -> None:
+def _post_form(webui: WebUI, payload: dict[str, str], *, expect_rejection: bool = False) -> None:
     """POST a fully-enumerated category-edit payload (token harvested fresh).
 
     GETs the page to obtain a current ``__csrf_magic`` (the csrf-magic output
@@ -110,11 +110,20 @@ def _post_form(webui: WebUI, payload: dict[str, str]) -> None:
     data["save"] = "save"
     resp = webui.session.post(webui.url(CATEGORY_PAGE), data=data, verify=webui._verify, timeout=SAVE_TIMEOUT)
     assert not looks_like_login_page(resp.text), "category POST returned the login form (session lost)"
-    # A REJECTED save renders its reason and aborts the whole write. Saying so here
-    # names the rejection; leaving it to the caller's next assertion names the config
-    # path instead, which is the wrong layer (issue #2954).
+    # A REJECTED save renders its reason and aborts the whole write, so the response
+    # already says which layer failed. Asserting on it here names the rejection;
+    # leaving it to the caller's next assertion names the config path (issue #2954).
+    #
+    # BOTH directions are asserted, because several callers POST payloads the page
+    # MUST reject and prove it only by reading config back afterwards -- which an
+    # unrelated no-op write would satisfy just as well. expect_rejection pins the
+    # rejection itself, so those cases assert the thing they are actually testing.
     errors = input_errors_block(resp.text)
-    assert errors == "<no input-errors block in response>", f"the page rejected this save: {errors}"
+    rejected = errors != "<no input-errors block in response>"
+    if expect_rejection:
+        assert rejected, "the page ACCEPTED a save this case requires it to reject: no input-errors block was rendered"
+    else:
+        assert not rejected, f"the page rejected this save: {errors}"
 
 
 def _dnsbl_payload(rowid: int, aliasname: str, **overrides: str) -> dict[str, str]:
@@ -295,7 +304,7 @@ def test_dnsbl_alias_bad_name_rejected_leaves_config_unchanged(
         assert helpers.config_get(vm, f"{base}/aliasname") == good, "precondition: valid alias did not persist"
 
         # REJECT: a space makes aliasname match /\W/ -> the whole save aborts.
-        _post_form(webui, _dnsbl_payload(rowid, "bad name"))
+        _post_form(webui, _dnsbl_payload(rowid, "bad name"), expect_rejection=True)
         assert helpers.config_get(vm, f"{base}/aliasname") == good, (
             "a bad aliasname must abort the save (alias unchanged), but it changed"
         )
@@ -333,7 +342,7 @@ def test_dnsbl_disabled_row_reserved_header_rejected_leaves_config_unchanged(
         assert helpers.config_get(vm, f"{base}/row/0/header") == "", "precondition: placeholder header not empty"
 
         # REJECT: a reserved Header on a Disabled row must abort the save (header UNCHANGED).
-        _post_form(webui, _dnsbl_payload(rowid, good, **{"header-0": "DNSBLIP"}))
+        _post_form(webui, _dnsbl_payload(rowid, good, **{"header-0": "DNSBLIP"}), expect_rejection=True)
         assert helpers.config_get(vm, f"{base}/row/0/header") == "", (
             "a Disabled row's reserved Header ('DNSBLIP') must abort the save (row/0/header unchanged), but it changed"
         )
@@ -455,6 +464,7 @@ def test_dnsbl_url_geoip_breakout_char_rejected_leaves_config_unchanged(
                     "url-0": "US <script>alert(1)</script>",
                 },
             ),
+            expect_rejection=True,
         )
         assert helpers.config_get(vm, cfg) == "US CA", (
             "a '<script>' breakout in url-0 must abort the save (row/0/url unchanged), but it changed"
@@ -667,7 +677,9 @@ def test_ipv4_alias_permit_any_guard_rejects_and_valid_persists(
         _post_form(webui, _ipv4_payload(rowid, "smokeip4", action="Deny_Both"))
         assert helpers.config_get(vm, cfg) == "Deny_Both", "valid Deny_Both action did not persist"
         # REJECT: Permit_Inbound + proto 'Any' + no custom port/dest -> save aborts.
-        _post_form(webui, _ipv4_payload(rowid, "smokeip4", action="Permit_Inbound", autoproto_in="any"))
+        _post_form(
+            webui, _ipv4_payload(rowid, "smokeip4", action="Permit_Inbound", autoproto_in="any"), expect_rejection=True
+        )
         assert helpers.config_get(vm, cfg) == "Deny_Both", (
             "Permit_Inbound + 'Any' must abort the save (action unchanged at Deny_Both)"
         )

--- a/tests/smoke/ui/test_category_edit.py
+++ b/tests/smoke/ui/test_category_edit.py
@@ -43,7 +43,7 @@ from typing import TYPE_CHECKING
 import pytest
 
 from .. import helpers
-from .render_oracle import body_has_php_error
+from .render_oracle import body_has_php_error, input_errors_block
 from .webui import extract_csrf_token, looks_like_login_page
 
 if TYPE_CHECKING:
@@ -110,6 +110,11 @@ def _post_form(webui: WebUI, payload: dict[str, str]) -> None:
     data["save"] = "save"
     resp = webui.session.post(webui.url(CATEGORY_PAGE), data=data, verify=webui._verify, timeout=SAVE_TIMEOUT)
     assert not looks_like_login_page(resp.text), "category POST returned the login form (session lost)"
+    # A REJECTED save renders its reason and aborts the whole write. Saying so here
+    # names the rejection; leaving it to the caller's next assertion names the config
+    # path instead, which is the wrong layer (issue #2954).
+    errors = input_errors_block(resp.text)
+    assert errors == "<no input-errors block in response>", f"the page rejected this save: {errors}"
 
 
 def _dnsbl_payload(rowid: int, aliasname: str, **overrides: str) -> dict[str, str]:

--- a/tests/smoke/ui/test_category_edit.py
+++ b/tests/smoke/ui/test_category_edit.py
@@ -43,7 +43,7 @@ from typing import TYPE_CHECKING
 import pytest
 
 from .. import helpers
-from .render_oracle import NO_INPUT_ERRORS, body_has_php_error, input_errors_block
+from .render_oracle import body_has_php_error, input_errors_block, rejection_verdict
 from .webui import extract_csrf_token, looks_like_login_page
 
 if TYPE_CHECKING:
@@ -97,8 +97,7 @@ def _post_form(
     webui: WebUI,
     payload: dict[str, str],
     *,
-    expect_rejection: bool = False,
-    expect_reason: str | None = None,
+    expect_rejection: bool | str = False,
 ) -> None:
     """POST a fully-enumerated category-edit payload (token harvested fresh).
 
@@ -124,17 +123,17 @@ def _post_form(
     # MUST reject and prove it only by reading config back afterwards -- which an
     # unrelated no-op write would satisfy just as well. expect_rejection pins the
     # rejection itself, so those cases assert the thing they are actually testing.
-    errors = input_errors_block(resp.text)
-    if not expect_rejection:
-        assert errors is None, f"the page rejected this save: {errors}"
-        return
-    assert errors is not None, f"the page ACCEPTED a save this case requires it to reject: {NO_INPUT_ERRORS}"
-    # WHICH rejection, not merely that one happened. Several validators append to
-    # $input_errors on the same page -- pfb_maxmind_credential_notice adds one to any
-    # geoip row when seeded credentials are missing -- so a case can go green on a
-    # rejection that has nothing to do with the guard it is testing.
-    if expect_reason is not None:
-        assert expect_reason in errors, f"rejected for the wrong reason: expected {expect_reason!r} in {errors!r}"
+    # A 500 is not an accepted save and not a rejection; without this it passes the
+    # accept branch silently, and on the reject branch prints the actively wrong
+    # "the page ACCEPTED a save this case requires it to reject".
+    assert resp.ok, f"category POST returned HTTP {resp.status_code}"
+    # A REJECTED save renders its reason and aborts the whole write, so the response
+    # already says which layer failed. Asserting on it here names the rejection;
+    # leaving it to the caller's next assertion names the config path (issue #2954).
+    # Pass the expected reason as a STRING to pin which rejection, not merely that one
+    # happened -- several validators append to $input_errors on this page.
+    verdict = rejection_verdict(input_errors_block(resp.text), expect_rejection)
+    assert verdict is None, verdict
 
 
 def _dnsbl_payload(rowid: int, aliasname: str, **overrides: str) -> dict[str, str]:
@@ -315,7 +314,11 @@ def test_dnsbl_alias_bad_name_rejected_leaves_config_unchanged(
         assert helpers.config_get(vm, f"{base}/aliasname") == good, "precondition: valid alias did not persist"
 
         # REJECT: a space makes aliasname match /\W/ -> the whole save aborts.
-        _post_form(webui, _dnsbl_payload(rowid, "bad name"), expect_rejection=True)
+        _post_form(
+            webui,
+            _dnsbl_payload(rowid, "bad name"),
+            expect_rejection="Name field cannot contain spaces",
+        )
         assert helpers.config_get(vm, f"{base}/aliasname") == good, (
             "a bad aliasname must abort the save (alias unchanged), but it changed"
         )
@@ -353,7 +356,11 @@ def test_dnsbl_disabled_row_reserved_header_rejected_leaves_config_unchanged(
         assert helpers.config_get(vm, f"{base}/row/0/header") == "", "precondition: placeholder header not empty"
 
         # REJECT: a reserved Header on a Disabled row must abort the save (header UNCHANGED).
-        _post_form(webui, _dnsbl_payload(rowid, good, **{"header-0": "DNSBLIP"}), expect_rejection=True)
+        _post_form(
+            webui,
+            _dnsbl_payload(rowid, good, **{"header-0": "DNSBLIP"}),
+            expect_rejection="is reserved by pfBlockerNG",
+        )
         assert helpers.config_get(vm, f"{base}/row/0/header") == "", (
             "a Disabled row's reserved Header ('DNSBLIP') must abort the save (row/0/header unchanged), but it changed"
         )
@@ -475,7 +482,7 @@ def test_dnsbl_url_geoip_breakout_char_rejected_leaves_config_unchanged(
                     "url-0": "US <script>alert(1)</script>",
                 },
             ),
-            expect_rejection=True,
+            expect_rejection="Source field contains a disallowed character",
         )
         assert helpers.config_get(vm, cfg) == "US CA", (
             "a '<script>' breakout in url-0 must abort the save (row/0/url unchanged), but it changed"
@@ -689,7 +696,9 @@ def test_ipv4_alias_permit_any_guard_rejects_and_valid_persists(
         assert helpers.config_get(vm, cfg) == "Deny_Both", "valid Deny_Both action did not persist"
         # REJECT: Permit_Inbound + proto 'Any' + no custom port/dest -> save aborts.
         _post_form(
-            webui, _ipv4_payload(rowid, "smokeip4", action="Permit_Inbound", autoproto_in="any"), expect_rejection=True
+            webui,
+            _ipv4_payload(rowid, "smokeip4", action="Permit_Inbound", autoproto_in="any"),
+            expect_rejection="Advanced Inbound Custom Protocol",
         )
         assert helpers.config_get(vm, cfg) == "Deny_Both", (
             "Permit_Inbound + 'Any' must abort the save (action unchanged at Deny_Both)"

--- a/tests/test_smoke_input_errors_block.py
+++ b/tests/test_smoke_input_errors_block.py
@@ -13,7 +13,7 @@ the caller asserted next -- naming the config path instead of the rejection.
 
 from __future__ import annotations
 
-from tests.smoke.ui.render_oracle import input_errors_block
+from tests.smoke.ui.render_oracle import NO_INPUT_ERRORS, input_errors_block
 
 # pfSense's print_input_errors() (guiconfig.inc) renders one non-nested
 # <div class="alert alert-danger input-errors"> per response.
@@ -34,18 +34,26 @@ _ACCEPTED = "<html><body><div class='pane'>saved</div><form>...</form></body></h
 def test_rejected_save_yields_the_rendered_reason() -> None:
     """The block is returned whole, so the reason reaches the failure message."""
     block = input_errors_block(_REJECTED)
+    assert block is not None, "a rendered rejection was reported as absent"
     assert "reserved name" in block, f"the rejection reason was dropped: {block!r}"
     assert block.startswith('<div class="alert alert-danger input-errors">'), block
 
 
-def test_accepted_save_says_so_rather_than_returning_empty() -> None:
-    """No block must read as an explicit marker, never as an empty response.
+def test_accepted_save_reports_absence_as_none_not_a_marker() -> None:
+    """Absence is ``None``, so no caller can gate a live assertion on marker TEXT.
 
-    An empty string here would render in a failure message as though the page came
-    back blank, which points at the wrong layer -- the defect this helper exists to
-    stop.
+    Callers branch on presence to decide whether a save was rejected. Comparing
+    against a sentinel string would make that string load-bearing: edit it and every
+    off-appliance check still passes while the guest-side assertions invert.
     """
-    assert input_errors_block(_ACCEPTED) == "<no input-errors block in response>"
+    assert input_errors_block(_ACCEPTED) is None
+    # The display marker still exists, and is deliberately not what anything branches on.
+    assert NO_INPUT_ERRORS == "<no input-errors block in response>"
+
+
+def test_a_similarly_named_class_is_not_a_rejection() -> None:
+    """`\\b` alone matches inside `no-input-errors`; the name must START at the match."""
+    assert input_errors_block('<div class="no-input-errors">nothing wrong</div>') is None
 
 
 def test_extraction_stops_at_the_first_closing_div() -> None:
@@ -56,6 +64,7 @@ def test_extraction_stops_at_the_first_closing_div() -> None:
     reason it was called to surface.
     """
     block = input_errors_block(_REJECTED)
+    assert block is not None
     assert "<form>" not in block, f"extraction ran past the alert: {block!r}"
     assert "footer" not in block, f"extraction ran to a later </div>: {block!r}"
     assert block.endswith("</div>"), block

--- a/tests/test_smoke_input_errors_block.py
+++ b/tests/test_smoke_input_errors_block.py
@@ -13,7 +13,7 @@ the caller asserted next -- naming the config path instead of the rejection.
 
 from __future__ import annotations
 
-from tests.smoke.ui.render_oracle import NO_INPUT_ERRORS, input_errors_block
+from tests.smoke.ui.render_oracle import input_errors_block, rejection_verdict
 
 # pfSense's print_input_errors() (guiconfig.inc) renders one non-nested
 # <div class="alert alert-danger input-errors"> per response.
@@ -47,13 +47,19 @@ def test_accepted_save_reports_absence_as_none_not_a_marker() -> None:
     off-appliance check still passes while the guest-side assertions invert.
     """
     assert input_errors_block(_ACCEPTED) is None
-    # The display marker still exists, and is deliberately not what anything branches on.
-    assert NO_INPUT_ERRORS == "<no input-errors block in response>"
 
 
 def test_a_similarly_named_class_is_not_a_rejection() -> None:
-    """`\\b` alone matches inside `no-input-errors`; the name must START at the match."""
+    """The class name must be exactly `input-errors`, bounded on BOTH sides.
+
+    `\\b` is no help either way, because `-` is a non-word character: it matches
+    inside `no-input-errors` AND inside `input-errors-template`. Both would read as a
+    rejection, and after issue #2954 that gates live assertions rather than shaping a
+    message, so either would turn a passing suite into a wrong verdict on the guest.
+    """
     assert input_errors_block('<div class="no-input-errors">nothing wrong</div>') is None
+    assert input_errors_block('<div class="input-errors-template">a template</div>') is None
+    assert input_errors_block('<div id="input-errors-template">a template</div>') is None
 
 
 def test_extraction_stops_at_the_first_closing_div() -> None:
@@ -68,3 +74,36 @@ def test_extraction_stops_at_the_first_closing_div() -> None:
     assert "<form>" not in block, f"extraction ran past the alert: {block!r}"
     assert "footer" not in block, f"extraction ran to a later </div>: {block!r}"
     assert block.endswith("</div>"), block
+
+
+# --- the guard, not just the extractor (issue #2954 review, finding D) -------------
+#
+# _post_form() needs a live session, so the decision it makes was reachable only from
+# a guest. Split out, it is a pure function of two strings and can be pinned here.
+
+_REASON = "is reserved by pfBlockerNG"
+_BLOCK = f"<div class=\"alert input-errors\"><p>Header field 'X' {_REASON}.</p></div>"
+
+
+def test_an_accepted_save_is_right_when_nothing_was_rendered() -> None:
+    assert rejection_verdict(None, False) is None
+
+
+def test_an_accepted_save_that_was_rejected_names_the_rejection() -> None:
+    verdict = rejection_verdict(_BLOCK, False)
+    assert verdict is not None and _REASON in verdict, verdict
+
+
+def test_a_required_rejection_that_did_not_happen_fails() -> None:
+    verdict = rejection_verdict(None, True)
+    assert verdict is not None and "ACCEPTED" in verdict, verdict
+
+
+def test_the_wrong_rejection_reason_fails() -> None:
+    """The point of passing a reason: several validators write to the same block."""
+    verdict = rejection_verdict(_BLOCK, "Source field contains a disallowed character")
+    assert verdict is not None and "wrong reason" in verdict, verdict
+
+
+def test_the_right_rejection_reason_passes() -> None:
+    assert rejection_verdict(_BLOCK, _REASON) is None

--- a/tests/test_smoke_input_errors_block.py
+++ b/tests/test_smoke_input_errors_block.py
@@ -1,0 +1,61 @@
+"""Hermetic cover for the smoke suite's ``$input_errors`` extractor (issue #2954).
+
+``tests/smoke/ui/render_oracle`` holds the page-diagnostic readers the UI tiers
+share. They are pure string functions, so they are pinned here rather than only
+on a live VM -- the same arrangement ``tests/test_bench_pfctl_parse.py`` uses for
+``tests.smoke.test_bench_pfctl``.
+
+What is pinned is the thing a failure message depends on: when a category-edit
+save is REJECTED, the page renders the reason and the helper has to hand it back.
+Before this, ``_post_form()`` discarded it and the failure surfaced at whatever
+the caller asserted next -- naming the config path instead of the rejection.
+"""
+
+from __future__ import annotations
+
+from tests.smoke.ui.render_oracle import input_errors_block
+
+# pfSense's print_input_errors() (guiconfig.inc) renders one non-nested
+# <div class="alert alert-danger input-errors"> per response.
+_REJECTED = (
+    "<html><body><div class='pane'>x</div>"
+    '<div class="alert alert-danger input-errors">'
+    "<p>The following input errors were detected:</p>"
+    "<ul><li>Header/Label field is a reserved name.</li></ul>"
+    "</div><form>...</form>"
+    # A closing </div> AFTER the alert, or the greedy/non-greedy distinction the
+    # extractor depends on is untestable: with nothing following, both match the
+    # same span and a greedy pattern passes.
+    '<div class="footer">y</div></body></html>'
+)
+_ACCEPTED = "<html><body><div class='pane'>saved</div><form>...</form></body></html>"
+
+
+def test_rejected_save_yields_the_rendered_reason() -> None:
+    """The block is returned whole, so the reason reaches the failure message."""
+    block = input_errors_block(_REJECTED)
+    assert "reserved name" in block, f"the rejection reason was dropped: {block!r}"
+    assert block.startswith('<div class="alert alert-danger input-errors">'), block
+
+
+def test_accepted_save_says_so_rather_than_returning_empty() -> None:
+    """No block must read as an explicit marker, never as an empty response.
+
+    An empty string here would render in a failure message as though the page came
+    back blank, which points at the wrong layer -- the defect this helper exists to
+    stop.
+    """
+    assert input_errors_block(_ACCEPTED) == "<no input-errors block in response>"
+
+
+def test_extraction_stops_at_the_first_closing_div() -> None:
+    """Only the alert is taken, not the rest of the page after it.
+
+    The pattern is non-greedy for this reason: pfSense renders the block
+    non-nested, so a greedy match would swallow the whole document and bury the
+    reason it was called to surface.
+    """
+    block = input_errors_block(_REJECTED)
+    assert "<form>" not in block, f"extraction ran past the alert: {block!r}"
+    assert "footer" not in block, f"extraction ran to a later </div>: {block!r}"
+    assert block.endswith("</div>"), block


### PR DESCRIPTION
Fixes #2954.

## The defect

`_post_form()` POSTs a category-edit payload and asserts only that the response is not the login page. When the page **rejects** the save — `$input_errors` non-empty, so the whole write aborts — it returned silently. The failure then surfaced at whatever the caller asserted next, typically a config read:

```
AssertionError: the source row did not persist at .../config/7/row/0/header: got '', expected 'Smokefail7'
```

That names the symptom. The page had already rendered the actual reason — a reserved header name, a failed protocol guard, a bad URL — and the helper discarded it.

## The fix, and what it reuses

The extractor for that block **already existed**, in `test_browser_category_edit.py` rather than in a shared home. So this moves it to `render_oracle.py` beside `body_has_php_error()` — the module the UI tiers already use for readers that pull a diagnostic out of a rendered page — and both tiers now call the one copy. `_post_form()` asserts on it, so a rejected save fails naming the rejection.

The issue suggested `body_has_php_error()` as the precedent to follow. The closer precedent turned out to be an implementation of this exact helper one file away, so this is a move rather than a second implementation.

## Evidence

**Nine hermetic rows** pin this off-appliance, the way `tests/test_bench_pfctl_parse.py` pins the smoke bench parser (`render_oracle` imports clean without a VM). They cover two things, and the second is the one earlier revisions of this body under-reported:

- the **extractor** — the reason survives extraction; absence is `None`, never a marker string; the match stops at the alert rather than swallowing the document; and a similarly-named class (`no-input-errors`, `input-errors-template`, as id or class) is not a rejection
- the **guard** — `rejection_verdict()`, split out of `_post_form()` precisely so the decision is reachable without a guest: accept-and-clean, accept-but-rejected, required-rejection-missing, wrong reason, right reason

Executed mutation table, one row per mutation:

| Mutation | Rows that go red |
|---|---|
| greedy match (`.*` for `.*?`) | `test_extraction_stops_at_the_first_closing_div` |
| return `""` when absent | `test_accepted_save_reports_absence_as_none_not_a_marker` |
| marker text changed | `test_accepted_save_reports_absence_as_none_not_a_marker` |
| wrong class matched | `test_rejected_save_yields_the_rendered_reason`, `test_extraction_stops_at_the_first_closing_div` |
| drop the leading lookbehind | `test_a_similarly_named_class_is_not_a_rejection` |
| drop the trailing lookahead | `test_a_similarly_named_class_is_not_a_rejection` |
| verdict ignores the expected reason | `test_the_wrong_rejection_reason_fails` |
| verdict's accept branch never checks | `test_an_accepted_save_that_was_rejected_names_the_rejection` |
| a missing required rejection passes | `test_a_required_rejection_that_did_not_happen_fails` |

**One row was vacuous when first written and is recorded rather than quietly fixed.** The greedy/non-greedy row could not fail: the fixture had no closing `</div>` after the alert, so a greedy pattern matched the same span. A later revision made the same mistake in the other direction — the boundary row covered only the `no-input-errors` prefix while `input-errors-template` still matched, so the suite gave false confidence about the half that was still broken. Both are fixed and both are in the table above.

## On test-first, stated rather than claimed

There is no meaningful red-before-green here and I am not presenting one. The only red available for the moved helper was an `ImportError` — an existence test, which `testing.md` names as coverage theater. The extraction behaviour is **pre-existing** and is pinned as an oracle (`testing.md` exception 1, behaviour-preserving work); the genuinely new behaviour is `_post_form()` failing early, which is observable only on a live guest.

**Not run here:** pfb-dev has no pool, so the live-VM assertion is unexecuted. Verified off-appliance:

- `uv run pytest -q` — **5731 passed, 7 skipped**
- `uv run pytest tests/smoke --collect-only` — 905 collected
- `ruff check` / `ruff format --check` / `mypy tests/` — all clean

## Scope note, corrected

`test_category_edit_failed_highlight.py` is the first sibling whose payload deliberately carries a non-empty `header-0`, which puts it on the reserved-name and `\W` validation lanes and is what makes this worth fixing now.

An earlier version of this section said that file "belongs to a different branch". **That is false**, and it was false when written: `git ls-tree` on this PR's merge-base (`67483afe`) shows the file present, and it has been on this branch since before its first commit. Corrected here rather than silently, because it is the kind of claim a merged body preserves.

Enumerated tree-wide from source: **46** `_post_form` call sites across five files — 4 reject, 42 accept. That count is unchanged post-merge, since devel's newer commits touch only `tests/php/ThemeSafetyUiTest.php`. The failed-highlight file contains exactly one call, an accept, needing no change: its header is alphanumeric so the `\W` gate passes, it is not in the reserved set, `state-0` is Disabled so the URL validators skip, and `Deny_Both` means the Permit guard cannot fire.
