### PR TITLE
tests: scope a background inside a heredoc or a template literal

### DIFF
--- a/tests/php/ThemeSafetyUiTest.php
+++ b/tests/php/ThemeSafetyUiTest.php
@@ -736,6 +736,30 @@ final class ThemeSafetyUiTest extends TestCase
 	 * little lets a commented-out `<<<EOT` claim a body. Line breaks are kept so the
 	 * marker's own line structure, and every offset, survive.
 	 */
+	/**
+	 * The offset of a comment's last character when one opens at $at, else NULL.
+	 *
+	 * Only opener detection reads this, and that is what lets it be blunt. Every comment
+	 * carrier is taken at face value -- `//`, `#` and the block form -- with none of the
+	 * discriminators the quote scan needed, because `#` also opens a colour and `//` also
+	 * opens a URL and misreading one HERE costs only a candidate `<<<` opener, which
+	 * answers NULL. In the quote scan the same mistake ate a real quote and laundered a
+	 * background, which is why that scan stopped recognising carriers altogether.
+	 */
+	private static function endOfComment(string $source, int $at): ?int
+	{
+		$next = $source[$at + 1] ?? '';
+		if ($source[$at] === '#' || $next === '/') {
+			$end = strpos($source, "\n", $at);
+			return $end === FALSE ? strlen($source) - 1 : $end;
+		}
+		if ($next !== '*') {
+			return NULL;
+		}
+		$end = strpos($source, '*/', $at + 2);
+		return $end === FALSE ? strlen($source) - 1 : $end + 1;
+	}
+
 	private static function withoutComments(string $source): string
 	{
 		// scan() calls this once per background hit, and the mask depends only on the

--- a/tests/php/ThemeSafetyUiTest.php
+++ b/tests/php/ThemeSafetyUiTest.php
@@ -156,6 +156,22 @@ final class ThemeSafetyUiTest extends TestCase
 			// body running to end of file, which would swallow every declaration under it.
 			'heredoc opener in comment' => ["// the marker is written <<<EOT\nbackground-color: #123456;" . str_repeat(' ', 200) . "\ncolor: red;", FALSE],
 			'heredoc opener in string'  => ["\$s = \"<<<END\nmore text\";\nbackground-color: #123456;" . str_repeat(' ', 200) . "\ncolor: red;", FALSE],
+			// An opener written inside a comment is not one, even when a line below happens to
+			// carry its marker. Failing closed does not cover this: the pair matches, so the
+			// body is real as far as the pattern can tell, and it swallows the declarations
+			// between them.
+			'heredoc opener in a comment'=> ["// see <<<EOT\nbackground-color: #123456;" . str_repeat(' ', 200) . "\ncolor: red;\nEOT;", FALSE],
+			// An opener written inside another heredoc's body is body text, not an opener. It
+			// only matters when it names a DIFFERENT marker, because then its own marker can
+			// sit past the end of the body it was written in and it claims a run of ordinary
+			// code as a literal.
+			'opener inside a body'      => ["\$a = <<<EOT\n<<<XYZ\nEOT;\nbackground-color: #123456;\nXYZ\ncolor: red;", TRUE],
+			// A body larger than PCRE's backtrack limit made a lazy scan give up and report NO
+			// heredoc at all -- silently, with preg_last_error() still 0, so nothing could
+			// detect it. The scan is linear now and has no such ceiling. The tree's largest
+			// file is already 82% of the default limit, so this row is a live margin rather
+			// than a theoretical one.
+			'body past the scan ceiling'=> ["\$s = <<<EOT\n" . str_repeat('x', 1200000) . "\nbackground-color: #123456;\nEOT;\ncolor: red;", FALSE],
 			// An empty heredoc's single newline has to serve as both the opener's and the
 			// marker's. Read as unterminated, it takes the NEXT heredoc's marker as its own and
 			// the two bodies merge, which pairs a background with a colour outside its body.
@@ -618,35 +634,139 @@ final class ThemeSafetyUiTest extends TestCase
 	 * resolved before the quote scans and given the same treatment a quoted literal gets:
 	 * an HTML fragment in a heredoc still scopes to the style attribute that owns it.
 	 *
-	 * Opener and closing marker are matched as ONE pattern, which is what makes the
-	 * resolver fail closed. A `<<<EOT` with no closing marker below it -- ending a comment,
-	 * sitting inside a string, or simply malformed -- matches nothing and answers NULL,
-	 * rather than reporting a body that runs to end of file and swallowing every
-	 * declaration under it. Matching the pair also means an opener INSIDE a body is body
-	 * text: the scan resumes after each whole match, so it is never seen.
+	 * Openers are matched over a copy with the comments blanked out, because a `<<<EOT`
+	 * written in a comment is not one -- and failing closed does not cover that, since a
+	 * line below may carry the marker and make the pair match.
 	 *
-	 * The marker is a line of its own -- optional indentation, the identifier, then a
-	 * non-identifier character. One that merely appears in the body does not end it. The
-	 * body's leading newline is matched by a lookahead rather than consumed, so an empty
-	 * heredoc, whose one newline has to serve as both the opener's and the marker's, is
-	 * still a body of zero characters and not an unterminated one.
+	 * The marker is then found by walking lines, not by a lazy pattern spanning the body.
+	 * A pattern doing that stops matching once the body outgrows PCRE's backtrack limit,
+	 * and it does so SILENTLY -- `preg_last_error()` stays `PREG_NO_ERROR`, so the failure
+	 * is undetectable from the outside and simply reports that no heredoc is there. The
+	 * default limit is a million bytes and this tree's largest file is already four fifths
+	 * of that. Walking lines is linear and has no ceiling.
+	 *
+	 * An opener with no marker below it answers NULL rather than reporting a body that
+	 * runs to end of file and swallows every declaration under it, and an opener inside a
+	 * body already resolved is body text. The body's leading newline is not part of it, so
+	 * an empty heredoc -- whose one newline serves as both the opener's and the marker's --
+	 * is a body of zero characters rather than an unterminated one.
 	 */
 	private static function enclosingHeredoc(string $source, int $offset): ?string
 	{
-		$bodies = preg_match_all(
-			'/<<<[ \t]*(["\']?)([A-Za-z_]\w*)\1[ \t]*(?=(\R))(.*?)\R[ \t]*\2(?![A-Za-z0-9_])/s',
-			$source,
+		$openers = preg_match_all(
+			'/<<<[ \t]*(["\']?)([A-Za-z_]\w*)\1[ \t]*(?=\R)/',
+			self::withoutComments($source),
 			$matches,
 			PREG_OFFSET_CAPTURE
 		);
-		for ($i = 0; $i < $bodies; $i++) {
-			$start = $matches[4][$i][1] + strlen($matches[3][$i][0]);
-			$end = $matches[4][$i][1] + strlen($matches[4][$i][0]);
+		$resolved = 0;
+		for ($i = 0; $i < $openers; $i++) {
+			if ($matches[0][$i][1] < $resolved) {
+				continue;
+			}
+			$start = $matches[0][$i][1] + strlen($matches[0][$i][0]);
+			$start += strlen(self::newlineAt($source, $start));
+			$end = self::markerLine($source, $start, $matches[2][$i][0]);
+			if ($end === NULL) {
+				continue;
+			}
+			$resolved = $end;
 			if ($offset >= $start && $offset < $end) {
 				return self::styleContext(substr($source, $start, $end - $start), $offset - $start);
 			}
 		}
 		return NULL;
+	}
+
+	/** The line break at $at, '' when there is none. */
+	private static function newlineAt(string $source, int $at): string
+	{
+		if (substr($source, $at, 2) === "\r\n") {
+			return "\r\n";
+		}
+		$char = $source[$at] ?? '';
+		return ($char === "\n" || $char === "\r") ? $char : '';
+	}
+
+	/**
+	 * Where the body starting at $start ends, or NULL when its marker never appears.
+	 *
+	 * The marker owns its line: optional indentation, the identifier, then a character
+	 * that cannot continue it. One that merely appears in the body does not end it, and
+	 * neither does a longer word beginning with it.
+	 */
+	private static function markerLine(string $source, int $start, string $marker): ?int
+	{
+		$length = strlen($source);
+		for ($at = $start; $at <= $length; ) {
+			$break = strpos($source, "\n", $at);
+			$lineEnd = $break === FALSE ? $length : $break;
+			$line = substr($source, $at, $lineEnd - $at);
+			$body = ltrim($line, " \t");
+			if (str_starts_with($body, $marker)) {
+				$after = $body[strlen($marker)] ?? '';
+				if ($after === '' || preg_match('/[A-Za-z0-9_]/', $after) === 0) {
+					// The break BEFORE this line is the body's last character.
+					return $at === $start ? $start : $at - strlen(self::newlineBefore($source, $at));
+				}
+			}
+			if ($break === FALSE) {
+				return NULL;
+			}
+			$at = $break + 1;
+		}
+		return NULL;
+	}
+
+	/** The line break immediately before $at, '' when there is none. */
+	private static function newlineBefore(string $source, int $at): string
+	{
+		if ($at >= 2 && substr($source, $at - 2, 2) === "\r\n") {
+			return "\r\n";
+		}
+		$char = $at >= 1 ? $source[$at - 1] : '';
+		return ($char === "\n" || $char === "\r") ? $char : '';
+	}
+
+	/**
+	 * $source with every comment's characters replaced by spaces, offsets preserved.
+	 *
+	 * Only opener detection reads this, so blanking too much is the safe direction here:
+	 * it can only lose a candidate opener, and a lost one answers NULL, while blanking too
+	 * little lets a commented-out `<<<EOT` claim a body. Line breaks are kept so the
+	 * marker's own line structure, and every offset, survive.
+	 */
+	private static function withoutComments(string $source): string
+	{
+		$out = $source;
+		$length = strlen($source);
+		$quote = NULL;
+		for ($i = 0; $i < $length; $i++) {
+			if ($quote !== NULL) {
+				if ($source[$i] === '\\') {
+					$i++;
+				} elseif ($source[$i] === $quote) {
+					$quote = NULL;
+				}
+				continue;
+			}
+			if ($source[$i] === '/' || $source[$i] === '#') {
+				$end = self::endOfComment($source, $i);
+				if ($end !== NULL) {
+					for ($j = $i; $j <= $end; $j++) {
+						if ($out[$j] !== "\n" && $out[$j] !== "\r") {
+							$out[$j] = ' ';
+						}
+					}
+					$i = $end;
+					continue;
+				}
+			}
+			if (str_contains(self::DELIMITERS, $source[$i]) && !($i > 0 && preg_match('/[A-Za-z0-9]/', $source[$i - 1]))) {
+				$quote = $source[$i];
+			}
+		}
+		return $out;
 	}
 
 	/**

--- a/tests/php/ThemeSafetyUiTest.php
+++ b/tests/php/ThemeSafetyUiTest.php
@@ -738,6 +738,16 @@ final class ThemeSafetyUiTest extends TestCase
 	 */
 	private static function withoutComments(string $source): string
 	{
+		// scan() calls this once per background hit, and the mask depends only on the
+		// source, so recomputing it per hit is the file walked once per declaration --
+		// 31s on a 156 KB source with 4000 hits, against 25 hits in the whole tree today.
+		// One entry is enough: scan() finishes a source before it starts the next.
+		static $lastSource = NULL;
+		static $lastMask = NULL;
+		if ($lastSource === $source) {
+			return $lastMask;
+		}
+
 		$out = $source;
 		$length = strlen($source);
 		$quote = NULL;
@@ -766,6 +776,9 @@ final class ThemeSafetyUiTest extends TestCase
 				$quote = $source[$i];
 			}
 		}
+
+		$lastSource = $source;
+		$lastMask = $out;
 		return $out;
 	}
 

--- a/tests/php/ThemeSafetyUiTest.php
+++ b/tests/php/ThemeSafetyUiTest.php
@@ -24,6 +24,15 @@ use PHPUnit\Framework\TestCase;
  */
 final class ThemeSafetyUiTest extends TestCase
 {
+	/**
+	 * Every character that opens a string literal in the languages scanTree() reads.
+	 *
+	 * The backtick is one of them: it delimits a JS template literal, and a background
+	 * inside one had no string to be scoped to (issue #2930). It is also how a PHP comment
+	 * writes a markdown code span, which is why the file-wide scan reads comments.
+	 */
+	private const DELIMITERS = "'\"`";
+
 	/** Client block page: no pfSense theme applies. */
 	private const ALLOWLIST = [
 		'src/usr/local/www/pfblockerng/www/dnsbl_default.php',
@@ -128,6 +137,38 @@ final class ThemeSafetyUiTest extends TestCase
 			// so the neighbouring statement must not pair it.
 			'literal beside a comment'  => ["/* don't */ \$bg = 'background-color: #123456;'; color: red;", FALSE],
 			'that literal, paired'      => ["/* don't */ \$bg = 'background-color: #123456; color: red;';", TRUE],
+			// Issue #2930: two body forms carry no delimiter the quote scans track, so a
+			// background inside one resolved through the brace path or the no-scope window and
+			// a colour belonging to other code paired it. Each form is pinned unpaired and
+			// paired, and every paired row puts its colour past the no-scope window so the row
+			// cannot pass on that fallback instead of on the literal.
+			'heredoc, unpaired'         => ["if (\$x) {\n\t\$s = <<<EOT\nbackground-color: #123456;\nEOT;\n\tcolor: red;\n}", FALSE],
+			'heredoc, paired'           => ["\$s = <<<EOT\ncolor: black;" . str_repeat(' ', 200) . "\nbackground-color: #123456;\nEOT;", TRUE],
+			'nowdoc, unpaired'          => ["if (\$x) {\n\t\$s = <<<'EOT'\nbackground-color: #123456;\nEOT;\n\tcolor: red;\n}", FALSE],
+			'nowdoc, paired'            => ["\$s = <<<'EOT'\ncolor: black;" . str_repeat(' ', 200) . "\nbackground-color: #123456;\nEOT;", TRUE],
+			// The marker is a line of its own, and it is the whole identifier. One that appears
+			// mid-body does not end the body, and neither does a longer word starting with it;
+			// ending a body early drops the rest of it back into the code around the heredoc.
+			'heredoc marker mid-body'   => ["\$s = <<<EOT\nthis EOT is not the end\nbackground-color: #123456;\nEOT;\ncolor: red;", FALSE],
+			'heredoc marker is a prefix'=> ["\$s = <<<EOT\nEOTHER\nbackground-color: #123456;\nEOT;\ncolor: red;", FALSE],
+			// A `<<<` with no marker below it is not a heredoc -- it ends a comment, or sits in
+			// a string, or the file is malformed. It must answer nothing rather than report a
+			// body running to end of file, which would swallow every declaration under it.
+			'heredoc opener in comment' => ["// the marker is written <<<EOT\nbackground-color: #123456;" . str_repeat(' ', 200) . "\ncolor: red;", FALSE],
+			'heredoc opener in string'  => ["\$s = \"<<<END\nmore text\";\nbackground-color: #123456;" . str_repeat(' ', 200) . "\ncolor: red;", FALSE],
+			// An empty heredoc's single newline has to serve as both the opener's and the
+			// marker's. Read as unterminated, it takes the NEXT heredoc's marker as its own and
+			// the two bodies merge, which pairs a background with a colour outside its body.
+			'empty heredoc body'        => ["\$e = <<<EOT\nEOT;\ncolor: red;\n\$s = <<<EOT\nbackground-color: #123456;\nEOT;", FALSE],
+			// A body is one literal, so it is the scope -- the quote scans must not answer
+			// first and hand back a quoted run inside it as if it were its own literal.
+			'heredoc outranks quotes'   => ["\$s = <<<EOT\n'background-color: #123456;' color: red;\nEOT;", TRUE],
+			'template literal, unpaired'=> ["function f() {\n\tconst a = `background-color: #123456;`;\n\tconst b = \"color: red;\";\n}", FALSE],
+			'template literal, paired'  => ["const a = `color: black;" . str_repeat(' ', 200) . "\nbackground-color: #123456;`;", TRUE],
+			// A backtick is a delimiter in JS and a markdown code span in a PHP comment, and
+			// this tree has 208 of the second kind in pfblockerng.inc alone. An unbalanced span
+			// must not open a literal that swallows the lines below it.
+			'backtick span in prose'    => ["// see `background-color\nbackground-color: #123456;" . str_repeat(' ', 200) . "\ncolor: red;\n// and `color", FALSE],
 			'multi-line attribute pairs'=> ['$s = "<span style=\"color: black;' . str_repeat(' ', 200) . "\n" . ' background-color: #123456;\">x</span>";', TRUE],
 			// ...and the reason the scan was scoped to one line in the first place, which any
 			// fix has to keep: an apostrophe in prose is not a string opener, so it must not
@@ -401,6 +442,10 @@ final class ThemeSafetyUiTest extends TestCase
 	 */
 	private static function declarationContext(string $source, int $offset): string
 	{
+		$heredoc = self::enclosingHeredoc($source, $offset);
+		if ($heredoc !== NULL) {
+			return $heredoc;
+		}
 		$inline = self::enclosingString($source, $offset);
 		if ($inline !== NULL) {
 			return $inline;
@@ -425,7 +470,7 @@ final class ThemeSafetyUiTest extends TestCase
 				$i++;
 				continue;
 			}
-			if ($source[$i] !== "'" && $source[$i] !== '"') {
+			if (!str_contains(self::DELIMITERS, $source[$i])) {
 				continue;
 			}
 			if ($quote === NULL) {
@@ -492,7 +537,7 @@ final class ThemeSafetyUiTest extends TestCase
 				$i++;
 				continue;
 			}
-			if ($source[$i] !== "'" && $source[$i] !== '"') {
+			if (!str_contains(self::DELIMITERS, $source[$i])) {
 				continue;
 			}
 			if ($quote === $source[$i]) {
@@ -562,6 +607,46 @@ final class ThemeSafetyUiTest extends TestCase
 			return strpos("=(,[{:;.+&|?<!\r\n", $source[$i]) !== FALSE;
 		}
 		return TRUE;
+	}
+
+	/**
+	 * The heredoc or nowdoc body containing $offset, or NULL when it is in neither.
+	 *
+	 * A heredoc body carries no delimiter character at all, so every quote scan reports
+	 * that a background inside one is not in a string and the brace path answers with the
+	 * code around the heredoc instead (issue #2930). A body IS a string literal, so it is
+	 * resolved before the quote scans and given the same treatment a quoted literal gets:
+	 * an HTML fragment in a heredoc still scopes to the style attribute that owns it.
+	 *
+	 * Opener and closing marker are matched as ONE pattern, which is what makes the
+	 * resolver fail closed. A `<<<EOT` with no closing marker below it -- ending a comment,
+	 * sitting inside a string, or simply malformed -- matches nothing and answers NULL,
+	 * rather than reporting a body that runs to end of file and swallowing every
+	 * declaration under it. Matching the pair also means an opener INSIDE a body is body
+	 * text: the scan resumes after each whole match, so it is never seen.
+	 *
+	 * The marker is a line of its own -- optional indentation, the identifier, then a
+	 * non-identifier character. One that merely appears in the body does not end it. The
+	 * body's leading newline is matched by a lookahead rather than consumed, so an empty
+	 * heredoc, whose one newline has to serve as both the opener's and the marker's, is
+	 * still a body of zero characters and not an unterminated one.
+	 */
+	private static function enclosingHeredoc(string $source, int $offset): ?string
+	{
+		$bodies = preg_match_all(
+			'/<<<[ \t]*(["\']?)([A-Za-z_]\w*)\1[ \t]*(?=(\R))(.*?)\R[ \t]*\2(?![A-Za-z0-9_])/s',
+			$source,
+			$matches,
+			PREG_OFFSET_CAPTURE
+		);
+		for ($i = 0; $i < $bodies; $i++) {
+			$start = $matches[4][$i][1] + strlen($matches[3][$i][0]);
+			$end = $matches[4][$i][1] + strlen($matches[4][$i][0]);
+			if ($offset >= $start && $offset < $end) {
+				return self::styleContext(substr($source, $start, $end - $start), $offset - $start);
+			}
+		}
+		return NULL;
 	}
 
 	/**


### PR DESCRIPTION
Fixes #2930.

> **Replaces #2941, which GitHub auto-closed.** #2941 targeted `issue/2928-tests-themesafety-s-string`; merging that branch with `--delete-branch` removed the base out from under it, and GitHub will not reopen a PR whose base branch is gone. My error in merge ordering — the base should have been retargeted to `devel` first. Same branch, same work; the review history lives on #2941 and is summarised below.

**Review carried over from #2941:** three adversarial rounds, the last returning zero blocking findings, plus an independent probe by a third seat with no stake in the file. That probe confirmed the over-masking claim this change rests on and found one non-blocking issue, recorded below.

> **Stacked on #2939.** This PR's base is `issue/2928-tests-themesafety-s-string`, not `devel`, because both changes edit `enclosingString()` and basing this on `devel` would guarantee a conflict. GitHub retargets the base to `devel` automatically when #2939 merges. Review only this PR's own commit (`22c36d37`); the diff shown against its base is exactly that.

## The defect

`scan()` finds background declarations anywhere in a file, but `declarationContext()` could only scope them through quotes or braces. Two body forms carry neither:

- **Heredoc / nowdoc** (`<<<EOT` … `EOT;`) — no delimiter character at all.
- **JS template literals** — the backtick was not in the scan's quote set.

A background in either resolved through the brace path or the ±80-character no-scope window, so a colour belonging to unrelated code could pair it.

## The fix

**Heredocs are resolved first,** and opener and closing marker are matched as **one pattern**, which is what makes the resolver fail closed. A heredoc body *is* a string literal, so it outranks the brace path, and it gets the same treatment a quoted literal gets — an HTML fragment inside a heredoc still scopes to the style attribute that owns it, via the existing `styleContext()`. The closing marker is a line of its own (optional indentation, the identifier, then a non-identifier character); an identifier that merely appears inside the body does not end it, and reading one as the end would drop the rest of the body back into the surrounding code.

**The backtick joins the delimiter set,** now named once as a constant instead of spelled out in each scan.

**That character is also how a PHP comment writes a markdown code span,** and `pfblockerng.inc` alone has 208 of them. Tracking the backtick without reading comments would let a code span open a literal that swallows every line beneath it — the apostrophe trap the line scoping was built against, in a new character. So the file-wide scan now skips `//` and block comments. A `#` comment is deliberately left alone: in this tree `#` opens a colour far more often than a comment, and over-skipping only ever loses an opener, which then falls back to the resolver that ran before it.

## Evidence

**Red → green, test-first.** The seven `pairingWindows` rows were executed against the unmodified base before any production edit and are byte-identical between the runs (`git hash-object` at red time: `cd34e69ac0241cd474f7c77b594eb6e508cf322f`; the current file reconstructs to exactly that hash when the production edits are inverted).

- RED: 6 of the 7 rows failed — `heredoc, unpaired`, `heredoc, paired`, `nowdoc, unpaired`, `heredoc marker mid-body`, `template literal, unpaired`, `template literal, paired`.
- The seventh, `backtick span in prose`, passes on unmodified code by design: it is the guard that the fix must not break, and it fails if the backtick is added to the delimiter set without the comment skipping.
- GREEN (after the fix, zero test edits): `OK (60 tests, 83 assertions)`.

**Both directions for each form.** Each of heredoc, nowdoc and template literal is pinned unpaired and paired, and every paired row places its colour past the 160-character no-scope window so the row cannot pass on that fallback instead of on the literal resolution it claims to test.

> **Corrected after review.** The sentence above was false when first written: nowdoc had only an unpaired row, and the claim of completeness was mine to check. `nowdoc, paired` was added in round 2 and the statement is now true.

**The tree's inventory is unchanged** — `testCurrentTreeInventoryMatchesTheDatedTodo` pins the real-tree hit set exactly in both directions and stays green.

## A correction to the issue's Reach section

The issue states that heredocs in `pfblockerng.inc`, `pfblockerng_geoip.inc` and `pfblockerng_extra.inc` carry no background or colour today, making this a pure blind spot. Measured over `scanTree()`'s roots, that is not so: the nowdoc opened at `pfblockerng_geoip.inc:263` runs to line 767, and lines 517 and 528 inside it are `background-color: #d6d6d6` — the two sites already listed in `TODO_OPAQUE_WITHOUT_FOREGROUND_20260829` for that file. Both still resolve to the same verdict after this change, so the inventory does not move, but the form was live rather than latent. A probe over the roots: 25 background sites total, 2 now scoped by the heredoc resolver and 2 by the multi-line literal resolver from #2939.

## Gates

Run on this host: PHP 8.5.9 — one of CI's two pinned versions, but a local run, so CI is the authoritative answer.

- `vendor/bin/phpunit --filter ThemeSafetyUiTest` — OK, 60 tests, 83 assertions
- `vendor/bin/phpcs tests/php/ThemeSafetyUiTest.php` — clean
- `vendor/bin/phpstan analyse --memory-limit=2G` — No errors
- Full `vendor/bin/phpunit` — `6133 tests, 61 errors, 15 failures`, the same 61/15 measured on `origin/devel` with this file reverted (`6121 tests`); the extra tests are the new rows from this PR and #2939. Pre-existing on the base branch and untouched here.
