### PR TITLE
www: correct the IP rule order help default and option name

### DIFF
--- a/src/usr/local/www/pfblockerng/pfblockerng_ip.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_ip.php
@@ -494,13 +494,13 @@ $section->addInput(new Form_Select(
 	'Firewall \'Auto\' Rule Order',
 	$pconfig['pass_order'],
 	$options_pass_order
-))->setHelp('Default Order:<strong> | pfB_Block/Reject | All other Rules | (original format)</strong><br />'
+))->setHelp('Default Order:<strong>| pfB_Pass/Match/Block/Reject | All other Rules | (Default format)</strong><br />'
 		. '<span class="text-danger"><strong>Note: \'Auto type\' Firewall Rules will be \'ordered\' by this selection.</strong></span>'
 		. '<div class="infoblock">'
 		. 'Refer to the blue infoblock \'List Action\' icon in the IPv4 tab for details on how to use \'Alias type\'<br />'
 		. '(ie: \'Alias Deny\') instead of \'Auto generated rules\', if required for your network design.<br /><br />'
 		. 'Select the \'<strong>Order</strong>\' of the Rules<br /><br />'
-		. '&emsp;Selecting \'original format\', sets pfBlockerNG rules at the top of the Firewall TAB.<br />'
+		. '&emsp;Selecting \'Default format\', sets pfBlockerNG rules at the top of the Firewall TAB.<br />'
 		. '&emsp;Selecting any other \'Order\' will re-order <strong>all the rules to the format indicated!</strong></div>')
   ->setAttribute('style', 'width: auto; max-width: 100%');
 

--- a/tests/php/IpRuleOrderHelpParityTest.php
+++ b/tests/php/IpRuleOrderHelpParityTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The Firewall 'Auto' Rule Order help must state the real order_0 default and
+ * must not name an option that the select does not offer (issue #2895).
+ */
+final class IpRuleOrderHelpParityTest extends TestCase
+{
+	private const PAGE = __DIR__ . '/../../src/usr/local/www/pfblockerng/pfblockerng_ip.php';
+
+	private static function source(): string
+	{
+		$source = file_get_contents(self::PAGE);
+		self::assertIsString($source, 'the IP page must be readable');
+		return $source;
+	}
+
+	/** Concatenate the single-quoted PHP string literals of a source slice. */
+	private static function rendered(string $slice): string
+	{
+		$count = preg_match_all("/'((?:[^'\\\\]|\\\\.)*)'/", $slice, $strings);
+		self::assertGreaterThanOrEqual(1, $count, 'could not read any PHP string literal');
+		$parts = array_map(
+			static fn (string $s): string => str_replace(['\\\'', '\\\\'], ["'", '\\'], $s),
+			$strings[1]
+		);
+		return implode('', $parts);
+	}
+
+	private static function help(): string
+	{
+		$source = self::source();
+		self::assertSame(1, preg_match("/new Form_Select\(\s*'pass_order'.*?->setHelp\((.*?)\)\s*->setAttribute/s", $source, $control),
+			'could not locate the Firewall Auto Rule Order control and its help');
+		return self::rendered($control[1]);
+	}
+
+	/** @return array<string, string> option value => rendered label */
+	private static function optionLabels(): array
+	{
+		$source = self::source();
+		self::assertSame(1, preg_match('/\$options_pass_order\s*=\s*\[(.*?)\];/s', $source, $block),
+			'could not locate the Firewall Auto Rule Order options');
+		preg_match_all("/'(order_\d+)'\s*=>\s*'([^']+)'/", $block[1], $options, PREG_SET_ORDER);
+		return array_column($options, 2, 1);
+	}
+
+	public function testStatedDefaultMatchesOrderZeroLabelExactly(): void
+	{
+		$labels = self::optionLabels();
+		$this->assertArrayHasKey('order_0', $labels, 'order_0 must remain an offered option');
+		self::assertSame(1, preg_match('/Default Order:<strong>(.*?)<\/strong>/', self::help(), $stated),
+			'the help must state the default order');
+		$this->assertSame(
+			$labels['order_0'],
+			$stated[1],
+			'the help default must match the order_0 option label verbatim'
+		);
+	}
+
+	public function testHelpNamesNoOptionLabelTheSelectDoesNotOffer(): void
+	{
+		$help = self::help();
+		$labels = self::optionLabels();
+		self::assertSame(1, preg_match("/Selecting '(.*?)', sets pfBlockerNG rules/", $help, $referenced),
+			'the help must name the option that pins pfBlockerNG rules at the top');
+		$this->assertStringContainsString(
+			$referenced[1],
+			$labels['order_0'],
+			"the referenced option name '{$referenced[1]}' must exist in the order_0 label"
+		);
+		$this->assertStringNotContainsString('original format', $help,
+			'the retired "original format" option name must not reappear in the help');
+	}
+
+	public function testHelpInfoblockStillExplainsTheSelection(): void
+	{
+		$help = self::help();
+		$this->assertStringContainsString('at the top of the Firewall TAB', $help,
+			'the top-of-firewall explanation must survive');
+		$this->assertStringContainsString('re-order', $help,
+			'the re-order warning must survive');
+	}
+}

--- a/tests/php/IpRuleOrderHelpParityTest.php
+++ b/tests/php/IpRuleOrderHelpParityTest.php
@@ -49,6 +49,7 @@ final class IpRuleOrderHelpParityTest extends TestCase
 		return array_column($options, 2, 1);
 	}
 
+	/** The help's stated default is the verbatim order_0 option label. */
 	public function testStatedDefaultMatchesOrderZeroLabelExactly(): void
 	{
 		$labels = self::optionLabels();
@@ -62,6 +63,7 @@ final class IpRuleOrderHelpParityTest extends TestCase
 		);
 	}
 
+	/** The help names no option label the select does not offer. */
 	public function testHelpNamesNoOptionLabelTheSelectDoesNotOffer(): void
 	{
 		$help = self::help();
@@ -77,6 +79,7 @@ final class IpRuleOrderHelpParityTest extends TestCase
 			'the retired "original format" option name must not reappear in the help');
 	}
 
+	/** The infoblock still explains the selection and the re-order warning. */
 	public function testHelpInfoblockStillExplainsTheSelection(): void
 	{
 		$help = self::help();

--- a/tests/smoke/ui/test_render_smoke.py
+++ b/tests/smoke/ui/test_render_smoke.py
@@ -613,6 +613,30 @@ def test_ip_page_renders_aggregate_select(webui: WebUI) -> None:
     )
 
 
+# issue #2895: the Firewall 'Auto' Rule Order help must state the REAL default -- the
+# verbatim order_0 label from $options_pass_order -- and must not name the retired
+# 'original format' option that no select row offers (a user following that help would
+# hunt for a nonexistent choice and be told the wrong rule order is active by default).
+# Substrings verified against the real pfblockerng_ip.php setHelp() copy and
+# $options_pass_order; pairs with tests/php/IpRuleOrderHelpParityTest.php, which pins
+# the same strings at unit level.
+_IP_ORDER_DEFAULT_LABEL = "| pfB_Pass/Match/Block/Reject | All other Rules | (Default format)"
+_IP_ORDER_RETIRED_OPTION_NAME = "original format"
+
+
+def test_ip_page_rule_order_help_states_the_order_zero_default(webui: WebUI) -> None:
+    """The IP page's 'Auto' Rule Order help states the verbatim order_0 default and
+    no longer names the retired 'original format' option (#2895).
+    """
+    resp = webui.get(_IP_PAGE)
+    assert resp.status_code == 200, f"GET {_IP_PAGE} -> HTTP {resp.status_code} (expected 200)"
+    body = resp.text
+    assert _IP_ORDER_DEFAULT_LABEL in body, "the rule-order help no longer states the verbatim order_0 default label"
+    assert _IP_ORDER_RETIRED_OPTION_NAME not in body, (
+        "the rule-order help still names the retired 'original format' option"
+    )
+
+
 def test_ip_page_renders_v6_suppression_section(webui: WebUI) -> None:
     """The IP page renders the new IPv6 Suppression section (ADR-53 Phase 6).
 

--- a/tests/smoke/ui/test_render_smoke.py
+++ b/tests/smoke/ui/test_render_smoke.py
@@ -617,9 +617,6 @@ def test_ip_page_renders_aggregate_select(webui: WebUI) -> None:
 # verbatim order_0 label from $options_pass_order -- and must not name the retired
 # 'original format' option that no select row offers (a user following that help would
 # hunt for a nonexistent choice and be told the wrong rule order is active by default).
-# Substrings verified against the real pfblockerng_ip.php setHelp() copy and
-# $options_pass_order; pairs with tests/php/IpRuleOrderHelpParityTest.php, which pins
-# the same strings at unit level.
 _IP_ORDER_DEFAULT_LABEL = "| pfB_Pass/Match/Block/Reject | All other Rules | (Default format)"
 _IP_ORDER_RETIRED_OPTION_NAME = "original format"
 


### PR DESCRIPTION
Fixes #2895

## Change

Two help strings on **Firewall → pfBlockerNG → IP** ("Firewall 'Auto' Rule Order") referenced a default and an option name that do not exist. Both now match the shipped select (`src/usr/local/www/pfblockerng/pfblockerng_ip.php:497` and `:503`):

- Stated default is now the verbatim `order_0` label `| pfB_Pass/Match/Block/Reject | All other Rules | (Default format)` — previously it claimed `| pfB_Block/Reject | All other Rules | (original format)`, omitting `Pass/Match` and misnaming the parenthetical.
- The infoblock now says "Selecting 'Default format'" — previously it told the user to select `original format`, an option absent from `$options_pass_order`. `original format` has zero product occurrences repo-wide after this change.

No change to option values, ordering behaviour, or the `order_0` default (`pfblockerng_ip.php:83/:158/:283`, `pfblockerng_apply.inc`, wizard). No #2894 surface touched; the #2898 `width: auto; max-width: 100%` attribute appears only as unchanged context.

## Tests

**Unit (frozen, new):** `tests/php/IpRuleOrderHelpParityTest.php` — 3 tests / 24 assertions:

1. `testStatedDefaultMatchesOrderZeroLabelExactly` — the help's stated default must equal `order_0`'s rendered label verbatim (kills label drift on either side).
2. `testHelpNamesNoOptionLabelTheSelectDoesNotOffer` — no help text may reference an option label absent from `$options_pass_order`.
3. `testHelpInfoblockStillExplainsTheSelection` — the infoblock must keep explaining the selection (two surviving explanation sentences pinned). The five option values, the `order_0` default at all three fallback sites, and the #2898 width attribute are pinned by the pre-existing `IpRuleOrderLayoutUiTest` (`testRuleOrderKeepsFiveDistinctValuesAndOrderZeroDefault`, `testRuleOrderKeepsIntrinsicDesktopWidthButCapsAtItsContainer`), reported combined below.

**Tier-A render pairing (new):** `tests/smoke/ui/test_render_smoke.py::test_ip_page_rule_order_help_states_the_order_zero_default` — on the live webConfigurator IP page: the corrected default help string renders present and the retired `original format` name renders absent (test mandate #4 www<->ui-tests pairing, same shape #2924 satisfied).

## RED / GREEN / mutation / live proof

- **RED (unit, before edit):** parity test against parent's `pfblockerng_ip.php` → **FAILURES (2)**, landing exactly on the two defect sentences: `testStatedDefaultMatchesOrderZeroLabelExactly` and `testHelpNamesNoOptionLabelTheSelectDoesNotOffer` (referenced 'original format' absent). 3 tests / 23 assertions.
- **GREEN (unit):** `OK (3 tests, 24 assertions)`; combined with `IpRuleOrderLayoutUiTest`: `OK (5 tests, 32 assertions)` (PHPUnit 12.5.31, PHP 8.5.10). Re-confirmed after rebasing onto `devel` tip.
- **Mutations killed (unit, 3/3):** (A) reintroduce stale default text → FAILURES (2); (B) reintroduce stale `original format` name → FAILURES (1); (C) rename `order_0`'s parenthetical to `(Legacy format)` → FAILURES (1). Source restored → GREEN after each.
- **Mutation killed (render row):** live-VM leg (`ui_render -k ip`) at scratch ref `3ec3959f` with the help string reverted to the exact pre-#2895 text → **1 failed, 58 passed**: only `test_ip_page_rule_order_help_states_the_order_zero_default` failed; no collateral failures. Scratch branch deleted.
- **GREEN (live render):** same leg at this PR's head → **59 passed, 606 deselected** on a live pfSense CE 2.8 VM with the branch `.pkg` (`pfSense-pkg-pfBlockerNG-edge-4.0.0.a1`) built from this head; the new row PASSED (`0.30s call`).

## Independent verifier

Low-lane verifier re-derived all four issue acceptance criteria from source (`original format` = 2 hits at base, 0 at head; `order_0` default at `:83/:158/:283`), replayed the unit parity test RED against the parent source and GREEN at head, reproduced all three unit mutation kills, and confirmed a clean tree at every step. Verdict: **PASS**, no blocking findings.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Firewall “Auto” Rule Order help text to accurately describe the default format.
  * Removed outdated “original format” wording from the guidance.

* **Tests**
  * Added coverage to ensure the displayed help text matches the available default option and retains key explanations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->