### PR TITLE
release: skip ci:false live-gate targets

### DIFF
--- a/.github/workflows/pkg-tagged-ingest.yml
+++ b/.github/workflows/pkg-tagged-ingest.yml
@@ -109,21 +109,31 @@ jobs:
           CI_MATRIX: ${{ steps.ci.outputs.ci_matrix }}
         run: |
           set -eu
+          # The ROUTE matrix (served set, verbatim from supported-versions.json) is the
+          # only place a varver's `ci: false` is visible -- the read-version-matrix
+          # action's outputs deliberately strip `ci`. The reader fetches ci-metadata
+          # itself, so no extra fetch step is needed here.
+          ROUTE_ROWS="$(sh scripts/read-version-matrix.sh --print-route)"
+          export ROUTE_ROWS
           python3 - <<'PY'
           import json
           import os
 
           from scripts.live_gate_matrix import compute_live_gate_matrix
 
-          matrix, untestable, drifted = compute_live_gate_matrix(
+          matrix, untestable, drifted, skipped = compute_live_gate_matrix(
               json.loads(os.environ["DESTINATIONS"]),
               json.loads(os.environ["TOUCHED"]),
               json.loads(os.environ["CI_MATRIX"]),
+              json.loads(os.environ["ROUTE_ROWS"]),
           )
           if untestable or drifted or not matrix:
-              raise SystemExit(f"untestable={untestable} drifted={drifted} matrix={matrix}")
+              raise SystemExit(f"untestable={untestable} drifted={drifted} skipped={skipped} matrix={matrix}")
+          if skipped:
+              print("::warning::live gate skipped (ci:false, no smoke image): " + ", ".join(skipped))
           with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
               output.write("matrix=" + json.dumps(matrix, separators=(",", ":")) + "\n")
+              output.write("skipped=" + json.dumps(skipped, separators=(",", ":")) + "\n")
           PY
 
   validate-live-pages-install:

--- a/scripts/live_gate_matrix.py
+++ b/scripts/live_gate_matrix.py
@@ -54,10 +54,11 @@ def compute_live_gate_matrix(
     destinations: Sequence[str],
     touched: Sequence[str],
     ci_matrix: Sequence[Mapping[str, Any]],
-) -> tuple[list[dict[str, Any]], list[str], list[str]]:
+    route_rows: Sequence[Mapping[str, Any]] = (),
+) -> tuple[list[dict[str, Any]], list[str], list[str], list[str]]:
     """Cross-reference a publish's touched targets against the CI matrix.
 
-    Returns ``(matrix, untestable, drifted)``:
+    Returns ``(matrix, untestable, drifted, skipped)``:
 
     - ``matrix``: one row per (destination, CI leg) pair whose
       ``"<destination>/<varver>"`` is in ``touched`` -- the exact set of live-VM
@@ -71,23 +72,47 @@ def compute_live_gate_matrix(
     - ``drifted``: ``touched`` entries whose channel prefix is not even present in
       ``destinations`` -- state drift between what ``resolve`` classified and what
       the stage step actually wrote.
+    - ``skipped``: ``touched`` entries whose varver has no CI-matrix leg BUT whose
+      ``route_rows`` entry declares ``ci: false`` -- a served varver the matrix says
+      deliberately has no smoke image (Plus 25.11: no licensed VM image exists, issue
+      #2926). Sorted, so one publish always renders one audit string. The caller warns
+      and carries on; these are never install-tested and never an error.
 
     ``ci_matrix`` rows are exactly ``read-version-matrix.sh --github-output``'s
     ``ci_matrix`` entries (one row per pfSense version, never deduped by
     freebsd_major); ``leg["variant"]`` is CE/Plus, unrelated to the destination
     ``channel`` in the returned rows.
+
+    ``route_rows`` are exactly ``read-version-matrix.sh --print-route`` rows (the
+    served set, verbatim from supported-versions.json, so ``ci`` survives untouched)
+    and ONLY classify tolerance -- ``ci_matrix`` stays the single source of smoke
+    legs. Tolerance needs an EXPLICIT ``ci: false``: an absent ``ci`` is the matrix's
+    build-role default, so a missing leg there is still disagreement between the two
+    matrices and stays ``untestable`` (fail closed). Omitting ``route_rows``
+    reproduces the pre-tolerance classification exactly -- nothing is ever skipped
+    without positive ci:false evidence.
     """
     per_leg_varver = [(leg, catalog_name_from_version(leg["pfsense_version"], leg["variant"])) for leg in ci_matrix]
     leg_varvers = {varver for _leg, varver in per_leg_varver}
     dest_set = set(destinations)
+    ci_false_varvers = {
+        catalog_name_from_version(row["pfsense_version"], row["variant"])
+        for row in route_rows
+        if row.get("ci") is False
+    }
 
     drifted: list[str] = []
     untestable: list[str] = []
+    skipped: list[str] = []
     for target in touched:
         channel, _, varver = target.partition("/")
         if channel not in dest_set:
             drifted.append(target)
-        elif varver not in leg_varvers:
+        elif varver in leg_varvers:
+            continue
+        elif varver in ci_false_varvers:
+            skipped.append(target)
+        else:
             untestable.append(target)
 
     touched_set = set(touched)
@@ -110,4 +135,4 @@ def compute_live_gate_matrix(
                     "extra_pkgs": leg.get("extra_pkgs", []),
                 }
             )
-    return matrix, untestable, drifted
+    return matrix, untestable, drifted, sorted(skipped)

--- a/tests/test_live_gate_matrix.py
+++ b/tests/test_live_gate_matrix.py
@@ -8,14 +8,17 @@ the workflow's logic fails here first.
 
 from __future__ import annotations
 
+import json
 import os
 import subprocess
 import sys
 from pathlib import Path
 
 import pytest
+import yaml
 
 from scripts.live_gate_matrix import compute_live_gate_matrix
+from tests._workflow_steps import extract_between
 
 _ROOT = Path(__file__).resolve().parents[1]
 
@@ -60,9 +63,32 @@ PLUS_LEG = {
     "extra_pkgs": ["textproc/py-charset-normalizer"],
 }
 
+# Plus 25.11 as the live ci-metadata matrix actually carries it (issue #2926): a
+# served, build-role varver with ci:false -- no licensed VM image exists, so it has
+# NO leg in ci_matrix and never will. Route rows are the ONLY place that state is
+# visible to the live gate.
+PLUS_2511_ROUTE = {
+    "pfsense_version": "25.11",
+    "variant": "Plus",
+    "freebsd_major": "16",
+    "php_version": "8.4",
+    "py_flavor": "py311",
+    "ci": False,
+}
+PLUS_2511_ROUTE_CI_TRUE = {**PLUS_2511_ROUTE, "ci": True}
+PLUS_2511_ROUTE_NO_CI = {key: value for key, value in PLUS_2511_ROUTE.items() if key != "ci"}
+CE_ROUTE = {
+    "pfsense_version": "2.8.1",
+    "variant": "CE",
+    "freebsd_major": "15",
+    "php_version": "8.3",
+    "py_flavor": "py311",
+    "ci": True,
+}
+
 
 def test_one_destination_one_leg_matches() -> None:
-    matrix, untestable, drifted = compute_live_gate_matrix(["stable"], ["stable/ce-2.8"], [CE_LEG])
+    matrix, untestable, drifted, skipped = compute_live_gate_matrix(["stable"], ["stable/ce-2.8"], [CE_LEG])
     assert matrix == [
         {
             "channel": "stable",
@@ -78,12 +104,13 @@ def test_one_destination_one_leg_matches() -> None:
     ]
     assert untestable == []
     assert drifted == []
+    assert skipped == []
 
 
 def test_multi_destination_fans_out_one_row_per_destination() -> None:
     """A final release touches stable+testing+edge for the same varver -- one live
     install test per destination, not one shared row."""
-    matrix, untestable, drifted = compute_live_gate_matrix(
+    matrix, untestable, drifted, skipped = compute_live_gate_matrix(
         ["stable", "testing", "edge"],
         ["stable/ce-2.8", "testing/ce-2.8", "edge/ce-2.8"],
         [CE_LEG],
@@ -92,52 +119,58 @@ def test_multi_destination_fans_out_one_row_per_destination() -> None:
     assert {row["varver"] for row in matrix} == {"ce-2.8"}
     assert untestable == []
     assert drifted == []
+    assert skipped == []
 
 
 def test_multi_leg_only_touched_targets_produce_rows() -> None:
     """A leg whose varver was never touched (e.g. only CE was published) is excluded,
     not silently included with a stale/empty identity."""
-    matrix, untestable, drifted = compute_live_gate_matrix(["edge"], ["edge/ce-2.8"], [CE_LEG, PLUS_LEG])
+    matrix, untestable, drifted, skipped = compute_live_gate_matrix(["edge"], ["edge/ce-2.8"], [CE_LEG, PLUS_LEG])
     assert len(matrix) == 1
     assert matrix[0]["varver"] == "ce-2.8"
     assert untestable == []
     assert drifted == []
+    assert skipped == []
 
 
 def test_touched_target_with_no_matching_leg_is_untestable() -> None:
     """Something the publisher shipped for a varver no CI leg can install-test."""
-    matrix, untestable, drifted = compute_live_gate_matrix(["edge"], ["edge/plus-26.07"], [CE_LEG])
+    matrix, untestable, drifted, skipped = compute_live_gate_matrix(["edge"], ["edge/plus-26.07"], [CE_LEG])
     assert matrix == []
     assert untestable == ["edge/plus-26.07"]
     assert drifted == []
+    assert skipped == []
 
 
 def test_touched_target_outside_destinations_is_drifted_not_untestable() -> None:
     """A touched channel resolve never classified is state drift, distinct from
     'no CI leg exists for this varver' -- must not double-count as untestable too."""
-    matrix, untestable, drifted = compute_live_gate_matrix(["stable"], ["testing/ce-2.8"], [CE_LEG])
+    matrix, untestable, drifted, skipped = compute_live_gate_matrix(["stable"], ["testing/ce-2.8"], [CE_LEG])
     assert matrix == []
     assert untestable == []
     assert drifted == ["testing/ce-2.8"]
+    assert skipped == []
 
 
 def test_empty_touched_produces_empty_matrix_and_no_problems() -> None:
     """A pure no-op publish (nothing touched) is a caller-level ('did we publish
     anything testable?') decision, not this function's to flag -- it just returns
     empty."""
-    matrix, untestable, drifted = compute_live_gate_matrix(["stable"], [], [CE_LEG])
+    matrix, untestable, drifted, skipped = compute_live_gate_matrix(["stable"], [], [CE_LEG])
     assert matrix == []
     assert untestable == []
     assert drifted == []
+    assert skipped == []
 
 
 def test_destination_with_no_touched_target_is_not_an_error() -> None:
     """destinations may legitimately contain a channel the publisher no-op'd for this
     run -- only a TOUCHED target outside destinations is drift."""
-    matrix, untestable, drifted = compute_live_gate_matrix(["stable", "testing"], ["stable/ce-2.8"], [CE_LEG])
+    matrix, untestable, drifted, skipped = compute_live_gate_matrix(["stable", "testing"], ["stable/ce-2.8"], [CE_LEG])
     assert [row["channel"] for row in matrix] == ["stable"]
     assert untestable == []
     assert drifted == []
+    assert skipped == []
 
 
 def test_leg_missing_image_name_or_mac_raises_instead_of_silently_defaulting() -> None:
@@ -151,3 +184,146 @@ def test_leg_missing_image_name_or_mac_raises_instead_of_silently_defaulting() -
     leg_no_mac = {k: v for k, v in CE_LEG.items() if k != "mac"}
     with pytest.raises(KeyError):
         compute_live_gate_matrix(["stable"], ["stable/ce-2.8"], [leg_no_mac])
+
+
+def test_ci_false_route_row_is_skipped_with_a_warning_not_a_failed_gate() -> None:
+    """Plus 25.11 is ci:false on the live matrix -- deliberately no licensed VM image
+    (issue #2926), so no CI leg can ever produce it. A stable publish touching that
+    varver must classify it as SKIPPED, never as untestable: untestable raises and
+    would hard-fail every tagged ingestion that ships plus-25.11."""
+    matrix, untestable, drifted, skipped = compute_live_gate_matrix(
+        ["stable"], ["stable/plus-25.11"], [CE_LEG], [PLUS_2511_ROUTE]
+    )
+    assert matrix == []
+    assert untestable == []
+    assert drifted == []
+    assert skipped == ["stable/plus-25.11"]
+
+
+def test_route_row_with_ci_true_and_no_leg_stays_untestable() -> None:
+    """A varver the matrix declares smoke-testable that nevertheless produced no CI
+    leg is real disagreement between the two matrices -- fail closed, never a silent
+    skip that drops live coverage."""
+    matrix, untestable, drifted, skipped = compute_live_gate_matrix(
+        ["stable"], ["stable/plus-25.11"], [CE_LEG], [PLUS_2511_ROUTE_CI_TRUE]
+    )
+    assert matrix == []
+    assert untestable == ["stable/plus-25.11"]
+    assert drifted == []
+    assert skipped == []
+
+
+def test_route_row_omitting_ci_stays_untestable() -> None:
+    """Only an EXPLICIT ``ci: false`` buys tolerance. An absent ``ci`` key is the
+    matrix's build-role default (truthy), not a declaration that the varver has no
+    smoke image -- so a missing leg is still drift."""
+    matrix, untestable, drifted, skipped = compute_live_gate_matrix(
+        ["stable"], ["stable/plus-25.11"], [CE_LEG], [PLUS_2511_ROUTE_NO_CI]
+    )
+    assert matrix == []
+    assert untestable == ["stable/plus-25.11"]
+    assert drifted == []
+    assert skipped == []
+
+
+def test_route_rows_omitted_keeps_todays_fail_closed_classification() -> None:
+    """The route argument is optional: a caller that supplies none gets byte-identical
+    classification to before this parameter existed (nothing is ever skipped without
+    positive ci:false evidence)."""
+    matrix, untestable, drifted, skipped = compute_live_gate_matrix(["stable"], ["stable/plus-25.11"], [CE_LEG])
+    assert matrix == []
+    assert untestable == ["stable/plus-25.11"]
+    assert drifted == []
+    assert skipped == []
+
+
+def test_skipped_target_coexists_with_the_legs_that_do_have_images() -> None:
+    """The normal stable publish: several varvers touched, one of them ci:false. The
+    testable ones still fan out -- tolerance must not swallow the whole matrix."""
+    matrix, untestable, drifted, skipped = compute_live_gate_matrix(
+        ["stable"],
+        ["stable/ce-2.8", "stable/plus-25.11"],
+        [CE_LEG],
+        [CE_ROUTE, PLUS_2511_ROUTE],
+    )
+    assert [row["varver"] for row in matrix] == ["ce-2.8"]
+    assert untestable == []
+    assert drifted == []
+    assert skipped == ["stable/plus-25.11"]
+
+
+def test_skipped_entries_are_sorted_regardless_of_touched_order() -> None:
+    """The skipped list lands in a warning annotation and a step output -- a stable
+    order keeps the same publish from rendering two different audit strings."""
+    matrix, untestable, drifted, skipped = compute_live_gate_matrix(
+        ["stable", "testing"],
+        ["testing/plus-25.11", "stable/plus-25.11"],
+        [CE_LEG],
+        [PLUS_2511_ROUTE],
+    )
+    assert skipped == ["stable/plus-25.11", "testing/plus-25.11"]
+    assert matrix == []
+    assert untestable == []
+    assert drifted == []
+
+
+def test_ci_false_route_row_does_not_rescue_a_drifted_channel() -> None:
+    """Tolerance is about a missing smoke IMAGE, never about a channel resolve never
+    classified: that stays drift and still fails the gate closed."""
+    matrix, untestable, drifted, skipped = compute_live_gate_matrix(
+        ["stable"], ["testing/plus-25.11"], [CE_LEG], [PLUS_2511_ROUTE]
+    )
+    assert matrix == []
+    assert untestable == []
+    assert drifted == ["testing/plus-25.11"]
+    assert skipped == []
+
+
+def test_ci_matrix_stays_the_only_source_of_legs_even_against_a_stale_ci_false_row() -> None:
+    """``ci_matrix`` decides what gets install-tested; route rows only classify
+    tolerance. A stale ci:false route row for a varver the CI matrix DID produce must
+    not delete that leg -- that would silently drop live coverage instead of adding
+    tolerance."""
+    stale = {**CE_ROUTE, "ci": False}
+    matrix, untestable, drifted, skipped = compute_live_gate_matrix(["stable"], ["stable/ce-2.8"], [CE_LEG], [stale])
+    assert [row["varver"] for row in matrix] == ["ce-2.8"]
+    assert untestable == []
+    assert drifted == []
+    assert skipped == []
+
+
+def test_prepare_live_gate_step_feeds_route_rows_and_warns_instead_of_failing(tmp_path: Path) -> None:
+    """pkg-tagged-ingest.yml's prepare-live-gate step is the ONLY caller of this
+    function (release-published.yml reaches it through that reusable workflow), so the
+    tolerance is worthless unless the step actually reads the ROUTE matrix, unpacks the
+    skipped list, and turns it into a warning. Runs the step's own inline python as a
+    subprocess -- the real bytes the workflow executes, never a paraphrase."""
+    workflow = yaml.safe_load((_ROOT / ".github/workflows/pkg-tagged-ingest.yml").read_text(encoding="utf-8"))
+    step = next(item for item in workflow["jobs"]["prepare-live-gate"]["steps"] if item.get("id") == "build")
+    run = step["run"]
+    assert "read-version-matrix.sh --print-route" in run, run
+    assert "ROUTE_ROWS" in run, run
+
+    script = extract_between(run, "python3 - <<'PY'\n", "\nPY\n")
+    env = dict(os.environ)
+    env.pop("PYTHONPATH", None)
+    env["DESTINATIONS"] = '["stable"]'
+    env["TOUCHED"] = '["stable/ce-2.8", "stable/plus-25.11"]'
+    env["CI_MATRIX"] = json.dumps([CE_LEG])
+    env["ROUTE_ROWS"] = json.dumps([CE_ROUTE, PLUS_2511_ROUTE])
+    github_output = tmp_path / "github_output"
+    github_output.write_text("", encoding="utf-8")
+    env["GITHUB_OUTPUT"] = str(github_output)
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=str(_ROOT),
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    emitted = github_output.read_text(encoding="utf-8")
+    assert result.returncode == 0, f"stdout={result.stdout!r} stderr={result.stderr!r}"
+    assert "::warning::live gate skipped (ci:false, no smoke image): stable/plus-25.11" in result.stdout, result.stdout
+    assert 'matrix=[{"channel":"stable","varver":"ce-2.8"' in emitted, emitted
+    assert 'skipped=["stable/plus-25.11"]' in emitted, emitted


### PR DESCRIPTION
## Summary

- Tagged-release ingestion's live gate fail-closed on any touched catalog varver without a CI smoke leg. With Plus 25.11 deliberately `ci:false` in the version matrix (no licensed smoke image exists, pfBlockerNG#2926), every stable release touching `plus-25.11` would fail ingestion.
- `compute_live_gate_matrix` now accepts the ROUTE matrix and returns a fourth `skipped` classification: a touched target whose route row carries an explicit `ci: false` is skipped with a loud `::warning::` instead of failing. Every other failure mode (no route row at all, drift, absent/`true` `ci` with no leg) stays fail-closed.

## Verification

- Independent correctness review: PASS/APPROVED, hostile-input probes clean.
- Legacy-call differential probe: 72 destination×touched×leg combinations byte-identical to `origin/devel` behavior (`skipped` always empty).
- Live step smoke against `origin/ci-metadata`: rc=0, `stable/plus-25.11` skipped with warning, matrix = ce-2.8 + plus-26.03.
- 5 mutants killed (absent-`ci` tolerance, unsorted skipped, ordering, dropped output, dropped warning).

| Frozen RED test | git hash-object | RED run tail |
| --- | --- | --- |
| `tests/test_live_gate_matrix.py` | `b74ff24ee36a51960827a245e8844851f0b577bb` | `16 failed, 2 passed; missing route_rows parameter, 4-tuple unpack failures, absent route read in step contract` |

Refs #2926.

Authored with OMP; no configured GitHub-recognized OMP coauthor identity was available.