### PR TITLE
pfblockerng: render threats page title and breadcrumb (#2896)

### DIFF
--- a/src/usr/local/www/pfblockerng/pfblockerng_threats.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_threats.php
@@ -21,8 +21,6 @@
  */
 
 require('guiconfig.inc');
-$shortcut_section = 'pfblockerng';
-include('head.inc');
 
 $title = $host = $domain = $port = '';
 if (isset($_REQUEST)) {
@@ -67,6 +65,8 @@ if (empty($host) && empty($domain) && empty($port)) {
 
 $pgtitle = array(gettext('Firewall'), gettext('pfBlockerNG'), gettext('Alerts'), gettext("Threat {$title} Lookup"));
 $pglinks = array('', '/pfblockerng/pfblockerng_general.php', '/pfblockerng/pfblockerng_alerts.php', '@self');
+$shortcut_section = 'pfblockerng';
+include('head.inc');
 ?>
 
 <div class="panel panel-default">

--- a/src/usr/local/www/pfblockerng/pfblockerng_threats.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_threats.php
@@ -41,7 +41,7 @@ if (isset($_REQUEST)) {
 		$domain	= htmlspecialchars($_REQUEST['domain']);
 	}
 	elseif (isset($_REQUEST['port'])) {
-		if (!is_port($_REQUEST['port'])) {
+		if (!is_string($_REQUEST['port']) || !is_port($_REQUEST['port'])) {
 			print_info_box("Invalid Port cannot proceed!");
 			exit;
 		}

--- a/tests/php/ThreatsPageHeaderTest.php
+++ b/tests/php/ThreatsPageHeaderTest.php
@@ -38,6 +38,7 @@ $state = [
 	'auth_loaded' => $GLOBALS['pfb_threats_auth_loaded'] ?? FALSE,
 	'pgtitle' => $pgtitle ?? NULL,
 	'pglinks' => $pglinks ?? NULL,
+	'shortcut_section' => $shortcut_section ?? NULL,
 ];
 echo 'PFB_HEAD_STATE:' . base64_encode(json_encode($state, JSON_THROW_ON_ERROR)) . "\n";
 PHP));
@@ -76,16 +77,18 @@ PHP));
 		$this->assertTrue($state['auth_loaded'], 'guiconfig authentication must load before head.inc');
 		$this->assertSame(['Firewall', 'pfBlockerNG', 'Alerts', $lookupTitle], $state['pgtitle']);
 		$this->assertSame(self::LINKS, $state['pglinks']);
+		$this->assertSame('pfblockerng', $state['shortcut_section']);
 		$this->assertStringContainsString('PFB_FOOT', $result['stdout']);
 		$this->assertStringContainsString('PFB_AFTER_PAGE', $result['stdout']);
 	}
 
-	/** @return iterable<string,array{0:array<string,string>,1:string}> */
+	/** @return iterable<string,array{0:array<string,mixed>,1:string}> */
 	public static function rejectedLookupProvider(): iterable
 	{
 		yield 'invalid host' => [['host' => 'not-an-ip'], 'Invalid IP Address, cannot proceed!'];
 		yield 'invalid domain' => [['domain' => 'not a domain'], 'Invalid Domain name, cannot proceed!'];
 		yield 'invalid port' => [['port' => '99999'], 'Invalid Port cannot proceed!'];
+		yield 'array port' => [['port' => ['8443']], 'Invalid Port cannot proceed!'];
 		yield 'missing request' => [[], 'No Requests found, cannot proceed!'];
 	}
 
@@ -102,7 +105,7 @@ PHP));
 		$this->assertStringNotContainsString('PFB_AFTER_PAGE', $result['stdout']);
 	}
 
-	/** @return array{auth_loaded:bool,pgtitle:list<string>,pglinks:list<string>} */
+	/** @return array{auth_loaded:bool,pgtitle:list<string>,pglinks:list<string>,shortcut_section:string} */
 	private function headState(string $stdout): array
 	{
 		$line = strtok($stdout, "\n");
@@ -115,7 +118,7 @@ PHP));
 		return $state;
 	}
 
-	/** @param array<string,string> $request @return array{status:int,stdout:string,stderr:string} */
+	/** @param array<string,mixed> $request @return array{status:int,stdout:string,stderr:string} */
 	private function request(array $request): array
 	{
 		$root = var_export(dirname(__DIR__, 2), TRUE);

--- a/tests/php/ThreatsPageHeaderTest.php
+++ b/tests/php/ThreatsPageHeaderTest.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/** Runtime coverage for the Threats page request and head.inc boundary. */
+final class ThreatsPageHeaderTest extends TestCase
+{
+	private const LINKS = [
+		'',
+		'/pfblockerng/pfblockerng_general.php',
+		'/pfblockerng/pfblockerng_alerts.php',
+		'@self',
+	];
+
+	private string $shim = '';
+
+	protected function setUp(): void
+	{
+		$this->shim = sys_get_temp_dir() . '/pfb_threats_' . bin2hex(random_bytes(8));
+		$this->assertTrue(mkdir($this->shim, 0700, TRUE));
+
+		$this->assertNotFalse(file_put_contents($this->shim . '/guiconfig.inc', <<<'PHP'
+<?php
+$GLOBALS['pfb_threats_auth_loaded'] = TRUE;
+if (!function_exists('print_info_box')) {
+	function print_info_box($message): void
+	{
+		echo 'PFB_INFO:' . $message;
+	}
+}
+PHP));
+		$this->assertNotFalse(file_put_contents($this->shim . '/head.inc', <<<'PHP'
+<?php
+$state = [
+	'auth_loaded' => $GLOBALS['pfb_threats_auth_loaded'] ?? FALSE,
+	'pgtitle' => $pgtitle ?? NULL,
+	'pglinks' => $pglinks ?? NULL,
+];
+echo 'PFB_HEAD_STATE:' . base64_encode(json_encode($state, JSON_THROW_ON_ERROR)) . "\n";
+PHP));
+		$this->assertNotFalse(file_put_contents($this->shim . '/foot.inc', "<?php echo '\nPFB_FOOT';"));
+	}
+
+	protected function tearDown(): void
+	{
+		foreach (glob($this->shim . '/*') ?: [] as $path) {
+			@unlink($path);
+		}
+		@rmdir($this->shim);
+	}
+
+	/** @return iterable<string,array{0:array<string,string>,1:string}> */
+	public static function validLookupProvider(): iterable
+	{
+		yield 'host' => [['host' => '203.0.113.5'], 'Threat Source IP Lookup'];
+		yield 'domain' => [['domain' => 'lookup.example.com'], 'Threat Domain Lookup'];
+		yield 'port' => [['port' => '8443'], 'Threat Port Lookup'];
+	}
+
+	#[DataProvider('validLookupProvider')]
+	public function testValidLookupSuppliesTitleAndLinksBeforeHead(array $request, string $lookupTitle): void
+	{
+		$result = $this->request($request);
+
+		$this->assertSame(0, $result['status'], $result['stderr']);
+		$this->assertSame('', $result['stderr'], $result['stderr']);
+		$this->assertStringStartsWith(
+			'PFB_HEAD_STATE:',
+			$result['stdout'],
+			'valid request parsing must not emit output before the authenticated page header'
+		);
+		$state = $this->headState($result['stdout']);
+		$this->assertTrue($state['auth_loaded'], 'guiconfig authentication must load before head.inc');
+		$this->assertSame(['Firewall', 'pfBlockerNG', 'Alerts', $lookupTitle], $state['pgtitle']);
+		$this->assertSame(self::LINKS, $state['pglinks']);
+		$this->assertStringContainsString('PFB_FOOT', $result['stdout']);
+		$this->assertStringContainsString('PFB_AFTER_PAGE', $result['stdout']);
+	}
+
+	/** @return iterable<string,array{0:array<string,string>,1:string}> */
+	public static function rejectedLookupProvider(): iterable
+	{
+		yield 'invalid host' => [['host' => 'not-an-ip'], 'Invalid IP Address, cannot proceed!'];
+		yield 'invalid domain' => [['domain' => 'not a domain'], 'Invalid Domain name, cannot proceed!'];
+		yield 'invalid port' => [['port' => '99999'], 'Invalid Port cannot proceed!'];
+		yield 'missing request' => [[], 'No Requests found, cannot proceed!'];
+	}
+
+	#[DataProvider('rejectedLookupProvider')]
+	public function testRejectedLookupKeepsMessageAndExitsBeforeHead(array $request, string $message): void
+	{
+		$result = $this->request($request);
+
+		$this->assertSame(0, $result['status'], $result['stderr']);
+		$this->assertSame('', $result['stderr'], $result['stderr']);
+		$this->assertSame('PFB_INFO:' . $message, $result['stdout']);
+		$this->assertStringNotContainsString('PFB_HEAD_STATE:', $result['stdout']);
+		$this->assertStringNotContainsString('PFB_FOOT', $result['stdout']);
+		$this->assertStringNotContainsString('PFB_AFTER_PAGE', $result['stdout']);
+	}
+
+	/** @return array{auth_loaded:bool,pgtitle:list<string>,pglinks:list<string>} */
+	private function headState(string $stdout): array
+	{
+		$line = strtok($stdout, "\n");
+		$this->assertIsString($line);
+		$encoded = substr($line, strlen('PFB_HEAD_STATE:'));
+		$decoded = base64_decode($encoded, TRUE);
+		$this->assertIsString($decoded);
+		$state = json_decode($decoded, TRUE, 512, JSON_THROW_ON_ERROR);
+		$this->assertIsArray($state);
+		return $state;
+	}
+
+	/** @param array<string,string> $request @return array{status:int,stdout:string,stderr:string} */
+	private function request(array $request): array
+	{
+		$root = var_export(dirname(__DIR__, 2), TRUE);
+		$page = var_export(dirname(__DIR__, 2) . '/src/usr/local/www/pfblockerng/pfblockerng_threats.php', TRUE);
+		$shim = var_export($this->shim, TRUE);
+		$script = <<<PHP
+\$_REQUEST = json_decode(stream_get_contents(STDIN), TRUE, 512, JSON_THROW_ON_ERROR);
+require {$root} . '/tests/php/bootstrap.php';
+error_reporting(E_ERROR | E_PARSE);
+set_include_path({$shim} . PATH_SEPARATOR . get_include_path());
+require {$page};
+echo "\nPFB_AFTER_PAGE";
+PHP;
+		$descriptors = [0 => ['pipe', 'r'], 1 => ['pipe', 'w'], 2 => ['pipe', 'w']];
+		$process = proc_open([PHP_BINARY, '-r', $script], $descriptors, $pipes);
+		$this->assertIsResource($process);
+		fwrite($pipes[0], json_encode($request, JSON_THROW_ON_ERROR));
+		fclose($pipes[0]);
+		$stdout = stream_get_contents($pipes[1]);
+		$stderr = stream_get_contents($pipes[2]);
+		fclose($pipes[1]);
+		fclose($pipes[2]);
+		$status = proc_close($process);
+
+		return ['status' => $status, 'stdout' => (string) $stdout, 'stderr' => (string) $stderr];
+	}
+}

--- a/tests/smoke/ui/test_render_smoke.py
+++ b/tests/smoke/ui/test_render_smoke.py
@@ -2778,8 +2778,7 @@ _THREATS_LOOKUP_TITLES = ("Threat Domain Lookup", "Threat Source IP Lookup", "Th
 def test_threats_rejects_malformed_lookup(name: str, query: str, message: str, webui: WebUI) -> None:
     """A malformed/absent threats lookup renders its info-box, NOT the lookup page.
 
-    HTTP 200 (head.inc is included before the dispatch, so the page still renders
-    its header) with the exact info-box message present and the "Threat ... Lookup"
+    HTTP 200 with the exact info-box message present and the "Threat ... Lookup"
     chrome absent -- proving the validator rejected and exit()ed rather than
     rendering the lookup view. The before-state (a valid param DOES render that
     chrome) is the positive threats_{domain,host,port} entries in PAGE_TABLE.

--- a/tests/smoke/ui/test_threats_header.py
+++ b/tests/smoke/ui/test_threats_header.py
@@ -32,6 +32,7 @@ REJECTED_LOOKUPS: tuple[tuple[str, str, str], ...] = (
     ("invalid_host", "host=not-an-ip", "Invalid IP Address, cannot proceed!"),
     ("invalid_domain", "domain=not%20a%20domain", "Invalid Domain name, cannot proceed!"),
     ("invalid_port", "port=99999", "Invalid Port cannot proceed!"),
+    ("array_port", "port[]=8443", "Invalid Port cannot proceed!"),
     ("missing", "", "No Requests found, cannot proceed!"),
 )
 LOOKUP_TITLES = tuple(row[2] for row in VALID_LOOKUPS)
@@ -84,6 +85,13 @@ def test_threats_http_title_and_breadcrumb(
 
     breadcrumb = _expected_breadcrumb(path, lookup_title)
     assert breadcrumb in response.text, f"{name}: expected ordered breadcrumb {breadcrumb!r}"
+    shortcut = re.search(
+        r'<ul class="context-links">.*?<a href="/status_logs_packages\.php\?pkg=[^"]+" '
+        r'title="Related log entries"><i class="fa-regular fa-rectangle-list"></i></a>',
+        response.text,
+        re.DOTALL,
+    )
+    assert shortcut is not None, f"{name}: pfBlockerNG package-log shortcut was not rendered"
 
 
 @pytest.mark.ui_render
@@ -137,6 +145,10 @@ def test_threats_browser_title_and_breadcrumb(
     assert crumbs.nth(1).locator("a").get_attribute("href") == "/pfblockerng/pfblockerng_general.php"
     assert crumbs.nth(2).locator("a").get_attribute("href") == "/pfblockerng/pfblockerng_alerts.php"
     assert crumbs.nth(3).locator("a").get_attribute("href") == path
+    shortcut = page.locator('ul.context-links a[title="Related log entries"][href^="/status_logs_packages.php?pkg="]')
+    sync_api.expect(shortcut).to_have_count(1)
+    sync_api.expect(shortcut.locator("i.fa-rectangle-list")).to_have_count(1)
+    assert page.locator('ul.context-links a[href^="status_logs_packages.php?pkg="]').count() == 0
 
     mask_page_identity(page)
     page.screenshot(path=str(screenshot_dir / f"threats_header_{name}.png"), full_page=True)

--- a/tests/smoke/ui/test_threats_header.py
+++ b/tests/smoke/ui/test_threats_header.py
@@ -1,0 +1,142 @@
+"""Threats-page title, breadcrumb, and request-short-circuit coverage."""
+
+from __future__ import annotations
+
+import html
+import re
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+from .. import helpers
+from .conftest import mask_page_identity
+from .render_oracle import PhpErrorLogGuard, evaluate_render
+from .webui import LOGIN_MARKERS
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from playwright.sync_api import Page
+
+    from ..conftest import SmokeVM
+    from .webui import WebUI
+
+THREATS_PAGE = "/pfblockerng/pfblockerng_threats.php"
+VALID_LOOKUPS: tuple[tuple[str, str, str], ...] = (
+    ("host", f"{THREATS_PAGE}?host=203.0.113.5", "Threat Source IP Lookup"),
+    ("domain", f"{THREATS_PAGE}?domain={{domain}}", "Threat Domain Lookup"),
+    ("port", f"{THREATS_PAGE}?port=8443", "Threat Port Lookup"),
+)
+REJECTED_LOOKUPS: tuple[tuple[str, str, str], ...] = (
+    ("invalid_host", "host=not-an-ip", "Invalid IP Address, cannot proceed!"),
+    ("invalid_domain", "domain=not%20a%20domain", "Invalid Domain name, cannot proceed!"),
+    ("invalid_port", "port=99999", "Invalid Port cannot proceed!"),
+    ("missing", "", "No Requests found, cannot proceed!"),
+)
+LOOKUP_TITLES = tuple(row[2] for row in VALID_LOOKUPS)
+
+
+def _lookup_path(template: str) -> str:
+    return template.format(domain=helpers.unique_domain())
+
+
+def _expected_breadcrumb(path: str, lookup_title: str) -> str:
+    return (
+        '<ol class="breadcrumb"><li>Firewall</li>'
+        '<li><a href="/pfblockerng/pfblockerng_general.php">pfBlockerNG</a></li>'
+        '<li><a href="/pfblockerng/pfblockerng_alerts.php">Alerts</a></li>'
+        f'<li><a href="{html.escape(path, quote=True)}">{lookup_title}</a></li></ol>'
+    )
+
+
+@pytest.fixture(scope="module")
+def threats_php_error_log_guard(smoke_vm: SmokeVM, webui: WebUI) -> Iterator[PhpErrorLogGuard]:
+    guard = PhpErrorLogGuard(smoke_vm)
+    guard.snapshot()
+    yield guard
+    guard.assert_no_growth()
+
+
+@pytest.mark.ui_render
+@pytest.mark.parametrize(
+    ("name", "path_template", "lookup_title"), VALID_LOOKUPS, ids=[row[0] for row in VALID_LOOKUPS]
+)
+def test_threats_http_title_and_breadcrumb(
+    name: str,
+    path_template: str,
+    lookup_title: str,
+    webui: WebUI,
+    threats_php_error_log_guard: PhpErrorLogGuard,
+) -> None:
+    """Each lookup view emits the authenticated document head and exact four-level breadcrumb."""
+    path = _lookup_path(path_template)
+    response = webui.get(path)
+    result = evaluate_render(path, response.status_code, response.text, (lookup_title,))
+    assert result.ok, f"{name}: render oracle failed: {result.detail}"
+    assert response.text.lstrip().startswith("<!DOCTYPE html>"), f"{name}: output preceded the document header"
+
+    title_match = re.search(r"<title>(.*?)</title>", response.text, re.DOTALL | re.IGNORECASE)
+    assert title_match is not None, f"{name}: response has no browser title"
+    title = html.unescape(title_match.group(1)).strip()
+    expected_page_title = f"Firewall: pfBlockerNG: Alerts: {lookup_title}"
+    assert expected_page_title in title, f"{name}: expected {expected_page_title!r} in title, got {title!r}"
+
+    breadcrumb = _expected_breadcrumb(path, lookup_title)
+    assert breadcrumb in response.text, f"{name}: expected ordered breadcrumb {breadcrumb!r}"
+
+
+@pytest.mark.ui_render
+@pytest.mark.parametrize(("name", "query", "message"), REJECTED_LOOKUPS, ids=[row[0] for row in REJECTED_LOOKUPS])
+def test_threats_http_rejects_before_page_header(
+    name: str,
+    query: str,
+    message: str,
+    webui: WebUI,
+    threats_php_error_log_guard: PhpErrorLogGuard,
+) -> None:
+    """Invalid and missing requests keep their message and exit before lookup chrome."""
+    path = f"{THREATS_PAGE}?{query}" if query else THREATS_PAGE
+    response = webui.get(path)
+    result = evaluate_render(path, response.status_code, response.text, (message,))
+    assert result.ok, f"{name}: reject render oracle failed: {result.detail}"
+    assert not any(marker in response.text for marker in LOGIN_MARKERS), f"{name}: authentication regressed"
+    assert "<title>" not in response.text, f"{name}: rejected request unexpectedly included the page head"
+    assert '<ol class="breadcrumb">' not in response.text, f"{name}: rejected request rendered a breadcrumb"
+    present = [title for title in LOOKUP_TITLES if title in response.text]
+    assert not present, f"{name}: rejected request rendered lookup titles {present}"
+
+
+@pytest.mark.ui_browser
+@pytest.mark.parametrize(
+    ("name", "path_template", "lookup_title"), VALID_LOOKUPS, ids=[row[0] for row in VALID_LOOKUPS]
+)
+def test_threats_browser_title_and_breadcrumb(
+    name: str,
+    path_template: str,
+    lookup_title: str,
+    browser_page: Page,
+    webui: WebUI,
+    screenshot_dir: Path,
+) -> None:
+    """Chromium shows the meaningful tab title and linked breadcrumb in DOM order."""
+    sync_api = pytest.importorskip("playwright.sync_api", reason="playwright not installed (Tier-B browser dep)")
+    path = _lookup_path(path_template)
+    page = browser_page
+    page.goto(webui.url(path), wait_until="domcontentloaded", timeout=30_000)
+    page.wait_for_load_state("networkidle", timeout=30_000)
+    assert page.locator("#usernamefld").count() == 0, f"{name}: authenticated browser showed the login form"
+    sync_api.expect(page).to_have_title(re.compile(re.escape(lookup_title)), timeout=10_000)
+
+    breadcrumb = page.locator("ol.breadcrumb")
+    sync_api.expect(breadcrumb).to_have_count(1)
+    crumbs = breadcrumb.locator(":scope > li")
+    sync_api.expect(crumbs).to_have_count(4)
+    assert [text.strip() for text in crumbs.all_inner_texts()] == ["Firewall", "pfBlockerNG", "Alerts", lookup_title]
+    assert crumbs.nth(0).locator("a").count() == 0
+    assert crumbs.nth(1).locator("a").get_attribute("href") == "/pfblockerng/pfblockerng_general.php"
+    assert crumbs.nth(2).locator("a").get_attribute("href") == "/pfblockerng/pfblockerng_alerts.php"
+    assert crumbs.nth(3).locator("a").get_attribute("href") == path
+
+    mask_page_identity(page)
+    page.screenshot(path=str(screenshot_dir / f"threats_header_{name}.png"), full_page=True)


### PR DESCRIPTION
Replaces #2950, which was closed only because the repository history/author identity was rewritten; it was not rejected. This PR carries the same reviewed change, re-authored as Andre Brait, plus the correctness and test-honesty review fixes.

Moves Threats request parsing and validation ahead of `head.inc`, then supplies the four-level `$pgtitle` / `$pglinks` and `pfblockerng` shortcut section at the actual head boundary. Invalid and missing requests retain their exact messages; array-shaped ports now reject before pfSense `is_port()` can throw.

## What changed

- `src/usr/local/www/pfblockerng/pfblockerng_threats.php`: authenticates first; validates/derives host, domain, or port; rejects non-string port values; assigns the exact Firewall > pfBlockerNG > Alerts > Threat … Lookup title, links, and package shortcut section; then includes `head.inc`.
- `tests/php/ThreatsPageHeaderTest.php`: subprocess coverage for three valid views, invalid host/domain/port, `port[]=8443`, and missing input; captures auth, title, links, and shortcut state at `head.inc` itself.
- `tests/smoke/ui/test_threats_header.py`: Tier-A HTTP coverage for the eight-row valid/reject matrix and Tier-B Chromium coverage for title, breadcrumb, and the pfBlockerNG package-log shortcut.
- `tests/smoke/ui/test_render_smoke.py`: removes the stale statement that rejected requests include `head.inc`.

## Acceptance evidence

- Original-order RED: `vendor/bin/phpunit tests/php/ThreatsPageHeaderTest.php` failed all 7 rows (71 assertions) because valid head state was null and rejects included head first.
- Scalar-port RED on the reviewed head: 8 tests / 98 assertions / 1 failure; `port[]=8443` exited 255 with `getservbyname()` TypeError instead of the exact invalid-port message.
- Focused GREEN on exact head `238f8aef57118c36ac20b2ba983dbc931c0df11f`: `OK (8 tests, 106 assertions)` under PHP 8.5.10 / PHPUnit 12.5.31.
- Frozen test blobs: PHP `1d4997e1242c24a7f53684edc955c1bb8f931cd6`; UI `2314322251a85aef60aaf62e49318ffc6a9e0965`.
- Mutation proof: removing the scalar guard reproduces the one exit-255 failure; removing, changing, or moving `$shortcut_section` after `head.inc` makes all three valid rows fail (8 tests / 100 assertions / 3 failures per mutant).
- Normal hooks passed: Ruff lint/format, PHP syntax, PHPCS, composer vendor, and repository policy checks.
- Exact-head CI: [Tests run 33357066584](https://github.com/pfBlockerNG/pfBlockerNG/actions/runs/33357066584) — PASS on `238f8aef` (25 successful checks, 2 conditional jobs skipped).
- Exact-head live Tier A: [UI render run 33357082538](https://github.com/pfBlockerNG/pfBlockerNG/actions/runs/33357082538) — CE 2.8 / FreeBSD 15, `15 passed, 659 deselected`; includes the live `port[]=8443` rejection and shortcut-link assertions. Diagnostics: `ui-diagnostics-render-CE-2.8` artifact 9745524402.
- Exact-head live Tier B: [UI browser run 33357084606](https://github.com/pfBlockerNG/pfBlockerNG/actions/runs/33357084606) — CE 2.8 / FreeBSD 15, `3 passed, 671 deselected`; host/domain/port Chromium rows assert title, breadcrumb, and package-log shortcut. Diagnostics/screenshots: `ui-diagnostics-browser-CE-2.8` artifact 9745614219.

## Acceptance criteria

- [x] Host, domain, and port views supply a meaningful browser title.
- [x] Each valid view supplies exactly four breadcrumb levels with the existing General, Alerts, and self links.
- [x] The pfBlockerNG package shortcut section is present when `head.inc` renders.
- [x] Invalid host/domain/port, array-shaped port, and missing requests preserve the exact rejection messages and exit before title/breadcrumb chrome.
- [x] Authentication remains ahead of `head.inc`; valid execution reaches the footer.

Fixes #2896

🤖 Generated by Oh My Pi and posted on behalf of @andrebrait.
