### PR TITLE
Validate processet publications before publishing

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -14465,6 +14465,7 @@ function pfb_download_fetch(PfbDownloadRequest $request): PfbDownloadResult {
 
 	// Remove any leading/trailing whitespace
 	$list_url = trim($list_url);
+	$is_et = strpos($list_url, 'iprepdata.txt') !== FALSE;
 
 	// Re-evaluate URL
 	if ($format == 'whois') {
@@ -15778,11 +15779,14 @@ function pfb_download_fetch(PfbDownloadRequest $request): PfbDownloadResult {
 						return PfbDownloadResult::failure();
 					}
 				} else {
-					// Rename file to 'orig' format
-					$renamed = @rename("{$file_download}", "{$orig_download}");
-					if (!$renamed) {
-						pfb_logger("\n[pfb_download] {$header} rename to .orig failed", 2);
-						return PfbDownloadResult::failure();
+					// ET keeps the fetched body at .raw until processet() validates
+					// and atomically replaces the live derived publication.
+					if (!$is_et) {
+						$renamed = @rename("{$file_download}", "{$orig_download}");
+						if (!$renamed) {
+							pfb_logger("\n[pfb_download] {$header} rename to .orig failed", 2);
+							return PfbDownloadResult::failure();
+						}
 					}
 					$retval = 0;
 				}
@@ -15790,9 +15794,21 @@ function pfb_download_fetch(PfbDownloadRequest $request): PfbDownloadResult {
 		}
 
 		if (pfb_download_retval_success($retval)) {
-			// Set downloaded file timestamp to remote timestamp
+			// Set downloaded file timestamp to remote timestamp. ET's accepted
+			// publication is derived later, so touching the stage cannot mutate live data.
 			if (isset($remote_stamp) && $remote_stamp != -1) {
-				@touch("{$orig_download}", $remote_stamp);
+				@touch($is_et ? $file_download : $orig_download, $remote_stamp);
+			}
+
+			if ($is_et) {
+				// issue #2683: gated on processet()'s exit status -- which is what lets
+				// issue #2658's ceiling ride along here.
+				exec(pfb_extract_cmd("{$pfb['script']} et {$header_esc} x x x x x {$pfb['etblock']} {$pfb['etmatch']} {$elog}"), $output, $retval);
+				if (!pfb_download_extraction_succeeded($retval)) {
+					pfb_logger("\n[pfb_download] et processing failed (script exit {$retval})" . pfb_extract_cap_note($retval), 2);
+					unlink_if_exists($file_download);
+					return PfbDownloadResult::failure();
+				}
 			}
 
 			// ADR-42 / issue #713 bug 5: refresh the content-hash sidecar at every
@@ -15803,17 +15819,20 @@ function pfb_download_fetch(PfbDownloadRequest $request): PfbDownloadResult {
 			// here must cover those same raw bytes too -- not the decompressed '.orig' --
 			// or a compressed feed (gz/bz2/zip) never matches and re-ingests every cron.
 			// pfb_source_hash_target() resolves to $file_download (the raw '.raw' download,
-			// still on disk for every compressed format) or falls back to $orig_download for
-			// an uncompressed feed, where $file_download was already renamed away (above)
-			// into $orig_download -- byte-identical to what was fetched, so the fallback is
-			// exact, not an approximation.  This covers both local and remote standard feeds
-			// (any path that finalises a plain .orig here).  The geoip/asn/top1m/blacklist
-			// archive early-returns above do not reach this block, so they correctly never get a sidecar.
+			// still on disk for every compressed format and staged ET body) or falls back
+			// to $orig_download for an uncompressed non-ET feed, where $file_download was
+			// already renamed away -- byte-identical to what was fetched, so the fallback
+			// is exact, not an approximation. This covers local and remote standard feeds.
+			// The geoip/asn/top1m/blacklist archive early-returns above do not reach this
+			// block, so they correctly never get a sidecar.
 			pfb_download_finalize_text(
 				"{$orig_download}",
 				"{$orig_download}",
 				pfb_source_hash_target($file_download, $orig_download)
 			);
+			if ($is_et) {
+				unlink_if_exists($file_download);
+			}
 
 			// issue #1797: normalization deliberately does NOT run here. Only the
 			// parse-loop consumers normalize: the helper's changed-verdict means
@@ -15822,25 +15841,7 @@ function pfb_download_fetch(PfbDownloadRequest $request): PfbDownloadResult {
 			// wrongly reuse stale staging (caught live by
 			// test_cron_detects_changed_local_feed). The geoip/asn/top1m/blacklist
 			// archive paths return above (issue #2735) and never reach the text pipeline.
-
-			// Process Emerging Threats IQRisk if required
-			if (strpos($list_url, 'iprepdata.txt') !== FALSE) {
-				// issue #2683: gated on processet()'s exit status -- which is what lets
-				// issue #2658's ceiling ride along here.
-				exec(pfb_extract_cmd("{$pfb['script']} et {$header_esc} x x x x x {$pfb['etblock']} {$pfb['etmatch']} {$elog}"), $output, $retval);
-				if (!pfb_download_extraction_succeeded($retval)) {
-					pfb_logger("\n[pfb_download] et processing failed (script exit {$retval})" . pfb_extract_cap_note($retval), 2);
-					// The '.orig' this pass published is the raw ET CSV (processet() rewrites it
-					// in place), which the apply loop's fail-marker fallback would parse. Both sidecar
-					// families go (pfb_force_clear_validators()' set) or a surviving ETag 304s the next pass.
-					foreach (array('', '.xxhash128', '.md5', '.etag', '.lastmod') as $et_sfx) {
-						unlink_if_exists("{$orig_download}{$et_sfx}");
-					}
-					unlink_if_exists($file_download);
-					return PfbDownloadResult::failure();
-				}
-			}
-				return PfbDownloadResult::success();
+			return PfbDownloadResult::success();
 		}
 		else {
 			$log = "   Decompression Failed\n";

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -12994,6 +12994,29 @@ function pfb_ip_render_attribution(array $fields): array {
 			);
 		}
 	}
+	$et_lock = FALSE;
+	if ($rq['folder'] === "{$pfb['etdir']}/*.txt") {
+		$et_lock = @fopen("{$pfb['etdir']}.transaction.lock", 'c');
+		$et_ready = is_resource($et_lock) && @flock($et_lock, LOCK_SH | LOCK_NB) &&
+			!file_exists("{$pfb['etdir']}.transaction");
+		if (!$et_ready) {
+			if (is_resource($et_lock)) {
+				@flock($et_lock, LOCK_UN);
+				@fclose($et_lock);
+			}
+			return array(
+				'host' => $rq['host'],
+				'hostname' => $rq['hostname'],
+				'pfb_geoip' => $rq['pfb_geoip'],
+				'field15' => $rq['field15'],
+				'mask' => '',
+				'feed_new' => 'Not listed!',
+				'eval_new' => 'Not listed!',
+				'alias_new' => '',
+				'pfb_matchtitle' => 'This IP is not currently listed!',
+			);
+		}
+	}
 	$memos = &pfb_ip_render_memos();
 	$mask = '';
 	if ($fields[4] == 4) {
@@ -13058,6 +13081,10 @@ function pfb_ip_render_attribution(array $fields): array {
 		'alias_new' => $alias_new,
 		'pfb_matchtitle' => $pfb_matchtitle,
 	);
+	if (is_resource($et_lock)) {
+		@flock($et_lock, LOCK_UN);
+		@fclose($et_lock);
+	}
 	pfb_geoip_generation_read_unlock($geoip_lock);
 	return $result;
 }
@@ -13308,20 +13335,40 @@ function pfb_ip_prefetch(array $rows): void {
 	global $pfb;
 
 	$geoip_lock = FALSE;
+	$et_lock = FALSE;
 	$has_geoip = FALSE;
+	$has_et = FALSE;
 	foreach ($rows as $row) {
-		if (!empty($row['pfb_geoip'])) {
-			$has_geoip = TRUE;
-			break;
-		}
+		$has_geoip = $has_geoip || !empty($row['pfb_geoip']);
+		$has_et = $has_et || $row['folder'] === "{$pfb['etdir']}/*.txt";
 	}
 	if ($has_geoip) {
 		$geoip_lock = pfb_geoip_generation_read_lock();
 	}
-	$rows = array_values(array_filter($rows, static function (array $row) use ($has_geoip, $geoip_lock): bool {
-		return empty($row['pfb_geoip']) || !$has_geoip || $geoip_lock !== FALSE;
-	}));
+	if ($has_et) {
+		$et_lock = @fopen("{$pfb['etdir']}.transaction.lock", 'c');
+		if (!is_resource($et_lock) || !@flock($et_lock, LOCK_SH | LOCK_NB) ||
+		    file_exists("{$pfb['etdir']}.transaction")) {
+			if (is_resource($et_lock)) {
+				@flock($et_lock, LOCK_UN);
+				@fclose($et_lock);
+			}
+			$et_lock = FALSE;
+		}
+	}
+	$rows = array_values(array_filter($rows,
+		static function (array $row) use ($has_geoip, $geoip_lock, $has_et, $et_lock, $pfb): bool {
+			$geoip_ready = empty($row['pfb_geoip']) || !$has_geoip || $geoip_lock !== FALSE;
+			$et_ready = $row['folder'] !== "{$pfb['etdir']}/*.txt" || !$has_et || $et_lock !== FALSE;
+			return $geoip_ready && $et_ready;
+		}
+	));
 	if (empty($rows)) {
+		if (is_resource($et_lock)) {
+			@flock($et_lock, LOCK_UN);
+			@fclose($et_lock);
+		}
+		pfb_geoip_generation_read_unlock($geoip_lock);
 		return;
 	}
 
@@ -13382,6 +13429,10 @@ function pfb_ip_prefetch(array $rows): void {
 
 	if (empty($miss_rows)) {
 		pfb_geoip_generation_read_unlock($geoip_lock);
+		if (is_resource($et_lock)) {
+			@flock($et_lock, LOCK_UN);
+			@fclose($et_lock);
+		}
 		return;
 	}
 
@@ -13449,6 +13500,10 @@ function pfb_ip_prefetch(array $rows): void {
 		// B3: the aliastables pattern file could not be created/written -- leave every
 		// remaining row unseeded (per-row fallback fires for all of them).
 		pfb_geoip_generation_read_unlock($geoip_lock);
+		if (is_resource($et_lock)) {
+			@flock($et_lock, LOCK_UN);
+			@fclose($et_lock);
+		}
 		return;
 	}
 
@@ -13456,6 +13511,10 @@ function pfb_ip_prefetch(array $rows): void {
 		$pfb_query    = $headers_by_host_folder[$miss_key];
 		$raw_validate = pfb_ip_prefetch_last_match($alias_lines, $eval_new) ?? '';
 		$memos['miss'][$miss_key] = array($pfb_query, $raw_validate);
+	}
+	if (is_resource($et_lock)) {
+		@flock($et_lock, LOCK_UN);
+		@fclose($et_lock);
 	}
 	pfb_geoip_generation_read_unlock($geoip_lock);
 }
@@ -14503,6 +14562,9 @@ function pfb_download_fetch(PfbDownloadRequest $request): PfbDownloadResult {
 	$orig_download	= trim("{$file_org_esc}", "'");
 	$list_download	= trim("{$list_url_esc}", "'");
 	$head_download	= trim("{$header_esc}", "'");
+	$et_stage	= "{$orig_download}.etstage";
+	$text_download	= $is_et ? $et_stage : $orig_download;
+	$text_download_esc = escapeshellarg($text_download);
 
 	$md5_download	= trim(escapeshellarg("{$file_dwn}.md5.raw"), "'");
 
@@ -15043,6 +15105,10 @@ function pfb_download_fetch(PfbDownloadRequest $request): PfbDownloadResult {
 			}
 		}
 
+		if ($is_et) {
+			unlink_if_exists($et_stage);
+		}
+
 		// Decompress file if required
 		if ($file_type == 'application/x-gzip' || $file_type == 'application/gzip') {
 			if (!pfb_validate_archive($file_download, $file_type)) {
@@ -15212,7 +15278,7 @@ function pfb_download_fetch(PfbDownloadRequest $request): PfbDownloadResult {
 				$retval = pfb_download_initial_retval();
 				$extract_tar = ($inner_type == 'application/x-tar');
 				$pfb_sanity = NULL;
-				if (!pfb_stage_publish($orig_download,
+				if (!pfb_stage_publish($text_download,
 				    static function (string $staged) use ($file_dwn_esc, $extract_tar, &$output, &$retval, &$pfb_sanity): int {
 					if ($extract_tar) {
 						exec(pfb_extract_cmd("set -o pipefail; /usr/bin/gunzip -c {$file_dwn_esc} | /usr/bin/tar -xOf - > " . escapeshellarg($staged)), $output, $retval);
@@ -15254,7 +15320,7 @@ function pfb_download_fetch(PfbDownloadRequest $request): PfbDownloadResult {
 			$retval = pfb_download_initial_retval();
 			$extract_tar = ($inner_type == 'application/x-tar');
 			$pfb_sanity = NULL;
-			if (!pfb_stage_publish($orig_download,
+			if (!pfb_stage_publish($text_download,
 			    static function (string $staged) use ($file_dwn_esc, $extract_tar, &$output, &$retval, &$pfb_sanity): int {
 				if ($extract_tar) {
 					exec(pfb_extract_cmd("set -o pipefail; /usr/bin/bzip2 -dkc {$file_dwn_esc} | /usr/bin/tar -xOf - > " . escapeshellarg($staged)), $output, $retval);
@@ -15531,10 +15597,14 @@ function pfb_download_fetch(PfbDownloadRequest $request): PfbDownloadResult {
 				$reject_detail = array();
 				$inner_rejected = FALSE;
 				$pfb_sanity = NULL;
-				if (!pfb_stage_publish($orig_download,
-				    static function (string $staged) use ($file_dwn_esc, $list_download,
+				if (!pfb_stage_publish($text_download,
+				    static function (string $staged) use ($file_dwn_esc, $list_download, $is_et,
 				        &$output, &$retval, &$reject_detail, &$inner_rejected, &$pfb_sanity): int {
-					exec(pfb_extract_cmd("set -o pipefail; /usr/bin/tar -xOf {$file_dwn_esc} | /usr/bin/sed 's/,[[:space:]]/; /g' | /usr/bin/tr ',' '\n' > " . escapeshellarg($staged)), $output, $retval);
+					if ($is_et) {
+						exec(pfb_extract_cmd("/usr/bin/tar -xOf {$file_dwn_esc} > " . escapeshellarg($staged)), $output, $retval);
+					} else {
+						exec(pfb_extract_cmd("set -o pipefail; /usr/bin/tar -xOf {$file_dwn_esc} | /usr/bin/sed 's/,[[:space:]]/; /g' | /usr/bin/tr ',' '\n' > " . escapeshellarg($staged)), $output, $retval);
+					}
 					if ($retval !== 0) {
 						return $retval;
 					}
@@ -15564,7 +15634,7 @@ function pfb_download_fetch(PfbDownloadRequest $request): PfbDownloadResult {
 			// (orig_download), not the outer archive -- the outer container is
 			// already covered by ADR-44's pfb_mime_normalise().
 			$reject_detail = array();
-			if (!pfb_filter(array("{$file_org_esc}", "{$orig_download}", "{$list_download}"), PFB_FILTER_FILE_MIME, 'pfb_download', '', FALSE, $reject_detail)) {
+			if (!pfb_filter(array("{$text_download_esc}", "{$text_download}", "{$list_download}"), PFB_FILTER_FILE_MIME, 'pfb_download', '', FALSE, $reject_detail)) {
 				pfb_validate_log($header, 'inner', 'inner_mime_not_allowed', pfb_reject_detail_summary($reject_detail));
 				unlink_if_exists($file_download);
 				return PfbDownloadResult::failure();
@@ -15764,7 +15834,7 @@ function pfb_download_fetch(PfbDownloadRequest $request): PfbDownloadResult {
 					}
 					$retval = pfb_download_initial_retval();
 					$pfb_sanity = NULL;
-					if (!pfb_stage_publish($orig_download,
+					if (!pfb_stage_publish($text_download,
 					    static function (string $staged) use ($file_dwn_esc, &$output, &$retval, &$pfb_sanity): int {
 						exec(pfb_extract_cmd("/usr/bin/tar -xOf {$file_dwn_esc} > " . escapeshellarg($staged)), $output, $retval);
 						$pfb_sanity = pfb_extracted_text_sanity($staged, $retval);
@@ -15807,6 +15877,7 @@ function pfb_download_fetch(PfbDownloadRequest $request): PfbDownloadResult {
 				if (!pfb_download_extraction_succeeded($retval)) {
 					pfb_logger("\n[pfb_download] et processing failed (script exit {$retval})" . pfb_extract_cap_note($retval), 2);
 					unlink_if_exists($file_download);
+					unlink_if_exists($et_stage);
 					return PfbDownloadResult::failure();
 				}
 			}
@@ -15832,6 +15903,7 @@ function pfb_download_fetch(PfbDownloadRequest $request): PfbDownloadResult {
 			);
 			if ($is_et) {
 				unlink_if_exists($file_download);
+				unlink_if_exists($et_stage);
 			}
 
 			// issue #1797: normalization deliberately does NOT run here. Only the
@@ -18094,15 +18166,24 @@ function pfb_daemon_filterlog() {
 						// Report specific ET IQRisk details
 						if ($et_enabled && strpos($pfb_query[0], "{$et_header}") !== FALSE) {
 							$ET_orig = $pfb_query;
-							$pfb_query = find_reported_header($host, "{$pfb['etdir']}/*", FALSE);
-
-							// ET IQRisk category is unknown.
-							if ($pfb_query[1] == 'Unknown') {
+							$et_lock = @fopen("{$pfb['etdir']}.transaction.lock", 'c');
+							$et_ready = is_resource($et_lock) && @flock($et_lock, LOCK_SH | LOCK_NB) &&
+								!file_exists("{$pfb['etdir']}.transaction");
+							if ($et_ready) {
+								$pfb_query = find_reported_header($host, "{$pfb['etdir']}/*", FALSE);
+								@flock($et_lock, LOCK_UN);
+								@fclose($et_lock);
+								if ($pfb_query[1] == 'Unknown') {
+									$pfb_query = $ET_orig;
+								} else {
+									$pfb_query[0] = "{$et_header}:{$pfb_query[0]}";
+								}
+							} else {
+								if (is_resource($et_lock)) {
+									@flock($et_lock, LOCK_UN);
+									@fclose($et_lock);
+								}
 								$pfb_query = $ET_orig;
-							}
-							else {
-								// Prepend ET Header name
-								$pfb_query[0] = "{$et_header}:{$pfb_query[0]}";
 							}
 						}
 

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.sh
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.sh
@@ -87,6 +87,7 @@ if [ -z "${PFB_SOURCED:-}" ]; then
 	pathtar=/usr/bin/tar
 	pathpfctl=/sbin/pfctl
 	pathphp=/usr/local/bin/php
+	pathlockf=/usr/bin/lockf
 	# issue #2016: the nested re-entry target and its budget (seconds). pfb_reentry()
 	# floors an empty/non-numeric/zero value to its own default, so a degraded value can
 	# never restore an unbounded wait.
@@ -2018,6 +2019,13 @@ pfb_et_output_valid() {
 		[ ! -s "${2}" ]
 		return
 	fi
+	LC_ALL=C od -An -v -tx1 "${1}" | grep -Eq '(^|[[:space:]])00([[:space:]]|$)'
+	etnulrc=$?
+	case "${etnulrc}" in
+		0) return 1 ;;
+		1) ;;
+		*) return "${etnulrc}" ;;
+	esac
 	LC_ALL=C awk -F. '
 		NF != 4 { exit 1 }
 		{
@@ -2036,111 +2044,316 @@ pfb_et_output_valid() {
 # issue #2683: the exit contract pfb_download() gates on. A failing status is
 # returned verbatim rather than collapsed to 1, so a child killed at issue
 # #2658's extraction ceiling reaches the caller as the 153 that names it.
-processet() {
+processet() (
+	blocklive="${pfborig}${alias}.orig"
+	matchlive="${pfbmatchgen}pfB_Match_ET_v4.txt"
 	etsource="${pfborig}${alias}.raw"
-	if [ -s "${etsource}" ]; then
-		# Remove previous ET IPRep files
-		[ -d "${etdir}" ] && [ "$(ls -A "${etdir}")" ] && rm -r "${etdir}/ET_"*
-		etgrep="${tempfile}.grep"
-		etsplit="${tempfile}.split"
-		if ! true > "${tempfile}" || ! true > "${tempfile2}" ||
-			! true > "${etgrep}" || ! true > "${etsplit}"; then
-			log="processet [ ${alias} ]: cannot create ET scratch file(s); aborting ET processing."
-			echo "${log}" | tee -a "${errorlog}"
-			return 1
-		fi
+	if [ -f "${blocklive}.etstage" ]; then
+		etsource="${blocklive}.etstage"
+	fi
+	etlock="${etdir}.transaction.lock"
+	etjournal="${etdir}.transaction"
+	etbak="${etdir}.rollback"
+	blockbak="${blocklive}.rollback"
+	matchbak="${matchlive}.rollback"
+	etstage=''
+	blockstage=''
+	matchstage=''
+	journal_tmp=''
+	etgrep="${tempfile}.grep"
+	etsplit="${tempfile}.split"
+	trap '
+		[ -n "${etstage}" ] && rm -rf "${etstage}"
+		[ -n "${blockstage}" ] && rm -f "${blockstage}"
+		[ -n "${matchstage}" ] && rm -f "${matchstage}"
+		[ -n "${journal_tmp}" ] && rm -f "${journal_tmp}"
+		rm -f "${etgrep}" "${etsplit}"
+	' 0
+	trap 'exit 1' 1 2 15
 
-		# ET CSV format (IP, Category, Score)
-		echo; echo; echo 'Compiling ET IPREP IQRisk based upon user selected categories'
+	pfb_et_restore_generation() {
+		restore_rc=0
+		case "${block_had}" in
+			1)
+				if [ -f "${blockbak}" ]; then
+					rm -f "${blocklive}" && mv -f "${blockbak}" "${blocklive}" || restore_rc=$?
+				fi
+				;;
+			0) rm -f "${blocklive}" || restore_rc=$? ;;
+		esac
+		case "${match_had}" in
+			1)
+				if [ -f "${matchbak}" ]; then
+					rm -f "${matchlive}" && mv -f "${matchbak}" "${matchlive}" || restore_rc=$?
+				fi
+				;;
+			0) rm -f "${matchlive}" || restore_rc=$? ;;
+			x) ;;
+		esac
+		case "${et_had}" in
+			1)
+				if [ -d "${etbak}" ]; then
+					rm -rf "${etdir}" && mv -f "${etbak}" "${etdir}" || restore_rc=$?
+				fi
+				;;
+			0) rm -rf "${etdir}" || restore_rc=$? ;;
+		esac
+		return "${restore_rc}"
+	}
 
-		category=1
-		etcat='ET_Cnc ET_Bot ET_Spam ET_Drop ET_Spywarecnc ET_Onlinegaming ET_Drivebysrc ET_Cat8 ET_Chatserver ET_Tornode
-			ET_Cat11 ET_Cat12 ET_Compromised ET_Cat14 ET_P2P ET_Proxy ET_Ipcheck ET_Cat18 ET_Utility ET_DDostarget
-			ET_Scanner ET_Cat22 ET_Brute ET_Fakeav ET_Dyndns ET_Undesireable ET_Abusedtld ET_Selfsignedssl ET_Blackhole ET_RAS
-			ET_P2Pcnc ET_Cat32 ET_Parking ET_VPN ET_Exesource ET_Cat36 ET_Mobilecnc ET_Mobilespyware ET_Skypenode
-			ET_Bitcoin ET_DDosattack'
-
-		for file in ${etcat}; do
-
-			case "${category}" in
-
-				8|11|12|14|18|22|32|36)
-					# Some ET categories are not in use (For future use)
-					;;
-				*)
-					# grep rc 1 is a legitimate empty category. Its hard errors must
-					# remain observable, so cut runs only after grep's status is saved.
-					grep ",${category}," "${etsource}" > "${etgrep}"
-					etrc=$?
-					case "${etrc}" in
-						0|1)
-							cut -d',' -f1 "${etgrep}" > "${etsplit}" || { etrc=$?; pfb_et_abort "the ${file} split" "${etrc}"; return "${etrc}"; }
-							pfb_et_output_valid "${etsplit}" '' || { etrc=$?; pfb_et_abort "the ${file} split validation" "${etrc}"; return "${etrc}"; }
-							mv -f "${etsplit}" "${etdir}/${file}.txt" || { etrc=$?; pfb_et_abort "the ${file} split publish" "${etrc}"; return "${etrc}"; }
-							;;
-						*)
-							pfb_et_abort "the ${file} category scan" "${etrc}"
-							return "${etrc}"
-							;;
-					esac
-					;;
-			esac
-			category="$((category + 1))"
-		done
-
-		data="$(ls "${etdir}" | sed 's/\.txt//')"
-		printf "%-10s %-25s\n" '  Action' 'Category'
-		echo '-------------------------------------------'
-
-		for list in ${data}; do
-			# etblock/etmatch are ", "-separated token lists (see the sed transform
-			# above); pad both sides with the delimiter and anchor on it so a token
-			# only matches its OWN whole entry -- a bare "*$list*" substring glob
-			# would let e.g. a selected ET_P2Pcnc also match list=ET_P2P (issue #713
-			# bug 6). The padded 'x' sentinel (no selection) still matches nothing
-			# real, since no category is literally named 'x'.
-			case ", ${etblock}, " in
-				*", ${list}, "*)
-					printf "%-10s %-25s\n" '  Block: ' "${list}"
-					# issue #1263: awk 1 supplies a record terminator cat doesn't --
-					# a category file no longer welds onto the next one accumulated.
-					# Both accumulations stay on ONE line: pfblockerng_cat_weld_more_spec.sh
-					# extracts each statement by line number and evals it.
-					awk 1 "${etdir}/${list}.txt" >> "${tempfile}" || { etrc=$?; pfb_et_abort "the ${list} block accumulation" "${etrc}"; return "${etrc}"; }
-					;;
-			esac
-			case ", ${etmatch}, " in
-				*", ${list}, "*)
-					printf "%-10s %-25s\n" '  Match: ' "${list}"
-					awk 1 "${etdir}/${list}.txt" >> "${tempfile2}" || { etrc=$?; pfb_et_abort "the ${list} match accumulation" "${etrc}"; return "${etrc}"; }
-					;;
-			esac
-		done
-		echo '-------------------------------------------'
-
-		if [ -f "${tempfile}" ]; then
-			pfb_et_output_valid "${tempfile}" "${pfborig}${alias}.orig" || { etrc=$?; pfb_et_abort 'the block validation' "${etrc}"; return "${etrc}"; }
-		fi
-		if [ "${etmatch}" != 'x' ]; then
-			pfb_et_output_valid "${tempfile2}" "${pfbmatchgen}pfB_Match_ET_v4.txt" || { etrc=$?; pfb_et_abort 'the match validation' "${etrc}"; return "${etrc}"; }
-		fi
-		if [ -f "${tempfile}" ]; then
-			mv -f "${tempfile}" "${pfborig}${alias}.orig" || { etrc=$?; pfb_et_abort 'the block publish' "${etrc}"; return "${etrc}"; }
-		fi
-		if [ "${etmatch}" != 'x' ]; then
-			mv -f "${tempfile2}" "${pfbmatchgen}pfB_Match_ET_v4.txt" || { etrc=$?; pfb_et_abort 'the match publish' "${etrc}"; return "${etrc}"; }
-		fi
-		# issue #1263: awk 1 supplies a record terminator cat doesn't -- an
-		# unterminated ET_* file no longer welds its last row onto the next file's first.
-		counto="$(awk 1 "${etdir}"/ET_* | grep -cv '^#\|^$')"; countf="$(grep -cv "^${ip_placeholder2}$" "${pfborig}${alias}.orig")"
-		echo; echo "All ET Folder count [ ${counto} ]  Final count [ ${countf} ]"
-		return 0
-	else
+	if [ ! -s "${etsource}" ] && [ ! -f "${etjournal}" ]; then
 		echo; echo 'No staged ET source file found!'
 		echo " [ ${alias} ] No staged ET source file found; aborting ET processing [ ${now} ]" >> "${errorlog}"
 		return 1
 	fi
-}
+
+	# A previous process may have died after the journal became visible. Recover
+	# it under the same lock readers take before looking at category files.
+	(
+		"${pathlockf:-true}" -s -t 60 9 || exit $?
+		if [ -f "${etjournal}" ]; then
+			IFS=' ' read -r et_had block_had match_had < "${etjournal}" || exit 1
+			case "${et_had}:${block_had}:${match_had}" in
+				[01]:[01]:[01x]) ;;
+				*) exit 1 ;;
+			esac
+			pfb_et_restore_generation || exit $?
+			rm -f "${etjournal}" || exit $?
+		else
+			rm -f "${blockbak}" "${matchbak}"
+			[ ! -d "${etbak}" ] || rm -rf "${etbak}"
+		fi
+	) 9>"${etlock}"
+	etrc=$?
+	if [ "${etrc}" -ne 0 ]; then
+		pfb_et_abort 'transaction recovery' "${etrc}"
+		return "${etrc}"
+	fi
+
+	if [ ! -s "${etsource}" ]; then
+		echo; echo 'No staged ET source file found!'
+		echo " [ ${alias} ] No staged ET source file found; aborting ET processing [ ${now} ]" >> "${errorlog}"
+		return 1
+	fi
+
+	etparent="$(dirname "${etdir}")"
+	etstage="$(mktemp -d "${etparent}/.pfbetstage.XXXXXX")" || {
+		pfb_et_abort 'the category stage creation' 1
+		return 1
+	}
+	blockstage="$(mktemp "${blocklive}.stage.XXXXXX")" || {
+		pfb_et_abort 'the block stage creation' 1
+		return 1
+	}
+	if [ "${etmatch}" != 'x' ]; then
+		matchstage="$(mktemp "${matchlive}.stage.XXXXXX")" || {
+			pfb_et_abort 'the match stage creation' 1
+			return 1
+		}
+	fi
+	if [ ! -w "${etdir}" ]; then
+		echo "processet: ET category directory is not writable" >&2
+		pfb_et_abort 'the category stage creation' 1
+		return 1
+	fi
+	if ! chmod 0755 "${etstage}" ||
+		! true > "${tempfile}" || ! true > "${tempfile2}" ||
+		! true > "${etgrep}" || ! true > "${etsplit}"; then
+		log="processet [ ${alias} ]: cannot create ET scratch file(s); aborting ET processing."
+		echo "${log}" | tee -a "${errorlog}"
+		return 1
+	fi
+
+	# ET CSV format (IP, Category, Score)
+	echo; echo; echo 'Compiling ET IPREP IQRisk based upon user selected categories'
+
+	category=1
+	etcat='ET_Cnc ET_Bot ET_Spam ET_Drop ET_Spywarecnc ET_Onlinegaming ET_Drivebysrc ET_Cat8 ET_Chatserver ET_Tornode
+		ET_Cat11 ET_Cat12 ET_Compromised ET_Cat14 ET_P2P ET_Proxy ET_Ipcheck ET_Cat18 ET_Utility ET_DDostarget
+		ET_Scanner ET_Cat22 ET_Brute ET_Fakeav ET_Dyndns ET_Undesireable ET_Abusedtld ET_Selfsignedssl ET_Blackhole ET_RAS
+		ET_P2Pcnc ET_Cat32 ET_Parking ET_VPN ET_Exesource ET_Cat36 ET_Mobilecnc ET_Mobilespyware ET_Skypenode
+		ET_Bitcoin ET_DDosattack'
+
+	for file in ${etcat}; do
+		case "${category}" in
+			8|11|12|14|18|22|32|36)
+				# Some ET categories are not in use (For future use)
+				;;
+			*)
+				grep ",${category}," "${etsource}" > "${etgrep}"
+				etrc=$?
+				case "${etrc}" in
+					0|1)
+						cut -d',' -f1 "${etgrep}" > "${etstage}/${file}.txt" || {
+							etrc=$?
+							pfb_et_abort "the ${file} split" "${etrc}"
+							return "${etrc}"
+						}
+						pfb_et_output_valid "${etstage}/${file}.txt" '' || {
+							etrc=$?
+							pfb_et_abort "the ${file} split validation" "${etrc}"
+							return "${etrc}"
+						}
+						;;
+					*)
+						pfb_et_abort "the ${file} category scan" "${etrc}"
+						return "${etrc}"
+						;;
+				esac
+				;;
+		esac
+		category="$((category + 1))"
+	done
+
+	data="$(ls "${etstage}" | sed 's/\.txt//')"
+	printf "%-10s %-25s\n" '  Action' 'Category'
+	echo '-------------------------------------------'
+
+	for list in ${data}; do
+		case ", ${etblock}, " in
+			*", ${list}, "*)
+				printf "%-10s %-25s\n" '  Block: ' "${list}"
+				awk 1 "${etstage}/${list}.txt" >> "${blockstage}" || { etrc=$?; pfb_et_abort "the ${list} block accumulation" "${etrc}"; return "${etrc}"; }
+				;;
+		esac
+		case ", ${etmatch}, " in
+			*", ${list}, "*)
+				printf "%-10s %-25s\n" '  Match: ' "${list}"
+				awk 1 "${etstage}/${list}.txt" >> "${matchstage}" || { etrc=$?; pfb_et_abort "the ${list} match accumulation" "${etrc}"; return "${etrc}"; }
+				;;
+		esac
+	done
+	echo '-------------------------------------------'
+
+	pfb_et_output_valid "${blockstage}" "${blocklive}" || {
+		etrc=$?
+		pfb_et_abort 'the block validation' "${etrc}"
+		return "${etrc}"
+	}
+	if [ "${etmatch}" != 'x' ]; then
+		pfb_et_output_valid "${matchstage}" "${matchlive}" || {
+			etrc=$?
+			pfb_et_abort 'the match validation' "${etrc}"
+			return "${etrc}"
+		}
+	fi
+	chmod 0644 "${blockstage}" "${etstage}"/*.txt || {
+		etrc=$?
+		pfb_et_abort 'the staged generation permissions' "${etrc}"
+		return "${etrc}"
+	}
+	if [ "${etmatch}" != 'x' ]; then
+		chmod 0644 "${matchstage}" || {
+			etrc=$?
+			pfb_et_abort 'the match stage permissions' "${etrc}"
+			return "${etrc}"
+		}
+	fi
+
+	# Commit categories and both aggregates while readers are excluded. Every
+	# candidate, backup, and journal sits beside its destination, so mv is rename.
+	(
+		"${pathlockf:-true}" -s -t 60 9 || exit $?
+		et_had=0
+		block_had=0
+		match_had=x
+		[ ! -d "${etdir}" ] || et_had=1
+		[ ! -e "${blocklive}" ] || block_had=1
+		if [ "${etmatch}" != 'x' ]; then
+			match_had=0
+			[ ! -e "${matchlive}" ] || match_had=1
+		fi
+		rm -f "${blockbak}" "${matchbak}"
+		[ ! -d "${etbak}" ] || rm -rf "${etbak}"
+		if [ "${block_had}" -eq 1 ]; then
+			cp -p "${blocklive}" "${blockbak}" || {
+				etrc=$?
+				pfb_et_abort 'the block backup' "${etrc}"
+				exit "${etrc}"
+			}
+		fi
+		if [ "${match_had}" = 1 ]; then
+			cp -p "${matchlive}" "${matchbak}" || {
+				etrc=$?
+				rm -f "${blockbak}"
+				pfb_et_abort 'the match backup' "${etrc}"
+				exit "${etrc}"
+			}
+		fi
+		journal_tmp="$(mktemp "${etjournal}.XXXXXX")" || {
+			etrc=$?
+			rm -f "${blockbak}" "${matchbak}"
+			pfb_et_abort 'the transaction journal creation' "${etrc}"
+			exit "${etrc}"
+		}
+		printf '%s %s %s\n' "${et_had}" "${block_had}" "${match_had}" > "${journal_tmp}" || {
+			etrc=$?
+			rm -f "${journal_tmp}" "${blockbak}" "${matchbak}"
+			pfb_et_abort 'the transaction journal write' "${etrc}"
+			exit "${etrc}"
+		}
+		mv -f "${journal_tmp}" "${etjournal}"
+		etrc=$?
+		if [ "${etrc}" -ne 0 ]; then
+			rm -f "${journal_tmp}" "${etjournal}" "${blockbak}" "${matchbak}"
+			pfb_et_abort 'the transaction journal publish' "${etrc}"
+			exit "${etrc}"
+		fi
+		journal_tmp=''
+
+		if [ "${et_had}" -eq 1 ]; then
+			mv -f "${etdir}" "${etbak}"
+			etrc=$?
+			if [ "${etrc}" -ne 0 ]; then
+				pfb_et_restore_generation && rm -f "${etjournal}"
+				pfb_et_abort 'the category backup' "${etrc}"
+				exit "${etrc}"
+			fi
+		fi
+		mv -f "${etstage}" "${etdir}"
+		etrc=$?
+		if [ "${etrc}" -ne 0 ]; then
+			pfb_et_restore_generation && rm -f "${etjournal}"
+			pfb_et_abort 'the category publish' "${etrc}"
+			exit "${etrc}"
+		fi
+		mv -f "${blockstage}" "${blocklive}"
+		etrc=$?
+		if [ "${etrc}" -ne 0 ]; then
+			pfb_et_restore_generation && rm -f "${etjournal}"
+			pfb_et_abort 'the block publish' "${etrc}"
+			exit "${etrc}"
+		fi
+		if [ "${etmatch}" != 'x' ]; then
+			mv -f "${matchstage}" "${matchlive}"
+			etrc=$?
+			if [ "${etrc}" -ne 0 ]; then
+				pfb_et_restore_generation && rm -f "${etjournal}"
+				pfb_et_abort 'the match publish' "${etrc}"
+				exit "${etrc}"
+			fi
+		fi
+		rm -f "${etjournal}"
+		etrc=$?
+		if [ "${etrc}" -ne 0 ]; then
+			pfb_et_restore_generation
+			pfb_et_abort 'the transaction journal retirement' "${etrc}"
+			exit "${etrc}"
+		fi
+		rm -f "${blockbak}" "${matchbak}"
+		[ ! -d "${etbak}" ] || rm -rf "${etbak}"
+	) 9>"${etlock}"
+	etrc=$?
+	if [ "${etrc}" -ne 0 ]; then
+		return "${etrc}"
+	fi
+
+	# issue #1263: awk 1 supplies a record terminator cat doesn't -- an
+	# unterminated ET_* file no longer welds its last row onto the next file's first.
+	counto="$(awk 1 "${etdir}"/ET_* | grep -cv '^#\|^$')"; countf="$(grep -cv "^${ip_placeholder2}$" "${blocklive}")"
+	echo; echo "All ET Folder count [ ${counto} ]  Final count [ ${countf} ]"
+	return 0
+)
 
 
 # Function to extract IP addresses from XLSX files.

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.sh
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.sh
@@ -2225,11 +2225,17 @@ processet() (
 	done
 	echo '-------------------------------------------'
 
-	pfb_et_output_valid "${blockstage}" "${blocklive}" || {
-		etrc=$?
-		pfb_et_abort 'the block validation' "${etrc}"
-		return "${etrc}"
-	}
+	# The 'x' sentinel (no Block category selected) publishes an intentionally
+	# empty block generation -- the commit below is unconditional for Block, as
+	# the base mv always was -- so the empty-over-live refusal applies only to a
+	# selected category whose staged derivation came back empty.
+	if [ "${etblock}" != 'x' ]; then
+		pfb_et_output_valid "${blockstage}" "${blocklive}" || {
+			etrc=$?
+			pfb_et_abort 'the block validation' "${etrc}"
+			return "${etrc}"
+		}
+	fi
 	if [ "${etmatch}" != 'x' ]; then
 		pfb_et_output_valid "${matchstage}" "${matchlive}" || {
 			etrc=$?

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.sh
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.sh
@@ -2010,16 +2010,41 @@ pfb_et_abort() {
 }
 
 
+# A candidate may be empty only when it is not replacing a non-empty live list.
+# Every non-empty row must be one IPv4 literal; this also rejects binary
+# diagnostics, BOMs, NUL-bearing rows, ranges, and CIDRs.
+pfb_et_output_valid() {
+	if [ ! -s "${1}" ]; then
+		[ ! -s "${2}" ]
+		return
+	fi
+	LC_ALL=C awk -F. '
+		NF != 4 { exit 1 }
+		{
+			for (i = 1; i <= 4; i++) {
+				if ($i !~ /^[0-9]+$/ || $i > 255) {
+					exit 1
+				}
+			}
+		}
+	' "${1}"
+}
+
+
 # Function to split ET Pro IPREP into category files and compile selected blocked categories into outfile.
 #
 # issue #2683: the exit contract pfb_download() gates on. A failing status is
 # returned verbatim rather than collapsed to 1, so a child killed at issue
 # #2658's extraction ceiling reaches the caller as the 153 that names it.
 processet() {
-	if [ -s "${pfborig}${alias}.orig" ]; then
+	etsource="${pfborig}${alias}.raw"
+	if [ -s "${etsource}" ]; then
 		# Remove previous ET IPRep files
 		[ -d "${etdir}" ] && [ "$(ls -A "${etdir}")" ] && rm -r "${etdir}/ET_"*
-		if ! true > "${tempfile}" || ! true > "${tempfile2}"; then
+		etgrep="${tempfile}.grep"
+		etsplit="${tempfile}.split"
+		if ! true > "${tempfile}" || ! true > "${tempfile2}" ||
+			! true > "${etgrep}" || ! true > "${etsplit}"; then
 			log="processet [ ${alias} ]: cannot create ET scratch file(s); aborting ET processing."
 			echo "${log}" | tee -a "${errorlog}"
 			return 1
@@ -2043,10 +2068,21 @@ processet() {
 					# Some ET categories are not in use (For future use)
 					;;
 				*)
-					# The pipeline's status is `cut`'s, never grep's: a category with
-					# no rows makes grep exit 1 and is entirely normal, while a failed
-					# WRITE must abort instead of publishing a truncated split.
-					grep ",${category}," "${pfborig}${alias}.orig" | cut -d',' -f1 > "${etdir}/${file}.txt" || { etrc=$?; pfb_et_abort "the ${file} split" "${etrc}"; return "${etrc}"; }
+					# grep rc 1 is a legitimate empty category. Its hard errors must
+					# remain observable, so cut runs only after grep's status is saved.
+					grep ",${category}," "${etsource}" > "${etgrep}"
+					etrc=$?
+					case "${etrc}" in
+						0|1)
+							cut -d',' -f1 "${etgrep}" > "${etsplit}" || { etrc=$?; pfb_et_abort "the ${file} split" "${etrc}"; return "${etrc}"; }
+							pfb_et_output_valid "${etsplit}" '' || { etrc=$?; pfb_et_abort "the ${file} split validation" "${etrc}"; return "${etrc}"; }
+							mv -f "${etsplit}" "${etdir}/${file}.txt" || { etrc=$?; pfb_et_abort "the ${file} split publish" "${etrc}"; return "${etrc}"; }
+							;;
+						*)
+							pfb_et_abort "the ${file} category scan" "${etrc}"
+							return "${etrc}"
+							;;
+					esac
 					;;
 			esac
 			category="$((category + 1))"
@@ -2083,6 +2119,12 @@ processet() {
 		echo '-------------------------------------------'
 
 		if [ -f "${tempfile}" ]; then
+			pfb_et_output_valid "${tempfile}" "${pfborig}${alias}.orig" || { etrc=$?; pfb_et_abort 'the block validation' "${etrc}"; return "${etrc}"; }
+		fi
+		if [ "${etmatch}" != 'x' ]; then
+			pfb_et_output_valid "${tempfile2}" "${pfbmatchgen}pfB_Match_ET_v4.txt" || { etrc=$?; pfb_et_abort 'the match validation' "${etrc}"; return "${etrc}"; }
+		fi
+		if [ -f "${tempfile}" ]; then
 			mv -f "${tempfile}" "${pfborig}${alias}.orig" || { etrc=$?; pfb_et_abort 'the block publish' "${etrc}"; return "${etrc}"; }
 		fi
 		if [ "${etmatch}" != 'x' ]; then
@@ -2094,8 +2136,8 @@ processet() {
 		echo; echo "All ET Folder count [ ${counto} ]  Final count [ ${countf} ]"
 		return 0
 	else
-		echo; echo 'No ET .orig File Found!'
-		echo " [ ${alias} ] No ET .orig file found; aborting ET processing [ ${now} ]" >> "${errorlog}"
+		echo; echo 'No staged ET source file found!'
+		echo " [ ${alias} ] No staged ET source file found; aborting ET processing [ ${now} ]" >> "${errorlog}"
 		return 1
 	fi
 }

--- a/tests/php/DownloadExtractRestrictiveFlagsTest.php
+++ b/tests/php/DownloadExtractRestrictiveFlagsTest.php
@@ -170,6 +170,8 @@ final class DownloadExtractRestrictiveFlagsTest extends TestCase
 	 *        for metadata to be restored onto, and the shell redirect that
 	 *        captures them already owns the mode of the file it creates.
 	 *
+	 * The eight are gzip-inner-tar, bzip2-inner-tar, GeoIP ZIP stdout,
+	 * ET ZIP CSV, ordinary ZIP transform, ASN tar, TOP1M tar, and generic tar.
 	 * Without this, moving the flags onto a -xO call would look like a fix.
 	 */
 	public function test_the_stdout_extractions_stay_unflagged(): void
@@ -183,8 +185,14 @@ final class DownloadExtractRestrictiveFlagsTest extends TestCase
 			$this->assertStringNotContainsString('PFB_TAR_EXTRACT_FLAGS', $statement,
 				"stdout extraction carrying disk-extraction flags in {$file}: {$statement}");
 		}
-		$this->assertSame(7, $seen,
-			'the seven stdout extractions are the whole class; the sweep must not silently match none');
+		$this->assertMatchesRegularExpression(
+			'/if \(\$is_et\) \{\s*exec\(pfb_extract_cmd\("\/usr\/bin\/tar -xOf '
+			. '\{\$file_dwn_esc\} > " \. escapeshellarg\(\$staged\)\), \$output, \$retval\);\s*\}/',
+			implode(' ', self::$sources),
+			'the eighth site must be the ET ZIP CSV extraction into its isolated stage'
+		);
+		$this->assertSame(8, $seen,
+			'the eight enumerated stdout extractions are the whole class; a ninth must be added deliberately');
 	}
 
 	/**

--- a/tests/php/DownloadExtractedPayloadSanityTest.php
+++ b/tests/php/DownloadExtractedPayloadSanityTest.php
@@ -56,7 +56,7 @@ final class DownloadExtractedPayloadSanityTest extends TestCase
 	{
 		$this->dir = sys_get_temp_dir() . '/pfb_extracted_sanity_' . getmypid() . '_' . uniqid();
 		$this->assertTrue(mkdir($this->dir, 0777, TRUE));
-		foreach (['log', 'errlog', 'pnow', 'dbdir', 'mime_types'] as $key) {
+		foreach (['log', 'errlog', 'pnow', 'dbdir', 'mime_types', 'script', 'etblock', 'etmatch'] as $key) {
 			$this->saved_pfb_exists[$key] = array_key_exists($key, $GLOBALS['pfb'] ?? []);
 			$this->saved_pfb[$key] = $GLOBALS['pfb'][$key] ?? NULL;
 		}
@@ -128,6 +128,35 @@ final class DownloadExtractedPayloadSanityTest extends TestCase
 			'zip'       => ['zip'],
 			'plain tar' => ['tar'],
 		];
+	}
+
+	/**
+	 * A compressed ET body is only input to processet(): helper refusal must leave
+	 * the accepted aggregate/hash pair untouched. The marker proves every archive
+	 * kind was extracted into the isolated ET stage, not over the live .orig.
+	 */
+	#[DataProvider('archiveKinds')]
+	public function test_et_archive_refusal_keeps_the_last_good_generation(string $kind): void
+	{
+		$payload = "192.0.2.10,1,90\n";
+		$base = $this->seedPublication();
+		$marker = "{$this->dir}/et-helper-input";
+		$this->assertNotFalse(file_put_contents("{$base}.orig.xxhash128", 'old-hash'));
+		$GLOBALS['pfb']['script'] = $this->rejectingEtHelper($base, $marker);
+		$GLOBALS['pfb']['etblock'] = 'ET_Cnc';
+		$GLOBALS['pfb']['etmatch'] = 'x';
+
+		$result = $this->downloadArchive($kind, $payload, $base, PfbToggle::Off, TRUE);
+
+		$this->assertFalse($result->success, 'the processet refusal must fail the ingest');
+		$this->assertSame($payload, file_get_contents($marker),
+			'the helper must receive the decompressed CSV from the isolated ET stage');
+		$this->assertSame(self::SERVED, file_get_contents("{$base}.orig"),
+			'refusal must preserve the accepted aggregate byte-for-byte');
+		$this->assertSame('old-hash', file_get_contents("{$base}.orig.xxhash128"),
+			'refusal must preserve the accepted raw-source hash');
+		$this->assertFileDoesNotExist("{$base}.raw");
+		$this->assertFileDoesNotExist("{$base}.orig.etstage");
 	}
 
 	/**
@@ -333,7 +362,13 @@ final class DownloadExtractedPayloadSanityTest extends TestCase
 		}
 	}
 
-	private function downloadArchive(string $kind, string $payload, string $base, PfbToggle $flag): PfbDownloadResult
+	private function downloadArchive(
+		string $kind,
+		string $payload,
+		string $base,
+		PfbToggle $flag,
+		bool $et = FALSE
+	): PfbDownloadResult
 	{
 		if ($kind === 'zip') {
 			$this->requirePipefailShell();
@@ -407,7 +442,7 @@ PHP;
 		);
 
 		return pfb_download(new PfbDownloadRequest(
-			listUrl: "http://127.0.0.1:{$port}/feed",
+			listUrl: "http://127.0.0.1:{$port}/" . ($et ? 'iprepdata.txt' : 'feed'),
 			downloadPath: $base,
 			flex: FALSE,
 			header: self::HEADER,
@@ -416,5 +451,15 @@ PHP;
 			timeout: 30,
 			type: '',
 		));
+	}
+
+	private function rejectingEtHelper(string $base, string $marker): string
+	{
+		$script = "{$this->dir}/reject-et";
+		$body = "#!/bin/sh\ncat " . escapeshellarg("{$base}.orig.etstage")
+			. ' > ' . escapeshellarg($marker) . "\nexit 1\n";
+		$this->assertNotFalse(file_put_contents($script, $body));
+		$this->assertTrue(chmod($script, 0700));
+		return $script;
 	}
 }

--- a/tests/php/DownloadExtractedPayloadSanityTest.php
+++ b/tests/php/DownloadExtractedPayloadSanityTest.php
@@ -370,7 +370,10 @@ final class DownloadExtractedPayloadSanityTest extends TestCase
 		bool $et = FALSE
 	): PfbDownloadResult
 	{
-		if ($kind === 'zip') {
+		// Only the non-ET ZIP arm extracts through a `set -o pipefail` pipeline. The ET
+		// arm is a plain `tar -xOf > stage` redirect, so requiring the capability there
+		// would skip a row every POSIX /bin/sh can run (issue #2359's gate then reds).
+		if ($kind === 'zip' && !$et) {
 			$this->requirePipefailShell();
 		}
 		$source = $this->archiveFixture($kind, $payload);

--- a/tests/php/DownloadExtractionExitCodeTest.php
+++ b/tests/php/DownloadExtractionExitCodeTest.php
@@ -636,9 +636,9 @@ final class DownloadExtractionExitCodeTest extends TestCase
 		$this->assertStringNotContainsString('unlink_if_exists("{$orig_download}', $refusal,
 			'the ET branch must not bypass the wrapper by clearing live artifacts directly');
 
-		$finalize = strpos(self::$source, 'pfb_download_finalize_text(', $scopeEnd);
+		$finalize = strpos(self::$source, 'pfb_download_finalize_text(', $start);
 		$this->assertNotFalse($finalize);
-		$this->assertLessThan($finalize, $scopeEnd,
+		$this->assertGreaterThan($scopeEnd, $finalize,
 			'the accepted raw body hash and text finalization must happen after processet succeeds');
 	}
 

--- a/tests/php/DownloadExtractionExitCodeTest.php
+++ b/tests/php/DownloadExtractionExitCodeTest.php
@@ -591,10 +591,10 @@ final class DownloadExtractionExitCodeTest extends TestCase
 	}
 
 	/**
-	 * pfb_download() keeps the downloaded ET IQRisk body at its raw staging path
-	 * until processet() has derived and validated the selected categories. A
-	 * refusal must remove only that staged input: the live publication and its
-	 * validators still describe the last accepted category output.
+	 * pfb_download_fetch() keeps the downloaded ET IQRisk body at its raw staging
+	 * path until processet() accepts the selected categories. A refusal removes
+	 * only that stage here: the live publication and its source-hash baseline
+	 * remain last-good, while pfb_download() owns the #2820 HTTP-validator clear.
 	 */
 	public function testEtBodyStagesUntilTheHelperAcceptsIt(): void
 	{
@@ -626,12 +626,37 @@ final class DownloadExtractionExitCodeTest extends TestCase
 			'a refused staged body must be discarded');
 		$this->assertStringContainsString('return PfbDownloadResult::failure();', $refusal);
 		$this->assertStringNotContainsString('unlink_if_exists("{$orig_download}', $refusal,
-			'a refusal must not remove the last accepted publication or its validators');
+			'the ET branch must not bypass the wrapper by clearing live artifacts directly');
 
 		$finalize = strpos(self::$source, 'pfb_download_finalize_text(', $scopeEnd);
 		$this->assertNotFalse($finalize);
 		$this->assertLessThan($finalize, $scopeEnd,
 			'the accepted raw body hash and text finalization must happen after processet succeeds');
+	}
+
+	public function testEtRefusalLeavesHttpValidatorClearingToTheDownloadWrapper(): void
+	{
+		$wrapper = strpos(self::$source, 'function pfb_download(PfbDownloadRequest $request): PfbDownloadResult {');
+		$fetch = strpos(self::$source, 'function pfb_download_fetch(PfbDownloadRequest $request): PfbDownloadResult {');
+		$this->assertNotFalse($wrapper);
+		$this->assertNotFalse($fetch);
+		$wrapperScope = substr(self::$source, $wrapper, $fetch - $wrapper);
+		$this->assertStringContainsString("if (!\$result->success && \$request->type === '')", $wrapperScope,
+			'standard-list failures must enter the one #2820 validator-clear boundary');
+		$this->assertStringContainsString('unlink_if_exists("{$request->downloadPath}.orig.etag");', $wrapperScope);
+		$this->assertStringContainsString('unlink_if_exists("{$request->downloadPath}.orig.lastmod");', $wrapperScope);
+		$this->assertStringNotContainsString('.orig.xxhash128', $wrapperScope,
+			'the last-good source hash is publication state, not an HTTP validator');
+
+		$et = strpos(self::$source, 'if ($is_et) {', $fetch);
+		$this->assertNotFalse($et);
+		$etBrace = strpos(self::$source, '{', $et);
+		$this->assertNotFalse($etBrace);
+		$etScope = substr(self::$source, $et, self::closingBraceExclusive(self::$source, $etBrace) - $et);
+		$this->assertStringNotContainsString('.orig.etag', $etScope,
+			'the ET branch must leave HTTP-validator clearing to the wrapper');
+		$this->assertStringNotContainsString('.orig.lastmod', $etScope,
+			'the ET branch must leave HTTP-validator clearing to the wrapper');
 	}
 
 	/** Exclusive end index of the brace block whose `{` is at `$openBrace`. */

--- a/tests/php/DownloadExtractionExitCodeTest.php
+++ b/tests/php/DownloadExtractionExitCodeTest.php
@@ -591,41 +591,47 @@ final class DownloadExtractionExitCodeTest extends TestCase
 	}
 
 	/**
-	 * pfb_download() hands the ET IQRisk feed to the shell helper, which splits it
-	 * into per-category files and republishes the feed from the selected ones;
-	 * issue #2683 gave that helper an exit contract, so this branch is pinned like
-	 * its siblings — captured exec, nonzero-exit gate, and the ceiling wrap that
-	 * only an exit gate makes safe. Without the gate an aborted pass reached
-	 * PfbDownloadResult::success() with the unfiltered CSV still published.
-	 *
-	 * The refusal also has to DROP that publication: processet() rewrites the
-	 * '.orig' in place, so what it published is the raw ET CSV the apply loop's
-	 * fail-marker fallback parses — and a surviving ETag would 304 the next pass,
-	 * so both sidecar families go with it.
+	 * pfb_download() keeps the downloaded ET IQRisk body at its raw staging path
+	 * until processet() has derived and validated the selected categories. A
+	 * refusal must remove only that staged input: the live publication and its
+	 * validators still describe the last accepted category output.
 	 */
-	public function testEtBodyCapturesAndChecksHelperExit(): void
+	public function testEtBodyStagesUntilTheHelperAcceptsIt(): void
 	{
-		$start = strpos(self::$source, "if (strpos(\$list_url, 'iprepdata.txt') !== FALSE) {");
-		$this->assertNotFalse($start, 'the ET branch must still be in pfb_download()');
+		$isEt = strpos(self::$source, "\$is_et = strpos(\$list_url, 'iprepdata.txt') !== FALSE;");
+		$this->assertNotFalse($isEt, 'the ET URL decision must be normalized once');
+		$guard = strpos(self::$source, 'if (!$is_et) {', $isEt);
+		$this->assertNotFalse($guard, 'the plain-body rename must be gated away from ET input');
+		$guardBrace = strpos(self::$source, '{', $guard);
+		$this->assertNotFalse($guardBrace);
+		$guardEnd = self::closingBraceExclusive(self::$source, $guardBrace);
+		$rename = strpos(self::$source, '@rename("{$file_download}", "{$orig_download}")', $guard);
+		$this->assertNotFalse($rename, 'non-ET plain bodies must retain their existing rename');
+		$this->assertLessThan($guardEnd, $rename,
+			'the raw-to-live rename must remain inside the non-ET guard');
+
+		$start = strpos(self::$source, 'if ($is_et) {', $guardEnd);
+		$this->assertNotFalse($start, 'the ET helper branch must still be in pfb_download()');
 		$brace = strpos(self::$source, '{', $start);
 		$this->assertNotFalse($brace);
-		$scope = substr(self::$source, $start, self::closingBraceExclusive(self::$source, $brace) - $start);
+		$scopeEnd = self::closingBraceExclusive(self::$source, $brace);
+		$scope = substr(self::$source, $start, $scopeEnd - $start);
 		$this->assertStringContainsString(
 			'exec(pfb_extract_cmd("{$pfb[\'script\']} et {$header_esc} x x x x x '
 			. '{$pfb[\'etblock\']} {$pfb[\'etmatch\']} {$elog}"), $output, $retval);', $scope);
-		$this->assertStringContainsString('return PfbDownloadResult::failure();', $scope);
 		$fail = strpos($scope, 'if (!pfb_download_extraction_succeeded($retval)) {');
 		$this->assertNotFalse($fail, 'the ET branch must gate on the helper exit status');
 		$refusal = substr($scope, $fail);
-		$this->assertStringContainsString('unlink_if_exists("{$orig_download}', $refusal);
-		// The whole suffix SET, not four of five: the empty member is what drops the
-		// raw publication the fail-marker fallback would parse. Parsed and compared
-		// canonically so a behaviour-neutral reordering of the literal cannot fail it.
-		preg_match('/foreach \(array\((.*?)\) as \$et_sfx\)/', $refusal, $m);
-		$this->assertEqualsCanonicalizing(array('', '.xxhash128', '.md5', '.etag', '.lastmod'),
-			array_map(static fn (string $s): string => trim(trim($s), "'"), explode(',', $m[1] ?? '')),
-			"the refusal must drop the '.orig' itself and BOTH sidecar families");
-		$this->assertStringContainsString('unlink_if_exists($file_download);', $refusal);
+		$this->assertStringContainsString('unlink_if_exists($file_download);', $refusal,
+			'a refused staged body must be discarded');
+		$this->assertStringContainsString('return PfbDownloadResult::failure();', $refusal);
+		$this->assertStringNotContainsString('unlink_if_exists("{$orig_download}', $refusal,
+			'a refusal must not remove the last accepted publication or its validators');
+
+		$finalize = strpos(self::$source, 'pfb_download_finalize_text(', $scopeEnd);
+		$this->assertNotFalse($finalize);
+		$this->assertLessThan($finalize, $scopeEnd,
+			'the accepted raw body hash and text finalization must happen after processet succeeds');
 	}
 
 	/** Exclusive end index of the brace block whose `{` is at `$openBrace`. */

--- a/tests/php/DownloadExtractionExitCodeTest.php
+++ b/tests/php/DownloadExtractionExitCodeTest.php
@@ -85,9 +85,9 @@ final class DownloadExtractionExitCodeTest extends TestCase
 	}
 
 	/**
-	 * pfb_download() decompresses bzip2 feeds onto the live publication; pin this
-	 * comment-free branch and its staged-publish guard so the branch cannot revert
-	 * to a raw redirect. Comments/docblocks cannot define this scope.
+	 * pfb_download() decompresses bzip2 feeds onto the selected publication stage;
+	 * pin this comment-free branch and its staged-publish guard so the branch cannot
+	 * revert to a raw redirect. Comments/docblocks cannot define this scope.
 	 */
 	public function testBzip2BodyCapturesAndChecksExit(): void
 	{
@@ -98,14 +98,14 @@ final class DownloadExtractionExitCodeTest extends TestCase
 		$scope = substr(self::$source, $bzip2, $zip - $bzip2);
 		$this->assertStringContainsString(
 			'exec(pfb_extract_cmd("/usr/bin/bzip2 -dkc {$file_dwn_esc} > " . escapeshellarg($staged)), $output, $retval);', $scope);
-		$this->assertStringContainsString('if (!pfb_stage_publish($orig_download,', $scope);
+		$this->assertStringContainsString('if (!pfb_stage_publish($text_download,', $scope);
 	}
 
 	/**
 	 * Issue #2739 — a bzip2 Blacklist body must fail closed. The arm
-	 * extracts onto $orig_download for IP feeds; Blacklist has no category
-	 * extract here, so a successful empty update is a lie. Comments and
-	 * docblocks cannot define this scope.
+	 * extracts onto the standard/ET-selected text target for IP feeds; Blacklist
+	 * has no category extract here, so a successful empty update is a lie. Comments
+	 * and docblocks cannot define this scope.
 	 */
 	public function testBzip2BlacklistBodyFailsClosedWithoutExtraction(): void
 	{
@@ -115,7 +115,7 @@ final class DownloadExtractionExitCodeTest extends TestCase
 		$this->assertNotFalse($zip);
 		$scope = substr(self::$source, $bzip2, $zip - $bzip2);
 		$reject = strpos($scope, "if (\$type == 'blacklist') {");
-		$publish = strpos($scope, 'if (!pfb_stage_publish($orig_download,');
+		$publish = strpos($scope, 'if (!pfb_stage_publish($text_download,');
 		$this->assertNotFalse($reject, $scope);
 		$this->assertNotFalse($publish, $scope);
 		$this->assertLessThan($publish, $reject, 'Blacklist reject must run before the IP-feed extract');
@@ -600,6 +600,12 @@ final class DownloadExtractionExitCodeTest extends TestCase
 	{
 		$isEt = strpos(self::$source, "\$is_et = strpos(\$list_url, 'iprepdata.txt') !== FALSE;");
 		$this->assertNotFalse($isEt, 'the ET URL decision must be normalized once');
+		$this->assertStringContainsString('$et_stage = "{$orig_download}.etstage";', self::$source);
+		$this->assertGreaterThanOrEqual(
+			4,
+			substr_count(self::$source, 'pfb_stage_publish($text_download,'),
+			'gzip, bzip2, zip, and tar standard-feed payloads must target the ET stage'
+		);
 		$guard = strpos(self::$source, 'if (!$is_et) {', $isEt);
 		$this->assertNotFalse($guard, 'the plain-body rename must be gated away from ET input');
 		$guardBrace = strpos(self::$source, '{', $guard);
@@ -624,6 +630,8 @@ final class DownloadExtractionExitCodeTest extends TestCase
 		$refusal = substr($scope, $fail);
 		$this->assertStringContainsString('unlink_if_exists($file_download);', $refusal,
 			'a refused staged body must be discarded');
+		$this->assertStringContainsString('unlink_if_exists($et_stage);', $refusal,
+			'a refused decompressed ET stage must be discarded');
 		$this->assertStringContainsString('return PfbDownloadResult::failure();', $refusal);
 		$this->assertStringNotContainsString('unlink_if_exists("{$orig_download}', $refusal,
 			'the ET branch must not bypass the wrapper by clearing live artifacts directly');
@@ -632,6 +640,86 @@ final class DownloadExtractionExitCodeTest extends TestCase
 		$this->assertNotFalse($finalize);
 		$this->assertLessThan($finalize, $scopeEnd,
 			'the accepted raw body hash and text finalization must happen after processet succeeds');
+	}
+
+
+	public function testEtAlertsReaderDefersWhileGenerationCommitOwnsTheLock(): void
+	{
+		$savedPfb = $GLOBALS['pfb'];
+		$savedContinents = $GLOBALS['continents'] ?? NULL;
+		$dir = sys_get_temp_dir() . '/pfb_et_lock_' . bin2hex(random_bytes(8));
+		$etdir = "{$dir}/ET";
+		$aliasdir = "{$dir}/alias";
+		$marker = "{$dir}/reader-invoked";
+		$this->assertTrue(mkdir($etdir, 0700, TRUE));
+		$this->assertTrue(mkdir($aliasdir, 0700, TRUE));
+		$this->assertNotFalse(file_put_contents("{$etdir}/ET_Cnc.txt", "192.0.2.10\n"));
+		$grep = "{$dir}/grep-probe";
+		$probe = "#!/bin/sh\ntouch " . escapeshellarg($marker) . "\necho "
+			. escapeshellarg("{$etdir}/ET_Cnc.txt:192.0.2.10") . "\n";
+		$this->assertNotFalse(file_put_contents($grep, $probe));
+		$this->assertTrue(chmod($grep, 0700));
+		$GLOBALS['pfb']['etdir'] = $etdir;
+		$GLOBALS['pfb']['aliasdir'] = $aliasdir;
+		$GLOBALS['pfb']['grep'] = $grep;
+		$GLOBALS['continents'] = [];
+		$fields = array_fill(0, 18, '');
+		$fields[3] = 'block';
+		$fields[4] = 4;
+		$fields[7] = '192.0.2.10';
+		$fields[11] = 'in';
+		$fields[13] = 'pfB_ET_v4';
+		$fields[14] = '192.0.2.10';
+		$fields[15] = 'IQRisk:ET_Cnc';
+		pfb_ip_render_memos_reset();
+		$lock = fopen("{$etdir}.transaction.lock", 'c');
+		$this->assertIsResource($lock);
+		$this->assertTrue(flock($lock, LOCK_EX));
+
+		try {
+			$result = pfb_ip_render_attribution($fields);
+			$this->assertSame('Not listed!', $result['feed_new']);
+			$this->assertSame(['validate' => [], 'miss' => []], pfb_ip_render_memos());
+			$this->assertFileDoesNotExist($marker);
+		} finally {
+			flock($lock, LOCK_UN);
+			fclose($lock);
+			pfb_ip_render_memos_reset();
+			$GLOBALS['pfb'] = $savedPfb;
+			if ($savedContinents === NULL) {
+				unset($GLOBALS['continents']);
+			} else {
+				$GLOBALS['continents'] = $savedContinents;
+			}
+			rmdir_recursive($dir);
+		}
+	}
+
+	public function testEveryEtAttributionReaderUsesTheGenerationCommitLock(): void
+	{
+		$render = strpos(self::$source, 'function pfb_ip_render_attribution(array $fields): array {');
+		$renderEnd = strpos(self::$source, 'function &pfb_ip_render_memos(', $render === FALSE ? 0 : $render);
+		$this->assertNotFalse($render);
+		$this->assertNotFalse($renderEnd);
+		$renderScope = substr(self::$source, $render, $renderEnd - $render);
+		$this->assertStringContainsString('"{$pfb[\'etdir\']}.transaction.lock"', $renderScope);
+		$this->assertStringContainsString('LOCK_SH | LOCK_NB', $renderScope);
+
+
+		$prefetch = strpos(self::$source, 'function pfb_ip_prefetch(array $rows): void {');
+		$prefetchEnd = strpos(self::$source, 'function pfb_ip_in_cidr(', $prefetch === FALSE ? 0 : $prefetch);
+		$this->assertNotFalse($prefetch);
+		$this->assertNotFalse($prefetchEnd);
+		$prefetchScope = substr(self::$source, $prefetch, $prefetchEnd - $prefetch);
+		$this->assertStringContainsString('"{$pfb[\'etdir\']}.transaction.lock"', $prefetchScope);
+		$this->assertStringContainsString('LOCK_SH | LOCK_NB', $prefetchScope);
+		$daemon = strpos(self::$source, 'if ($et_enabled && strpos($pfb_query[0], "{$et_header}") !== FALSE) {');
+		$daemonEnd = strpos(self::$source, 'if (!empty($pathgeoip)) {', $daemon === FALSE ? 0 : $daemon);
+		$this->assertNotFalse($daemon);
+		$this->assertNotFalse($daemonEnd);
+		$daemonScope = substr(self::$source, $daemon, $daemonEnd - $daemon);
+		$this->assertStringContainsString('"{$pfb[\'etdir\']}.transaction.lock"', $daemonScope);
+		$this->assertStringContainsString('LOCK_SH | LOCK_NB', $daemonScope);
 	}
 
 	public function testEtRefusalLeavesHttpValidatorClearingToTheDownloadWrapper(): void

--- a/tests/php/DownloadStagePublishTest.php
+++ b/tests/php/DownloadStagePublishTest.php
@@ -160,8 +160,8 @@ final class DownloadStagePublishTest extends TestCase
 		$source = file_get_contents(self::INC);
 		$this->assertNotFalse($source);
 
-		$open = strpos($source, 'if (!pfb_stage_publish($orig_download,'
-			. "\n\t\t\t\t    static function (string \$staged) use (\$file_dwn_esc, \$list_download,");
+		$open = strpos($source, 'if (!pfb_stage_publish($text_download,'
+			. "\n\t\t\t\t    static function (string \$staged) use (\$file_dwn_esc, \$list_download, \$is_et,");
 		$this->assertNotFalse($open,
 			'the piped ZIP branch no longer stages with the list URL in scope for its MIME probe');
 

--- a/tests/shell/pfblockerng_cat_weld_more_spec.sh
+++ b/tests/shell/pfblockerng_cat_weld_more_spec.sh
@@ -56,6 +56,9 @@ Describe 'processet() etblock/etmatch tempfile accumulation: multi-category conc
     etdir="${work}/ET"; mkdir -p "$etdir"
     tempfile="${work}/t1"
     tempfile2="${work}/t2"
+    etstage="${etdir}"
+    blockstage="${tempfile}"
+    matchstage="${tempfile2}"
     true > "$tempfile"
     true > "$tempfile2"
     # Two selected categories, the first unterminated -- deterministic single-line
@@ -63,8 +66,8 @@ Describe 'processet() etblock/etmatch tempfile accumulation: multi-category conc
     # identically so the same fixture drives both the block and match statements).
     printf '1.2.3.4' > "${etdir}/ET_Cnc.txt"
     printf '5.6.7.8\n' > "${etdir}/ET_Bot.txt"
-    blockstmt="$(extract_stmt "${PFB_PKGDIR}/pfblockerng.sh" '"${etdir}/${list}.txt" >> "${tempfile}"')"
-    matchstmt="$(extract_stmt "${PFB_PKGDIR}/pfblockerng.sh" '"${etdir}/${list}.txt" >> "${tempfile2}"')"
+    blockstmt="$(extract_stmt "${PFB_PKGDIR}/pfblockerng.sh" '"${etstage}/${list}.txt" >> "${blockstage}"')"
+    matchstmt="$(extract_stmt "${PFB_PKGDIR}/pfblockerng.sh" '"${etstage}/${list}.txt" >> "${matchstage}"')"
   }
   cleanup() { rm -rf "$work"; }
   Before 'setup'

--- a/tests/shell/pfblockerng_et_category_match_spec.sh
+++ b/tests/shell/pfblockerng_et_category_match_spec.sh
@@ -55,6 +55,13 @@ Describe 'processet() ET category selection (issue #713 bug 6)'
       The stdout should include 'ET processing failed'
       The contents of file "${pfborig}${alias}.orig" should equal '198.51.100.77'
     End
+
+    It 'rejects a NUL suffix before a text parser can truncate the row'
+      nul_candidate="${work}/nul-candidate"
+      printf '192.0.2.10\000garbage\n' > "${nul_candidate}"
+      When call pfb_et_output_valid "${nul_candidate}" ''
+      The status should be failure
+    End
   End
 
   # Scenario: selecting ET_P2Pcnc alone must not also pull in ET_P2P.

--- a/tests/shell/pfblockerng_et_category_match_spec.sh
+++ b/tests/shell/pfblockerng_et_category_match_spec.sh
@@ -19,27 +19,52 @@ Describe 'processet() ET category selection (issue #713 bug 6)'
     pfbmatchgen="${work}/match/generated/"
     mkdir -p "$pfborig" "$etdir" "$pfbmatch" "$pfbmatchgen"
     tempfile="${work}/t1"; tempfile2="${work}/t2"
+    errorlog="${work}/error.log"
     alias='MYLIST'
     ip_placeholder='240.0.0.0'
     ip_placeholder2="$(echo "${ip_placeholder}" | sed 's/\./\\\./g')"
     # ET_P2P is category 15, ET_P2Pcnc is category 31 in processet()'s etcat
     # position table (1-based index into the etcat word list) -- both are
     # "in use" categories (neither sits in the 8|11|12|14|18|22|32|36 skip set).
-    printf '10.0.0.15,15,50\n10.0.0.31,31,60\n' > "${pfborig}${alias}.orig"
+    printf '10.0.0.15,15,50\n10.0.0.31,31,60\n' > "${pfborig}${alias}.raw"
   }
   cleanup() { rm -rf "$work"; }
   BeforeAll 'pfb_source'
   Before 'setup'
   After 'cleanup'
 
+  Describe 'derived category rows must be IPv4 literals (issue #2778)'
+    It 'rejects a nonnumeric address and keeps the live publication'
+      printf '%s\n' 'not-an-ip,1,90' > "${pfborig}${alias}.raw"
+      printf '%s\n' '198.51.100.77' > "${pfborig}${alias}.orig"
+      etblock='ET_Cnc'
+      etmatch='x'
+      When call processet
+      The status should be failure
+      The stdout should include 'ET processing failed'
+      The contents of file "${pfborig}${alias}.orig" should equal '198.51.100.77'
+    End
+
+    It 'rejects an out-of-range octet and keeps the live publication'
+      printf '%s\n' '999.0.0.1,1,90' > "${pfborig}${alias}.raw"
+      printf '%s\n' '198.51.100.77' > "${pfborig}${alias}.orig"
+      etblock='ET_Cnc'
+      etmatch='x'
+      When call processet
+      The status should be failure
+      The stdout should include 'ET processing failed'
+      The contents of file "${pfborig}${alias}.orig" should equal '198.51.100.77'
+    End
+  End
+
   # Scenario: selecting ET_P2Pcnc alone must not also pull in ET_P2P.
-  #   Given .orig rows for BOTH ET_P2P (category 15) and ET_P2Pcnc (category 31),
+  #   Given .raw rows for BOTH ET_P2P (category 15) and ET_P2Pcnc (category 31),
   #   When  processet runs with etblock='ET_P2Pcnc' (etmatch='x' = none selected),
-  #   Then  only ET_P2Pcnc's IP survives into the rewritten .orig -- ET_P2P's IP,
-  #         which a bare substring match would have pulled in too, does not.
+  #   Then  only ET_P2Pcnc's IP reaches the live .orig -- ET_P2P's IP, which a
+  #         bare substring match would have pulled in too, does not.
   Describe 'etblock selects one category whose name is a substring of another'
-    It 'starts with both categories present in the unprocessed .orig'
-      When call cat "${pfborig}${alias}.orig"
+    It 'starts with both categories present in the staged .raw'
+      When call cat "${pfborig}${alias}.raw"
       The output should include '10.0.0.15,15,'
       The output should include '10.0.0.31,31,'
     End

--- a/tests/shell/pfblockerng_processet_exit_spec.sh
+++ b/tests/shell/pfblockerng_processet_exit_spec.sh
@@ -12,10 +12,10 @@
 # #2658's extraction ceiling reaches the caller as the status that names it), and a
 # failed pass leaves the live pfB_Match_ET_v4.txt publication byte-unchanged.
 #
-# Fixture shape: the feed's ".orig" is the raw ET IQRisk CSV ("IP,category,
+# Fixture shape: the feed's ".raw" is the staged ET IQRisk CSV ("IP,category,
 # score"). processet() splits it into one file per category, accumulates the
-# selected Block categories onto the ".orig" and the selected Match categories
-# onto pfB_Match_ET_v4.txt.
+# selected Block categories onto the live ".orig" and the selected Match
+# categories onto pfB_Match_ET_v4.txt.
 
 Describe 'processet() exit contract (issue #2683)'
 	setup() {
@@ -75,8 +75,8 @@ RUNNER
 	Before 'setup'
 	After 'cleanup'
 
-	plant_et_orig() {
-		printf '%s\n' "${et_csv}" > "${orig}${alias}.orig"
+	plant_et_raw() {
+		printf '%s\n' "${et_csv}" > "${orig}${alias}.raw"
 	}
 
 	# A live match publication left by a previous, successful pass.
@@ -95,7 +95,7 @@ RUNNER
 	}
 
 	Context 'on a healthy ET feed'
-		Before 'plant_et_orig'
+		Before 'plant_et_raw'
 		Before 'plant_prior_match'
 
 		It 'publishes both artifacts and reports success'
@@ -107,11 +107,25 @@ RUNNER
 		End
 	End
 
+	Context 'when a selected Match category derives an empty replacement'
+		Before 'plant_prior_match'
+
+		It 'validates both candidates before publishing either one'
+			printf '%s\n' '192.0.2.10,1,90' > "${orig}${alias}.raw"
+			printf '%s\n' '198.51.100.77' > "${orig}${alias}.orig"
+			When run sh "${runner}" ET_Cnc ET_Spam
+			The status should be failure
+			The output should include 'ET processing failed'
+			The contents of file "${orig}${alias}.orig" should equal '198.51.100.77'
+			The contents of file "${match}pfB_Match_ET_v4.txt" should equal "${prior_match}"
+		End
+	End
+
 	Context 'when the ET scratch files cannot be created'
 		# The abort issue #2683 names by hand. It printed its message and then
 		# handed back the status of the `tee` that printed it -- 0.
 		plant_readonly_scratch() { chmod 555 "${scratch}"; }
-		Before 'plant_et_orig'
+		Before 'plant_et_raw'
 		Before 'plant_prior_match'
 		Before 'plant_readonly_scratch'
 
@@ -124,7 +138,7 @@ RUNNER
 		End
 	End
 
-	Context 'when no ET .orig file is present'
+	Context 'when no staged ET source is present'
 		# The other abort: the function fell off the end of its `else` branch, so
 		# its status was the closing `echo`'s.
 		Before 'plant_prior_match'
@@ -132,9 +146,9 @@ RUNNER
 		It 'fails instead of reporting a pass that processed nothing'
 			When run sh "${runner}"
 			The status should be failure
-			The output should include 'No ET .orig File Found!'
+			The output should include 'No staged ET source file found!'
 			The contents of file "${match}pfB_Match_ET_v4.txt" should equal "${prior_match}"
-			The contents of file "${errorlog}" should include 'No ET .orig file'
+			The contents of file "${errorlog}" should include 'No staged ET source file'
 		End
 	End
 
@@ -143,7 +157,7 @@ RUNNER
 		# category with no rows makes grep exit 1 and is entirely normal, while a
 		# failed WRITE has to abort rather than publish a truncated block list.
 		plant_readonly_etdir() { chmod 555 "${etdir}"; }
-		Before 'plant_et_orig'
+		Before 'plant_et_raw'
 		Before 'plant_prior_match'
 		Before 'plant_readonly_etdir'
 
@@ -152,9 +166,9 @@ RUNNER
 			The status should be failure
 			The output should include 'ET processing failed'
 			The contents of file "${match}pfB_Match_ET_v4.txt" should equal "${prior_match}"
-			# processet() rewrites the ".orig" in place, so this is the raw CSV the
-			# download left -- the state pfb_download()'s refusal then has to drop.
-			The contents of file "${orig}${alias}.orig" should equal "${et_csv}"
+			# The staged input stays available for pfb_download() to discard after
+			# it observes this failure.
+			The contents of file "${orig}${alias}.raw" should equal "${et_csv}"
 			The stderr should be present
 		End
 	End
@@ -167,7 +181,7 @@ RUNNER
 		# The shim breaks every `awk` in the pass, so the two accumulations get one
 		# example each with only their own categories selected -- otherwise whichever
 		# runs first covers for the other and neither check is isolated.
-		Before 'plant_et_orig'
+		Before 'plant_et_raw'
 		Before 'plant_prior_match'
 		Before 'plant_killed_awk'
 
@@ -181,7 +195,7 @@ RUNNER
 	End
 
 	Context 'when the match accumulation is killed'
-		Before 'plant_et_orig'
+		Before 'plant_et_raw'
 		Before 'plant_prior_match'
 		Before 'plant_killed_awk'
 
@@ -199,7 +213,7 @@ RUNNER
 		# filesystem from /var on a default use_mfs_tmpvar install -- so it copies
 		# rather than renames, and can fail on its own.
 		plant_readonly_origdir() { chmod 555 "${orig}"; }
-		Before 'plant_et_orig'
+		Before 'plant_et_raw'
 		Before 'plant_prior_match'
 		Before 'plant_readonly_origdir'
 
@@ -217,7 +231,7 @@ RUNNER
 		# the block publish -- so this is where the pfB_Match_ET_v4.txt artifact
 		# the issue names is the one left byte-unchanged by the failure itself.
 		plant_readonly_matchdir() { chmod 555 "${match}"; }
-		Before 'plant_et_orig'
+		Before 'plant_et_raw'
 		Before 'plant_prior_match'
 		Before 'plant_readonly_matchdir'
 
@@ -238,11 +252,11 @@ RUNNER
 		# is guaranteed to be killed. The fixture carries Match rows too, so a pass
 		# that got through would REPLACE the prior match publication -- the prior
 		# surviving is therefore evidence of the refusal, not of an empty feed.
-		plant_large_et_orig() {
+		plant_large_et_raw() {
 			awk 'BEGIN { for (i = 1; i < 4000; i++) printf "192.0.2.%d,1,90\n203.0.113.%d,3,40\n", i % 254 + 1, i % 254 + 1 }' \
-				> "${orig}${alias}.orig"
+				> "${orig}${alias}.raw"
 		}
-		Before 'plant_large_et_orig'
+		Before 'plant_large_et_raw'
 		Before 'plant_prior_match'
 
 		It 'refuses the feed instead of publishing the truncated remains of one'
@@ -259,14 +273,14 @@ Describe 'pfblockerng.sh et dispatch arm (issue #2683)'
 	# one -- the same wiring bug the `recompute` arm fixed in issue #1084. Runs
 	# the REAL entrypoint, because the propagation lives in the dispatch rather
 	# than in the function.
-	It 'exits non-zero when the feed has no ET .orig file'
+	It 'exits non-zero when the feed has no staged ET source'
 		# Off-appliance /var/db/pfblockerng/original/ holds nothing, so the
-		# no-.orig abort is the one reached, before any appliance-only tool is
+		# no-source abort is the one reached before any appliance-only tool is
 		# needed. Argument order mirrors pfb_download()'s exec():
 		# et <header> x x x x x <etblock> <etmatch> <elog>.
 		When run sh "${PFB_PKGDIR}/pfblockerng.sh" et NoSuchEtFeed x x x x x ET_Cnc x
 		The status should be failure
-		The stdout should include 'No ET .orig File Found!'
+		The stdout should include 'No staged ET source file found!'
 		# The top-level init spews unrelated noise off-appliance (missing
 		# read_xml_tag.sh, /cf/conf/config.xml, unwritable /var/db) -- real but
 		# incidental here, so only asserted as present.

--- a/tests/shell/pfblockerng_processet_exit_spec.sh
+++ b/tests/shell/pfblockerng_processet_exit_spec.sh
@@ -225,9 +225,6 @@ RUNNER
 	End
 
 	Context 'when the block publication cannot be moved into place'
-		# The publish is a `mv` off the private temp directory, which is a separate
-		# filesystem from /var on a default use_mfs_tmpvar install -- so it copies
-		# rather than renames, and can fail on its own.
 		plant_readonly_origdir() { chmod 555 "${orig}"; }
 		Before 'plant_et_raw'
 		Before 'plant_prior_generation'

--- a/tests/shell/pfblockerng_processet_exit_spec.sh
+++ b/tests/shell/pfblockerng_processet_exit_spec.sh
@@ -40,6 +40,10 @@ Describe 'processet() exit contract (issue #2683)'
 		# What a live match publication looks like before a failed refresh: a
 		# failure must leave exactly this behind.
 		prior_match='PRIOR-MATCH-MARKER'
+		prior_block='198.51.100.77'
+		prior_hash='old-hash'
+		prior_cnc='203.0.113.71'
+		prior_bot='203.0.113.72'
 
 		# processet() reads its inputs from the top-level init's globals, which
 		# never resolve off-appliance. Source the script as a library, point those
@@ -84,6 +88,14 @@ RUNNER
 		printf '%s\n' "${prior_match}" > "${match}pfB_Match_ET_v4.txt"
 	}
 
+	plant_prior_generation() {
+		printf '%s\n' "${prior_block}" > "${orig}${alias}.orig"
+		printf '%s\n' "${prior_hash}" > "${orig}${alias}.orig.xxhash128"
+		printf '%s\n' "${prior_match}" > "${match}pfB_Match_ET_v4.txt"
+		printf '%s\n' "${prior_cnc}" > "${etdir}/ET_Cnc.txt"
+		printf '%s\n' "${prior_bot}" > "${etdir}/ET_Bot.txt"
+	}
+
 	# A child killed the way the appliance's ceiling kills one: SIGXFSZ, which a
 	# shell reports as 128 + 25. The shim stands in for the signal: a real
 	# RLIMIT_FSIZE overrun does not report 153 everywhere (Darwin's awk exits 2),
@@ -126,7 +138,7 @@ RUNNER
 		# handed back the status of the `tee` that printed it -- 0.
 		plant_readonly_scratch() { chmod 555 "${scratch}"; }
 		Before 'plant_et_raw'
-		Before 'plant_prior_match'
+		Before 'plant_prior_generation'
 		Before 'plant_readonly_scratch'
 
 		It 'fails and keeps the live match publication byte-unchanged'
@@ -134,6 +146,10 @@ RUNNER
 			The status should be failure
 			The output should include 'cannot create ET scratch file'
 			The contents of file "${match}pfB_Match_ET_v4.txt" should equal "${prior_match}"
+			The contents of file "${orig}${alias}.orig" should equal "${prior_block}"
+			The contents of file "${orig}${alias}.orig.xxhash128" should equal "${prior_hash}"
+			The contents of file "${etdir}/ET_Cnc.txt" should equal "${prior_cnc}"
+			The contents of file "${etdir}/ET_Bot.txt" should equal "${prior_bot}"
 			The stderr should be present
 		End
 	End
@@ -214,7 +230,7 @@ RUNNER
 		# rather than renames, and can fail on its own.
 		plant_readonly_origdir() { chmod 555 "${orig}"; }
 		Before 'plant_et_raw'
-		Before 'plant_prior_match'
+		Before 'plant_prior_generation'
 		Before 'plant_readonly_origdir'
 
 		It 'fails and keeps the live match publication byte-unchanged'
@@ -222,6 +238,10 @@ RUNNER
 			The status should be failure
 			The output should include 'ET processing failed'
 			The contents of file "${match}pfB_Match_ET_v4.txt" should equal "${prior_match}"
+			The contents of file "${orig}${alias}.orig" should equal "${prior_block}"
+			The contents of file "${orig}${alias}.orig.xxhash128" should equal "${prior_hash}"
+			The contents of file "${etdir}/ET_Cnc.txt" should equal "${prior_cnc}"
+			The contents of file "${etdir}/ET_Bot.txt" should equal "${prior_bot}"
 			The stderr should be present
 		End
 	End
@@ -232,7 +252,7 @@ RUNNER
 		# the issue names is the one left byte-unchanged by the failure itself.
 		plant_readonly_matchdir() { chmod 555 "${match}"; }
 		Before 'plant_et_raw'
-		Before 'plant_prior_match'
+		Before 'plant_prior_generation'
 		Before 'plant_readonly_matchdir'
 
 		It 'fails and keeps the live match publication byte-unchanged'
@@ -240,7 +260,128 @@ RUNNER
 			The status should be failure
 			The output should include 'ET processing failed'
 			The contents of file "${match}pfB_Match_ET_v4.txt" should equal "${prior_match}"
+			The contents of file "${orig}${alias}.orig" should equal "${prior_block}"
+			The contents of file "${orig}${alias}.orig.xxhash128" should equal "${prior_hash}"
+			The contents of file "${etdir}/ET_Cnc.txt" should equal "${prior_cnc}"
+			The contents of file "${etdir}/ET_Bot.txt" should equal "${prior_bot}"
 			The stderr should be present
+		End
+	End
+
+
+	Context 'when an early category is valid and the next category is invalid'
+		Before 'plant_prior_generation'
+
+		It 'keeps the complete prior category and aggregate generation'
+			printf '%s\n' '192.0.2.10,1,90' 'not-an-ip,2,80' > "${orig}${alias}.raw"
+			When run sh "${runner}"
+			The status should be failure
+			The output should include 'ET processing failed'
+			The contents of file "${orig}${alias}.orig" should equal "${prior_block}"
+			The contents of file "${orig}${alias}.orig.xxhash128" should equal "${prior_hash}"
+			The contents of file "${match}pfB_Match_ET_v4.txt" should equal "${prior_match}"
+			The contents of file "${etdir}/ET_Cnc.txt" should equal "${prior_cnc}"
+			The contents of file "${etdir}/ET_Bot.txt" should equal "${prior_bot}"
+		End
+	End
+
+	Context 'when a same-filesystem block rename fails after writing partial bytes'
+		Before 'plant_et_raw'
+		Before 'plant_prior_generation'
+
+		It 'restores every prior artifact and exposes same-directory staging'
+			mkdir "${work}/shim"
+			cat > "${work}/shim/mv" <<SHIM
+#!/bin/sh
+src=''
+dest=''
+for arg do
+	case "\${arg}" in
+		-*) ;;
+		*) [ -z "\${src}" ] && src="\${arg}"; dest="\${arg}" ;;
+	esac
+done
+if [ "\${dest}" = "${orig}${alias}.orig" ] && [ ! -e "${work}/block-failed" ]; then
+	printf '%s' '192.' > "\${dest}"
+	printf '%s\n%s\n' "\${src%/*}" "\${dest%/*}" > "${work}/block-paths"
+	touch "${work}/block-failed"
+	exit 73
+fi
+exec /bin/mv "\$@"
+SHIM
+			chmod +x "${work}/shim/mv"
+			When run sh -c "PATH='${work}/shim:${PATH}' sh '${runner}'"
+			The status should equal 73
+			The output should include 'ET processing failed'
+			The contents of file "${orig}${alias}.orig" should equal "${prior_block}"
+			The contents of file "${orig}${alias}.orig.xxhash128" should equal "${prior_hash}"
+			The contents of file "${match}pfB_Match_ET_v4.txt" should equal "${prior_match}"
+			The contents of file "${etdir}/ET_Cnc.txt" should equal "${prior_cnc}"
+			The contents of file "${etdir}/ET_Bot.txt" should equal "${prior_bot}"
+			The contents of file "${work}/block-paths" should equal "$(printf '%s\n%s' "${orig%/}" "${orig%/}")"
+		End
+	End
+
+	Context 'when the second aggregate rename fails after writing partial bytes'
+		Before 'plant_et_raw'
+		Before 'plant_prior_generation'
+
+		It 'rolls block, Match, and categories back as one generation'
+			mkdir "${work}/shim"
+			cat > "${work}/shim/mv" <<SHIM
+#!/bin/sh
+src=''
+dest=''
+for arg do
+	case "\${arg}" in
+		-*) ;;
+		*) [ -z "\${src}" ] && src="\${arg}"; dest="\${arg}" ;;
+	esac
+done
+if [ "\${dest}" = "${match}pfB_Match_ET_v4.txt" ] && [ ! -e "${work}/match-failed" ]; then
+	printf '%s' '203.' > "\${dest}"
+	printf '%s\n%s\n' "\${src%/*}" "\${dest%/*}" > "${work}/match-paths"
+	touch "${work}/match-failed"
+	exit 73
+fi
+exec /bin/mv "\$@"
+SHIM
+			chmod +x "${work}/shim/mv"
+			When run sh -c "PATH='${work}/shim:${PATH}' sh '${runner}'"
+			The status should equal 73
+			The output should include 'ET processing failed'
+			The contents of file "${orig}${alias}.orig" should equal "${prior_block}"
+			The contents of file "${orig}${alias}.orig.xxhash128" should equal "${prior_hash}"
+			The contents of file "${match}pfB_Match_ET_v4.txt" should equal "${prior_match}"
+			The contents of file "${etdir}/ET_Cnc.txt" should equal "${prior_cnc}"
+			The contents of file "${etdir}/ET_Bot.txt" should equal "${prior_bot}"
+			The contents of file "${work}/match-paths" should equal "$(printf '%s\n%s' "${match%/}" "${match%/}")"
+		End
+	End
+
+
+	Context 'when an interrupted transaction left its rollback journal'
+		It 'recovers the whole prior generation before processing new input'
+			printf '%s\n' "${prior_hash}" > "${orig}${alias}.orig.xxhash128"
+			printf '%s\n' 'partial-block' > "${orig}${alias}.orig"
+			printf '%s\n' "${prior_block}" > "${orig}${alias}.orig.rollback"
+			printf '%s\n' 'partial-match' > "${match}pfB_Match_ET_v4.txt"
+			printf '%s\n' "${prior_match}" > "${match}pfB_Match_ET_v4.txt.rollback"
+			printf '%s\n' 'partial-category' > "${etdir}/ET_Cnc.txt"
+			mkdir "${etdir}.rollback"
+			printf '%s\n' "${prior_cnc}" > "${etdir}.rollback/ET_Cnc.txt"
+			printf '%s\n' "${prior_bot}" > "${etdir}.rollback/ET_Bot.txt"
+			printf '%s\n' '1 1 1' > "${etdir}.transaction"
+			printf '%s\n' 'not-an-ip,1,90' > "${orig}${alias}.raw"
+			When run sh "${runner}"
+			The status should be failure
+			The output should include 'ET processing failed'
+			The contents of file "${orig}${alias}.orig" should equal "${prior_block}"
+			The contents of file "${orig}${alias}.orig.xxhash128" should equal "${prior_hash}"
+			The contents of file "${match}pfB_Match_ET_v4.txt" should equal "${prior_match}"
+			The contents of file "${etdir}/ET_Cnc.txt" should equal "${prior_cnc}"
+			The contents of file "${etdir}/ET_Bot.txt" should equal "${prior_bot}"
+			The path "${etdir}.transaction" should not be exist
 		End
 	End
 

--- a/tests/shell/pfblockerng_processet_publication_spec.sh
+++ b/tests/shell/pfblockerng_processet_publication_spec.sh
@@ -1,0 +1,138 @@
+#shellcheck shell=sh
+# issue #2778: ET input is staged separately from the live publication. Category
+# no-match (grep rc 1) is normal; hard grep errors and invalid/empty replacements
+# fail through processet()'s exit contract without touching a good live list.
+
+Describe 'processet() validates staged ET category output before publication (issue #2778)'
+	setup() {
+		work="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/etpublish.XXXXXX")"
+		orig="${work}/orig/"
+		match="${work}/match/"
+		etdir="${work}/etdir"
+		scratch="${work}/scratch"
+		alias='EtFeed'
+		errorlog="${work}/error.log"
+		runner="${work}/run.sh"
+		live="${orig}${alias}.orig"
+		raw="${orig}${alias}.raw"
+		prior='198.51.100.77'
+		mkdir -p "${orig}" "${match}" "${etdir}" "${scratch}"
+		printf '%s\n' "${prior}" > "${live}"
+
+		cat > "${runner}" <<RUNNER
+#!/bin/sh
+PFB_SOURCED=1
+. "${PFB_PKGDIR}/pfblockerng.sh"
+pfborig="${orig}"
+alias="${alias}"
+etdir="${etdir}"
+pfbmatchgen="${match}"
+errorlog="${errorlog}"
+tempfile="${scratch}/et.tmp"
+tempfile2="${scratch}/et2.tmp"
+etblock="\${1:-ET_Cnc}"
+etmatch="\${2:-x}"
+now='2026-01-01 00:00:00'
+ip_placeholder2='127\.1\.7\.7'
+processet
+RUNNER
+		chmod +x "${runner}"
+	}
+
+	cleanup() {
+		chmod -R u+w "${work}" 2>/dev/null
+		rm -rf "${work}"
+	}
+	Before 'setup'
+	After 'cleanup'
+
+
+	Context 'when the staged body has no commas'
+		It 'refuses the empty replacement and keeps the live publication'
+			printf '%s\n' 'not an ET CSV' > "${raw}"
+			When run sh "${runner}"
+			The status should be failure
+			The output should include 'ET processing failed'
+			The contents of file "${live}" should equal "${prior}"
+			The contents of file "${live}" should not include "${work}"
+		End
+	End
+
+	Context 'when the staged body has a nonnumeric category'
+		It 'refuses the empty replacement and keeps the live publication'
+			printf '%s\n' '192.0.2.10,not-a-category,90' > "${raw}"
+			When run sh "${runner}"
+			The status should be failure
+			The output should include 'ET processing failed'
+			The contents of file "${live}" should equal "${prior}"
+			The contents of file "${live}" should not include "${work}"
+		End
+	End
+
+	Context 'when grep emits its binary-file diagnostic'
+		It 'rejects the diagnostic instead of publishing its scratch path'
+			printf '192.0.2.10,1,90\000tail\n' > "${raw}"
+			When run sh "${runner}"
+			The status should be failure
+			The output should include 'ET processing failed'
+			The contents of file "${live}" should equal "${prior}"
+			The contents of file "${live}" should not include "${work}"
+		End
+	End
+
+	Context 'when the staged body is UTF-16LE with a BOM'
+		It 'rejects the NUL-bearing rows and keeps the live publication'
+			printf '\377\3761\0009\0002\000.\0000\000.\0002\000.\0001\0000\000,\0001\000,\0009\0000\000\n\000' > "${raw}"
+			When run sh "${runner}"
+			The status should be failure
+			The output should include 'ET processing failed'
+			The contents of file "${live}" should equal "${prior}"
+			The contents of file "${live}" should not include "${work}"
+		End
+	End
+
+	Context 'when the staged source is unreadable'
+		It 'returns grep hard failure through the existing exit contract'
+			printf '%s\n' '192.0.2.10,1,90' > "${raw}"
+			chmod 000 "${raw}"
+			When run sh "${runner}"
+			The status should equal 2
+			The output should include 'ET processing failed'
+			The stderr should not equal ''
+			The contents of file "${errorlog}" should include 'exit 2'
+			The contents of file "${live}" should equal "${prior}"
+		End
+	End
+
+	Context 'when every selected category has valid IPv4 rows'
+		It 'publishes only the derived addresses'
+			printf '%s\n' '192.0.2.10,1,90' '203.0.113.20,2,80' > "${raw}"
+			When run sh "${runner}" 'ET_Cnc, ET_Bot' x
+			The status should be success
+			The output should include 'Final count'
+			The contents of file "${live}" should equal "$(printf '%s\n' '203.0.113.20' '192.0.2.10')"
+			The contents of file "${live}" should not include "${work}"
+		End
+	End
+
+	Context 'when one selected category has no rows'
+		It 'treats grep rc 1 as an empty category and publishes the valid sibling'
+			printf '%s\n' '192.0.2.10,1,90' > "${raw}"
+			When run sh "${runner}" 'ET_Cnc, ET_Bot' x
+			The status should be success
+			The output should include 'Final count'
+			The contents of file "${live}" should equal '192.0.2.10'
+		End
+	End
+
+	Context 'when the selected categories derive an empty candidate'
+		It 'does not replace a non-empty live publication'
+			printf '%s\n' '203.0.113.20,2,80' > "${raw}"
+			When run sh "${runner}" ET_Cnc x
+			The status should be failure
+			The output should include 'ET processing failed'
+			The contents of file "${live}" should equal "${prior}"
+			The contents of file "${live}" should not include "${work}"
+		End
+	End
+End

--- a/tests/shell/pfblockerng_processet_publication_spec.sh
+++ b/tests/shell/pfblockerng_processet_publication_spec.sh
@@ -95,10 +95,11 @@ RUNNER
 
 	Context 'when a conforming grep emits matching binary bytes'
 		It 'rejects the NUL-bearing category and preserves the prior category generation'
+			greppath="$(command -v grep)"
 			mkdir "${work}/shim"
-			cat > "${work}/shim/grep" <<'SHIM'
+			cat > "${work}/shim/grep" <<SHIM
 #!/bin/sh
-exec /usr/bin/grep -a "$@"
+exec "${greppath}" -a "\$@"
 SHIM
 			chmod +x "${work}/shim/grep"
 			printf '%s\n' "${prior_category}" > "${etdir}/ET_Cnc.txt"
@@ -181,4 +182,24 @@ SHIM
 			The contents of file "${etdir}/ET_Cnc.txt" should equal "${prior_category}"
 		End
 	End
+
+Context 'when no Block category is selected'
+	It 'publishes the empty block generation instead of refusing the pass'
+		printf '%s\n' '192.0.2.10,1,90' > "${raw}"
+		When run sh "${runner}" x x
+		The status should be success
+		The output should include 'Final count'
+		The contents of file "${live}" should equal ''
+		The contents of file "${etdir}/ET_Cnc.txt" should equal '192.0.2.10'
+	End
+
+	It 'still publishes the Match aggregate when Match categories are selected'
+		printf '%s\n' '192.0.2.10,1,90' > "${raw}"
+		When run sh "${runner}" x ET_Cnc
+		The status should be success
+		The output should include 'Final count'
+		The contents of file "${live}" should equal ''
+		The contents of file "${match}pfB_Match_ET_v4.txt" should equal '192.0.2.10'
+	End
+End
 End

--- a/tests/shell/pfblockerng_processet_publication_spec.sh
+++ b/tests/shell/pfblockerng_processet_publication_spec.sh
@@ -4,6 +4,13 @@
 # fail through processet()'s exit contract without touching a good live list.
 
 Describe 'processet() validates staged ET category output before publication (issue #2778)'
+	portable_binary_stderr() {
+		case "${portable_binary_stderr}" in
+			''|"grep: ${raw}: binary file matches") return 0 ;;
+		esac
+		return 1
+	}
+
 	setup() {
 		work="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/etpublish.XXXXXX")"
 		orig="${work}/orig/"
@@ -75,6 +82,7 @@ RUNNER
 			When run sh "${runner}"
 			The status should be failure
 			The output should include 'ET processing failed'
+			The stderr should satisfy portable_binary_stderr
 			The contents of file "${live}" should equal "${prior}"
 			The contents of file "${live}" should not include "${work}"
 		End

--- a/tests/shell/pfblockerng_processet_publication_spec.sh
+++ b/tests/shell/pfblockerng_processet_publication_spec.sh
@@ -100,8 +100,9 @@ RUNNER
 #!/bin/sh
 exec /usr/bin/grep -a "$@"
 SHIM
+			chmod +x "${work}/shim/grep"
 			printf '%s\n' "${prior_category}" > "${etdir}/ET_Cnc.txt"
-			printf '192.0.2.10,1,90\000garbage\n' > "${raw}"
+			printf '192.0.2.10\000garbage,1,90\n' > "${raw}"
 			When run sh -c "PATH='${work}/shim:${PATH}' sh '${runner}'"
 			The status should be failure
 			The output should include 'ET processing failed'

--- a/tests/shell/pfblockerng_processet_publication_spec.sh
+++ b/tests/shell/pfblockerng_processet_publication_spec.sh
@@ -23,8 +23,10 @@ Describe 'processet() validates staged ET category output before publication (is
 		live="${orig}${alias}.orig"
 		raw="${orig}${alias}.raw"
 		prior='198.51.100.77'
+		prior_category='203.0.113.99'
 		mkdir -p "${orig}" "${match}" "${etdir}" "${scratch}"
 		printf '%s\n' "${prior}" > "${live}"
+		printf '%s\n' "${prior_category}" > "${etdir}/ET_Cnc.txt"
 
 		cat > "${runner}" <<RUNNER
 #!/bin/sh
@@ -62,6 +64,7 @@ RUNNER
 			The output should include 'ET processing failed'
 			The contents of file "${live}" should equal "${prior}"
 			The contents of file "${live}" should not include "${work}"
+			The contents of file "${etdir}/ET_Cnc.txt" should equal "${prior_category}"
 		End
 	End
 
@@ -73,6 +76,7 @@ RUNNER
 			The output should include 'ET processing failed'
 			The contents of file "${live}" should equal "${prior}"
 			The contents of file "${live}" should not include "${work}"
+			The contents of file "${etdir}/ET_Cnc.txt" should equal "${prior_category}"
 		End
 	End
 
@@ -85,6 +89,24 @@ RUNNER
 			The stderr should satisfy portable_binary_stderr
 			The contents of file "${live}" should equal "${prior}"
 			The contents of file "${live}" should not include "${work}"
+			The contents of file "${etdir}/ET_Cnc.txt" should equal "${prior_category}"
+		End
+	End
+
+	Context 'when a conforming grep emits matching binary bytes'
+		It 'rejects the NUL-bearing category and preserves the prior category generation'
+			mkdir "${work}/shim"
+			cat > "${work}/shim/grep" <<'SHIM'
+#!/bin/sh
+exec /usr/bin/grep -a "$@"
+SHIM
+			printf '%s\n' "${prior_category}" > "${etdir}/ET_Cnc.txt"
+			printf '192.0.2.10,1,90\000garbage\n' > "${raw}"
+			When run sh -c "PATH='${work}/shim:${PATH}' sh '${runner}'"
+			The status should be failure
+			The output should include 'ET processing failed'
+			The contents of file "${live}" should equal "${prior}"
+			The contents of file "${etdir}/ET_Cnc.txt" should equal "${prior_category}"
 		End
 	End
 
@@ -96,6 +118,7 @@ RUNNER
 			The output should include 'ET processing failed'
 			The contents of file "${live}" should equal "${prior}"
 			The contents of file "${live}" should not include "${work}"
+			The contents of file "${etdir}/ET_Cnc.txt" should equal "${prior_category}"
 		End
 	End
 
@@ -109,6 +132,19 @@ RUNNER
 			The stderr should not equal ''
 			The contents of file "${errorlog}" should include 'exit 2'
 			The contents of file "${live}" should equal "${prior}"
+			The contents of file "${etdir}/ET_Cnc.txt" should equal "${prior_category}"
+		End
+	End
+
+	Context 'when PHP staged a decompressed archive payload'
+		It 'processes the isolated CSV stage instead of the compressed raw source'
+			printf '\037\213\010\000compressed\n' > "${raw}"
+			printf '%s\n' '192.0.2.10,1,90' > "${live}.etstage"
+			When run sh "${runner}"
+			The status should be success
+			The output should include 'Final count'
+			The contents of file "${live}" should equal '192.0.2.10'
+			The contents of file "${raw}" should not equal '192.0.2.10,1,90'
 		End
 	End
 
@@ -141,6 +177,7 @@ RUNNER
 			The output should include 'ET processing failed'
 			The contents of file "${live}" should equal "${prior}"
 			The contents of file "${live}" should not include "${work}"
+			The contents of file "${etdir}/ET_Cnc.txt" should equal "${prior_category}"
 		End
 	End
 End

--- a/tests/shell/pfblockerng_processet_publication_spec.sh
+++ b/tests/shell/pfblockerng_processet_publication_spec.sh
@@ -5,7 +5,7 @@
 
 Describe 'processet() validates staged ET category output before publication (issue #2778)'
 	portable_binary_stderr() {
-		case "${portable_binary_stderr}" in
+		case "$1" in
 			''|"grep: ${raw}: binary file matches") return 0 ;;
 		esac
 		return 1

--- a/tests/shell/pfblockerng_processet_weld_spec.sh
+++ b/tests/shell/pfblockerng_processet_weld_spec.sh
@@ -2,8 +2,8 @@
 # issue #1263, site 2: processet()'s `counto="$(cat "${etdir}"/ET_* | grep -cv ...)"`
 # welds an unterminated ET_*.txt onto its neighbour, same as the other 8
 # `cat`-of-a-multi-file-glob sites. processet() itself REGENERATES etdir/ET_*.txt
-# from '.orig' via grep+cut at every call, so a fixture can't durably plant an
-# unterminated derived file through the public processet() entry point.
+# from staged '.raw' input via separate grep/cut steps at every call, so a fixture
+# can't durably plant an unterminated derived file through the public entry point.
 # Extracting the counto assignment's literal, currently-committed text (never a
 # hand-retyped copy -- avoids testing a stale/wrong shape) and eval'ing it
 # against a directly-crafted etdir proves the exact shipped pipeline, order-

--- a/tests/shell/pfblockerng_truncate_survival_spec.sh
+++ b/tests/shell/pfblockerng_truncate_survival_spec.sh
@@ -350,8 +350,10 @@ STUB
       errorlog="${work}/err.log"
       etblock='ET_Cnc'
       etmatch='ET_Bot'
-      expected_orig="$(printf '%s\n' '192.0.2.10,1,90' '198.51.100.20,2,80')"
-      printf '%s\n' "${expected_orig}" > "${pfborig}${alias}.orig"
+      et_csv="$(printf '%s\n' '192.0.2.10,1,90' '198.51.100.20,2,80')"
+      prior_orig='203.0.113.77'
+      printf '%s\n' "${et_csv}" > "${pfborig}${alias}.raw"
+      printf '%s\n' "${prior_orig}" > "${pfborig}${alias}.orig"
       # Crash-leftover DIRECTORY at the tempfile2 (match-category scratch) truncate target.
       mkdir "${tempfile2}"
     }
@@ -359,12 +361,12 @@ STUB
     Before 'setup'
     After 'cleanup'
 
-    It 'aborts ET processing, leaving the .orig file unchanged and never creating pfB_Match_ET_v4.txt'
+    It 'aborts ET processing, leaving the live .orig unchanged and never creating pfB_Match_ET_v4.txt'
       When run _truncF_run
       The status should be success
       The output should include 'SURVIVED_F'
       The contents of file "${errorlog}" should include 'cannot create'
-      The contents of file "${pfborig}${alias}.orig" should equal "${expected_orig}"
+      The contents of file "${pfborig}${alias}.orig" should equal "${prior_orig}"
       The path "${pfbmatchgen}/pfB_Match_ET_v4.txt" should not be exist
     End
   End


### PR DESCRIPTION
## Summary

- `processet()` derives every ET publication from a staged source: the fetched `.raw` body, or the isolated `.orig.etstage` that `pfb_download_fetch()` writes for a compressed ET feed. The live `.orig` is never the input to its own regeneration.
- Category filtering is split into an explicit `grep` stage and a separate `cut` stage. A category with no rows (`grep` 1) stays a normal empty category, while a hard `grep` or `cut` status propagates verbatim through issue #2683's exit contract.
- `pfb_et_output_valid()` validates every category file and both aggregate candidates before anything live changes: a non-empty candidate must contain only IPv4 literals (which also rejects binary diagnostics, BOMs, NUL-bearing rows, ranges and CIDRs), and an empty candidate may never replace a non-empty live list.
- Publication is transactional. Candidates, backups and the journal all sit beside their destinations, so every commit step is a rename. The commit runs under `lockf` on `<etdir>.transaction.lock` behind an `<etdir>.transaction` journal; a failed step rolls the category directory, the block `.orig` and the Match aggregate back to the generation that was in service; a process that dies mid-commit is recovered by the next run under the same lock.
- The attribution readers take the same shared lock and decline to read a half-committed generation instead of reporting a torn one: `pfb_ip_render_attribution()`, `pfb_ip_prefetch()` and `pfb_daemon_filterlog()`.
- On ET refusal the last accepted `.orig` and its `.orig.xxhash128` source hash stay in service, and `processet()` runs before `pfb_download_finalize_text()` so a rejected pass cannot publish a sidecar for a body that was never accepted. The outer `pfb_download()` wrapper remains the sole owner of issue #2820 HTTP-validator clearing (`.orig.etag` and `.orig.lastmod`).

## Hostile ET matrix

`tests/shell/pfblockerng_processet_publication_spec.sh` drives the exact production helper under POSIX `dash` against real files and sentinels. Every refusal row asserts the live block aggregate and the prior category generation byte-for-byte, and that no scratch path leaks into a published list.

| Staged input | Status | Observable |
| --- | ---: | --- |
| no commas | 1 | refused; live publication and prior category generation unchanged; no path leak |
| nonnumeric category | 1 | refused; unchanged; no path leak |
| NUL-bearing body, grep's binary diagnostic | 1 | refused; portable stderr (empty on BSD grep, GNU's exact `grep: <raw>: binary file matches`); unchanged |
| NUL-bearing body through a `grep -a` shim | 1 | NUL-bearing category refused; prior category generation preserved |
| UTF-16LE body with a BOM | 1 | refused; unchanged; no path leak |
| unreadable staged source | 2 | grep's hard status preserved end to end; error log records `exit 2`; unchanged |
| compressed `.raw` plus a PHP-staged `.orig.etstage` | 0 | the isolated stage is processed, not the compressed source; publishes `192.0.2.10` |
| two valid categories | 0 | publishes only `203.0.113.20` and `192.0.2.10` |
| one valid category plus a `grep` 1 sibling | 0 | `grep` 1 treated as an empty category; publishes only `192.0.2.10` |
| selected category derives an empty candidate over a live list | 1 | refused; live publication and prior category generation unchanged |

## Red, green, and mutation evidence

The staged-publication behaviour was developed test-first, and the frozen specs stayed unchanged across the production work:

- Base production plus the frozen shell spec: **8 examples, 8 failures**; head production with the same spec: **8 examples, 0 failures**.
- Base `pfblockerng.inc` plus the original frozen PHP contract: **24 tests, 151 assertions, 1 failure** at the normalized ET decision.
- GNU-stderr portability: BSD grep row **8 examples, 0 failures**; GNU-diagnostic shim **8 examples, 0 failures**; an unrelated-stderr mutant rejected with **8 examples, 1 failure**.
- The two archive-staging compatibility tests were replayed at their pre-fix parent `78d8a8e7`: **15 tests, 102 assertions, 2 failures** (the stdout-transform enumeration observed 8 against a stale 7, and the stage-publish anchor still searched `$orig_download`), then **15 tests, 105 assertions** green at the corrected head.
- Focused suites at the verified head: ShellSpec over the six touched spec files under `dash` **52 examples, 0 failures**; PHPUnit over the ET and attribution neighbours **121 tests, 1300 assertions**.

Single-site mutants, each killed by an unchanged assertion:

| Mutation | Observable failure |
| --- | --- |
| treat `grep`'s hard rc 2 as a normal empty category | unreadable row expected 2, got 1 |
| drop the cut-status gate (cut shim returning 73) | helper returned 1 instead of 73 |
| accept every non-empty candidate | binary diagnostic, `not-an-ip` and `999.0.0.1` were published |
| allow an empty candidate over a live list | five empty or corrupt rows destroyed the live publication |
| read the ET source from `.orig` instead of the stage | the unreadable row and both valid publication rows failed |
| publish the block candidate before Match validation | the block list changed after a Match refusal |
| finalize before the ET helper | finalization-order assertion failed |
| remove `.orig.xxhash128` on ET refusal | last-good hash assertion failed |
| redirect the wrapper's `.orig.etag` clear to a mutant path | ownership contract failed, and `bad-v1` survived 16 behaviour cases |
| change the ordinary ZIP stdout transform to `-tf` | stdout-site enumeration observed 7, expected 8 |
| change only the ET ZIP staged extraction to `-tf` | the ET ZIP isolated-stage assertion failed |
| point `pfb_stage_publish()` back at `$orig_download` | stage callback anchor failed |
| drop `$is_et` from the stage callback capture | callback-scope anchor failed |
| replace the MIME probe's `$list_download` argument with `$staged` | verdict-gating MIME-probe assertion failed |

### Review fix in this push

The first exact-head CI run exposed one real portability defect in the new ET archive test: it reaches `downloadArchive()`, whose `zip` rows require `/bin/sh` to support `set -o pipefail`. That requirement belongs to the non-ET ZIP arm, which extracts through `tar -xOf | sed | tr`; the ET arm is a plain `tar -xOf > stage` redirect. On a `/bin/sh` without `pipefail` the ET `zip` row therefore skipped, and issue #2359's skip-allowlist gate correctly failed the build.

- RED: [run 33347196736](https://github.com/pfBlockerNG/pfBlockerNG/actions/runs/33347196736). PHPUnit itself was clean on PHP 8.3, 8.4 and 8.5 (**6274 tests, 0 failures**); all three legs failed because `phpunit:DownloadExtractedPayloadSanityTest::test_et_archive_refusal_keeps_the_last_good_generation with data set "zip"` skipped and is not on `tests/skip-allowlist.txt`.
- GREEN: the guard is now scoped to non-ET `zip` rows, so the row executes on every POSIX `/bin/sh`. `vendor/bin/phpunit tests/php/DownloadExtractedPayloadSanityTest.php`: **27 tests, 372 assertions**, no skips. No allowlist entry was added: the skip was avoidable, and allowlisting it would have recorded an assertion that never runs.

## Rebase and patch identity

The verified series was rebased onto current `devel` with no content resolution.

```text
base e2931a7cb416694a6607d925f90a1234ca2e6da3
12291af661ed8f41fe3b442ff1900eb7175946d6 download: validate processet publication
bba68506375b6f919f03bab8a1198a935ff938d6 tests: clarify ET validator ownership
3dd084851b44101b8ddf7b64a825286c2b349535 tests: accept GNU grep binary diagnostics
558f48c344c66e933e17384fea391ae2a9cc02d6 fix(download): make ET publication transactional
eaba504673d12a1e0253e0c742dbc876210be900 test(download): exercise forced-text ET NULs
179729d2ae34fb332ef9d94013e8d26c324542be test(download): remove stale ET publish note
d3dc06ea389b2622179e507d9ee84ccaf1886c6a test(download): update ET archive staging pins
d25bb3023e10ddd86557740b8b6bd7576f4e4c79 test(download): run the ET zip row without pipefail
```

`git range-diff` against the pre-rebase series reports all seven verified commits unchanged and the review fix as the sole addition:

```text
1:  5892af7c = 1:  12291af6 download: validate processet publication
2:  49aa2a45 = 2:  bba68506 tests: clarify ET validator ownership
3:  54257b17 = 3:  3dd08485 tests: accept GNU grep binary diagnostics
4:  e0bed4dd = 4:  558f48c3 fix(download): make ET publication transactional
5:  ae0c57e2 = 5:  eaba5046 test(download): exercise forced-text ET NULs
6:  6347dd41 = 6:  179729d2 test(download): remove stale ET publish note
7:  bd810e70 = 7:  d3dc06ea test(download): update ET archive staging pins
-:  -------- > 8:  d25bb302 test(download): run the ET zip row without pipefail
```

At the pre-review-fix rebased head the whole stable patch-id was byte-identical to the verified pre-rebase series (`3008582f6a02c7d0ed90bff1cad6e6f97b818cd8`), and all twelve per-file patch-ids matched. With the review fix the whole stable patch-id is `ab6cb90aa6e384fa3f610cce4ac2e3a402c28a0b`; eleven of the twelve per-file patch-ids are still the verified values, and only `tests/php/DownloadExtractedPayloadSanityTest.php` differs, by the four-line guard scope above.

Per-symbol production deltas are byte-identical before and after the rebase (SHA-256 over the `+`/`-` lines of each changed function's own diff):

| Production symbol | Delta lines | SHA-256 |
| --- | ---: | --- |
| `pfb_daemon_filterlog()` | 25 | `06dcb1a03f44a911a58b0d7859a07fb5ebb5cf53da1a17a15f36b8f9e24a994e` |
| `pfb_download_fetch()` | 92 | `f5b51c7871cd15e4b3f9f5d835ca9f3ae406c272fc6fd50598b00c255a3c33b4` |
| `pfb_ip_prefetch()` | 46 | `6a9a87680fa25cff11e30102b51eeddd2a9669ac3fc4fe9401353e2632a71bc3` |
| `pfb_ip_render_attribution()` | 27 | `da825d129487d7e23ca91120920cfd39d9b5e01ca3e0636addf935b153d91080` |
| `pfb_et_output_valid()` | 23 | `333ba2bb24375448fb2ab08de85060f1dcf44a67859e4a364cb682486fc7b4ce` |
| `processet()` | 84 | `d232b105ead6ffa64b9a026184ea09fd67e501f9ccdaa1610f84ca47c2f44dea` |

Only `pfblockerng.inc` overlapped a touched file upstream. Seven upstream commits changed it between the previously published base and this one, touching eight functions — `pfb_determine_list_detail()`, `pfb_feed_pass_acquire()`, `pfb_feed_pass_begin()`, `pfb_feed_pass_deferral_message()`, `pfb_feed_pass_exit_code()`, `pfb_global()`, `pfb_resolve_enabled()` and `pfb_stop_start_unbound()` — none of which this patch touches. No upstream commit since the previous rebase base touched any of the other eleven paths, so the rebase replayed all seven commits with zero conflicts.

## Exact twelve-file diff

| File | Base blob | Head blob | Per-file patch-id |
| --- | --- | --- | --- |
| `src/usr/local/pkg/pfblockerng/pfblockerng.inc` | `88fec7a616970b03d32e4763560628c690591faf` | `eb0d77e8fa64f2e601b76eca158f77c7d47ec028` | `fff04a7d5982b127e76355347ea461b38bd93243` |
| `src/usr/local/pkg/pfblockerng/pfblockerng.sh` | `833c81ea3d7e6816699233b5e51342562831f586` | `178b6053e8d0a60d366dec193153fb34dbca8d3b` | `d4fffb3a92576e7d6503feea6c49a0c01b9c0c3f` |
| `tests/php/DownloadExtractRestrictiveFlagsTest.php` | `928c7ae10962ad5fbdc3495422dedf499dea3d86` | `a17df0b80c7402d906b6c47a54f23fde24e34ca0` | `5c02588530cb4392532f7b884f8b4085b550e6f5` |
| `tests/php/DownloadExtractedPayloadSanityTest.php` | `9144b03dc5dcf086e60a56e75dd9f64c0b0ad5fe` | `c86126f37ceb24b9247fa4ad8415e65faff0ae4a` | `9355328af8a45dd922bdee4c0f15350405b26380` |
| `tests/php/DownloadExtractionExitCodeTest.php` | `65775073dc06f9d832b54402b6fc3d0dbbb976d9` | `74d375729ac61feec99992afadc5067d65ac8153` | `a761112c88355140b3d48f6fcc7f33c45e58b3e3` |
| `tests/php/DownloadStagePublishTest.php` | `e2a1ee7904bc047f1cc94fe854467f1910d42b80` | `b56fe3b994970f1980f7bb73c5442f20348fd978` | `1cf1431a6b18b3e02e0042885b36323cde5eb05a` |
| `tests/shell/pfblockerng_cat_weld_more_spec.sh` | `5bff81a0ce7f23ac5163473c8618f165523c38fd` | `4c9f11636cb81407b36cb11ebaaf718d62d35c49` | `954d44f3e3a1b96197ad6da0761149e6d3440164` |
| `tests/shell/pfblockerng_et_category_match_spec.sh` | `ab10fd8ebf4514eb484d35dff058b6aad1a04bc3` | `497563e919debaa7d49f4e35526dcb45fb405c20` | `c35190a0c3596bd5710d20f79c8a790c2f5dcdc1` |
| `tests/shell/pfblockerng_processet_exit_spec.sh` | `e072d2348dd9be7841a2a772d96b6c4c8c6ff7e3` | `fd37b8668bb12964b2738a0da60411b4b7563ac8` | `f808f343230d6e1d43557e211dd133e18915af42` |
| `tests/shell/pfblockerng_processet_publication_spec.sh` | absent | `5b21834f3e3492bd4ca0d001ed4e9385c6516100` | `91412d3f78467b5a19183896d14cd3222fd1ebc0` |
| `tests/shell/pfblockerng_processet_weld_spec.sh` | `bd7163f152ced184f2e94b26ad875756dec4bc51` | `9bac32f0a62b564cc05686403175cb47e6e33e6e` | `3aff35bac8ea12ac019c192ffd9d335d9c7a0732` |
| `tests/shell/pfblockerng_truncate_survival_spec.sh` | `76fe1f7a68ea565f2da61aaa549b2fb21f6587e5` | `f8809365f541c30f3db3b3ece72fc696dc8b78ee` | `0be8672b92119e6d33741f63d92509530b8f2c79` |

Exact diff against base `e2931a7cb416694a6607d925f90a1234ca2e6da3`: **12 files, 1097 insertions, 212 deletions**. `git diff --check` is clean.

## Canonical gates

At exact head `d25bb3023e10ddd86557740b8b6bd7576f4e4c79` against exact base `e2931a7cb416694a6607d925f90a1234ca2e6da3`:

```text
scripts/agent/run-gates.sh --diff e2931a7cb416694a6607d925f90a1234ca2e6da3
21 GATE PASS, 0 GATE FAIL, 0 GATE SKIP — GATES: PASS
```

The run covered coverage pairing, the Composer vendor check, the toggle registry, re-entry bounds, five `php -l` checks, the full PHPUnit suite, PHPStan, PHPCS, production `sh -n` and ShellCheck, six shell-spec syntax checks, and the full ShellSpec suite under `dash`.

## CI

Exact-head CI for `d25bb3023e10ddd86557740b8b6bd7576f4e4c79`: **PASS**.

- [Tests run 33347839708](https://github.com/pfBlockerNG/pfBlockerNG/actions/runs/33347839708): success — 25 successful jobs, 2 path-conditional skips, 0 failed, 0 pending.
- [shellspec (POSIX sh)](https://github.com/pfBlockerNG/pfBlockerNG/actions/runs/33347839708/job/99355308532): success.
- [PHPUnit unit tests / PHP 8.3](https://github.com/pfBlockerNG/pfBlockerNG/actions/runs/33347839708/job/99355330643): success.
- [All tests passed aggregate](https://github.com/pfBlockerNG/pfBlockerNG/actions/runs/33347839708/job/99355913343): success.
- `scripts/agent/wait-checks.sh --repo pfBlockerNG/pfBlockerNG --pr 2936 --sha d25bb3023e10ddd86557740b8b6bd7576f4e4c79`: pinned exact head, `PASS`.

Fixes #2778

🤖 Generated by Oh My Pi and posted on behalf of @andrebrait.

## Lane restart

PR #2936 was closed as a side effect of a history rewrite and could not be reopened: upstream `devel` was rewritten after the PR's base lineage was recorded, and GitHub rejects the reopen with "the branch has no history in common with devel" against the orphaned base. This PR is its continuation: the same verified eight-commit series, rebased onto current `devel` (`149caa67`) with zero conflicts, plus the CodeRabbit triage commit at the head. Review and gate evidence on #2936 transports patch-identically; the findings ledger continues there and in the audit comments below.

### CodeRabbit triage on this head

- **Major (`etblock='x'` block validation)** — applied: `processet()` validated the always-created block stage even with no Block category selected, refusing the whole pass (empty candidate over a non-empty live list) where the base published the intentional empty generation. Block validation is now guarded on the `'x'` sentinel exactly as the Match arm already was. Red: two new publication-spec examples failed at the pre-fix head; green: 35 examples, 0 failures across the publication, category-match, and exit specs under `dash`.
- **Minor (grep shim path)** — applied in the same commit: the conforming-grep shim resolves the real `grep` with `command -v` before the `PATH` override instead of hardcoding `/usr/bin/grep`.
- Both nitpicks (the `od`-based NUL probe and the shared ET reader-lock helper) are skipped as nitpick-tier, consistent with the prior leg ledger (the `od` check was verified false-positive-free by the correctness leg; the lock refactor is behavior-preserving only).

Fixes #2778


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * ET threat-feed processing now stages and validates downloaded data before publishing it.
  * Previous working data is preserved when downloads or processing fail.
  * Reader operations defer during feed updates to avoid exposing incomplete results.
  * Interrupted updates can recover automatically.
* **Bug Fixes**
  * Improved handling of invalid, empty, malformed, or unsafe feed content.
  * Prevented partial updates and corruption of published threat lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->