### PR TITLE
fix: recover the .inc language override after a graphify upgrade, and register the merge driver locally

### DIFF
--- a/.agents/patches/graphify-3075-language-overrides.patch
+++ b/.agents/patches/graphify-3075-language-overrides.patch
@@ -5,8 +5,18 @@
 #
 # The PR's tests/test_language_overrides.py and README.md hunks are stripped: the
 # published wheel ships neither, so they cannot apply to an installed package.
-diff --git a/graphify/cache.py b/graphify/cache.py
-index 8fb168ce3..440993882 100644
+#
+# This patch SURVIVES AN UPGRADE ONLY IN HALF, which is its most dangerous property.
+# graphify/rcfile.py is created here from /dev/null, so it is absent from the wheel's
+# RECORD and `uv tool install --upgrade` leaves it in place as an orphan. The five
+# files this patch MODIFIES are owned by the wheel, so the same upgrade replaces them
+# and silently reverts their hunks. The install is then left with the override API
+# present and wired into nothing: detect.classify_file reads path.suffix again and
+# .inc extracts as Pascal. Measured on 0.9.53 in this repository -- .inc nodes fell
+# 783 -> 29 while extraction reported success and every other extension grew, so the
+# loss read as ordinary shrinkage. patch-graphify.sh detects that half-patched state
+# and clears the orphan before re-applying; its probe requires the wiring, not just
+# the API, because the surviving orphan satisfies an API-only check.
 --- a/graphify/cache.py
 +++ b/graphify/cache.py
 @@ -921,11 +921,19 @@ def cache_dir(root: Path = Path("."), kind: str = "ast",

--- a/scripts/agent/patch-graphify.sh
+++ b/scripts/agent/patch-graphify.sh
@@ -73,13 +73,54 @@ main() {
 	[ -d "$package" ] || fail "Graphify package directory '$package' does not exist"
 	site=$(CDPATH='' cd "$package/.." && pwd -P) || exit 2
 
-	# Ask the package itself, not the file text: this no-ops both on an already
-	# patched install and on the release that finally carries the change upstream.
-	if "$interpreter" -I -c \
-		'import graphify.rcfile as rc; raise SystemExit(0 if hasattr(rc, "activate_language_overrides") else 1)' \
-		>/dev/null 2>&1; then
+	# Ask the package itself, not the file text -- and ask whether the override is
+	# WIRED IN, not merely whether its API exists. This patch creates
+	# graphify/rcfile.py from /dev/null, so that file is absent from the wheel's
+	# RECORD and `uv tool install --upgrade` leaves it behind as an orphan while
+	# replacing the five files the patch MODIFIES. The install is then left with the
+	# API present and wired into nothing, and an `hasattr(rc,
+	# "activate_language_overrides")` probe is satisfied by the orphan: it skips the
+	# patch and reports success while .inc extracts as Pascal again. Measured on
+	# 0.9.53 in this repository, .inc nodes fell 783 -> 29 that way. So the probe
+	# requires the seam the patch actually adds -- detect must consult
+	# effective_suffix -- which no-ops on a fully patched install and on the release
+	# that finally carries the change end to end, and fires on the half-patched one.
+	if "$interpreter" -I -c '
+import inspect
+import graphify.detect as detect
+import graphify.rcfile as rc
+
+api = hasattr(rc, "activate_language_overrides") and hasattr(rc, "effective_suffix")
+wired = "effective_suffix" in inspect.getsource(detect)
+raise SystemExit(0 if api and wired else 1)
+' >/dev/null 2>&1; then
 		echo "patch-graphify.sh: '$package' already provides the .inc language override; nothing to patch" >&2
 		return 0
+	fi
+
+	# Half-patched: the orphan rcfile.py survived an upgrade that reverted the
+	# wiring. The patch creates that file, so its hunk cannot apply over the
+	# survivor and `patch --forward` fails the whole run on the ignored hunk.
+	# Clear the orphan first -- but only after confirming no installed distribution
+	# claims it, so a release that starts shipping rcfile.py is never deleted here.
+	if [ -f "$package/rcfile.py" ]; then
+		if "$interpreter" -I -c '
+import pathlib, sys
+
+site = pathlib.Path(sys.argv[1])
+owned = any(
+    line.startswith("graphify/rcfile.py,")
+    for record in site.glob("*.dist-info/RECORD")
+    for line in record.read_text(encoding="utf-8").splitlines()
+)
+raise SystemExit(1 if owned else 0)
+' "$site" >/dev/null 2>&1; then
+			rm -f "$package/rcfile.py"
+			rm -rf "$package/__pycache__"
+			echo "patch-graphify.sh: cleared the orphan rcfile.py left by an upgrade that reverted the wiring" >&2
+		else
+			fail "'$package/rcfile.py' is owned by an installed distribution but the wiring is absent; reinstall Graphify with 'uv tool install --reinstall graphifyy'"
+		fi
 	fi
 
 	require_tool patch

--- a/scripts/setup-hooks.sh
+++ b/scripts/setup-hooks.sh
@@ -20,6 +20,36 @@ if command -v codegraph >/dev/null 2>&1; then
 	sh "$script_dir/agent/ensure-codegraph.sh" "$root"
 fi
 
+# .gitattributes marks graphify-out/graph.json merge=graphify. CI registers that
+# driver through scripts/agent/ensure-graphify-merge-driver.sh, but a developer
+# clone needs it too: without the driver, git text-merges generated JSON on any
+# local merge, rebase or cherry-pick that touches the graph, which yields a
+# conflicted or structurally invalid graph instead of a union. Registered here
+# rather than by that script because the CI one force-upgrades Graphify, which is
+# not a developer's opt-in to make.
+#
+# The interpreter must be one that can import graphify — a bare python3 on PATH
+# usually cannot — so probe the way the hooks do, and stay silent when Graphify
+# is absent: this is an optional local convenience, not a precondition.
+if command -v graphify >/dev/null 2>&1; then
+	gfy_py=''
+	[ -f "$root/graphify-out/.graphify_python" ] && gfy_py=$(cat "$root/graphify-out/.graphify_python")
+	if [ -z "$gfy_py" ] && command -v uv >/dev/null 2>&1; then
+		gfy_py=$(uv tool run --from graphifyy python -c 'import sys; print(sys.executable)' 2>/dev/null || true)
+	fi
+	if [ -z "$gfy_py" ]; then
+		gfy_bin=$(command -v graphify || true)
+		[ -n "$gfy_bin" ] && gfy_py=$(head -1 "$gfy_bin" | tr -d '#!')
+	fi
+	if [ -n "$gfy_py" ] && "$gfy_py" -c 'import graphify' 2>/dev/null; then
+		git -C "$root" config merge.graphify.name 'graphify graph.json union merge'
+		git -C "$root" config merge.graphify.driver "\"$gfy_py\" -m graphify merge-driver %O %A %B"
+		printf 'merge.graphify.driver registered\n'
+	else
+		printf 'Graphify found but its interpreter is not resolvable; merge=graphify driver not registered\n' >&2
+	fi
+fi
+
 printf 'core.hooksPath set to: %s\n' "$(git -C "$root" config core.hooksPath)"
 printf 'Active hooks:\n'
 for hook in "$root"/.githooks/*; do

--- a/tests/shell/setup_hooks_spec.sh
+++ b/tests/shell/setup_hooks_spec.sh
@@ -1,5 +1,6 @@
 #shellcheck shell=sh
-# setup-hooks.sh also bootstraps CodeGraph for the main checkout when available.
+# setup-hooks.sh also bootstraps CodeGraph and registers the Graphify merge driver
+# for the main checkout when those CLIs are available.
 
 Describe 'setup-hooks.sh CodeGraph bootstrap'
   script_abs="${SHELLSPEC_PROJECT_ROOT:-$PWD}/scripts/setup-hooks.sh"
@@ -35,11 +36,29 @@ case "$1" in
   *) exit 9 ;;
 esac
 CODEGRAPH
+    cat > "$stubdir/graphify" <<'GRAPHIFY'
+#!/bin/sh
+exit 0
+GRAPHIFY
+    chmod +x "$stubdir/graphify"
+    # A python that CAN import graphify, so the probe's verification passes.
+    cat > "$stubdir/python3" <<'PY'
+#!/bin/sh
+exit 0
+PY
+    chmod +x "$stubdir/python3"
+    # setup-hooks.sh resolves the Graphify interpreter from the sidecar first, then
+    # `uv tool run`, then the launcher's shebang. Pin the sidecar so the probe is
+    # hermetic: without it the example resolves whatever Graphify the HOST has, so it
+    # passed on a developer machine that had one and failed on a runner that did not.
+    mkdir -p "$primary/graphify-out"
+    printf '%s\n' "$stubdir/python3" > "$primary/graphify-out/.graphify_python"
     chmod +x "$stubdir/codegraph"
     export CODEGRAPH_LOG="$codegraph_log"
     PATH="$stubdir:$PATH"; export PATH
   }
   cleanup() { rm -rf "$fixture"; }
+  registered_driver() { git_fixture -C "$primary" config --local --get merge.graphify.driver; }
   BeforeEach 'setup'
   AfterEach 'cleanup'
 
@@ -58,5 +77,20 @@ CODEGRAPH
     The output should include 'core.hooksPath set to: .githooks'
     The stderr should equal ''
     The file "$codegraph_log" should not be exist
+  End
+
+  It 'registers the Graphify merge driver that .gitattributes names'
+    When run sh -c 'cd "$1" && exec sh "$2"' _ "$primary" "$script_abs"
+    The status should equal 0
+    The output should include 'merge.graphify.driver registered'
+    The stderr should include 'Initializing CodeGraph'
+    The result of function registered_driver should include 'graphify merge-driver %O %A %B'
+  End
+
+  It 'leaves the merge driver alone when Graphify is unavailable'
+    When run env PATH="$missing_codegraph_path" sh -c 'cd "$1" && exec sh "$2"' _ "$primary" "$script_abs"
+    The status should equal 0
+    The output should not include 'merge.graphify.driver registered'
+    The stderr should equal ''
   End
 End


### PR DESCRIPTION
## Two independent fixes to the local Graphify tooling

### 1. The `.inc` language override silently reverted on upgrade

The vendored `#3075` patch survives an upgrade **only in half**, which is its most dangerous property:

| patch hunk | owned by the wheel? | outcome of `uv tool install --upgrade` |
| --- | --- | --- |
| `graphify/rcfile.py` (created from `/dev/null`) | **no** — absent from `RECORD` | **survives as an orphan** |
| `cache.py`, `detect.py`, `extract.py`, `hooks.py`, `resolver_registry.py` | yes | **replaced, hunks reverted** |

That leaves the override API present and wired into nothing: `detect.classify_file` reads `path.suffix` again and `.inc` extracts as Pascal. `patch-graphify.sh` could not see it, because its probe asked `hasattr(rc, "activate_language_overrides")` — which the surviving orphan satisfies. It skipped the patch and reported success.

**Measured on graphify 0.9.53 in this repository:** `.inc` nodes fell **783 → 29** while extraction reported success, and every other extension *grew*, so the loss read as ordinary shrinkage rather than a parse failure. After recovery: **803**.

Two changes:

- The probe now requires the seam the patch actually adds — the API present **and** `detect` consulting `effective_suffix` — so a surviving orphan no longer answers for the wiring.
- A half-patched install is **repaired** rather than refused: the orphan `rcfile.py` is cleared before re-applying, but only after confirming no installed distribution's `RECORD` claims that path, so a release that starts shipping `rcfile.py` is never deleted.

Verified against a pristine `graphifyy==0.9.53` venv in all three states: pristine applies the full patch; a `--force-reinstall` reproduces the half-patched state exactly (orphan survives, wiring reverts) and is then recovered; a fully patched install no-ops.

### 2. `merge=graphify` had no driver behind it in a developer clone

`.gitattributes` marks `graphify-out/graph.json merge=graphify`, and CI registers that driver through `ensure-graphify-merge-driver.sh`, but a developer clone carried the attribute with nothing behind it: a local merge, rebase or cherry-pick touching the graph fell back to a line-based text merge on generated JSON.

`setup-hooks.sh` now registers it, resolving an interpreter that can actually `import graphify` — the sidecar, then the uv tool install, then the launcher shebang — and verifying the import before writing the config, so a driver that would fail on first use is never registered. It stays silent when Graphify is absent, because this is an optional local convenience rather than a precondition; `ensure-graphify-merge-driver.sh` keeps the force-upgrade, which is not a developer's opt-in to make.

## Landing evidence

| Frozen RED test | git hash-object | RED run tail |
| --- | --- | --- |
| `tests/shell/setup_hooks_spec.sh` | `d871bc233bb5c26629bd6717202f3e776e5b6d3d` | `shellspec tests/shell/setup_hooks_spec.sh:82 # 1) setup-hooks.sh CodeGraph bootstrap registers the Graphify merge driver that .gitattributes names FAILED` |

RED was produced by restoring `scripts/setup-hooks.sh` from `origin/devel` and re-running the spec under `dash`: `4 examples, 1 failure`. Restoring the fix returns `4 examples, 0 failures`.

## Gates

```
shellcheck  scripts/setup-hooks.sh scripts/agent/*.sh          PASS
shellspec   69 examples, 0 failures  (graphify + hooks + agent tooling)
shellspec   4 examples, 0 failures   (setup_hooks_spec.sh under dash, PATH without uv or graphify)
pytest      31 passed                (test_cross_agent_tooling.py, test_ci_graphify_merge_driver.py)
```

GATES: PASS

## Two rejected revisions, recorded

**A third `patch-graphify.sh` call site in `setup-agent-tools.sh`** was added on the theory that its `uv tool install --upgrade graphifyy` was an unpatched upgrade path. `test_graphify_inc_language_override_rides_as_a_local_patch` correctly rejected it: that script ends by running `init-worktree-tools.sh`, which patches, so the call was redundant. Dropped. The genuinely unpatched path is a **manual** `uv tool upgrade graphifyy` outside all three scripts, which no call site can cover — the tracked-graph `.inc` corpus test remains the net for that, and it works.

**Dropping the patch's `rcfile.py` hunk** was briefly done on the false premise that 0.9.53 ships that file. It does not: a pristine install has no `rcfile.py` and it is absent from `RECORD`. The hunk is restored, and the surviving-orphan behaviour above is the correct explanation.

**The first CI run also caught a real defect in the new spec:** it resolved whatever Graphify the *host* had, so it passed locally and failed on a runner with neither `uv` nor `graphify`. The fixture now pins `graphify-out/.graphify_python`, making the probe hermetic, and the example is verified under `dash` with a PATH carrying neither.
