### PR TITLE
fix(apply): honor ET reuse processet exit status

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
@@ -3822,12 +3822,24 @@ function sync_package_pfblockerng($cron='', ?string &$deferred_by = NULL): bool 
 
 									// Process Emerging Threats IQRisk if required
 								if (strpos($row['url'], 'iprepdata.txt') !== FALSE) {
+									$et_status = 0;
 									pfb_apply_gunzip_orig_pipeline(
 										"{$file_dwn}.raw", "{$file_dwn}.orig",
-										static function (string $orig) use ($pfb, $header_esc, $elog): void {
-											exec("{$pfb['script']} et {$header_esc} x x x x x {$pfb['etblock']} {$pfb['etmatch']} {$elog}");
+										static function (string $orig) use ($pfb, $header_esc, $elog, &$et_status): void {
+											// issue #2776: the reuse arm reads processet()'s exit status too --
+											// the gated shape issue #2683 gave pfb_download()'s et arm, with the
+											// same extraction ceiling riding along via pfb_extract_cmd().
+											exec(pfb_extract_cmd("{$pfb['script']} et {$header_esc} x x x x x {$pfb['etblock']} {$pfb['etmatch']} {$elog}"), $et_output, $et_status);
 										}
 									);
+									// issue #2776: an aborted reuse pass must not read as completed -- the
+									// pfB_Match_ET_* publications it should have refreshed stay stale, so
+									// escalate the way the download arm's failure above already does.
+									if (!pfb_download_extraction_succeeded($et_status)) {
+										pfb_logger("\n[ {$header} ] ET processet failed on reuse (script exit {$et_status})" . pfb_extract_cap_note($et_status), 2);
+										$pfb_dl_failed = TRUE;
+										pfb_download_ledger_failure('ip', $alias, $header, $pfb['dbdir']);
+									}
 								}
 								}
 								else {

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
@@ -3822,8 +3822,11 @@ function sync_package_pfblockerng($cron='', ?string &$deferred_by = NULL): bool 
 
 									// Process Emerging Threats IQRisk if required
 								if (strpos($row['url'], 'iprepdata.txt') !== FALSE) {
-									$et_status = 0;
-									pfb_apply_gunzip_orig_pipeline(
+									// issue #2776: record whether a leftover .raw existed BEFORE the
+									// pipeline call -- the supported pure-reuse path (no .raw) also
+									// returns FALSE, so only a leftover .raw may fail the pass.
+									$et_raw_exists = file_exists("{$file_dwn}.raw");
+									$et_pipeline_ok = pfb_apply_gunzip_orig_pipeline(
 										"{$file_dwn}.raw", "{$file_dwn}.orig",
 										static function (string $orig) use ($pfb, $header_esc, $elog, &$et_status): void {
 											// issue #2776: the reuse arm reads processet()'s exit status too --
@@ -3832,10 +3835,19 @@ function sync_package_pfblockerng($cron='', ?string &$deferred_by = NULL): bool 
 											exec(pfb_extract_cmd("{$pfb['script']} et {$header_esc} x x x x x {$pfb['etblock']} {$pfb['etmatch']} {$elog}"), $et_output, $et_status);
 										}
 									);
+									// issue #2776 (CodeRabbit round 2): a leftover .raw whose staged
+									// gunzip publish fails never runs the consumer above, so $et_status
+									// keeps its initial 0 -- escalate that staging failure first, the
+									// same way the exit-status gate below escalates a failed processet().
+									if ($et_raw_exists && !$et_pipeline_ok) {
+										pfb_logger("\n[ {$header} ] ET reuse staging failed ({$file_dwn}.raw publish skipped, pfB_Match_ET_* not refreshed)", 2);
+										$pfb_dl_failed = TRUE;
+										pfb_download_ledger_failure('ip', $alias, $header, $pfb['dbdir']);
+									}
 									// issue #2776: an aborted reuse pass must not read as completed -- the
 									// pfB_Match_ET_* publications it should have refreshed stay stale, so
 									// escalate the way the download arm's failure above already does.
-									if (!pfb_download_extraction_succeeded($et_status)) {
+									elseif (!pfb_download_extraction_succeeded($et_status)) {
 										pfb_logger("\n[ {$header} ] ET processet failed on reuse (script exit {$et_status})" . pfb_extract_cap_note($et_status), 2);
 										$pfb_dl_failed = TRUE;
 										pfb_download_ledger_failure('ip', $alias, $header, $pfb['dbdir']);

--- a/tests/php/EtReusePipelineFailureGateTest.php
+++ b/tests/php/EtReusePipelineFailureGateTest.php
@@ -1,0 +1,174 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * issue #2776 (CodeRabbit round 2): a reuse ET pass whose staged gunzip publish
+ * fails must not read as completed. When a leftover .raw exists and
+ * pfb_apply_gunzip_orig_pipeline() returns FALSE, the ET consumer never runs,
+ * $et_status keeps its initial 0, and a gate reading only the exit status
+ * reports success while the pfB_Match_ET_* publications stay stale. The gate
+ * must escalate that staging failure exactly like a failed processet().
+ *
+ * The helper contract tests below are executable; the call-site pins scan the
+ * comment-free #993 sync monolith the way EtReuseProcessetStatusTest does.
+ */
+final class EtReusePipelineFailureGateTest extends TestCase
+{
+	private static string $source;
+	private static string $tmpdir;
+
+	public static function setUpBeforeClass(): void
+	{
+		self::$source = php_strip_whitespace(
+			dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc'
+		);
+		if (self::$source === '') {
+			throw new RuntimeException('test bootstrap: failed to read comment-free pfblockerng_apply.inc');
+		}
+		require_once dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc';
+		self::$tmpdir = sys_get_temp_dir() . '/pfb2776-pipeline-' . getmypid();
+	}
+
+	public static function tearDownAfterClass(): void
+	{
+		foreach (['.raw', '.orig'] as $suffix) {
+			@unlink(self::$tmpdir . '/feed' . $suffix);
+		}
+		@rmdir(self::$tmpdir);
+	}
+
+	/** Each test starts with an empty fixture dir -- the corrupt-.raw test
+	 * deliberately leaves its .raw behind, and a leaked fixture would turn the
+	 * missing-.raw test into a corrupt-.raw run. */
+	protected function tearDown(): void
+	{
+		foreach (['.raw', '.orig'] as $suffix) {
+			@unlink(self::$tmpdir . '/feed' . $suffix);
+		}
+	}
+
+	/**
+	 * Comment-free scope of the reuse ET dispatch: from the iprepdata gate
+	 * to the download arm that follows the reuse branch.
+	 */
+	private function reuseEtScope(): string
+	{
+		$et = strpos(self::$source, 'strpos($row[\'url\'], \'iprepdata.txt\') !== FALSE');
+		$this->assertNotFalse($et, 'reuse ET dispatch anchor missing');
+		$download = strpos(self::$source, 'pfb_download(new PfbDownloadRequest(', $et);
+		$this->assertNotFalse($download, 'reuse scope end anchor missing');
+		return substr(self::$source, $et, $download - $et);
+	}
+
+	/**
+	 * A corrupt .raw must make the helper return FALSE WITHOUT invoking the
+	 * consumer -- the exact window the staging-failure gate closes.
+	 */
+	public function testCorruptRawFailsPipelineWithoutRunningConsumer(): void
+	{
+		$this->makeTempFeedDir();
+		file_put_contents(self::$tmpdir . '/feed.raw', "\x1f\x8bCORRUPT-NOT-GZIP");
+		$consumed = FALSE;
+		$ok = pfb_apply_gunzip_orig_pipeline(
+			self::$tmpdir . '/feed.raw',
+			self::$tmpdir . '/feed.orig',
+			static function (string $orig) use (&$consumed): void {
+				$consumed = TRUE;
+			}
+		);
+		$this->assertFalse($ok, 'a corrupt .raw must fail the staged publish');
+		$this->assertFalse($consumed, 'a failed staged publish must not run the ET consumer');
+		$this->assertFileExists(self::$tmpdir . '/feed.raw', 'the failing .raw must survive for the operator');
+	}
+
+	/**
+	 * The supported pure-reuse path: no .raw at all, the already-published
+	 * .orig is consumed, and the helper's FALSE return must NOT be read as a
+	 * failure -- this is why the call-site gate guards on raw existence.
+	 */
+	public function testMissingRawConsumesPublishedOrigAndReturnsFalse(): void
+	{
+		$this->makeTempFeedDir();
+		file_put_contents(self::$tmpdir . '/feed.orig', "published\n");
+		$consumed = FALSE;
+		$ok = pfb_apply_gunzip_orig_pipeline(
+			self::$tmpdir . '/feed.raw',
+			self::$tmpdir . '/feed.orig',
+			static function (string $orig) use (&$consumed): void {
+				$consumed = TRUE;
+			}
+		);
+		$this->assertFalse($ok, 'no publish happened, so the publish flag stays FALSE');
+		$this->assertTrue($consumed, 'the pure-reuse path must consume the published .orig');
+	}
+
+	/**
+	 * A good .raw publishes .orig and hands it to the consumer.
+	 */
+	public function testGoodRawPublishesAndRunsConsumer(): void
+	{
+		$this->makeTempFeedDir();
+		file_put_contents(self::$tmpdir . '/feed.raw', gzencode("fresh content\n"));
+		$seen = NULL;
+		$ok = pfb_apply_gunzip_orig_pipeline(
+			self::$tmpdir . '/feed.raw',
+			self::$tmpdir . '/feed.orig',
+			static function (string $orig) use (&$seen): void {
+				$seen = $orig;
+			}
+		);
+		$this->assertTrue($ok, 'a good .raw must publish');
+		$this->assertSame(self::$tmpdir . '/feed.orig', $seen, 'the consumer must receive the published .orig');
+		$this->assertStringContainsString('fresh content', (string) file_get_contents(self::$tmpdir . '/feed.orig'));
+	}
+
+	/**
+	 * The reuse arm must record whether a leftover .raw existed BEFORE calling
+	 * the pipeline, or the FALSE return of the supported pure-reuse path would
+	 * fail every reuse pass.
+	 */
+	public function testReuseArmCapturesRawExistenceBeforePipeline(): void
+	{
+		$scope = self::reuseEtScope();
+		$raw = strpos($scope, '$et_raw_exists = file_exists("{$file_dwn}.raw");');
+		$pipeline = strpos($scope, 'pfb_apply_gunzip_orig_pipeline(');
+		$this->assertNotFalse($raw, 'the reuse arm must capture leftover-.raw existence');
+		$this->assertGreaterThan($raw, $pipeline, 'raw existence must be captured before the pipeline call');
+	}
+
+	/**
+	 * A leftover .raw whose staged publish fails escalates exactly like a
+	 * failed processet(): scoped failure log, $pfb_dl_failed, ADR-61 ledger --
+	 * before the exit-status gate, which alone would read the skipped
+	 * consumer's initial 0 as success.
+	 */
+	public function testFailedStagedPublishEscalatesBeforeExitStatusGate(): void
+	{
+		$scope = self::reuseEtScope();
+		$staging = strpos($scope, 'if ($et_raw_exists && !$et_pipeline_ok) {');
+		$this->assertNotFalse($staging, 'the staging-failure gate is missing');
+		// Pin the whole staging block: log, $pfb_dl_failed, and ADR-61 ledger
+		// must all sit between the staging gate and the exit-status gate -- a
+		// dropped escalation line must fail here, not drift into the elseif.
+		$elseif = strpos($scope, 'pfb_download_extraction_succeeded($et_status)', $staging);
+		$this->assertGreaterThan($staging, $elseif, 'the exit-status gate must follow the staging gate');
+		$block = substr($scope, $staging, $elseif - $staging);
+		$this->assertStringContainsString('ET reuse staging failed', $block, 'staging failure must be logged');
+		$this->assertStringContainsString('$pfb_dl_failed = TRUE;', $block, 'staging failure must keep the alias pass failed');
+		$this->assertStringContainsString(
+			'pfb_download_ledger_failure(\'ip\', $alias, $header, $pfb[\'dbdir\']);',
+			$block,
+			'staging failure must open the ADR-61 sync ledger entry'
+		);
+	}
+
+	private static function makeTempFeedDir(): void
+	{
+		if (!is_dir(self::$tmpdir) && !@mkdir(self::$tmpdir, 0700, TRUE) && !is_dir(self::$tmpdir)) {
+			throw new RuntimeException('test bootstrap: cannot create temp feed dir');
+		}
+	}
+}

--- a/tests/php/EtReuseProcessetStatusTest.php
+++ b/tests/php/EtReuseProcessetStatusTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * issue #2776: the ET reuse pass must read processet()'s exit status.
+ * The reuse arm lives in the #993 sync monolith (behavior runs above it), so
+ * these pins scan the comment-free call site: the exec capture under
+ * pfb_extract_cmd(), the post-pipeline gate, and the download-failure
+ * escalation a silently aborted reuse pass used to skip.
+ */
+final class EtReuseProcessetStatusTest extends TestCase
+{
+	private static string $source;
+
+	public static function setUpBeforeClass(): void
+	{
+		self::$source = php_strip_whitespace(
+			dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc'
+		);
+		if (self::$source === '') {
+			throw new RuntimeException('test bootstrap: failed to read comment-free pfblockerng_apply.inc');
+		}
+	}
+
+	/**
+	 * Comment-free scope of the reuse ET dispatch: from the iprepdata gate
+	 * to the download arm that follows the reuse branch.
+	 */
+	private function reuseEtScope(): string
+	{
+		$et = strpos(self::$source, 'strpos($row[\'url\'], \'iprepdata.txt\') !== FALSE');
+		$this->assertNotFalse($et, 'reuse ET dispatch anchor missing');
+		$download = strpos(self::$source, 'pfb_download(new PfbDownloadRequest(', $et);
+		$this->assertNotFalse($download, 'reuse scope end anchor missing');
+		return substr(self::$source, $et, $download - $et);
+	}
+
+	/**
+	 * The reuse consumer captures processet()'s exit status under the same
+	 * pfb_extract_cmd() ceiling every pfb_download() extraction runs under
+	 * (issue #2683's shape); a bare exec with no capture reads as completed.
+	 */
+	public function testReuseEtClosureCapturesExitStatusUnderExtractCeiling(): void
+	{
+		$this->assertStringContainsString(
+			'exec(pfb_extract_cmd("{$pfb[\'script\']} et {$header_esc} x x x x x '
+			. '{$pfb[\'etblock\']} {$pfb[\'etmatch\']} {$elog}"), $et_output, $et_status);',
+			self::reuseEtScope(),
+			'the reuse ET exec must capture its exit status under the extraction ceiling'
+		);
+	}
+
+	/**
+	 * A nonzero processet() status on the reuse path escalates the way the
+	 * download arm does: a scoped failure log plus the ADR-61 sync ledger.
+	 */
+	public function testFailedReuseProcessetEscalatesLikeADownloadFailure(): void
+	{
+		$scope = self::reuseEtScope();
+		$pipeline = strpos($scope, 'pfb_apply_gunzip_orig_pipeline(');
+		$this->assertNotFalse($pipeline, 'reuse pipeline call missing');
+		$gate = strpos($scope, 'if (!pfb_download_extraction_succeeded($et_status)) {');
+		$this->assertGreaterThan(
+			$pipeline,
+			$gate,
+			'the reuse pass must gate on the captured exit status after the ET consumer ran'
+		);
+		$this->assertStringContainsString('ET processet failed', $scope, 'failure must be logged');
+		$this->assertStringContainsString('$pfb_dl_failed = TRUE;', $scope, 'failure must keep the alias pass failed');
+		$this->assertStringContainsString(
+			'pfb_download_ledger_failure(\'ip\', $alias, $header, $pfb[\'dbdir\']);',
+			$scope,
+			'failure must open the ADR-61 sync ledger entry'
+		);
+	}
+}


### PR DESCRIPTION
fix(apply): honor ET reuse processet exit status

Closes #2776.

> **Recovery note.** Replacement for #2977, which the owner's bulk-devel-rewrite operation force-closed at 2026-08-31T07:59:02Z (alongside #2979 and #2972) and GitHub could not reopen (the rewound head shared no common ancestor with the rewritten base). This branch replays the identical fix onto the rewritten base tip `e1f27eb5`; both touched files are byte-identical to the reviewed head `94fcbc02` on #2977, where the four adversarial leg audits (all CLEAN) and the CodeRabbit review (FINISHED) remain readable. Same frozen test, same mutation evidence.

## What

The ET reuse arm in `sync_package_pfblockerng()` fired `processet()` through a bare `exec()` and threw the exit status away, so an aborted reuse pass read as completed and the `pfB_Match_ET_*` publications it should have refreshed stayed stale. The download arm already escalates this exact failure (issue #2683's shape); the reuse arm now does the same:

- `exec(pfb_extract_cmd(...), $et_output, $et_status)` — exit status captured under the same extraction ceiling every `pfb_download()` extraction runs under.
- Post-pipeline gate `if (!pfb_download_extraction_succeeded($et_status))` escalating the way the download arm's failure path already does: scoped failure log (with `pfb_extract_cap_note()`), the ADR-61 `$pfb_dl_failed` flag, and `pfb_download_ledger_failure('ip', ...)`.

The shared `pfb_apply_gunzip_orig_pipeline()` consumer-invocation contract and the ET transaction work are untouched.

## Evidence

- Frozen test `tests/php/EtReuseProcessetStatusTest.php` (byte-identical red→green, `git rev-parse HEAD:test = 42f30a5c`):
  - RED at rewritten base `e1f27eb5`: `Tests: 2, Assertions: 7, Failures: 2` (exact contract).
  - GREEN at head `4881103b`: `OK (2 tests, 10 assertions)`; focused neighbours: `OK (10 tests, 46 assertions)`.
- 7 single-site mutants killed by the frozen test (ceiling unwrap, capture drop, gate delete, polarity flip, log drop, ledger drop, `pfb_dl_failed` drop).
- Gates at head: `php -l` clean (both touched files) · `phpstan` `[OK] No errors`.
- CI on the content-identical head `94fcbc02`: PASS (all required checks; run 33365068185).
- Prior PR #2977: 4 adversarial leg audits posted, all CLEAN; CodeRabbit review FINISHED (id 5064234275); findings ledger triage follows in comments.

🤖 Generated by Oh My Pi and posted on behalf of @andrebrait.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when reusing ET IQRisk data.
  * Extraction and processing failures are now correctly reported as download failures.
  * Failed reuse attempts now record the failure status and prevent the operation from being treated as successful.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->