### PR TITLE
hooks: guard commit identity and signing prerequisites (#2982)

### DIFF
--- a/.githooks/check-commit-identity.sh
+++ b/.githooks/check-commit-identity.sh
@@ -44,8 +44,21 @@ check_email() { # $1=role  $2=value
 	*@*) ;;
 	*) bad "$1 email is malformed (no '@'): '$2'" ;;
 	esac
-	case ${e##*@} in
-	''|example.invalid|example.com|localhost) bad "$1 email domain is a placeholder or empty: '$2'" ;;
+	# Interior whitespace is judged on the RAW value (outer-trimmed only): norm
+	# deletes control whitespace, which would silently rewrite an address such
+	# as 'a@example<TAB>invalid' into a different one before any comparison.
+	ws=$(printf '%s' "$2" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+	case $ws in
+	*[[:space:]]*) bad "$1 email contains internal whitespace: '$2'" ;;
+	esac
+	d=${e##*@}
+	# A trailing dot carries no identity ('example.invalid.' is the same reserved
+	# domain), and the placeholder families cover every subdomain depth
+	# ('sub.example.com'), so a fabricated identity cannot hide one label deep.
+	while [ "$d" != "${d%.}" ]; do d=${d%.}; done
+	case $d in
+	''|example.invalid|example.com|example.net|example.org|localhost|*.example.invalid|*.example.com|*.example.net|*.example.org|*.localhost)
+		bad "$1 email domain is a placeholder or empty: '$2'" ;;
 	esac
 }
 

--- a/.githooks/check-commit-identity.sh
+++ b/.githooks/check-commit-identity.sh
@@ -1,0 +1,85 @@
+#!/bin/sh
+# Commit identity & signing prerequisite gate (issue #2982): fail-closed check of
+# the identity and signing configuration Git would use for THIS commit. The hook
+# (.githooks/pre-commit) resolves this file relative to its own $0 so the absolute
+# shared core.hooksPath works from linked release worktrees; a missing or
+# non-executable checker is a hook-level hard failure. Git's own signing remains
+# the cryptographic proof -- this gate only rejects known-bad prerequisites, so a
+# `key::ssh-...` literal signing key is left for Git to validate.
+
+set -u
+
+bad() { printf '[check-commit-identity] FAILED: %s\n' "$1" >&2; exit 1; }
+cfg() { git config --get "$1" 2>/dev/null; }
+have() { command -v "$1" >/dev/null 2>&1; }
+
+# Lowercase + outer-whitespace trim, bound once: generic names and placeholder
+# domains are compared case- and whitespace-insensitively (issue #2982).
+norm() {
+	printf '%s' "$1" \
+		| tr -d '[:cntrl:]' \
+		| sed 's/^[[:space:]]*//;s/[[:space:]]*$//' \
+		| tr '[:upper:]' '[:lower:]'
+}
+
+# Effective identity value: the GIT_* override wins when set (even empty, which
+# Git itself would reject for a name), otherwise the config key.
+ident_val() { # $1=env var name  $2=config key
+	_key=$2
+	eval "set -- \"\${$1+set}\" \"\${$1-}\""
+	if [ "$1" = set ]; then printf '%s' "$2"; else cfg "$_key"; fi
+}
+
+check_name() { # $1=role  $2=value
+	case $(norm "$2") in
+	'') bad "$1 name is missing or empty" ;;
+	verifier|root|ci) bad "$1 name is a generic placeholder: '$2'" ;;
+	esac
+}
+
+check_email() { # $1=role  $2=value
+	e=$(norm "$2")
+	[ -n "$e" ] || bad "$1 email is missing or empty"
+	case $e in
+	*@*) ;;
+	*) bad "$1 email is malformed (no '@'): '$2'" ;;
+	esac
+	case ${e##*@} in
+	''|example.invalid|example.com|localhost) bad "$1 email domain is a placeholder or empty: '$2'" ;;
+	esac
+}
+
+check_name author "$(ident_val GIT_AUTHOR_NAME user.name)"
+check_email author "$(ident_val GIT_AUTHOR_EMAIL user.email)"
+check_name committer "$(ident_val GIT_COMMITTER_NAME user.name)"
+check_email committer "$(ident_val GIT_COMMITTER_EMAIL user.email)"
+
+[ "$(git config --get --bool commit.gpgsign 2>/dev/null)" = true ] \
+	|| bad 'commit.gpgsign is not enabled (set git config commit.gpgsign true)'
+signkey=$(cfg user.signingkey)
+[ -n "$signkey" ] || bad 'user.signingkey is not configured'
+
+fmt=$(cfg gpg.format)
+case ${fmt:-openpgp} in
+ssh)
+	prog=$(cfg gpg.ssh.program)
+	[ -n "$prog" ] || prog=ssh-keygen
+	have "$prog" || bad "SSH signing program not found in PATH: $prog"
+	case $signkey in
+	key::*) ;;
+	*) [ -r "$signkey" ] || bad "SSH signing key not found or unreadable: $signkey" ;;
+	esac
+	;;
+openpgp)
+	prog=$(cfg gpg.openpgp.program)
+	[ -n "$prog" ] || prog=$(cfg gpg.program)
+	[ -n "$prog" ] || prog=gpg
+	have "$prog" || bad "OpenPGP signing program not found in PATH: $prog"
+	;;
+x509)
+	prog=$(cfg gpg.x509.program)
+	[ -n "$prog" ] || prog=gpgsm
+	have "$prog" || bad "X.509 signing program not found in PATH: $prog"
+	;;
+*) bad "unknown gpg.format: '$fmt' (expected openpgp, x509, or ssh)" ;;
+esac

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -101,12 +101,13 @@ gate_exempt() { printf '[pre-commit] exempt (gate not adopted on this branch; li
 
 # --- Stage classification: run a language's gates ONLY when this commit stages a
 #     file of that type. (diff-filter ACMR = added/copied/modified/renamed; a pure
-#     deletion stages nothing to lint.) Nothing staged -> nothing to do.
+#     deletion stages nothing to lint.) Nothing staged -> nothing left to run;
+#     the identity gate's verdict above still decides via the exit below.
 #     -z + tr: the newline listing C-quotes a path holding a quote, backslash,
 #     control byte or non-ASCII byte, so the suffix regexes below match nothing
 #     and that commit's language gates silently never run (issue #2212). ---
 staged_all=$(git diff --cached --name-only -z --diff-filter=ACMRD | tr '\0' '\n' | grep -v '^legacy/' || true)
-[ -n "$staged_all" ] || exit 0
+[ -n "$staged_all" ] || exit "$fail"
 staged=$(git diff --cached --name-only -z --diff-filter=ACMR | tr '\0' '\n' | grep -v '^legacy/' || true)
 staged_has() { printf '%s\n' "$staged" | grep -qE "$1"; }
 staged_py=0;  staged_has '\.py$'        && staged_py=1

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -48,6 +48,20 @@ step() { printf '[pre-commit] %s\n' "$1"; }
 failed() { printf '[pre-commit] FAILED: %s\n' "$1" >&2; fail=1; }
 skip() { skipped="${skipped}${skipped:+,} $1"; }
 
+# --- Commit identity & signing prerequisites (issue #2982): fail-closed gate
+#     before the no-staged exit, so allow-empty commits are covered too. Resolved
+#     relative to $0 because core.hooksPath is the absolute shared path (linked
+#     release worktrees must reach the same checker). Missing/non-executable
+#     checker fails closed; a checker failure joins the other `fail` results
+#     without suppressing them. Git's own signing stays the cryptographic proof. ---
+step 'commit identity & signing prerequisites'
+identity_checker=$(dirname -- "$0")/check-commit-identity.sh
+if [ ! -x "$identity_checker" ]; then
+	failed "commit identity checker missing or not executable: $identity_checker"
+else
+	"$identity_checker" || failed 'commit identity & signing prerequisites'
+fi
+
 # Explicit legacy-branch opt-out (issue #2633): every worktree runs THIS hook via the
 # absolute shared core.hooksPath, but release-line trees never shipped the devel
 # checker corpus. A repo-script gate whose checker is absent from the tree is skipped

--- a/tests/shell/precommit_composer_vendor_spec.sh
+++ b/tests/shell/precommit_composer_vendor_spec.sh
@@ -7,9 +7,18 @@ Describe '.githooks/pre-commit Composer vendor guard'
     scrub_git_env
     repo="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/precommitphp.XXXXXX")"
     git_fixture -C "$repo" init -q
-    gitc config commit.gpgsign false
+    # issue #2982: the pre-commit identity gate is fail-closed, so the sandbox
+    # carries a valid identity and SSH signing prerequisites for hook-pass rows.
+    gitc config user.name t
+    gitc config user.email t@t
+    gitc config commit.gpgsign true
+    gitc config gpg.format ssh
+    : > "$repo/key.pub"
+    gitc config user.signingkey "$repo/key.pub"
     mkdir -p "$repo/.githooks" "$repo/scripts" "$repo/src" "$repo/vendor/bin"
     cp "$PFB_ROOT/.githooks/pre-commit" "$repo/.githooks/pre-commit"
+    cp "$PFB_ROOT/.githooks/check-commit-identity.sh" "$repo/.githooks/" \
+      && chmod +x "$repo/.githooks/check-commit-identity.sh"
     printf '<?php echo 1;\n' > "$repo/src/a.php"
     gitc add src/a.php
 

--- a/tests/shell/precommit_composer_vendor_spec.sh
+++ b/tests/shell/precommit_composer_vendor_spec.sh
@@ -13,7 +13,7 @@ Describe '.githooks/pre-commit Composer vendor guard'
     gitc config user.email t@t
     gitc config commit.gpgsign true
     gitc config gpg.format ssh
-    : > "$repo/key.pub"
+    true > "$repo/key.pub"
     gitc config user.signingkey "$repo/key.pub"
     mkdir -p "$repo/.githooks" "$repo/scripts" "$repo/src" "$repo/vendor/bin"
     cp "$PFB_ROOT/.githooks/pre-commit" "$repo/.githooks/pre-commit"

--- a/tests/shell/precommit_githooks_exempt_spec.sh
+++ b/tests/shell/precommit_githooks_exempt_spec.sh
@@ -24,9 +24,18 @@ scripts/agent/check-agent-config-parity.sh'
     scrub_git_env
     repo="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/precommitexempt.XXXXXX")"
     git_fixture -C "$repo" init -q
-    gitc config commit.gpgsign false
+    # issue #2982: the pre-commit identity gate is fail-closed, so the sandbox
+    # carries a valid identity and SSH signing prerequisites for hook-pass rows.
+    gitc config user.name t
+    gitc config user.email t@t
+    gitc config commit.gpgsign true
+    gitc config gpg.format ssh
+    : > "$repo/key.pub"
+    gitc config user.signingkey "$repo/key.pub"
     mkdir -p "$repo/.githooks" "$repo/scripts" "$repo/src" "$repo/vendor/bin"
     cp "$PFB_ROOT/.githooks/pre-commit" "$repo/.githooks/pre-commit"
+    cp "$PFB_ROOT/.githooks/check-commit-identity.sh" "$repo/.githooks/" \
+      && chmod +x "$repo/.githooks/check-commit-identity.sh"
     printf '<?php echo 1;\n' > "$repo/src/a.php"
     gitc add src/a.php
 
@@ -177,7 +186,9 @@ scripts/agent/check-agent-config-parity.sh'
     # so a gate cannot be dropped by a change reviewers never see.
     printf '%s\ngate:shellcheck\n' "$ALL_CHECKERS" > "$repo/.githooks-exempt"
     gitc add .githooks-exempt
-    gitc commit -q -m seed --no-verify
+    # -c commit.gpgsign=false: the sandbox key.pub is an empty stand-in, and this
+    # fixture commit is plumbing, not a signing test.
+    gitc -c commit.gpgsign=false commit -q -m seed --no-verify
     printf '%s\n' "$ALL_CHECKERS" > "$repo/.githooks-exempt"
     gitc add .githooks-exempt
     printf 'gate:shellcheck\n' >> "$repo/.githooks-exempt"

--- a/tests/shell/precommit_githooks_exempt_spec.sh
+++ b/tests/shell/precommit_githooks_exempt_spec.sh
@@ -30,7 +30,7 @@ scripts/agent/check-agent-config-parity.sh'
     gitc config user.email t@t
     gitc config commit.gpgsign true
     gitc config gpg.format ssh
-    : > "$repo/key.pub"
+    true > "$repo/key.pub"
     gitc config user.signingkey "$repo/key.pub"
     mkdir -p "$repo/.githooks" "$repo/scripts" "$repo/src" "$repo/vendor/bin"
     cp "$PFB_ROOT/.githooks/pre-commit" "$repo/.githooks/pre-commit"

--- a/tests/shell/precommit_hostile_path_spec.sh
+++ b/tests/shell/precommit_hostile_path_spec.sh
@@ -13,9 +13,21 @@ Describe '.githooks/pre-commit with a C-quoted path'
     scrub_git_env
     repo="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/precommithostile.XXXXXX")"
     git_fixture -C "$repo" init -q
-    gitc config commit.gpgsign false
+    # issue #2982: the pre-commit identity gate is fail-closed, so the sandbox
+    # carries a valid identity, SSH signing prerequisites, and the checker itself.
+    gitc config user.name t
+    gitc config user.email t@t
+    gitc config commit.gpgsign true
+    gitc config gpg.format ssh
+    : > "$repo/key.pub"
+    gitc config user.signingkey "$repo/key.pub"
     mkdir -p "$repo/.githooks" "$repo/src" "$repo/vendor/bin"
     cp "$PFB_ROOT/.githooks/pre-commit" "$repo/.githooks/pre-commit"
+    cp "$PFB_ROOT/.githooks/check-commit-identity.sh" "$repo/.githooks/" \
+      && chmod +x "$repo/.githooks/check-commit-identity.sh"
+    # The staged checker makes staged_sh=1, so the shell gates run; create their
+    # scan roots so the sandbox stays silent (the spec pins classification only).
+    mkdir -p "$repo/scripts" "$repo/tests" "$repo/.claude/hooks"
     # Stubs stand in for the real analysis tools: this spec pins WHICH gates the
     # hook decides to run and what its own scans see, not what those tools conclude.
     stubdir="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/precommithostilestub.XXXXXX")"

--- a/tests/shell/precommit_hostile_path_spec.sh
+++ b/tests/shell/precommit_hostile_path_spec.sh
@@ -19,7 +19,7 @@ Describe '.githooks/pre-commit with a C-quoted path'
     gitc config user.email t@t
     gitc config commit.gpgsign true
     gitc config gpg.format ssh
-    : > "$repo/key.pub"
+    true > "$repo/key.pub"
     gitc config user.signingkey "$repo/key.pub"
     mkdir -p "$repo/.githooks" "$repo/src" "$repo/vendor/bin"
     cp "$PFB_ROOT/.githooks/pre-commit" "$repo/.githooks/pre-commit"

--- a/tests/shell/precommit_identity_spec.sh
+++ b/tests/shell/precommit_identity_spec.sh
@@ -22,7 +22,7 @@ Describe '.githooks/check-commit-identity.sh + pre-commit wiring (issue #2982)'
     gitc config user.email 'andrebrait@gmail.com'
     gitc config commit.gpgsign true
     gitc config gpg.format ssh
-    : > "$repo/key.pub"
+    true > "$repo/key.pub"
     gitc config user.signingkey "$repo/key.pub"
     mkdir -p "$repo/.githooks"
     cp "$PFB_ROOT/.githooks/pre-commit" "$repo/.githooks/pre-commit"
@@ -69,6 +69,12 @@ Describe '.githooks/check-commit-identity.sh + pre-commit wiring (issue #2982)'
     When run env GIT_AUTHOR_NAME=verifier sh -c "cd '$repo' && sh .githooks/check-commit-identity.sh"
     The status should equal 1
     The stderr should include "[check-commit-identity] FAILED: author name is a generic placeholder: 'verifier'"
+  End
+
+  It 'rejects a placeholder author email from GIT_AUTHOR_EMAIL despite valid config'
+    When run env GIT_AUTHOR_EMAIL=b@localhost sh -c "cd '$repo' && sh .githooks/check-commit-identity.sh"
+    The status should equal 1
+    The stderr should include "[check-commit-identity] FAILED: author email domain is a placeholder or empty: 'b@localhost'"
   End
 
   It 'rejects a missing author name'
@@ -202,7 +208,7 @@ Describe '.githooks/check-commit-identity.sh + pre-commit wiring (issue #2982)'
   End
 
   It 'rejects an unreadable SSH signing key path'
-    : > "$repo/locked.pub"
+    true > "$repo/locked.pub"
     chmod 000 "$repo/locked.pub"
     gitc config user.signingkey "$repo/locked.pub"
     When run sh -c "cd '$repo' && sh .githooks/check-commit-identity.sh"
@@ -211,7 +217,7 @@ Describe '.githooks/check-commit-identity.sh + pre-commit wiring (issue #2982)'
   End
 
   It 'accepts a readable SSH signing key path containing spaces'
-    : > "$repo/my key file.pub"
+    true > "$repo/my key file.pub"
     gitc config user.signingkey "$repo/my key file.pub"
     When run sh -c "cd '$repo' && sh .githooks/check-commit-identity.sh"
     The status should equal 0

--- a/tests/shell/precommit_identity_spec.sh
+++ b/tests/shell/precommit_identity_spec.sh
@@ -104,14 +104,43 @@ Describe '.githooks/check-commit-identity.sh + pre-commit wiring (issue #2982)'
       'a@EXAMPLE.com'
       'a@localhost'
       'a@'
+      'a@example.invalid.'
+      'a@EXAMPLE.invalid.'
+      'a@sub.example.com'
+      'a@sub.example.invalid'
+      'a@deep.sub.example.org'
+      'a@x.example.net'
+      'a@y.localhost'
     End
 
-    It 'rejects the domain case-insensitively'
+    It 'rejects the domain case-insensitively, including trailing-dot and subdomain variants'
       gitc config user.email "$1"
       When run sh -c "cd '$repo' && sh .githooks/check-commit-identity.sh"
       The status should equal 1
       The stderr should include "[check-commit-identity] FAILED: author email domain is a placeholder or empty: '$1'"
     End
+  End
+
+  Describe 'hostile author email internal-whitespace variants'
+    Parameters
+      'a@ example.invalid'
+      'a@ex ample.com'
+      'a b@realcorp.dev'
+    End
+
+    It 'rejects the email without deleting the whitespace into a different address'
+      gitc config user.email "$1"
+      When run sh -c "cd '$repo' && sh .githooks/check-commit-identity.sh"
+      The status should equal 1
+      The stderr should include "[check-commit-identity] FAILED: author email contains internal whitespace: '$1'"
+    End
+    End
+
+  It 'rejects an email whose domain contains a tab'
+    gitc config user.email "a@example$(printf '\t')invalid"
+    When run sh -c "cd '$repo' && sh .githooks/check-commit-identity.sh"
+    The status should equal 1
+    The stderr should include "[check-commit-identity] FAILED: author email contains internal whitespace: 'a@example$(printf '\t')invalid'"
   End
 
   It 'rejects a placeholder committer email from GIT_COMMITTER_EMAIL despite valid config'
@@ -131,6 +160,7 @@ Describe '.githooks/check-commit-identity.sh + pre-commit wiring (issue #2982)'
       'Andre Brait|andrebrait@gmail.com'
       'BBcan177|bbcan177@gmail.com'
       'Some Contributor|some@realcorp.dev'
+      'Deep Sub|a@mail.realcorp.dev'
     End
 
     It 'accepts the identity when signing prerequisites are valid'
@@ -204,7 +234,7 @@ Describe '.githooks/check-commit-identity.sh + pre-commit wiring (issue #2982)'
     gitc config user.signingkey "$repo/my missing key.pub"
     When run sh -c "cd '$repo' && sh .githooks/check-commit-identity.sh"
     The status should equal 1
-    The stderr should include '[check-commit-identity] FAILED: SSH signing key not found or unreadable: '
+    The stderr should include "[check-commit-identity] FAILED: SSH signing key not found or unreadable: $repo/my missing key.pub"
   End
 
   It 'rejects an unreadable SSH signing key path'
@@ -213,7 +243,7 @@ Describe '.githooks/check-commit-identity.sh + pre-commit wiring (issue #2982)'
     gitc config user.signingkey "$repo/locked.pub"
     When run sh -c "cd '$repo' && sh .githooks/check-commit-identity.sh"
     The status should equal 1
-    The stderr should include '[check-commit-identity] FAILED: SSH signing key not found or unreadable: '
+    The stderr should include "[check-commit-identity] FAILED: SSH signing key not found or unreadable: $repo/locked.pub"
   End
 
   It 'accepts a readable SSH signing key path containing spaces'
@@ -326,7 +356,13 @@ scripts/agent/check-agent-config-parity.sh'
     make_repo
     mkdir -p "$repo/src" "$repo/scripts" "$repo/tests" "$repo/.claude/hooks"
     printf '%s\n' "$ALL_CHECKERS" > "$repo/.githooks-exempt"
+    # Commit the manifest so the index starts EMPTY: the allow-empty example
+    # below must exercise the hook's no-staged exit, not a staged manifest
+    # (review round: the ordering claim was never truly exercised before).
+    # -c commit.gpgsign=false: the sandbox key.pub is an empty stand-in, and this
+    # fixture commit is plumbing, not a signing test.
     gitc add .githooks-exempt
+    gitc -c commit.gpgsign=false commit -q -m seed --no-verify
     printf '#!/bin/sh\nexit 0\n' > "$repo/src/ok.sh"
     printf '#!/bin/sh\nexit 0\n' > "$stubdir/shellcheck"
     chmod +x "$stubdir/shellcheck"
@@ -358,6 +394,16 @@ scripts/agent/check-agent-config-parity.sh'
     When run sh -c "cd '$repo' && sh .githooks/pre-commit"
     The status should equal 1
     The stderr should include '[pre-commit] FAILED: commit identity & signing prerequisites'
+    The stderr should include "[check-commit-identity] FAILED: author name is a generic placeholder: 'Verifier'"
+    The output should include '[pre-commit] commit identity & signing prerequisites'
+  End
+
+  It 'fails closed on a missing checker even with an empty index (allow-empty path)'
+    make_wired_repo
+    rm -f "$repo/.githooks/check-commit-identity.sh"
+    When run sh -c "cd '$repo' && sh .githooks/pre-commit"
+    The status should equal 1
+    The stderr should include '[pre-commit] FAILED: commit identity checker missing or not executable: '
     The output should include '[pre-commit] commit identity & signing prerequisites'
   End
 

--- a/tests/shell/precommit_identity_spec.sh
+++ b/tests/shell/precommit_identity_spec.sh
@@ -1,0 +1,376 @@
+#shellcheck shell=sh
+# Commit identity & signing prerequisite gate (issue #2982): the checker rejects
+# placeholder/generic author and committer identity (config and GIT_* overrides)
+# and missing signing prerequisites fail-closed; the pre-commit hook runs it even
+# for allow-empty commits (before the no-staged exit), resolves it relative to $0,
+# and fails closed on a missing or non-executable checker without suppressing the
+# other staged gates. A PATH of only test stubs proves binary selection without
+# host leakage; no signing-key material is ever printed.
+
+Describe '.githooks/check-commit-identity.sh + pre-commit wiring (issue #2982)'
+  gitc() { git_fixture -C "$repo" "$@"; }
+
+  # Sandbox repo with a fully VALID baseline (identity + SSH signing); each
+  # example overrides exactly one prerequisite, so failures are deterministic.
+  make_repo() {
+    scrub_git_env
+    export GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null
+    repo="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/precommit-identity.XXXXXX")"
+    stubdir="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/precommit-identity-stub.XXXXXX")"
+    git_fixture -C "$repo" init -q
+    gitc config user.name 'Andre Brait'
+    gitc config user.email 'andrebrait@gmail.com'
+    gitc config commit.gpgsign true
+    gitc config gpg.format ssh
+    : > "$repo/key.pub"
+    gitc config user.signingkey "$repo/key.pub"
+    mkdir -p "$repo/.githooks"
+    cp "$PFB_ROOT/.githooks/pre-commit" "$repo/.githooks/pre-commit"
+    if [ -f "$PFB_ROOT/.githooks/check-commit-identity.sh" ]; then
+      cp "$PFB_ROOT/.githooks/check-commit-identity.sh" "$repo/.githooks/"
+      chmod +x "$repo/.githooks/check-commit-identity.sh"
+    fi
+    PATH="$stubdir:$PATH"
+  }
+  cleanup() {
+    rm -rf "$repo" "$stubdir"
+    unset GIT_CONFIG_GLOBAL GIT_CONFIG_SYSTEM
+  }
+  Before 'make_repo'
+  After 'cleanup'
+
+  # ------------- identity: effective config (author and committer) ------------- #
+
+  Describe 'generic placeholder author name variants'
+    Parameters
+      'Verifier'
+      'verifier'
+      '  VERIFIER  '
+      'root'
+      'ROOT'
+      'ci'
+    End
+
+    It 'rejects the name case- and whitespace-insensitively'
+      gitc config user.name "$1"
+      When run sh -c "cd '$repo' && sh .githooks/check-commit-identity.sh"
+      The status should equal 1
+      The stderr should include "[check-commit-identity] FAILED: author name is a generic placeholder: '$1'"
+    End
+  End
+
+  It 'rejects a generic placeholder committer name from GIT_COMMITTER_NAME despite valid config'
+    When run env GIT_COMMITTER_NAME=Verifier sh -c "cd '$repo' && sh .githooks/check-commit-identity.sh"
+    The status should equal 1
+    The stderr should include "[check-commit-identity] FAILED: committer name is a generic placeholder: 'Verifier'"
+  End
+
+  It 'rejects a generic placeholder author name from GIT_AUTHOR_NAME despite valid config'
+    When run env GIT_AUTHOR_NAME=verifier sh -c "cd '$repo' && sh .githooks/check-commit-identity.sh"
+    The status should equal 1
+    The stderr should include "[check-commit-identity] FAILED: author name is a generic placeholder: 'verifier'"
+  End
+
+  It 'rejects a missing author name'
+    gitc config --unset user.name
+    When run sh -c "cd '$repo' && sh .githooks/check-commit-identity.sh"
+    The status should equal 1
+    The stderr should include '[check-commit-identity] FAILED: author name is missing or empty'
+  End
+
+  It 'rejects a missing author email'
+    gitc config --unset user.email
+    When run sh -c "cd '$repo' && sh .githooks/check-commit-identity.sh"
+    The status should equal 1
+    The stderr should include '[check-commit-identity] FAILED: author email is missing or empty'
+  End
+
+  It 'rejects a malformed author email without an @'
+    gitc config user.email 'andrebrait_at_gmail.com'
+    When run sh -c "cd '$repo' && sh .githooks/check-commit-identity.sh"
+    The status should equal 1
+    The stderr should include "[check-commit-identity] FAILED: author email is malformed (no '@'): 'andrebrait_at_gmail.com'"
+  End
+
+  Describe 'placeholder and empty author email domain variants'
+    Parameters
+      'a@example.invalid'
+      'a@EXAMPLE.com'
+      'a@localhost'
+      'a@'
+    End
+
+    It 'rejects the domain case-insensitively'
+      gitc config user.email "$1"
+      When run sh -c "cd '$repo' && sh .githooks/check-commit-identity.sh"
+      The status should equal 1
+      The stderr should include "[check-commit-identity] FAILED: author email domain is a placeholder or empty: '$1'"
+    End
+  End
+
+  It 'rejects a placeholder committer email from GIT_COMMITTER_EMAIL despite valid config'
+    When run env GIT_COMMITTER_EMAIL=b@localhost sh -c "cd '$repo' && sh .githooks/check-commit-identity.sh"
+    The status should equal 1
+    The stderr should include "[check-commit-identity] FAILED: committer email domain is a placeholder or empty: 'b@localhost'"
+  End
+
+  It 'rejects a malformed committer email from GIT_COMMITTER_EMAIL despite valid config'
+    When run env GIT_COMMITTER_EMAIL=no-at-sign sh -c "cd '$repo' && sh .githooks/check-commit-identity.sh"
+    The status should equal 1
+    The stderr should include "[check-commit-identity] FAILED: committer email is malformed (no '@'): 'no-at-sign'"
+  End
+
+  Describe 'real human identities (no exact allowlist: external contributors pass too)'
+    Parameters
+      'Andre Brait|andrebrait@gmail.com'
+      'BBcan177|bbcan177@gmail.com'
+      'Some Contributor|some@realcorp.dev'
+    End
+
+    It 'accepts the identity when signing prerequisites are valid'
+      gitc config user.name "${1%%|*}"
+      gitc config user.email "${1##*|}"
+      When run sh -c "cd '$repo' && sh .githooks/check-commit-identity.sh"
+      The status should equal 0
+      The stderr should not include 'FAILED'
+    End
+  End
+
+  # --------------------------- signing prerequisites --------------------------- #
+
+  It 'rejects when commit.gpgsign is absent'
+    gitc config --unset commit.gpgsign
+    When run sh -c "cd '$repo' && sh .githooks/check-commit-identity.sh"
+    The status should equal 1
+    The stderr should include '[check-commit-identity] FAILED: commit.gpgsign is not enabled'
+  End
+
+  It 'rejects when commit.gpgsign is false'
+    gitc config commit.gpgsign false
+    When run sh -c "cd '$repo' && sh .githooks/check-commit-identity.sh"
+    The status should equal 1
+    The stderr should include '[check-commit-identity] FAILED: commit.gpgsign is not enabled'
+  End
+
+  It 'rejects when user.signingkey is absent'
+    gitc config --unset user.signingkey
+    When run sh -c "cd '$repo' && sh .githooks/check-commit-identity.sh"
+    The status should equal 1
+    The stderr should include '[check-commit-identity] FAILED: user.signingkey is not configured'
+  End
+
+  It 'rejects an unknown gpg.format'
+    gitc config gpg.format pgp
+    When run sh -c "cd '$repo' && sh .githooks/check-commit-identity.sh"
+    The status should equal 1
+    The stderr should include "[check-commit-identity] FAILED: unknown gpg.format: 'pgp'"
+  End
+
+  It 'rejects a configured SSH signing program that does not exist'
+    gitc config gpg.ssh.program pfb-test-ssh-keygen
+    When run sh -c "cd '$repo' && sh .githooks/check-commit-identity.sh"
+    The status should equal 1
+    The stderr should include '[check-commit-identity] FAILED: SSH signing program not found in PATH: pfb-test-ssh-keygen'
+  End
+
+  It 'rejects a missing default SSH signing program under a PATH of only test stubs'
+    ln -s "$(command -v git)" "$stubdir/git"
+    ln -s /usr/bin/tr "$stubdir/tr"
+    ln -s /usr/bin/sed "$stubdir/sed"
+    ln -s "$(command -v dash)" "$stubdir/sh"
+    When run sh -c "cd '$repo' && PATH='$stubdir' sh .githooks/check-commit-identity.sh"
+    The status should equal 1
+    The stderr should include '[check-commit-identity] FAILED: SSH signing program not found in PATH: ssh-keygen'
+  End
+
+  It 'accepts SSH signing with only stub PATH binaries, proving binary selection without host leakage'
+    ln -s "$(command -v git)" "$stubdir/git"
+    ln -s /usr/bin/tr "$stubdir/tr"
+    ln -s /usr/bin/sed "$stubdir/sed"
+    ln -s "$(command -v dash)" "$stubdir/sh"
+    ln -s /usr/bin/ssh-keygen "$stubdir/ssh-keygen"
+    When run sh -c "cd '$repo' && PATH='$stubdir' sh .githooks/check-commit-identity.sh"
+    The status should equal 0
+    The stderr should not include 'FAILED'
+  End
+
+  It 'rejects a missing SSH signing key path (including paths with spaces)'
+    gitc config user.signingkey "$repo/my missing key.pub"
+    When run sh -c "cd '$repo' && sh .githooks/check-commit-identity.sh"
+    The status should equal 1
+    The stderr should include '[check-commit-identity] FAILED: SSH signing key not found or unreadable: '
+  End
+
+  It 'rejects an unreadable SSH signing key path'
+    : > "$repo/locked.pub"
+    chmod 000 "$repo/locked.pub"
+    gitc config user.signingkey "$repo/locked.pub"
+    When run sh -c "cd '$repo' && sh .githooks/check-commit-identity.sh"
+    The status should equal 1
+    The stderr should include '[check-commit-identity] FAILED: SSH signing key not found or unreadable: '
+  End
+
+  It 'accepts a readable SSH signing key path containing spaces'
+    : > "$repo/my key file.pub"
+    gitc config user.signingkey "$repo/my key file.pub"
+    When run sh -c "cd '$repo' && sh .githooks/check-commit-identity.sh"
+    The status should equal 0
+    The stderr should not include 'FAILED'
+  End
+
+  It 'accepts a key:: SSH literal key and leaves its validation to Git'
+    gitc config user.signingkey 'key::ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAI test-only-literal'
+    When run sh -c "cd '$repo' && sh .githooks/check-commit-identity.sh"
+    The status should equal 0
+    The stderr should not include 'FAILED'
+  End
+
+  It 'rejects a configured OpenPGP program that does not exist'
+    gitc config gpg.format openpgp
+    gitc config gpg.openpgp.program pfb-test-gpg
+    When run sh -c "cd '$repo' && sh .githooks/check-commit-identity.sh"
+    The status should equal 1
+    The stderr should include '[check-commit-identity] FAILED: OpenPGP signing program not found in PATH: pfb-test-gpg'
+  End
+
+  It 'selects the legacy gpg.program when gpg.openpgp.program is unset, and rejects it if missing'
+    gitc config gpg.format openpgp
+    gitc config gpg.program pfb-test-gpg-legacy
+    When run sh -c "cd '$repo' && sh .githooks/check-commit-identity.sh"
+    The status should equal 1
+    The stderr should include '[check-commit-identity] FAILED: OpenPGP signing program not found in PATH: pfb-test-gpg-legacy'
+  End
+
+  It 'rejects a missing default gpg under a PATH of only test stubs'
+    ln -s "$(command -v git)" "$stubdir/git"
+    ln -s /usr/bin/tr "$stubdir/tr"
+    ln -s /usr/bin/sed "$stubdir/sed"
+    ln -s "$(command -v dash)" "$stubdir/sh"
+    gitc config gpg.format openpgp
+    When run sh -c "cd '$repo' && PATH='$stubdir' sh .githooks/check-commit-identity.sh"
+    The status should equal 1
+    The stderr should include '[check-commit-identity] FAILED: OpenPGP signing program not found in PATH: gpg'
+  End
+
+  It 'accepts a readable OpenPGP program under a PATH of only test stubs'
+    ln -s "$(command -v git)" "$stubdir/git"
+    ln -s /usr/bin/tr "$stubdir/tr"
+    ln -s /usr/bin/sed "$stubdir/sed"
+    ln -s "$(command -v dash)" "$stubdir/sh"
+    printf '#!/bin/sh\nexit 0\n' > "$stubdir/pfb-test-gpg"
+    chmod +x "$stubdir/pfb-test-gpg"
+    gitc config gpg.format openpgp
+    gitc config gpg.program pfb-test-gpg
+    When run sh -c "cd '$repo' && PATH='$stubdir' sh .githooks/check-commit-identity.sh"
+    The status should equal 0
+    The stderr should not include 'FAILED'
+  End
+
+  It 'rejects a configured X.509 program that does not exist'
+    gitc config gpg.format x509
+    gitc config gpg.x509.program pfb-test-gpgsm
+    When run sh -c "cd '$repo' && sh .githooks/check-commit-identity.sh"
+    The status should equal 1
+    The stderr should include '[check-commit-identity] FAILED: X.509 signing program not found in PATH: pfb-test-gpgsm'
+  End
+
+  It 'rejects a missing default gpgsm under a PATH of only test stubs'
+    ln -s "$(command -v git)" "$stubdir/git"
+    ln -s /usr/bin/tr "$stubdir/tr"
+    ln -s /usr/bin/sed "$stubdir/sed"
+    ln -s "$(command -v dash)" "$stubdir/sh"
+    gitc config gpg.format x509
+    When run sh -c "cd '$repo' && PATH='$stubdir' sh .githooks/check-commit-identity.sh"
+    The status should equal 1
+    The stderr should include '[check-commit-identity] FAILED: X.509 signing program not found in PATH: gpgsm'
+  End
+
+  It 'accepts a readable X.509 program under a PATH of only test stubs'
+    ln -s "$(command -v git)" "$stubdir/git"
+    ln -s /usr/bin/tr "$stubdir/tr"
+    ln -s /usr/bin/sed "$stubdir/sed"
+    ln -s "$(command -v dash)" "$stubdir/sh"
+    printf '#!/bin/sh\nexit 0\n' > "$stubdir/pfb-test-gpgsm"
+    chmod +x "$stubdir/pfb-test-gpgsm"
+    gitc config gpg.format x509
+    gitc config gpg.x509.program pfb-test-gpgsm
+    When run sh -c "cd '$repo' && PATH='$stubdir' sh .githooks/check-commit-identity.sh"
+    The status should equal 0
+    The stderr should not include 'FAILED'
+  End
+
+  # ------------------------------ hook wiring ---------------------------------- #
+
+  ALL_CHECKERS='scripts/check_noopener.py
+scripts/check_appliance_python.py
+scripts/check_version_literals.py
+scripts/check_comment_narration.py
+scripts/check_agent_roles.py
+scripts/check_context_budget.py
+scripts/check_composer_vendor.py
+scripts/check_url_encoding.py
+scripts/check_toggle_registry.py
+scripts/check_reentry_bounds.py
+scripts/agent/check-agent-config-parity.sh'
+
+  # Sandbox laid out like the repo (all sh -n scan roots exist), the legacy
+  # opt-out manifest committed, and shellcheck stubbed, so ONLY the identity
+  # gate decides the hook verdict.
+  make_wired_repo() {
+    make_repo
+    mkdir -p "$repo/src" "$repo/scripts" "$repo/tests" "$repo/.claude/hooks"
+    printf '%s\n' "$ALL_CHECKERS" > "$repo/.githooks-exempt"
+    gitc add .githooks-exempt
+    printf '#!/bin/sh\nexit 0\n' > "$repo/src/ok.sh"
+    printf '#!/bin/sh\nexit 0\n' > "$stubdir/shellcheck"
+    chmod +x "$stubdir/shellcheck"
+  }
+
+  It 'fails closed when the checker file is missing'
+    make_wired_repo
+    rm -f "$repo/.githooks/check-commit-identity.sh"
+    gitc add src/ok.sh
+    When run sh -c "cd '$repo' && sh .githooks/pre-commit"
+    The status should equal 1
+    The stderr should include '[pre-commit] FAILED: commit identity checker missing or not executable: '
+    The output should include '[pre-commit] commit identity & signing prerequisites'
+  End
+
+  It 'fails closed when the checker is not executable'
+    make_wired_repo
+    chmod -x "$repo/.githooks/check-commit-identity.sh"
+    gitc add src/ok.sh
+    When run sh -c "cd '$repo' && sh .githooks/pre-commit"
+    The status should equal 1
+    The stderr should include '[pre-commit] FAILED: commit identity checker missing or not executable: '
+    The output should include '[pre-commit] commit identity & signing prerequisites'
+  End
+
+  It 'runs the identity gate before the no-staged-files exit, covering allow-empty commits'
+    make_wired_repo
+    gitc config user.name Verifier
+    When run sh -c "cd '$repo' && sh .githooks/pre-commit"
+    The status should equal 1
+    The stderr should include '[pre-commit] FAILED: commit identity & signing prerequisites'
+    The output should include '[pre-commit] commit identity & signing prerequisites'
+  End
+
+  It 'does not suppress the other staged gates when the identity check fails'
+    make_wired_repo
+    gitc config user.name Verifier
+    gitc add src/ok.sh
+    When run sh -c "cd '$repo' && sh .githooks/pre-commit"
+    The status should equal 1
+    The stderr should include '[pre-commit] FAILED: commit identity & signing prerequisites'
+    The output should include '[pre-commit] shell (sh -n)'
+  End
+
+  It 'passes the hook end to end with a valid identity and signing setup'
+    make_wired_repo
+    gitc add src/ok.sh
+    When run sh -c "cd '$repo' && sh .githooks/pre-commit"
+    The status should equal 0
+    The output should include '[pre-commit] commit identity & signing prerequisites'
+    The stderr should not include 'FAILED'
+  End
+End


### PR DESCRIPTION
Closes #2982

## Summary

Fail-closed pre-commit gate that blocks commits Git would make under a placeholder/automation identity or without the configured signing prerequisites — fixing the `Verifier <verifier@example.invalid>` fabricated-identity incident.

- **`.githooks/check-commit-identity.sh`** (new, POSIX sh, 98 lines): rejects missing/generic/placeholder author–committer identity (case/whitespace variants included), including all four `GIT_AUTHOR_*`/`GIT_COMMITTER_*` environment overrides beating valid config; requires `commit.gpgsign=true` and `user.signingkey`; validates the format-appropriate signing binary (OpenPGP `gpg.openpgp.program` → `gpg.program` → `gpg`; X.509 `gpg.x509.program` → `gpgsm`; SSH `ssh-keygen` plus a readable key path, with `key::ssh-…` literals left to Git) and rejects unknown `gpg.format`. No exact identity allowlist: real external contributors and policy-permitted bot identities pass; only generic placeholder names (`verifier`/`root`/`ci`) and placeholder domains (`example.invalid`/`example.com`/`localhost`) are rejected.
- **`.githooks/pre-commit`** (+15): gate wired before the no-staged-files exit so allow-empty commits are covered; checker resolved relative to `$0` (absolute shared `core.hooksPath` works from linked release worktrees); missing/non-executable checker fails closed; checker failure joins the other `fail` results without suppressing them. The no-staged branch ends in `exit "$fail"` so the gate's verdict survives an empty index. Git's own signing operation remains the cryptographic proof — the hook only rejects known-bad prerequisites.
- **Review-fix round 1** (`29ca4f50`): closed the round-1 contract blocking finding (allow-empty commits bypassed the gate — the no-staged `exit 0` discarded the gate's failure; now `exit "$fail"`, with the empty-index and missing-checker-on-empty-index paths pinned by tests) and the round-1 correctness MEDIUM (interior-whitespace / trailing-dot / subdomain placeholder-email evasion): internal whitespace is rejected on the raw value before normalization, trailing dots are stripped, and reserved placeholder-domain subdomains (`*.example.{invalid,com,net,org}`, `*.localhost`) are rejected at every depth — with contract-verified positives confirming no over-rejection (`a@mail.realcorp.dev`, reserved-prefix/suffix lookalikes, FQDN trailing dot all pass).

Test-first per canonical policy: frozen spec executed RED against untouched production, then GREEN with zero assertion edits — re-proven at each round by independent revert-probes (spec blob held fixed, production reverted to parent).

## Test evidence (shellspec under `dash`, CI's shell)

All red runs predate their respective production/test-final state; test blob hashes recorded via `git hash-object`.

| Gate | Result |
| --- | --- |
| RED — committed focused spec vs parent production `553029a5` (blob `2084146cfae5d093ba16e01292676f9097c78dab`) | exit 101 — **43 examples, 43 failures**, every failure the missing-gate reason (`sh: .githooks/check-commit-identity.sh: No such file or directory` → 127; old hook exits 0 on allow-empty → expected 1 got 0) |
| Mutation RED — `GIT_AUTHOR_EMAIL` handling dropped from checker (`ident_val GIT_AUTHOR_EMAILX`), final spec blob `9cf3466ca14bb6f2ccac44ef132204c0f08c1378` held fixed | exit 101 — **44 examples, 1 failure**, exactly the new override example (`expected: 1, got: 0` + missing placeholder-domain stderr) |
| GREEN — focused `tests/shell/precommit_identity_spec.sh`, zero edits | exit 0 — **44 examples, 0 failures** |
| Full shellspec under dash | exit 0 — **1733 examples, 0 failures, 1 skip** (pre-existing ADR-26 locale skip, unrelated to this diff) |
| RED round 2 — head spec blob `df7c1eb1436d57a7ab48c37b962bea530ef0afff` held fixed, production reverted to round-1 blobs | exit 101 — **57 examples, 13 failures**, exactly the 13 new assertions (11 email-evasion + 2 empty-index wiring), zero prior assertions failing |
| GREEN round 2 — focused spec at head, zero edits | exit 0 — **57 examples, 0 failures** |
| Full shellspec under dash at head | exit 0 — **1746 examples, 0 failures, 1 skip** (same pre-existing ADR-26 locale skip) |
| `sh -n` both `.githooks` files + changed specs | clean |
| ShellCheck `--severity=info` checker + hook | checker zero findings; hook 2 pre-existing SC2016 infos byte-identical to parent |

CI on head `29ca4f5021ac755aae9ecbaf2f11254388a4de82`: all required checks green (run 33388260831).

Post-rebase re-verification (rebased onto `origin/devel` @ `f6a2e857`):

- Focused spec at round-1 head: exit 0 — **44 examples, 0 failures** (`/tmp/pfb2982-pr-focused.txt`)
- Full suite at round-1 head: exit 0 — **1733 examples, 0 failures, 1 skip** (`/tmp/pfb2982-pr-full.txt`)

## Commits (3, all signed)

1. `72f30778` — `hooks: fail-closed commit identity and signing gate (#2982)`
2. `92c370b2` — `tests: fix round 1 for #2982 — 'true >' truncation forms and GIT_AUTHOR_EMAIL row`
3. `29ca4f50` — `hooks: close empty-index gate bypass and email evasion (#2982)`

All three: `Good "git" signature for andrebrait@gmail.com with ED25519 key SHA256:TWOpw6FOQreHf+1JiNmNsjK/bXvpJwOOyoLdWv0v/VE`, `%G?` = `G`, author and committer `Andre Brait <andrebrait@gmail.com>`.

## Review record

Four adversarial legs reviewed round 1 at `92c370b2` (contract: BLOCK → fixed; correctness: CLEAN with 1 MEDIUM → fixed; test honesty: CLEAN; over-engineering: CLEAN, 3 nitpicks) and all affected legs re-reviewed round 2 at `29ca4f50` — every leg CLEAN, no blockers. Findings ledger with per-finding outcomes in the audit comment.

🤖 Generated by Oh My Pi and posted on behalf of @andrebrait.
