### PR TITLE
Release: omit unused dependency provenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1276,6 +1276,7 @@ jobs:
           COMMIT:        ${{ needs.resolve-stamp.outputs.commit }}
           CREATED:       ${{ needs.resolve-stamp.outputs.created }}
           MATRIX_ROW:    ${{ toJson(matrix) }}
+          EXTRA_PKGS:   ${{ steps.extras.outputs.extra_pkgs }}
           PORTS_SHA:     ${{ needs.read-matrix.outputs.ports_sha }}
           DEPENDENCY_BUILDER: ${{ needs.read-matrix.outputs.dependency_builder }}
         run: |
@@ -1288,6 +1289,7 @@ jobs:
           from scripts.pfb_pkg import build_input_digest
 
           row = json.loads(os.environ["MATRIX_ROW"])
+          row["extra_pkgs"] = json.loads(os.environ["EXTRA_PKGS"])
           channel = os.environ["CHANNEL"]
           version = os.environ["PORTVERSION"]
           major, minor = row["pfsense_version"].split(".", 1)
@@ -1307,9 +1309,10 @@ jobs:
               "freebsd_ports_sha": os.environ["PORTS_SHA"],
               "route": f"{channel}/{row['variant'].lower()}-{major}.{minor}",
               "source_date_epoch": int(os.environ["CREATED"]),
-              "dependency_builder": json.loads(os.environ["DEPENDENCY_BUILDER"]),
               "build_input_digest": "",
           }
+          if row["extra_pkgs"]:
+              record["dependency_builder"] = json.loads(os.environ["DEPENDENCY_BUILDER"])
           record["build_input_digest"] = build_input_digest(record)
           Path(os.environ["RUNNER_TEMP"], "build-record.json").write_text(
               json.dumps(record, ensure_ascii=False, sort_keys=True, separators=(",", ":")) + "\n",

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -486,8 +486,8 @@ jobs:
       route_matrix: ${{ steps.pins.outputs.route_matrix }}
       ci_metadata_sha: ${{ steps.pins.outputs.ci_metadata_sha }}
       ports_sha: ${{ steps.pins.outputs.ports_sha }}
-      dependency_builder: ${{ steps.pins.outputs.dependency_builder }}
-      dependency_packages: ${{ steps.pins.outputs.dependency_packages }}
+      dependency_builder: ${{ steps.dependencies.outputs.dependency_builder || 'null' }}
+      dependency_packages: ${{ steps.dependencies.outputs.dependency_packages || '{}' }}
       pkg_channel:  ${{ steps.channel.outputs.pkg_channel }}
       portversion:  ${{ steps.channel.outputs.portversion }}
       release_stage: ${{ steps.channel.outputs.release_stage }}
@@ -578,18 +578,6 @@ jobs:
           PY
           echo "source_sha=${SOURCE_SHA}" >> "$GITHUB_OUTPUT"
 
-      - name: Check out pinned dependency-builder source
-        uses: actions/checkout@v6
-        with:
-          ref: ${{ github.event.inputs.source == 'release/3.3' && github.workflow_sha || steps.destinations.outputs.source_sha }}
-          fetch-depth: 1
-          persist-credentials: false
-          path: pinned-builder
-          sparse-checkout: |
-            scripts/
-            uv.lock
-          sparse-checkout-cone-mode: false
-
       - name: Pin ci-metadata, ROUTE, and Ports identities
         id: pins
         env:
@@ -616,72 +604,103 @@ jobs:
           if [ "$INPUT_SOURCE" = "release/3.3" ]; then
             ROUTE_MATRIX=$(printf '%s' "$ROUTE_MATRIX" | jq -ce 'map(.extra_pkgs = [])')
           fi
-          PINNED_BUILDER="$GITHUB_WORKSPACE/pinned-builder"
-          DEPENDENCY_BUILDER="$(python3 "$PINNED_BUILDER/scripts/build-dep-pkg-portable.py" --print-toolchain | jq -ce .)"
-          SOURCE_DATE_EPOCH="$(git show -s --format=%ct "$SOURCE_SHA")"
-          DEPENDENCY_PACKAGES='{}'
           ORIGINS=$(printf '%s' "$ROUTE_MATRIX" | jq -r '[.[].extra_pkgs[]?] | unique[]')
           if [ -n "$ORIGINS" ]; then
-            PORTS_DIR="$RUNNER_TEMP/dependency-identity-ports"
-            git clone --filter=blob:none --no-checkout --depth 1 \
-              --branch pfblockerng/use-github \
-              https://github.com/pfBlockerNG/FreeBSD-ports "$PORTS_DIR"
-            git -C "$PORTS_DIR" sparse-checkout init --cone
-            for ORIGIN in $ORIGINS; do
-              git -C "$PORTS_DIR" sparse-checkout add "$ORIGIN"
-            done
-            git -C "$PORTS_DIR" checkout --detach "$PORTS_SHA"
-            ROW_COUNT=$(printf '%s' "$ROUTE_MATRIX" | jq 'length')
-            ROW_INDEX=0
-            while [ "$ROW_INDEX" -lt "$ROW_COUNT" ]; do
-              ROW=$(printf '%s' "$ROUTE_MATRIX" | jq -ce ".[$ROW_INDEX]")
-              SUFFIX=$(printf '%s' "$ROW" | jq -r '"-" + .variant + "-" + .pfsense_version + ".pkg"')
-              PY_FLAVOR=$(printf '%s' "$ROW" | jq -r '.py_flavor')
-              FREEBSD_MAJOR=$(printf '%s' "$ROW" | jq -r '.freebsd_major')
-              ROW_ORIGINS=$(printf '%s' "$ROW" | jq -r '.extra_pkgs[]?')
-              for ORIGIN in $ROW_ORIGINS; do
-                IDENTITY=$(python3 "$PINNED_BUILDER/scripts/build-dep-pkg-portable.py" \
-                  --print-port-identity \
-                  --ports "$PORTS_DIR" \
-                  --ports-sha "$PORTS_SHA" \
-                  --port "$ORIGIN")
-                DEPENDENCY_PACKAGES=$(printf '%s' "$IDENTITY" | jq -ce \
-                  --argjson current "$DEPENDENCY_PACKAGES" \
-                  --arg suffix "$SUFFIX" \
-                  --arg origin "$ORIGIN" \
-                  --arg py_flavor "$PY_FLAVOR" \
-                  --arg freebsd_major "$FREEBSD_MAJOR" \
-                  --arg ports_sha "$PORTS_SHA" \
-                  --argjson source_date_epoch "$SOURCE_DATE_EPOCH" \
-                  --argjson toolchain "$DEPENDENCY_BUILDER" \
-                  'if .port_origin != $origin then error("dependency origin mismatch")
-                   else . as $recipe
-                   | ($py_flavor + "-" + $recipe.portname) as $package_name
-                   | ($recipe | del(.port_origin) + {
-                       package_name: $package_name,
-                       package_version: $recipe.port_version,
-                       filename: ($package_name + "-" + $recipe.port_version + $suffix),
-                       freebsd_ports_sha: $ports_sha,
-                       source_date_epoch: $source_date_epoch,
-                       toolchain: $toolchain,
-                       abi: ("FreeBSD:" + $freebsd_major + ":*"),
-                       freebsd_major: $freebsd_major,
-                       py_flavor: $py_flavor
-                     }) as $identity
-                   | $current + {
-                       ($suffix): (($current[$suffix] // {}) + {($origin): $identity})
-                     }
-                   end')
-              done
-              ROW_INDEX=$((ROW_INDEX + 1))
-            done
+            HAS_DEPENDENCIES=true
+          else
+            HAS_DEPENDENCIES=false
           fi
           {
             echo "ci_metadata_sha=${CI_METADATA_SHA}"
             echo "ports_sha=${PORTS_SHA}"
+            echo "route_matrix=${ROUTE_MATRIX}"
+            echo "source_date_epoch=$(git show -s --format=%ct "$SOURCE_SHA")"
+            echo "has_dependencies=${HAS_DEPENDENCIES}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Check out pinned dependency-builder source
+        if: steps.pins.outputs.has_dependencies == 'true'
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.inputs.source == 'release/3.3' && github.workflow_sha || steps.destinations.outputs.source_sha }}
+          fetch-depth: 1
+          persist-credentials: false
+          path: pinned-builder
+          sparse-checkout: |
+            scripts/
+            uv.lock
+          sparse-checkout-cone-mode: false
+
+      - name: Resolve dependency identities
+        id: dependencies
+        if: steps.pins.outputs.has_dependencies == 'true'
+        env:
+          ROUTE_MATRIX: ${{ steps.pins.outputs.route_matrix }}
+          PORTS_SHA: ${{ steps.pins.outputs.ports_sha }}
+          SOURCE_DATE_EPOCH: ${{ steps.pins.outputs.source_date_epoch }}
+        run: |
+          set -eu
+          PINNED_BUILDER="$GITHUB_WORKSPACE/pinned-builder"
+          DEPENDENCY_BUILDER="$(python3 "$PINNED_BUILDER/scripts/build-dep-pkg-portable.py" --print-toolchain | jq -ce .)"
+          DEPENDENCY_PACKAGES='{}'
+          ORIGINS=$(printf '%s' "$ROUTE_MATRIX" | jq -r '[.[].extra_pkgs[]?] | unique[]')
+          [ -n "$ORIGINS" ] || { echo "::error::dependency identity step has no origins"; exit 1; }
+          PORTS_DIR="$RUNNER_TEMP/dependency-identity-ports"
+          git clone --filter=blob:none --no-checkout --depth 1 \
+            --branch pfblockerng/use-github \
+            https://github.com/pfBlockerNG/FreeBSD-ports "$PORTS_DIR"
+          git -C "$PORTS_DIR" sparse-checkout init --cone
+          for ORIGIN in $ORIGINS; do
+            git -C "$PORTS_DIR" sparse-checkout add "$ORIGIN"
+          done
+          git -C "$PORTS_DIR" checkout --detach "$PORTS_SHA"
+          ROW_COUNT=$(printf '%s' "$ROUTE_MATRIX" | jq 'length')
+          ROW_INDEX=0
+          while [ "$ROW_INDEX" -lt "$ROW_COUNT" ]; do
+            ROW=$(printf '%s' "$ROUTE_MATRIX" | jq -ce ".[$ROW_INDEX]")
+            SUFFIX=$(printf '%s' "$ROW" | jq -r '"-" + .variant + "-" + .pfsense_version + ".pkg"')
+            PY_FLAVOR=$(printf '%s' "$ROW" | jq -r '.py_flavor')
+            FREEBSD_MAJOR=$(printf '%s' "$ROW" | jq -r '.freebsd_major')
+            ROW_ORIGINS=$(printf '%s' "$ROW" | jq -r '.extra_pkgs[]?')
+            for ORIGIN in $ROW_ORIGINS; do
+              IDENTITY=$(python3 "$PINNED_BUILDER/scripts/build-dep-pkg-portable.py" \
+                --print-port-identity \
+                --ports "$PORTS_DIR" \
+                --ports-sha "$PORTS_SHA" \
+                --port "$ORIGIN")
+              DEPENDENCY_PACKAGES=$(printf '%s' "$IDENTITY" | jq -ce \
+                --argjson current "$DEPENDENCY_PACKAGES" \
+                --arg suffix "$SUFFIX" \
+                --arg origin "$ORIGIN" \
+                --arg py_flavor "$PY_FLAVOR" \
+                --arg freebsd_major "$FREEBSD_MAJOR" \
+                --arg ports_sha "$PORTS_SHA" \
+                --argjson source_date_epoch "$SOURCE_DATE_EPOCH" \
+                --argjson toolchain "$DEPENDENCY_BUILDER" \
+                'if .port_origin != $origin then error("dependency origin mismatch")
+                 else . as $recipe
+                 | ($py_flavor + "-" + $recipe.portname) as $package_name
+                 | ($recipe | del(.port_origin) + {
+                     package_name: $package_name,
+                     package_version: $recipe.port_version,
+                     filename: ($package_name + "-" + $recipe.port_version + $suffix),
+                     freebsd_ports_sha: $ports_sha,
+                     source_date_epoch: $source_date_epoch,
+                     toolchain: $toolchain,
+                     abi: ("FreeBSD:" + $freebsd_major + ":*"),
+                     freebsd_major: $freebsd_major,
+                     py_flavor: $py_flavor
+                   }) as $identity
+                 | $current + {
+                     ($suffix): (($current[$suffix] // {}) + {($origin): $identity})
+                   }
+                 end')
+            done
+            ROW_INDEX=$((ROW_INDEX + 1))
+          done
+          {
             echo "dependency_builder=${DEPENDENCY_BUILDER}"
             echo "dependency_packages=${DEPENDENCY_PACKAGES}"
-            echo "route_matrix=${ROUTE_MATRIX}"
           } >> "$GITHUB_OUTPUT"
 
       - name: Read matrix from ci-metadata
@@ -1209,15 +1228,29 @@ jobs:
           ref: ${{ needs.prepare-release.outputs.sha || needs.read-matrix.outputs.source_sha }}
           persist-credentials: false
 
+      - name: Resolve release-line extras
+        id: extras
+        env:
+          SOURCE: ${{ github.event.inputs.source }}
+          MATRIX_EXTRA_PKGS: ${{ toJson(matrix.extra_pkgs) }}
+        run: |
+          set -eu
+          case "$SOURCE" in
+            release/3.3) EXTRA_PKGS='[]' ;;
+            *) EXTRA_PKGS="$MATRIX_EXTRA_PKGS" ;;
+          esac
+          EXTRA_PKGS="$(printf '%s' "$EXTRA_PKGS" | jq -c .)"
+          printf 'extra_pkgs=%s\n' "$EXTRA_PKGS" >> "$GITHUB_OUTPUT"
+
       - name: Set up the pinned dependency-package toolchain
-        if: github.event.inputs.source != 'release/3.3'
+        if: steps.extras.outputs.extra_pkgs != '[]'
         uses: astral-sh/setup-uv@v7
         with:
           version: "0.12.6"
           activate-environment: true
 
       - name: Sync the locked dependency-package toolchain
-        if: github.event.inputs.source != 'release/3.3'
+        if: steps.extras.outputs.extra_pkgs != '[]'
         run: uv sync --locked --only-group dep-pkg-build
 
       - name: Compute this leg's LEG/ABI
@@ -1251,20 +1284,6 @@ jobs:
           else
             git tag "${TAG}" "$COMMIT"
           fi
-
-      - name: Resolve release-line extras
-        id: extras
-        env:
-          SOURCE: ${{ github.event.inputs.source }}
-          MATRIX_EXTRA_PKGS: ${{ toJson(matrix.extra_pkgs) }}
-        run: |
-          set -eu
-          case "$SOURCE" in
-            release/3.3) EXTRA_PKGS='[]' ;;
-            *) EXTRA_PKGS="$MATRIX_EXTRA_PKGS" ;;
-          esac
-          EXTRA_PKGS="$(printf '%s' "$EXTRA_PKGS" | jq -c .)"
-          printf 'extra_pkgs=%s\n' "$EXTRA_PKGS" >> "$GITHUB_OUTPUT"
 
       - name: Write the destination-bound build record
         env:

--- a/graphify-out/memory/query_20260831_110525_how_does_release_build_record_dependency_builder_i.md
+++ b/graphify-out/memory/query_20260831_110525_how_does_release_build_record_dependency_builder_i.md
@@ -1,0 +1,17 @@
+---
+type: "query"
+date: "2026-08-31T11:05:25.699841+00:00"
+question: "How does release build-record dependency_builder interact with matrix_row.extra_pkgs and release/3.3 compatibility, and which tests cover that workflow/schema contract?"
+contributor: "graphify"
+outcome: "useful"
+---
+
+# Q: How does release build-record dependency_builder interact with matrix_row.extra_pkgs and release/3.3 compatibility, and which tests cover that workflow/schema contract?
+
+## Answer
+
+The release workflow writes build records in .github/workflows/release.yml; scripts/pfb_pkg.py validates the strict schema. tests/test_release_tag_after_verify.py exercises release/3.3 matrix/extras emission, while tests/test_pfb_pkg.py covers dependency_builder validation.
+
+## Outcome
+
+- Signal: useful

--- a/graphify-out/memory/query_20260831_111534_issue_2985_dependency_free_release_records_workflo.md
+++ b/graphify-out/memory/query_20260831_111534_issue_2985_dependency_free_release_records_workflo.md
@@ -1,0 +1,17 @@
+---
+type: "query"
+date: "2026-08-31T11:15:34.237411+00:00"
+question: "Issue 2985 dependency-free release records workflow validator regression tests and release 3.3 bridge"
+contributor: "graphify"
+outcome: "useful"
+---
+
+# Q: Issue 2985 dependency-free release records workflow validator regression tests and release 3.3 bridge
+
+## Answer
+
+Relevant contracts remain in the release workflow and strict pfb_pkg validator; release workflow and handoff regression suites cover the bridge and dependency provenance.
+
+## Outcome
+
+- Signal: useful

--- a/scripts/pfb_pkg.py
+++ b/scripts/pfb_pkg.py
@@ -252,9 +252,9 @@ def validate_build_record(
         raise _record_error("record must be an object")
     _json_safe(record)
     keys = set(record)
-    if keys != _RECORD_FIELDS:
-        missing = sorted(_RECORD_FIELDS - keys)
-        unknown = sorted(keys - _RECORD_FIELDS)
+    missing = sorted((_RECORD_FIELDS - {"dependency_builder"}) - keys)
+    unknown = sorted(keys - _RECORD_FIELDS)
+    if missing or unknown:
         raise _record_error(f"exact fields required (missing={missing}, unknown={unknown})")
     if type(record["schema"]) is not int or record["schema"] != 1:
         raise _record_error("schema must be integer 1")
@@ -262,6 +262,8 @@ def validate_build_record(
     if channel not in ("stable", "testing", "edge", "nightly"):
         raise _record_error("channel is invalid")
     row = validate_build_matrix_row(record["matrix_row"])
+    if row["extra_pkgs"] and "dependency_builder" not in record:
+        raise _record_error("dependency_builder is required when matrix_row.extra_pkgs is non-empty")
     if abi is not None:
         if not isinstance(abi, str) or not re.fullmatch(r"FreeBSD:[0-9]+:[A-Za-z0-9._+-]+", abi):
             raise _record_error("abi is malformed")
@@ -281,7 +283,8 @@ def validate_build_record(
     epoch = record["source_date_epoch"]
     if type(epoch) is not int or epoch < 0:
         raise _record_error("source_date_epoch must be a non-negative integer")
-    validate_dependency_builder(record["dependency_builder"])
+    if "dependency_builder" in record:
+        validate_dependency_builder(record["dependency_builder"])
 
     expected_recipe = CANONICAL_EMITTED_IDENTITY if channel == "stable" else f"{CANONICAL_EMITTED_IDENTITY}-{channel}"
     if record["emitted_identity"] != CANONICAL_EMITTED_IDENTITY or record["native_recipe_identity"] != expected_recipe:

--- a/scripts/tagged_release_handoff.py
+++ b/scripts/tagged_release_handoff.py
@@ -150,7 +150,7 @@ def _dependency_packages(
     *,
     ports_sha: str,
     source_date_epoch: int,
-    dependency_builder: Mapping[str, str],
+    dependency_builder: Mapping[str, str] | None,
 ) -> dict[str, dict[str, dict[str, object]]]:
     if not isinstance(value, Mapping):
         raise HandoffError("dependency_packages must be an object")
@@ -240,10 +240,16 @@ def build_handoff(
     rows = _route_matrix(route_matrix)
     if type(source_date_epoch) is not int or source_date_epoch < 0:
         raise HandoffError("source_date_epoch must be a non-negative integer")
-    try:
-        normalized_dependency_builder = validate_dependency_builder(dependency_builder)
-    except PkgError as exc:
-        raise HandoffError(str(exc)) from exc
+    has_dependencies = any(row["extra_pkgs"] for row in rows)
+    if dependency_builder is None:
+        if has_dependencies:
+            raise HandoffError("dependency_builder is required when route_matrix contains extra packages")
+        normalized_dependency_builder = None
+    else:
+        try:
+            normalized_dependency_builder = validate_dependency_builder(dependency_builder)
+        except PkgError as exc:
+            raise HandoffError(str(exc)) from exc
     normalized_dependency_packages = _dependency_packages(
         dependency_packages,
         rows,
@@ -312,7 +318,6 @@ def validate_build_records(handoff: Mapping[str, object], records: Sequence[Mapp
         "source_sha": handoff.get("source_sha"),
         "freebsd_ports_sha": handoff.get("ports_sha"),
         "source_date_epoch": handoff.get("source_date_epoch"),
-        "dependency_builder": handoff.get("dependency_builder"),
     }
     for index, record in enumerate(records):
         if not isinstance(record, Mapping):
@@ -320,6 +325,13 @@ def validate_build_records(handoff: Mapping[str, object], records: Sequence[Mapp
         for name, value in expected.items():
             if record.get(name) != value:
                 raise HandoffError(f"build record {index} {name} does not match tagged release handoff")
+        dependency_builder = record.get("dependency_builder")
+        if dependency_builder is None:
+            row = record.get("matrix_row")
+            if not isinstance(row, Mapping) or row.get("extra_pkgs") != []:
+                raise HandoffError(f"build record {index} dependency_builder does not match tagged release handoff")
+        elif dependency_builder != handoff.get("dependency_builder"):
+            raise HandoffError(f"build record {index} dependency_builder does not match tagged release handoff")
 
 
 def _dependency_requirements(

--- a/tests/test_issue2143_review_round2.py
+++ b/tests/test_issue2143_review_round2.py
@@ -49,7 +49,8 @@ def test_build_record_step_uses_pinned_ports_sha_in_python_child(tmp_path: Path)
             "CLASSIFICATION": "final",
             "COMMIT": "0" * 40,
             "CREATED": "1700000000",
-            "MATRIX_ROW": '{"variant":"CE","pfsense_version":"2.8"}',
+            "MATRIX_ROW": '{"variant":"CE","pfsense_version":"2.8","extra_pkgs":[]}',
+            "EXTRA_PKGS": "[]",
             "PORTS_SHA": ports_sha,
             "DEPENDENCY_BUILDER": json.dumps(
                 {

--- a/tests/test_pfb_pkg.py
+++ b/tests/test_pfb_pkg.py
@@ -79,6 +79,24 @@ def test_build_record_valid_and_digest_is_canonical() -> None:
     assert pfb_pkg.build_input_digest(changed) != record["build_input_digest"]
 
 
+def test_build_record_allows_missing_dependency_builder_without_extra_packages() -> None:
+    record = _record()
+    record["matrix_row"] = {**record["matrix_row"], "extra_pkgs": []}
+    record.pop("dependency_builder")
+    record["build_input_digest"] = pfb_pkg.build_input_digest(record)
+
+    assert pfb_pkg.validate_build_record(record) == record
+
+
+def test_build_record_requires_dependency_builder_with_extra_packages() -> None:
+    record = _record()
+    record.pop("dependency_builder")
+    record["build_input_digest"] = pfb_pkg.build_input_digest(record)
+
+    with pytest.raises(pfb_pkg.PkgError, match="dependency_builder"):
+        pfb_pkg.validate_build_record(record)
+
+
 def test_build_record_rejects_malformed_dependency_builder() -> None:
     record = _record(dependency_builder={**DEPENDENCY_BUILDER, "wheel": "not-a-version"})
     with pytest.raises(pfb_pkg.PkgError, match="dependency_builder"):

--- a/tests/test_pfb_pkg.py
+++ b/tests/test_pfb_pkg.py
@@ -88,6 +88,23 @@ def test_build_record_allows_missing_dependency_builder_without_extra_packages()
     assert pfb_pkg.validate_build_record(record) == record
 
 
+def test_build_record_allows_valid_dependency_builder_without_extra_packages() -> None:
+    record = _record()
+    record["matrix_row"] = {**record["matrix_row"], "extra_pkgs": []}
+    record["build_input_digest"] = pfb_pkg.build_input_digest(record)
+
+    assert pfb_pkg.validate_build_record(record) == record
+
+
+def test_build_record_rejects_malformed_dependency_builder_without_extra_packages() -> None:
+    record = _record(dependency_builder={**DEPENDENCY_BUILDER, "wheel": "not-a-version"})
+    record["matrix_row"] = {**record["matrix_row"], "extra_pkgs": []}
+    record["build_input_digest"] = pfb_pkg.build_input_digest(record)
+
+    with pytest.raises(pfb_pkg.PkgError, match="dependency_builder"):
+        pfb_pkg.validate_build_record(record)
+
+
 def test_build_record_requires_dependency_builder_with_extra_packages() -> None:
     record = _record()
     record.pop("dependency_builder")

--- a/tests/test_release_ci_path_consistency.py
+++ b/tests/test_release_ci_path_consistency.py
@@ -134,13 +134,14 @@ def test_issue_2387_tagged_build_uses_one_pinned_route_and_ports_identity() -> N
     read_matrix = "\n".join(jobs["read-matrix"])
     build = "\n".join(jobs["build-pkgs-portable"])
 
-    for output in ("route_matrix", "ci_metadata_sha", "ports_sha", "dependency_packages"):
+    for output in ("route_matrix", "ci_metadata_sha", "ports_sha"):
         assert re.search(
             rf"^      {output}:\s+\$\{{\{{ steps\.pins\.outputs\.{output} \}}\}}$",
             read_matrix,
             re.MULTILINE,
         ), f"read-matrix must expose the build-time {output}"
-    assert "ref: ${{ steps.pins.outputs.ci_metadata_sha }}" in read_matrix
+    assert "dependency_builder: ${{ steps.dependencies.outputs.dependency_builder || 'null' }}" in read_matrix
+    assert "dependency_packages: ${{ steps.dependencies.outputs.dependency_packages || '{}' }}" in read_matrix
     assert read_matrix.count("git ls-remote https://github.com/pfBlockerNG/FreeBSD-ports") == 1
     builder_checkout = extract_step(release, "Check out pinned dependency-builder source")
     assert "uses: actions/checkout@v6" in builder_checkout
@@ -157,20 +158,24 @@ def test_issue_2387_tagged_build_uses_one_pinned_route_and_ports_identity() -> N
 
 
 @pytest.mark.parametrize(
-    ("source", "expected_extra_pkgs"),
+    ("source", "expected_extra_pkgs", "expected_has_dependencies"),
     [
-        ("release/4.0", '["textproc/py-charset-normalizer"]'),
-        ("release/3.3", "[]"),
+        ("release/4.0", '["textproc/py-charset-normalizer"]', "true"),
+        ("release/3.3", "[]", "false"),
     ],
 )
 def test_issue_2387_pin_step_executes_against_exact_ci_metadata_sha(
     tmp_path: Path,
     source: str,
     expected_extra_pkgs: str,
+    expected_has_dependencies: str,
 ) -> None:
     release = (ROOT / ".github/workflows/release.yml").read_text(encoding="utf-8")
     script = textwrap.dedent(
         extract_after(extract_step(release, "Pin ci-metadata, ROUTE, and Ports identities"), "run: |\n")
+    )
+    dependency_script = textwrap.dedent(
+        extract_after(extract_step(release, "Resolve dependency identities"), "run: |\n")
     )
     fake_bin = tmp_path / "bin"
     fake_bin.mkdir()
@@ -261,10 +266,34 @@ def test_issue_2387_pin_step_executes_against_exact_ci_metadata_sha(
     assert f"ci_metadata_sha={ci_sha}" in emitted
     assert f"ports_sha={ports_sha}" in emitted
     assert f'"extra_pkgs":{expected_extra_pkgs}' in emitted
+    assert f"has_dependencies={expected_has_dependencies}" in emitted
     if source == "release/3.3":
-        assert "dependency_packages={}" in emitted
+        assert "dependency_builder=" not in emitted
+        assert "dependency_packages=" not in emitted
         assert "textproc/py-charset-normalizer" not in emitted
     else:
+        route_line = next(line for line in emitted.splitlines() if line.startswith("route_matrix="))
+        dependency_output = tmp_path / "dependency-output"
+        dependency_completed = subprocess.run(
+            ["sh", "-c", dependency_script],
+            cwd=ROOT,
+            env=os.environ
+            | {
+                "PATH": f"{fake_bin}:{os.environ.get('PATH', '')}",
+                "GITHUB_OUTPUT": str(dependency_output),
+                "GITHUB_WORKSPACE": str(tmp_path),
+                "RUNNER_TEMP": str(tmp_path),
+                "GIT_LOG": str(git_log),
+                "ROUTE_MATRIX": route_line.partition("=")[2],
+                "PORTS_SHA": ports_sha,
+                "SOURCE_DATE_EPOCH": str(source_epoch),
+            },
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert dependency_completed.returncode == 0, dependency_completed.stderr
+        dependency_emitted = dependency_output.read_text(encoding="utf-8")
         toolchain = {
             "python": "3.11.15",
             "pip": "26.2.1",
@@ -294,7 +323,7 @@ def test_issue_2387_pin_step_executes_against_exact_ci_metadata_sha(
                 "toolchain": toolchain,
             }
             expected[suffix] = {"textproc/py-charset-normalizer": identity}
-        line = next(line for line in emitted.splitlines() if line.startswith("dependency_packages="))
+        line = next(line for line in dependency_emitted.splitlines() if line.startswith("dependency_packages="))
         assert json.loads(line.partition("=")[2]) == expected
     commands = git_log.read_text(encoding="utf-8")
     assert "fetch --no-tags origin +refs/heads/ci-metadata:refs/remotes/origin/ci-metadata" in commands

--- a/tests/test_release_tag_after_verify.py
+++ b/tests/test_release_tag_after_verify.py
@@ -891,34 +891,34 @@ def test_other_release_lines_keep_matrix_extra_packages(tmp_path: Path, extra_pk
     assert json.loads(_run_extra_pkgs_decision(tmp_path, "release/4.0", rendered)) == extra_pkgs
 
 
-def test_build_record_keeps_the_original_release_33_matrix_row(tmp_path: Path) -> None:
+def _run_build_record(
+    tmp_path: Path,
+    *,
+    source: str,
+    matrix_extra_pkgs: list[str],
+    effective_extra_pkgs: list[str],
+) -> dict[str, object]:
     script = _step_run_script(_step(_jobs()["build-pkgs-portable"], "Write the destination-bound build record"))
-    bin_dir = tmp_path / "bin"
-    bin_dir.mkdir()
-    git_stub = bin_dir / "git"
-    git_stub.write_text("#!/bin/sh\nprintf '%s\\n' 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'\n")
-    git_stub.chmod(0o755)
     row = {
         "variant": "CE",
         "pfsense_version": "2.8",
         "freebsd_major": "15",
-        "extra_pkgs": ["textproc/py-charset-normalizer"],
+        "extra_pkgs": matrix_extra_pkgs,
     }
-    github_env = tmp_path / "github_env"
-    github_env.write_text("")
     completed = subprocess.run(  # noqa: S603
         ["sh", "-c", script],
         cwd=ROOT,
         env={
-            "PATH": f"{bin_dir}:/usr/bin:/bin:/usr/local/bin",
-            "TAG": "v3.3.3.a1",
-            "CHANNEL": "testing",
-            "SOURCE": "release/3.3",
-            "PORTVERSION": "3.3.3.a1",
-            "CLASSIFICATION": "alpha",
+            "PATH": "/usr/bin:/bin:/usr/local/bin",
+            "TAG": "v3.3.5",
+            "CHANNEL": "stable",
+            "SOURCE": source,
+            "PORTVERSION": "3.3.5",
+            "CLASSIFICATION": "final",
             "COMMIT": "b" * 40,
             "CREATED": "1",
             "MATRIX_ROW": json.dumps(row),
+            "EXTRA_PKGS": json.dumps(effective_extra_pkgs),
             "PORTS_SHA": "a" * 40,
             "DEPENDENCY_BUILDER": json.dumps(
                 {
@@ -932,13 +932,45 @@ def test_build_record_keeps_the_original_release_33_matrix_row(tmp_path: Path) -
                 }
             ),
             "RUNNER_TEMP": str(tmp_path),
-            "GITHUB_ENV": str(github_env),
         },
         capture_output=True,
         text=True,
     )
     assert completed.returncode == 0, completed.stdout + completed.stderr
-    assert json.loads((tmp_path / "build-record.json").read_text())["matrix_row"] == row
+    return json.loads((tmp_path / "build-record.json").read_text())
+
+
+def test_release_33_build_record_uses_effective_empty_extras(tmp_path: Path) -> None:
+    record = _run_build_record(
+        tmp_path,
+        source="release/3.3",
+        matrix_extra_pkgs=["textproc/py-charset-normalizer"],
+        effective_extra_pkgs=[],
+    )
+
+    matrix_row = record["matrix_row"]
+    assert isinstance(matrix_row, dict)
+    assert matrix_row["extra_pkgs"] == []
+    assert "dependency_builder" not in record
+
+
+@pytest.mark.parametrize(
+    ("extra_pkgs", "has_dependency_builder"),
+    [([], False), (["textproc/py-charset-normalizer"], True)],
+)
+def test_build_record_only_records_dependency_builder_for_extra_packages(
+    tmp_path: Path,
+    extra_pkgs: list[str],
+    has_dependency_builder: bool,
+) -> None:
+    record = _run_build_record(
+        tmp_path,
+        source="release/4.0",
+        matrix_extra_pkgs=extra_pkgs,
+        effective_extra_pkgs=extra_pkgs,
+    )
+
+    assert ("dependency_builder" in record) is has_dependency_builder
 
 
 def test_release_33_decision_and_matrix_bindings_are_not_bypassed() -> None:

--- a/tests/test_tagged_release_handoff.py
+++ b/tests/test_tagged_release_handoff.py
@@ -170,6 +170,22 @@ def test_cli_creates_canonical_build_time_handoff(tmp_path: Path) -> None:
     assert payload["dependency_builder"] == DEPENDENCY_BUILDER
 
 
+def test_dependency_free_handoff_may_omit_builder() -> None:
+    module = _module()
+    handoff = module.build_handoff(
+        release_tag=TAG,
+        source_sha=SOURCE_SHA,
+        ci_metadata_sha=CI_METADATA_SHA,
+        ports_sha=PORTS_SHA,
+        route_matrix=[ROW],
+        dependency_packages={},
+        source_date_epoch=SOURCE_DATE_EPOCH,
+        dependency_builder=None,
+    )
+
+    assert handoff["dependency_builder"] is None
+
+
 def test_load_accepts_exact_release_and_source(tmp_path: Path) -> None:
     path = tmp_path / "handoff.json"
     _write(path, _payload())
@@ -312,6 +328,17 @@ def _write_package(path: Path, record: dict[str, object], *, name: str) -> None:
         member.size = len(payload)
         tf.addfile(member, io.BytesIO(payload))
     path.write_bytes(lzma.compress(archive.getvalue()))
+
+
+def test_dependency_free_package_record_may_omit_builder(tmp_path: Path) -> None:
+    module = _module()
+    package = tmp_path / CANONICAL_ASSET
+    record = _canonical_record()
+    record.pop("dependency_builder")
+    record["build_input_digest"] = pfb_pkg.build_input_digest(record)
+    _write_package(package, record, name=pfb_pkg.CANONICAL_EMITTED_IDENTITY)
+
+    module.validate_packages(_payload(), [package])
 
 
 def _dependency_record(**changes: object) -> dict[str, object]:

--- a/tests/test_ui_release_gate_wiring.py
+++ b/tests/test_ui_release_gate_wiring.py
@@ -508,6 +508,7 @@ def test_release_dependency_builder_receives_structured_reproducibility_inputs()
     build_steps = workflow["jobs"]["build-pkgs-portable"]["steps"]
     setup = next(step for step in build_steps if step.get("name") == "Set up the pinned dependency-package toolchain")
     sync = next(step for step in build_steps if step.get("name") == "Sync the locked dependency-package toolchain")
+    extras = next(step for step in build_steps if step.get("name") == "Resolve release-line extras")
     record = next(step for step in build_steps if step.get("name") == "Write the destination-bound build record")
     build = next(step for step in build_steps if step.get("name") == "Build the .pkg via build-leg.sh")
     read_matrix_steps = workflow["jobs"]["read-matrix"]["steps"]
@@ -517,6 +518,7 @@ def test_release_dependency_builder_receives_structured_reproducibility_inputs()
     pinned_builder = next(
         step for step in read_matrix_steps if step.get("name") == "Check out pinned dependency-builder source"
     )
+    dependencies = next(step for step in read_matrix_steps if step.get("name") == "Resolve dependency identities")
     handoffs = [
         step
         for job in workflow["jobs"].values()
@@ -524,8 +526,12 @@ def test_release_dependency_builder_receives_structured_reproducibility_inputs()
         if step.get("name") == "Create tagged release handoff"
     ]
 
+    read_matrix_outputs = workflow["jobs"]["read-matrix"]["outputs"]
     assert setup["with"] == {"version": "0.12.6", "activate-environment": True}
     assert sync["run"] == "uv sync --locked --only-group dep-pkg-build"
+    assert build_steps.index(extras) < build_steps.index(setup) < build_steps.index(sync)
+    assert setup["if"] == "steps.extras.outputs.extra_pkgs != '[]'"
+    assert sync["if"] == "steps.extras.outputs.extra_pkgs != '[]'"
     assert pinned_builder["uses"] == "actions/checkout@v6"
     assert pinned_builder["with"]["ref"] == (
         "${{ github.event.inputs.source == 'release/3.3' && github.workflow_sha || "
@@ -534,14 +540,23 @@ def test_release_dependency_builder_receives_structured_reproducibility_inputs()
     assert pinned_builder["with"]["path"] == "pinned-builder"
     assert "scripts/" in pinned_builder["with"]["sparse-checkout"]
     assert "uv.lock" in pinned_builder["with"]["sparse-checkout"]
-    assert 'python3 "$PINNED_BUILDER/scripts/build-dep-pkg-portable.py" --print-toolchain' in pins["run"]
-    assert "python3 scripts/build-dep-pkg-portable.py --print-toolchain" not in pins["run"]
-    assert "--print-port-identity" in pins["run"]
-    assert "dependency_packages=${DEPENDENCY_PACKAGES}" in pins["run"]
+    assert (
+        read_matrix_steps.index(pins) < read_matrix_steps.index(pinned_builder) < read_matrix_steps.index(dependencies)
+    )
+    assert pinned_builder["if"] == "steps.pins.outputs.has_dependencies == 'true'"
+    assert dependencies["if"] == "steps.pins.outputs.has_dependencies == 'true'"
+    assert 'python3 "$PINNED_BUILDER/scripts/build-dep-pkg-portable.py" --print-toolchain' in dependencies["run"]
+    assert "python3 scripts/build-dep-pkg-portable.py --print-toolchain" not in dependencies["run"]
+    assert "--print-port-identity" in dependencies["run"]
+    assert "dependency_packages=${DEPENDENCY_PACKAGES}" in dependencies["run"]
     assert pins["env"]["INPUT_SOURCE"] == "${{ github.event.inputs.source }}"
     assert pins["env"]["SOURCE_SHA"] == "${{ steps.destinations.outputs.source_sha }}"
     assert "map(.extra_pkgs = [])" in pins["run"]
-    assert {"CREATED", "DEPENDENCY_BUILDER", "EXTRA_PKGS"} <= record["env"].keys()
+    assert "has_dependencies=${HAS_DEPENDENCIES}" in pins["run"]
+    assert read_matrix_outputs["dependency_builder"] == "${{ steps.dependencies.outputs.dependency_builder || 'null' }}"
+    assert read_matrix_outputs["dependency_packages"] == "${{ steps.dependencies.outputs.dependency_packages || '{}' }}"
+    assert {"CREATED", "DEPENDENCY_BUILDER"} <= record["env"].keys()
+    assert record["env"]["EXTRA_PKGS"] == "${{ steps.extras.outputs.extra_pkgs }}"
     assert '"source_date_epoch": int(os.environ["CREATED"])' in record["run"]
     assert 'if row["extra_pkgs"]:' in record["run"]
     assert 'record["dependency_builder"] = json.loads(os.environ["DEPENDENCY_BUILDER"])' in record["run"]
@@ -556,8 +571,6 @@ def test_release_dependency_builder_receives_structured_reproducibility_inputs()
     assert '--dependency-builder "$DEPENDENCY_BUILDER_FILE"' in handoffs[0]["run"]
     assert "DEPENDENCY_PACKAGES" in handoffs[0]["env"]
     assert '--dependency-packages "$DEPENDENCY_PACKAGES_FILE"' in handoffs[0]["run"]
-    assert setup["if"] == "github.event.inputs.source != 'release/3.3'"
-    assert sync["if"] == "github.event.inputs.source != 'release/3.3'"
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/test_ui_release_gate_wiring.py
+++ b/tests/test_ui_release_gate_wiring.py
@@ -541,9 +541,10 @@ def test_release_dependency_builder_receives_structured_reproducibility_inputs()
     assert pins["env"]["INPUT_SOURCE"] == "${{ github.event.inputs.source }}"
     assert pins["env"]["SOURCE_SHA"] == "${{ steps.destinations.outputs.source_sha }}"
     assert "map(.extra_pkgs = [])" in pins["run"]
-    assert "CREATED" in record["env"] and "DEPENDENCY_BUILDER" in record["env"]
+    assert {"CREATED", "DEPENDENCY_BUILDER", "EXTRA_PKGS"} <= record["env"].keys()
     assert '"source_date_epoch": int(os.environ["CREATED"])' in record["run"]
-    assert '"dependency_builder": json.loads(os.environ["DEPENDENCY_BUILDER"])' in record["run"]
+    assert 'if row["extra_pkgs"]:' in record["run"]
+    assert 'record["dependency_builder"] = json.loads(os.environ["DEPENDENCY_BUILDER"])' in record["run"]
     assert 'record["build_input_digest"] = build_input_digest(record)' in record["run"]
     assert '--ports-sha "$PORTS_SHA"' in build["run"]
     assert '--source-date-epoch "$CREATED"' in build["run"]


### PR DESCRIPTION
## Summary

- record the effective release-line `extra_pkgs` set in each package build record
- omit `dependency_builder` when the effective set is empty, while preserving strict validation when present or required
- skip dependency-toolchain checkout/setup and handoff provenance when no effective dependency exists
- accept dependency-free package records throughout tagged-release handoff validation

## Frozen RED evidence

Initial schema/emitter RED ran on `devel@f6a2e857933550e22822f9ecce831447be17cdea`; review RED replay ran final test bytes against pre-review head `1f3162151b5e199e0bf31b5de72d83c0856defd6`.

| Frozen RED test | git hash-object | RED run tail |
| --- | --- | --- |
| `tests/test_pfb_pkg.py` | `8d329fd3453b83e288fe38a2f21b3e4b80a6974c` | `review RED: 6 failed, 2 passed in 0.68s` |
| `tests/test_release_tag_after_verify.py` | `79bb15e28205875bbeb0a026125f71df65c80431` | `initial RED: 4 failed, 3 passed in 0.82s` |
| `tests/test_issue2143_review_round2.py` | `d5fe2bf924402b845e3b9111b417e51674b84d74` | `initial RED: 4 failed, 3 passed in 0.82s` |
| `tests/test_ui_release_gate_wiring.py` | `0749d39f1c7028d172a9d1b4b8724061ecf33b01` | `review RED: 6 failed, 2 passed in 0.68s` |
| `tests/test_tagged_release_handoff.py` | `afb4ed590a0f91b67fa5b0ad698f82c89ec84e77` | `review RED: 6 failed, 2 passed in 0.68s` |
| `tests/test_release_ci_path_consistency.py` | `ba4ee87e8fea0d51e0b2f9188c62a86b195dfb5e` | `review RED: 6 failed, 2 passed in 0.68s` |

## GREEN evidence

- exact review regression command: 8 passed
- affected release suites: 445 passed
- `actionlint .github/workflows/release.yml`: passed
- `scripts/agent/run-gates.sh --diff origin/devel` with Node 24 (Node 26 baseline tracked by #2983): all selected gates passed

Fixes #2985

🤖 Generated by Oh My Pi and posted on behalf of @andrebrait.