### PR TITLE
pfblockerng: align update feed statuses

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -7095,19 +7095,8 @@ function pfb_determine_list_detail($list='', $header='', $confconfig='', $key=''
 		$pfbarr['descr'] = ' Auto ';
 	}
 
-	// Determine length of header to format log output
-	$tabtype = strlen($header);
-	if ($tabtype > 27) {
-		$pfbarr['logtab'] = '';
-	} elseif ($tabtype > 19) {
-		$pfbarr['logtab'] = "\t";
-	} elseif ($tabtype > 11) {
-		$pfbarr['logtab'] = "\t\t";
-	} elseif ($tabtype < 4) {
-		$pfbarr['logtab'] = "\t\t\t\t";
-	} else {
-		$pfbarr['logtab'] = "\t\t\t";
-	}
+	// issue #2989: fixed spaces keep status columns aligned after the 20-character ISO timestamp.
+	$pfbarr['logtab'] = str_repeat(' ', max(0, 28 - strlen($header)));
 
 	// Configure autoports/protocol and auto destination if required.
 	$conf_path = "installedpackages/{$confconfig}/config/{$key}";

--- a/tests/php/UpdateLogAlignmentTest.php
+++ b/tests/php/UpdateLogAlignmentTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+#[CoversFunction('pfb_determine_list_detail')]
+#[CoversFunction('pfb_logger')]
+final class UpdateLogAlignmentTest extends TestCase
+{
+	/** @var array<string,array{bool,mixed}> */
+	private array $saved = [];
+	private string $log;
+
+	protected function setUp(): void
+	{
+		foreach (['pfb', 'pfbarr', 'config'] as $name) {
+			$this->saved[$name] = [array_key_exists($name, $GLOBALS), $GLOBALS[$name] ?? NULL];
+		}
+
+		$this->log = (string) tempnam(sys_get_temp_dir(), 'pfb_update_alignment_');
+		$this->assertNotSame('', $this->log, 'failed to create update-log fixture');
+		$GLOBALS['pfb']['log'] = $this->log;
+		$GLOBALS['pfb']['denydir'] = '/tmp/pfb_deny';
+		$GLOBALS['pfb']['origdir'] = '/tmp/pfb_orig';
+		$GLOBALS['pfb']['nativedir'] = '/tmp/pfb_native';
+		$GLOBALS['pfb']['reuse'] = '';
+		$GLOBALS['pfb']['runlog_active'] = FALSE;
+
+		$off = [];
+		foreach (['autoproto', 'autonot', 'autoaddrnot', 'agateway', 'autoports', 'autoaddr'] as $key) {
+			$off["{$key}_in"] = '';
+			$off["{$key}_out"] = '';
+		}
+		$GLOBALS['config'] = ['installedpackages' => ['pfblockerngtest' => ['config' => [0 => $off]]]];
+	}
+
+	protected function tearDown(): void
+	{
+		if (is_file($this->log)) {
+			$this->assertTrue(unlink($this->log), 'failed to remove update-log fixture');
+		}
+		foreach ($this->saved as $name => [$existed, $value]) {
+			if ($existed) {
+				$GLOBALS[$name] = $value;
+			} else {
+				unset($GLOBALS[$name]);
+			}
+		}
+	}
+
+	/** @return list<string> */
+	private function loggedLines(array $headers): array
+	{
+		foreach ($headers as $header) {
+			$detail = pfb_determine_list_detail('Deny_Both', $header, 'pfblockerngtest', '0');
+			pfb_logger("[ {$header} ]{$detail['logtab']} exists.\n", 1);
+		}
+		return explode("\n", rtrim((string) file_get_contents($this->log), "\n"));
+	}
+
+	public function testFeedStatusesAlignAcrossSupportedHeaderLengths(): void
+	{
+		$headers = [
+			'abc',
+			'abcd',
+			str_repeat('a', 11),
+			str_repeat('a', 12),
+			str_repeat('a', 19),
+			str_repeat('a', 20),
+			str_repeat('a', 27),
+			str_repeat('a', 28),
+		];
+
+		foreach ($this->loggedLines($headers) as $line) {
+			$this->assertSame(53, strpos($line, 'exists.'), "status must start in column 54: {$line}");
+		}
+	}
+
+	public function testLongFeedHeaderKeepsOneSeparatingSpace(): void
+	{
+		$header = str_repeat('a', 29);
+		[$line] = $this->loggedLines([$header]);
+
+		$this->assertStringContainsString("[ {$header} ] exists.", $line);
+	}
+}


### PR DESCRIPTION
## Summary

- replace tab-count buckets with fixed-width space padding for Update feed statuses
- keep one separator for feed headers longer than the aligned field
- add boundary coverage across every former tab bucket

Fixes #2989

## Evidence

### RED

`vendor/bin/phpunit tests/php/UpdateLogAlignmentTest.php` on unchanged production code:

```text
FAILURES!
Tests: 2, Assertions: 6, Failures: 1.
status must start in column 54 ... Failed asserting that 32 is identical to 53.
```

Frozen test hash: `4693ee0ccdcd65d75dffdb01313b42a4f4c795e1`.

### GREEN

```text
OK (2 tests, 13 assertions)
No syntax errors detected in src/usr/local/pkg/pfblockerng/pfblockerng.inc
No syntax errors detected in tests/php/UpdateLogAlignmentTest.php
```

Pre-commit PHPCS passed. `composer phpstan` and `composer phpcs -- --standard=phpcs.xml.dist src/` passed in both canonical gate runs. Two full-suite attempts each reached 6,315 tests but encountered different process-fixture flakes; focused reruns passed (`RsyncWallDeadlineTest`: 6 tests/53 assertions; `HttpFixtureReadinessBehaviorTest`: 10 tests/4,909 assertions). Tracked separately in #2992; CI remains authoritative.

🤖 Generated by Oh My Pi and posted on behalf of @andrebrait.