### PR TITLE
registry: sweep the last seven page-declared toggle defaults (#2812) [replay of #2972]

### DIFF
--- a/scripts/check_toggle_registry.py
+++ b/scripts/check_toggle_registry.py
@@ -91,26 +91,11 @@ _MIN_REGISTRY_KEYS = 100
 
 # (page basename, bare key) -> reason. Every entry is a deliberate, recorded decision.
 #
-# RULE 2's pre-existing backlog, tracked by issue #2812. Every key here was registered
-# BEFORE issue #2123 and is therefore outside its key set, and every one was checked on
-# #2123's branch to be behaviour-equivalent today: six declare the same token twice, and
-# `pfb_dnsbl_lenient` declares `''` in the page against `'off'` in the registry, which
-# the #2120 toggle contract resolves to the same Off. Recorded as a documented set with
-# a tracking issue, so this gate stays BLOCKING for anything new instead of being
-# downgraded to advisory. An entry whose site is gone is dead weight -- delete it.
-EXEMPT: dict[tuple[str, str], str] = {
-    ("pfblockerng_dnsbl.php", "pfb_dnsbl"): "#2812 pre-registered toggle, page and registry defaults agree",
-    ("pfblockerng_dnsbl.php", "pfb_dnsvip_auto"): "#2812 pre-registered toggle, page and registry defaults agree",
-    ("pfblockerng_dnsbl.php", "pfb_dnsbl_nonat"): "#2812 pre-registered toggle, page and registry defaults agree",
-    ("pfblockerng_dnsbl.php", "pfb_idn_escalate_suspicious"): (
-        "#2812 pre-registered toggle, page and registry defaults agree"
-    ),
-    ("pfblockerng_dnsbl.php", "pfb_regex_cap"): "#2812 pre-registered toggle, page and registry defaults agree",
-    ("pfblockerng_dnsbl.php", "pfb_dnsbl_lenient"): (
-        "#2812 pre-registered toggle, page '' vs registry 'off' -- both read Off under #2120"
-    ),
-    ("pfblockerng_general.php", "enable_cb"): "#2812 pre-registered toggle, page and registry defaults agree",
-}
+# Empty since issue #2812: the last seven pre-#2123 toggle sites it recorded were routed
+# through PfbConfig::read() and their rows deleted. The table stays as the shape for a
+# DELIBERATE exemption -- a future row must name the decision that makes the duplication
+# acceptable, and a row whose site is gone is dead weight -- delete it.
+EXEMPT: dict[tuple[str, str], str] = {}
 
 
 class Violation(NamedTuple):

--- a/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
@@ -49,14 +49,14 @@ if (strpos(config_get_path('system/domain'), '.') !== FALSE) {
 $default_tlds = array('arpa',$local_tld,'com','net','org','edu','ca','co','io');
 
 $pconfig = array();
-$pconfig['pfb_dnsbl']		= $pfb['dconfig']['pfb_dnsbl']				?: '';
+$pconfig['pfb_dnsbl']		= PfbConfig::read('dnsbl/pfb_dnsbl');
 $pconfig['tld_wildcard']		= $pfb['dconfig']['tld_wildcard']				?: '';
 $pconfig['pfb_control']		= $pfb['dconfig']['pfb_control']			?: '';
 $pconfig['pfb_control_legacy']	= $pfb['dconfig']['pfb_control_legacy']			?: '';
 $pconfig['pfb_dnsvip4'] = $pfb['dconfig']['pfb_dnsvip4'] ?: 'none';
 $pconfig['pfb_dnsvip6'] = $pfb['dconfig']['pfb_dnsvip6'] ?: 'none';
-$pconfig['pfb_dnsvip_auto']	= $pfb['dconfig']['pfb_dnsvip_auto']			?: '';
-$pconfig['pfb_dnsbl_nonat']	= $pfb['dconfig']['pfb_dnsbl_nonat']			?: '';
+$pconfig['pfb_dnsvip_auto']	= PfbConfig::read('dnsbl/pfb_dnsvip_auto');
+$pconfig['pfb_dnsbl_nonat']	= PfbConfig::read('dnsbl/pfb_dnsbl_nonat');
 $pconfig['pfb_dnsport']		= $pfb['dconfig']['pfb_dnsport']			?: '8081';
 $pconfig['pfb_dnsport_ssl']	= $pfb['dconfig']['pfb_dnsport_ssl']			?: '8443';
 $pconfig['dnsbl_interface']	= $pfb['dconfig']['dnsbl_interface']			?: 'lo0';
@@ -86,13 +86,13 @@ $pconfig['pfb_idn']		= PfbConfig::read('dnsbl/pfb_idn')->value;
 // escalate suspicious mixed-script (else alert only) is opt-in (default off).
 // Default 'on' owned by the registry (ADR-29); PfbConfig::read applies it when absent.
 $pconfig['pfb_idn_block_malicious']	= PfbConfig::read('dnsbl/pfb_idn_block_malicious');
-$pconfig['pfb_idn_escalate_suspicious']	= $pfb['dconfig']['pfb_idn_escalate_suspicious']		?: '';
+$pconfig['pfb_idn_escalate_suspicious']	= PfbConfig::read('dnsbl/pfb_idn_escalate_suspicious');
 $pconfig['pfb_regex']		= $pfb['dconfig']['pfb_regex']				?: '';
-$pconfig['pfb_regex_cap']	= $pfb['dconfig']['pfb_regex_cap']			?: '';
+$pconfig['pfb_regex_cap']	= PfbConfig::read('dnsbl/pfb_regex_cap');
 $pconfig['pfb_cname']		= $pfb['dconfig']['pfb_cname']				?: '';
 // ADR-22: lenient scheme parsing. Absent = unchecked (strict) for new installs; existing
 // installs are grandfathered to 'on' by the registry pass at install/upgrade (issue #1921).
-$pconfig['pfb_dnsbl_lenient']	= $pfb['dconfig']['pfb_dnsbl_lenient']			?: '';
+$pconfig['pfb_dnsbl_lenient']	= PfbConfig::read('dnsbl/pfb_dnsbl_lenient');
 $pconfig['pfb_noaaaa']		= $pfb['dconfig']['pfb_noaaaa']				?: '';
 $pconfig['pfb_gp']		= $pfb['dconfig']['pfb_gp']				?: '';
 $pconfig['tld_allow']		= $pfb['dconfig']['tld_allow']				?: '';

--- a/src/usr/local/www/pfblockerng/pfblockerng_general.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_general.php
@@ -48,7 +48,7 @@ if (pfb_wizard_suppress_autolaunch($wizard_action,
 $pfb['gconfig'] = PfbConfig::readSection('installedpackages/pfblockerng/config/0');
 
 $pconfig = array();
-$pconfig['enable_cb']			= $pfb['gconfig']['enable_cb']				?: '';
+$pconfig['enable_cb']			= PfbConfig::read('gen/enable_cb');
 
 // Default 'on' — owned by the registry (ADR-29); PfbConfig::read applies it when absent.
 $pconfig['pfb_keep']			= PfbConfig::read('gen/pfb_keep')->value;

--- a/tests/php/CfgToggleRegistryPageParityTest.php
+++ b/tests/php/CfgToggleRegistryPageParityTest.php
@@ -312,4 +312,140 @@ final class CfgToggleRegistryPageParityTest extends TestCase
 				"{$path_key}: registered default must reproduce the deleted page default");
 		}
 	}
+
+	/**
+	 * issue #2812 — the seven registered toggles whose page still restated the
+	 * default the registry already owned, exempted from RULE 2 until swept.
+	 *
+	 * The same PARITY claim as the #2123 matrix above, re-evaluated against the
+	 * pre-#2812 page expression: all seven pages carried the FALSY_EMPTY shape
+	 * (`$pfb['<mirror>']['<key>'] ?: ''`), so absent and every falsy token must
+	 * collapse to Off through the gateway too.
+	 *
+	 * `pfb_dnsbl_lenient` is the one recorded divergence: the page declared `''`
+	 * while the registry declares `'off'` — two spellings of the same Off under
+	 * the #2120 toggle contract, which the matrix pins state by state. Its
+	 * `grandfather => [PFB_GF_ABSENT => 'on']` arm is an install/upgrade-time
+	 * write (pfblockerng.inc's registry pass), never a read-time resolution, so
+	 * a genuinely absent key resolves through the registered default here.
+	 *
+	 * @var array<string,array{0:string,1:string,2:string}>
+	 */
+	private const FIELDS_2812 = [
+		'dnsbl/pfb_dnsbl' => [
+			'installedpackages/pfblockerngdnsblsettings/config/0',
+			'pfblockerng_dnsbl.php:52',
+			self::SHAPE_FALSY_EMPTY,
+		],
+		'dnsbl/pfb_dnsvip_auto' => [
+			'installedpackages/pfblockerngdnsblsettings/config/0',
+			'pfblockerng_dnsbl.php:58',
+			self::SHAPE_FALSY_EMPTY,
+		],
+		'dnsbl/pfb_dnsbl_nonat' => [
+			'installedpackages/pfblockerngdnsblsettings/config/0',
+			'pfblockerng_dnsbl.php:59',
+			self::SHAPE_FALSY_EMPTY,
+		],
+		'dnsbl/pfb_idn_escalate_suspicious' => [
+			'installedpackages/pfblockerngdnsblsettings/config/0',
+			'pfblockerng_dnsbl.php:89',
+			self::SHAPE_FALSY_EMPTY,
+		],
+		'dnsbl/pfb_regex_cap' => [
+			'installedpackages/pfblockerngdnsblsettings/config/0',
+			'pfblockerng_dnsbl.php:91',
+			self::SHAPE_FALSY_EMPTY,
+		],
+		'dnsbl/pfb_dnsbl_lenient' => [
+			'installedpackages/pfblockerngdnsblsettings/config/0',
+			'pfblockerng_dnsbl.php:95',
+			self::SHAPE_FALSY_EMPTY,
+		],
+		'gen/enable_cb' => [
+			'installedpackages/pfblockerng/config/0',
+			'pfblockerng_general.php:51',
+			self::SHAPE_FALSY_EMPTY,
+		],
+	];
+
+	/** @return iterable<string,array{0:string,1:string,2:string,3:string,4:mixed}> */
+	public static function fieldRawMatrix2812(): iterable
+	{
+		foreach (self::FIELDS_2812 as $path_key => [$section, $site, $shape]) {
+			foreach (self::RAW_STATES as $state => $raw) {
+				yield "{$path_key} [{$state}]" => [$path_key, $section, $shape, $site, $raw];
+			}
+		}
+	}
+
+	/**
+	 * Scenario:
+	 *   Background: a configuration written before #2812 swept the seven sites.
+	 *   Given one of the seven keys holds raw stored value v (or is absent).
+	 *   When PfbConfig::read('<alias>/<key>') resolves it.
+	 *   Then the result equals what the page's pre-sweep `?: ''` expression
+	 *        produced for the same v — the page default is deleted without the
+	 *        behaviour moving.
+	 */
+	#[DataProvider('fieldRawMatrix2812')]
+	public function testGatewayReadReproducesThePre2812PageValue(
+		string $path_key,
+		string $section,
+		string $shape,
+		string $site,
+		mixed $raw
+	): void {
+		$bare = substr($path_key, strpos($path_key, '/') + 1);
+		if ($raw !== NULL) {
+			config_set_path("{$section}/{$bare}", $raw);
+		}
+
+		// Before: the raw state is exactly what a pre-#2812 config presents.
+		$this->assertSame($raw, config_get_path("{$section}/{$bare}"),
+			"before: {$path_key} raw stored state");
+
+		$expected = self::preRegistrationPageValue($shape, $raw);
+
+		// When/Then.
+		$this->assertSame($expected, PfbConfig::read($path_key), sprintf(
+			'%s: gateway read must equal the pre-#2812 %s expression (%s) for raw %s',
+			$path_key, $shape, $site, var_export($raw, TRUE)
+		));
+	}
+
+	/**
+	 * Every one of the seven is registered, adapter-bearing, and its registered
+	 * default is spelled out as a literal. For six, the default is the page's
+	 * own `''`; for `pfb_dnsbl_lenient` it is the registry's canonical `'off'`
+	 * — the recorded page/registry spelling divergence, both reading Off.
+	 */
+	public function testAll2812SitesAreRegisteredClassifiedToggles(): void
+	{
+		$expected_defaults = [
+			'dnsbl/pfb_dnsbl'                   => '',
+			'dnsbl/pfb_dnsvip_auto'             => '',
+			'dnsbl/pfb_dnsbl_nonat'             => '',
+			'dnsbl/pfb_idn_escalate_suspicious' => '',
+			'dnsbl/pfb_regex_cap'               => '',
+			'dnsbl/pfb_dnsbl_lenient'           => 'off',
+			'gen/enable_cb'                     => '',
+		];
+
+		$this->assertSame(array_keys(self::FIELDS_2812), array_keys($expected_defaults),
+			'the default table must cover exactly the seven #2812 fields under test');
+
+		$registry = pfb_cfg_registry();
+		foreach (self::FIELDS_2812 as $path_key => [, $site,]) {
+			$this->assertArrayHasKey($path_key, $registry,
+				"{$path_key} must be registered (issue #2812 premise)");
+			$entry = $registry[$path_key];
+			$this->assertSame('pfb_cfg_toggle_read', $entry['read_adapter'],
+				"{$path_key} must carry the toggle read adapter");
+			$this->assertSame('pfb_cfg_toggle_write', $entry['write_adapter'],
+				"{$path_key} must carry the toggle write adapter");
+			$this->assertSame($expected_defaults[$path_key], $entry['default'] ?? NULL,
+				"{$path_key} ({$site}): registered default flipped from the recorded value");
+		}
+	}
 }

--- a/tests/smoke/ui/test_toggle_registry_default_render.py
+++ b/tests/smoke/ui/test_toggle_registry_default_render.py
@@ -195,3 +195,87 @@ def test_absent_syncinterfaces_renders_unchecked_from_the_registered_default(
         "an absent syncinterfaces must render UNCHECKED -- the registered '' default "
         "must reproduce the page default #2123 deleted"
     )
+
+
+# ---------------------------------------------------------------------------
+# issue #2812: the seven residue toggles whose page-level default the registry
+# now owns exclusively (the sites #2123's regrowth gate exempted). The sweep is
+# behaviour-equivalent by design -- every toggle-contract state renders exactly
+# as before -- so these tests pin the end-state observable on the real pages: a
+# stored 'on' renders CHECKED (control), and an absent key renders UNCHECKED
+# (registry defaults: '' for five, legacy-'off' for lenient), plus the lenient
+# key's two Off spellings ('' and legacy 'off') both rendering UNCHECKED.
+# Every case mutates config.xml, so each rides the isolation net (dual-marked
+# ui_e2e per conftest's _ui_pfb_isolation marker discipline).
+
+_DNSBL_SETTINGS_PAGE = "/pfblockerng/pfblockerng_dnsbl.php"
+_GENERAL_SETTINGS_PAGE = "/pfblockerng/pfblockerng_general.php"
+
+_SWEPT_DNSBL_TOGGLES = {
+    "pfb_dnsbl": "installedpackages/pfblockerngdnsblsettings/config/0/pfb_dnsbl",
+    "pfb_dnsvip_auto": "installedpackages/pfblockerngdnsblsettings/config/0/pfb_dnsvip_auto",
+    "pfb_dnsbl_nonat": "installedpackages/pfblockerngdnsblsettings/config/0/pfb_dnsbl_nonat",
+    "pfb_idn_escalate_suspicious": "installedpackages/pfblockerngdnsblsettings/config/0/pfb_idn_escalate_suspicious",
+    "pfb_regex_cap": "installedpackages/pfblockerngdnsblsettings/config/0/pfb_regex_cap",
+    "pfb_dnsbl_lenient": "installedpackages/pfblockerngdnsblsettings/config/0/pfb_dnsbl_lenient",
+}
+CFG_ENABLE_CB = "installedpackages/pfblockerng/config/0/enable_cb"
+
+
+@pytest.mark.ui_e2e
+@pytest.mark.parametrize("name", sorted(_SWEPT_DNSBL_TOGGLES))
+def test_swept_dnsbl_toggle_renders_on_when_stored_and_off_when_absent(
+    smoke_vm: SmokeVM, webui: WebUI, node_state: Callable[[str, str | None], None], name: str
+) -> None:
+    """issue #2812: each swept DNSBL toggle's checked state comes from the registry.
+
+    Given the key stored as 'on', the checkbox renders CHECKED -- the control that
+    the page can render this box checked at all. Given the key absent, it renders
+    UNCHECKED: the registered '' (or, for the lenient key, legacy-'off') default
+    that replaced the page literal #2812 deleted.
+    """
+    path = _SWEPT_DNSBL_TOGGLES[name]
+    node_state(path, "on")
+    html = _render(smoke_vm, webui, _DNSBL_SETTINGS_PAGE, "DNSBL Webserver Configuration")
+    assert _checkbox_is_checked(html, name), f"control: a stored 'on' {name} must render checked"
+
+    node_state(path, None)
+    html = _render(smoke_vm, webui, _DNSBL_SETTINGS_PAGE, "DNSBL Webserver Configuration")
+    assert not _checkbox_is_checked(html, name), (
+        f"an absent {name} must render UNCHECKED -- the registered default "
+        "must reproduce the page default #2812 deleted"
+    )
+
+
+@pytest.mark.ui_e2e
+def test_swept_pfb_dnsbl_lenient_off_spellings_render_unchecked(
+    smoke_vm: SmokeVM, webui: WebUI, node_state: Callable[[str, str | None], None]
+) -> None:
+    """issue #2812: the lenient key's registry default is legacy 'off' where the old
+    page literal was '' -- under the #2120 toggle contract both spell Off, so both
+    stored spellings render UNCHECKED (the equivalence the sweep relied on)."""
+    for stored in ("off", ""):
+        node_state(_SWEPT_DNSBL_TOGGLES["pfb_dnsbl_lenient"], stored)
+        html = _render(smoke_vm, webui, _DNSBL_SETTINGS_PAGE, "DNSBL Webserver Configuration")
+        assert not _checkbox_is_checked(html, "pfb_dnsbl_lenient"), (
+            f"a stored {stored!r} pfb_dnsbl_lenient must render UNCHECKED -- both Off "
+            "spellings agree under the #2120 toggle contract"
+        )
+
+
+@pytest.mark.ui_e2e
+def test_swept_general_enable_cb_renders_on_when_stored_and_off_when_absent(
+    smoke_vm: SmokeVM, webui: WebUI, node_state: Callable[[str, str | None], None]
+) -> None:
+    """issue #2812: the General page's master-enable checkbox with no stored key
+    renders UNCHECKED (registered '' default); a stored 'on' renders CHECKED."""
+    node_state(CFG_ENABLE_CB, "on")
+    html = _render(smoke_vm, webui, _GENERAL_SETTINGS_PAGE, "General Settings")
+    assert _checkbox_is_checked(html, "enable_cb"), "control: a stored 'on' enable_cb must render checked"
+
+    node_state(CFG_ENABLE_CB, None)
+    html = _render(smoke_vm, webui, _GENERAL_SETTINGS_PAGE, "General Settings")
+    assert not _checkbox_is_checked(html, "enable_cb"), (
+        "an absent enable_cb must render UNCHECKED -- the registered '' default "
+        "must reproduce the page default #2812 deleted"
+    )

--- a/tests/test_toggle_registry_check.py
+++ b/tests/test_toggle_registry_check.py
@@ -322,3 +322,37 @@ def test_whitespace_between_brackets_does_not_evade_either_rule() -> None:
     assert _rules(save) == ["unregistered-toggle"]
     read = mirror + "$pconfig['enable_dup'] = $pfb ['iconfig'] ['enable_dup'] ?: '';\n"
     assert _rules(read) == ["page-level-default"]
+
+
+# --------------------------------------------------------------------------- #
+# Issue #2812 -- the recorded RULE 2 backlog is swept, not merely recorded
+# --------------------------------------------------------------------------- #
+
+
+def test_exempt_table_is_empty_after_the_2812_sweep() -> None:
+    """Every #2812 residue row was swept, so the recorded backlog ends empty.
+
+    EXEMPT records deliberate, still-live duplication. Once issue #2812 routed the
+    seven pre-registered toggle sites through PfbConfig::read(), no duplication is
+    deliberate any more and the table must hold no rows: a re-added row would
+    re-license a page default the registry owns.
+    """
+    assert ctr.EXEMPT == {}, (
+        "EXEMPT rows remain after issue #2812's sweep "
+        f"(route them through PfbConfig::read() and delete them): {sorted(ctr.EXEMPT)}"
+    )
+
+
+def test_www_tree_is_clean_with_the_exempt_table_emptied(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The real pages carry no RULE 2 residue at all -- not one hidden by a row.
+
+    Issue #2812's acceptance clause: with an empty EXEMPT table the gate still
+    exits 0, so the sweep is proven against the live tree, not against the
+    record of it.
+    """
+    monkeypatch.setattr(ctr, "EXEMPT", {})
+    assert ctr.main([]) == 0, (
+        "src/usr/local/www/pfblockerng still carries page-level toggle defaults: issue #2812's sweep is incomplete"
+    )


### PR DESCRIPTION
Fixes #2812. Replacement for closed #2972 (unmerged — the bulk `devel` rewrite created disjoint histories under its head, so the exact reviewed patch is replayed here rather than rebased).

## Recovery / replay evidence

The branch was reconstructed from the exact final prepared head `394ab92b` of #2972 (recovered intact from the local worktree and `origin/issue-2812-toggle-page-default-sweep`, both still at that SHA):

- **Merge base visible:** replayed onto current `origin/devel` @ `f6a2e857` (parent of the new head). The old line of development (`149caa67`) has no common ancestor with the rewritten `devel` (`git merge-base` = NONE), so the patch was replayed by 3-way cherry-pick, not rebase of the old commit.
- **Byte identity:** all six changed blobs are byte-identical to `394ab92b` — `git diff 394ab92b HEAD -- <six files>` is empty; per-file blob hashes below match the Frozen RED table exactly:
  - `scripts/check_toggle_registry.py` → `6cc0185d8`
  - `src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php` → `aa5947302`
  - `src/usr/local/www/pfblockerng/pfblockerng_general.php` → `ac16da0d0`
  - `tests/php/CfgToggleRegistryPageParityTest.php` → `8a528b246`
  - `tests/smoke/ui/test_toggle_registry_default_render.py` → `a1e5b0247`
  - `tests/test_toggle_registry_check.py` → `624701cda`
- **Patch identity:** `git patch-id --stable` = `c57fa9b9a7ab4c99c76f9d4412d99359177fc39b`, identical to #2972's final six-file head (the pre-UI-amendment five-file patch-id recorded on that PR was `3094e52d`).
- **Signature:** new head `479e8a72` authored and committed as Andre Brait <andrebrait@gmail.com>; author date preserved from `394ab92b`; pushed with `--force-with-lease` against the recorded old value `394ab92b`.
- **Gate evidence carried, not re-run:** the prior test/gate evidence below is byte-frozen to these exact file hashes (the runs quoted executed these bytes), so it remains valid for the replay; fresh exact-head CI on `479e8a72` is the new execution gate.

## What

Sweeps the last seven registered **toggle** sites whose pages still restate the default the registry owns (the residue #2123's regrowth gate exempted):

- `pfblockerng_dnsbl.php:52,:58,:59,:89,:91,:95` (`dnsbl/pfb_dnsbl`, `pfb_dnsvip_auto`, `pfb_dnsbl_nonat`, `pfb_idn_escalate_suspicious`, `pfb_regex_cap`, `pfb_dnsbl_lenient`)
- `pfblockerng_general.php:51` (`gen/enable_cb`)

Each site now reads through `PfbConfig::read()`, and the checker's `EXEMPT` table is emptied — `EXEMPT = {}` — so RULE 2 stays blocking with zero exemptions.

## Behaviour equivalence

- Six sites declared the same token twice; the seventh (`pfb_dnsbl_lenient`) declared `''` in the page vs `'off'` in the registry — both spell the same state under the #2120 toggle contract, and its `grandfather => [ABSENT => 'on']` arm means post-install configurations have the key present anyway.
- All seven consumers re-normalize via `pfb_cfg_toggle_read(...) === PfbToggle::On`; `fromStored` is enum-idempotent, so routing the read through `PfbConfig::read()` cannot change what consumers see.
- Saves read `$_POST` only, independent of `$pconfig`, so the enum value cannot leak into writes.

## Verification

- `python3 scripts/check_toggle_registry.py` exits 0 with `EXEMPT` empty; `--self-test` red canary still fires for both rules.
- Focused PHPUnit: `CfgToggleRegistryPageParityTest` — new 7×9 parity matrix (gateway read equals the pre-sweep page expression for every raw stored state) plus the registered-toggle/defaults guard — green with the #2817 regression suites.
- Tier-A `ui_render`: `test_toggle_registry_default_render.py` gains the swept toggles' checked-state coverage (stored-`'on'` control renders CHECKED; absent key renders UNCHECKED; the lenient key's two Off spellings both render UNCHECKED), executed by the labelled `ui-tests` CI row.
- `php -l`, phpcs, ruff, mypy all pass.

### Frozen RED evidence (coverage-pairing gate)

One row per changed test-side path. Hashes are `git hash-object` on the shipped file, which is byte-identical to what the quoted run executed (re-verified for this replay, hashes above).

| Frozen RED test | git hash-object | RED run tail |
| --- | --- | --- |
| `tests/test_toggle_registry_check.py` | `624701cda6b341a6573686b89ea8c6780281e588` | Shipped file run against the parent tree (`149caa67`): `2 failed, 23 passed in 0.16s` — `test_exempt_table_is_empty_after_the_2812_sweep` and `test_www_tree_is_clean_with_the_exempt_table_emptied` fail, and the checker names all seven sites (`pfblockerng_dnsbl.php:52`, `:58`, `:59`, `:89`, `:91`, `:95`, `pfblockerng_general.php:51`). |
| `tests/php/CfgToggleRegistryPageParityTest.php` | `8a528b2462384b98dc8b250f7c9d2ea980b1aa6d` | No parent-tree RED exists by design — these additions pin the equivalence **premise** (`PfbConfig::read` equals the pre-sweep `?: ''` expression for every raw state), so they are green-on-arrival. Quoted failing run is the executed M2 mutation on the shipped file: registry default of `pfb_dnsbl_lenient` flipped `off`→`on` → `FAILURES! Tests: 221, Assertions: 593, Failures: 2.` — `registered default flipped from the recorded value` (`- 'off' + 'on'`). |
| `tests/smoke/ui/test_toggle_registry_default_render.py` | `a1e5b0247ca75adae1709ac0be3c5674829c8e3e` | NOT executed locally and not claimed as executed: Tier-A `ui_render` needs a leased CE box (`smoke_vm`/`webui` fixtures). RED reason: none is possible — the sweep is behaviour-equivalent, so the rendered checked state is identical before and after on every toggle-contract state (that premise is what the parity matrix pins); these tests pin the end-state observable. Executed by the labelled `ui-tests` CI row. |

## Out of scope

Issue work item 2 (plain-scalar divergences: `pfb_dnsport` `?: '8081'`, `pfb_dnsvip4/6` `?: 'none'`, `pfb_dnsbl_rule`, `aliaslog`, …) needs per-site authority decisions and stays untouched, exactly as #2812 scopes it. It now has its own v4.0.0 ticket: #2994 (parented under the v4.0.0 backlog tracker, #1974) — merging this PR closes #2812 for the toggle sweep only; #2994 stays open.

🤖 Generated by Oh My Pi and posted on behalf of @andrebrait.
