### PR TITLE
Release: skip Graphify for tag pushes

### DIFF
--- a/.agents/context/repository-intelligence.md
+++ b/.agents/context/repository-intelligence.md
@@ -34,7 +34,7 @@ Load when: every agent session, from `AGENTS.md`.
   reports success. Until upstream releases Graphify-Labs/graphify#3075, that fix rides
   as `.agents/patches/graphify-3075-language-overrides.patch`, applied to the installed
   package by `scripts/agent/patch-graphify.sh` from its two call sites:
-  `ensure-graphify-merge-driver.sh` (the entry point 8 CI workflows use) and
+  `ensure-graphify-merge-driver.sh` (the entry point seven branch/content mutation workflows use) and
   `init-worktree-tools.sh`, before it refreshes the graph. It patches only the package
   owned by the interpreter named on the `graphify` shebang, so a `pip --user` or
   PYTHONPATH-only Graphify is skipped rather than patched — caught by the tracked

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -821,7 +821,6 @@ jobs:
             fi
             echo "Tag ${TAG} already at ${SHA} — reusing it (resuming a run that crashed after tagging)."
           else
-            # Compatibility oracle: git tag -a "$TAG" -m "$TAG" "$SHA"
             MESSAGE=$(mktemp)
             printf '%s\n\n' "$TAG" | git interpret-trailers \
               --trailer "pfBlockerNG-Release-Channel: ${CHANNEL}" > "$MESSAGE"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -784,12 +784,6 @@ jobs:
           fetch-depth: 0             # full history + tags: the resume check below
           persist-credentials: true  # need to push the tag via GITHUB_TOKEN
 
-      - name: Set up uv
-        uses: astral-sh/setup-uv@v7
-
-      - name: Install the Graphify merge driver
-        run: sh scripts/agent/ensure-graphify-merge-driver.sh .
-
       - name: Create + push the tag on the verified commit
         id: tag
         # RESUME semantics, narrowed to the crash-after-tag window: the only

--- a/graphify-out/memory/query_20260831_134649_issue_2997_release_tag_only_mutation_graphify_merg.md
+++ b/graphify-out/memory/query_20260831_134649_issue_2997_release_tag_only_mutation_graphify_merg.md
@@ -1,0 +1,17 @@
+---
+type: "query"
+date: "2026-08-31T13:46:49.105902+00:00"
+question: "Issue 2997 release tag-only mutation Graphify merge-driver inventory and tests"
+contributor: "graphify"
+outcome: "useful"
+---
+
+# Q: Issue 2997 release tag-only mutation Graphify merge-driver inventory and tests
+
+## Answer
+
+The exhaustive driver inventory treated refs/tags pushes as content mutations. release/3.3 contains no Graphify files, and tag-release only pushes an annotated tag ref, so the tag job should be excluded while seven branch/content mutation jobs remain guarded.
+
+## Outcome
+
+- Signal: useful

--- a/tests/test_ci_graphify_merge_driver.py
+++ b/tests/test_ci_graphify_merge_driver.py
@@ -25,7 +25,9 @@ _GIT_MUTATION_RE = re.compile(
 )
 _GH_MUTATION_RE = re.compile(r"^gh\s+pr\s+merge(?:\s|$)")
 _WRAPPER_MUTATION_RE = re.compile(r"^sh\s+\S*scripts/(?:publish-pkg-repo|render-pkg-site)\.sh(?:\s|$)")
-_TAG_ONLY_PUSH_RE = re.compile(r"""^git\s+push\s+origin\s+["']?refs/tags/""")
+_TAG_ONLY_PUSH_RE = re.compile(
+    r"""^git\s+push\s+origin\s+(?:"refs/tags/[^"\s:]+"|'refs/tags/[^'\s:]+'|refs/tags/[^\s:]+)$"""
+)
 
 
 @dataclass(frozen=True)
@@ -326,6 +328,24 @@ def test_tag_ref_push_does_not_require_a_content_merge_driver() -> None:
     command = 'git push origin "refs/tags/${TAG}"'
     job = f"      - name: Push tag\n        run: {command}\n"
     assert _first_mutation(_steps(job)) is None
+
+
+@pytest.mark.parametrize(
+    "command",
+    (
+        "git push origin refs/tags/v1 refs/heads/main",
+        "git push origin refs/tags/",
+        "git push origin refs/tags/v1:refs/heads/main",
+        'git push origin "refs/tags/v1" "HEAD:refs/heads/main"',
+        "git push origin refs/tags/v1 && git push origin main",
+        "git push --atomic origin refs/tags/v1",
+        "env TOKEN=x git push origin refs/tags/v1",
+        "git push origin HEAD:refs/heads/refs/tags/main",
+    ),
+)
+def test_tag_ref_exemption_rejects_non_tag_only_pushes(command: str) -> None:
+    job = f"      - name: Push\n        run: {command}\n"
+    assert _first_mutation(_steps(job)) == (0, command)
 
 
 def test_driver_scanner_distinguishes_a_nonmutating_job() -> None:

--- a/tests/test_ci_graphify_merge_driver.py
+++ b/tests/test_ci_graphify_merge_driver.py
@@ -25,6 +25,7 @@ _GIT_MUTATION_RE = re.compile(
 )
 _GH_MUTATION_RE = re.compile(r"^gh\s+pr\s+merge(?:\s|$)")
 _WRAPPER_MUTATION_RE = re.compile(r"^sh\s+\S*scripts/(?:publish-pkg-repo|render-pkg-site)\.sh(?:\s|$)")
+_TAG_ONLY_PUSH_RE = re.compile(r"""^git\s+push\s+origin\s+["']?refs/tags/""")
 
 
 @dataclass(frozen=True)
@@ -78,13 +79,6 @@ PUSH_JOBS = (
         "sh scripts/agent/ensure-graphify-merge-driver.sh .",
         'git push --force origin "$1"',
         checkout_groups=(("uses: actions/checkout@v6",),),
-    ),
-    PushJob(
-        "release.yml",
-        "tag-release",
-        "sh scripts/agent/ensure-graphify-merge-driver.sh .",
-        'git push origin "refs/tags/${TAG}"',
-        checkout_groups=(("uses: actions/checkout@v6", "ref: ${{ needs.prepare-release.outputs.sha }}"),),
     ),
     PushJob(
         "release-published.yml",
@@ -150,6 +144,8 @@ def _command_step(steps: list[str], command: str, label: str) -> int:
 def _first_mutation(steps: list[str]) -> tuple[int, str] | None:
     for index, step in enumerate(steps):
         for command in _run_commands(step):
+            if _TAG_ONLY_PUSH_RE.match(command):
+                continue
             if _GIT_MUTATION_RE.match(command) or _GH_MUTATION_RE.match(command) or _WRAPPER_MUTATION_RE.match(command):
                 return index, command
     return None
@@ -223,12 +219,12 @@ def _discovered_driver_jobs() -> set[tuple[str, str]]:
 
 def test_exhaustive_push_matrix_has_graphify_driver_before_each_mutation() -> None:
     expected = {(spec.workflow, spec.job) for spec in PUSH_JOBS}
-    assert len(PUSH_JOBS) == len(expected) == 8, "issue #2713 defines 8 unique mutating jobs"
+    assert len(PUSH_JOBS) == len(expected) == 7, "issue #2713 defines 7 branch/content mutation jobs"
     assert _discovered_mutation_jobs() == expected, (
-        "the workflow push/pull/merge inventory changed; update the issue #2713 matrix"
+        "the workflow branch/content push/pull/merge inventory changed; update the issue #2713 matrix"
     )
     assert _discovered_driver_jobs() == expected, (
-        "Graphify merge-driver setup exists outside the 8 push/pull/merge jobs"
+        "Graphify merge-driver setup exists outside the 7 branch/content mutation jobs"
     )
 
     failures: list[str] = []
@@ -324,6 +320,12 @@ def test_comments_cannot_spoof_tool_pins_or_checkout_paths() -> None:
 def test_mutation_scanner_recognizes_every_guarded_command_class(command: str) -> None:
     job = f"      - name: Mutate\n        run: {command}\n"
     assert _first_mutation(_steps(job)) == (0, command)
+
+
+def test_tag_ref_push_does_not_require_a_content_merge_driver() -> None:
+    command = 'git push origin "refs/tags/${TAG}"'
+    job = f"      - name: Push tag\n        run: {command}\n"
+    assert _first_mutation(_steps(job)) is None
 
 
 def test_driver_scanner_distinguishes_a_nonmutating_job() -> None:

--- a/tests/test_release_tag_after_verify.py
+++ b/tests/test_release_tag_after_verify.py
@@ -282,12 +282,10 @@ def test_prepare_release_pins_a_sha_output() -> None:
     )
 
 
-def test_tag_release_creates_the_tag_on_the_pinned_sha() -> None:
-    jobs = _jobs()
-    script = _step_run_script(_step(jobs["tag-release"], "Create + push the tag on the verified commit"))
-    assert 'git tag -a "$TAG" -m "$TAG" "$SHA"' in script, (
-        f"the tag must be created ON the pinned SHA (the channel branch may have moved), got:\n{script}"
-    )
+def test_tag_release_creates_an_annotated_tag_on_the_pinned_sha() -> None:
+    script = _step_run_script(_step(_jobs()["tag-release"], "Create + push the tag on the verified commit"))
+    commands = {line.strip() for line in script.splitlines() if line.strip() and not line.lstrip().startswith("#")}
+    assert 'git tag -a "$TAG" -F "$MESSAGE" "$SHA"' in commands, commands
 
 
 @pytest.mark.parametrize("job", ["resolve-stamp", "build-pkgs-portable", "release"])
@@ -1077,13 +1075,18 @@ def _run_tag_step(repo: Path, tag: str, sha: str) -> subprocess.CompletedProcess
     )
 
 
-def test_tag_step_creates_and_pushes_the_tag_on_the_pinned_sha(tmp_path: Path) -> None:
-    repo, head, _older = _tag_repo(tmp_path)
-    result = _run_tag_step(repo, "v9.9.9.r1", head)
+def test_tag_step_creates_and_pushes_an_annotated_tag_on_the_pinned_sha(tmp_path: Path) -> None:
+    repo, head, older = _tag_repo(tmp_path)
+    assert head != older
+    result = _run_tag_step(repo, "v9.9.9.r1", older)
     assert result.returncode == 0, result.stdout + result.stderr
-    assert _git(repo, "rev-list", "-n", "1", "refs/tags/v9.9.9.r1") == head
-    assert "v9.9.9.r1" in _git(repo, "ls-remote", "--tags", "origin")
-    assert f"sha={head}" in (repo / "gh_output").read_text()
+    origin = Path(_git(repo, "remote", "get-url", "origin"))
+    assert _git(origin, "cat-file", "-t", "refs/tags/v9.9.9.r1") == "tag"
+    assert _git(origin, "rev-parse", "refs/tags/v9.9.9.r1^{commit}") == older
+    contents = _git(origin, "for-each-ref", "--format=%(contents)", "refs/tags/v9.9.9.r1")
+    trailers = [line for line in contents.splitlines() if line.startswith("pfBlockerNG-Release-Channel:")]
+    assert trailers == ["pfBlockerNG-Release-Channel: testing"]
+    assert f"sha={older}" in (repo / "gh_output").read_text()
 
 
 def test_tag_step_resumes_a_tag_that_already_points_at_the_verified_sha(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- classify only one exact direct `refs/tags/*` refspec as tag-only
- keep Graphify merge-driver enforcement on all seven branch/content mutation jobs
- remove unused Graphify setup from the historical-source tag job
- strengthen annotated-tag, pinned-SHA, and channel-trailer behavior tests

## Evidence

Final test bytes replayed against pre-fix `devel@cd425d0f9af8162894de2297a3559e148d283454`:

| Frozen RED test | git hash-object | RED run tail |
| --- | --- | --- |
| `tests/test_ci_graphify_merge_driver.py` | `21be56a64e20329ab2ae6b72f3f15e0f0bd7d72b` | `pytest: 1 failed, 143 passed in 4.17s; release.yml:tag-release remained an extra driver job` |
| `tests/test_release_tag_after_verify.py` | `2d5f3626184ce6d9a0bdd255551958fa842545a5` | `pytest: 1 failed, 143 passed in 4.17s` |

GREEN at `83b224b79e60cece7faa025af31c84842a690678`:

- exact frozen pair: 144 passed
- release workflow suites: 242 passed
- hostile classifier mutation: 5/10 failed before hardening, 10/10 passed after
- `actionlint .github/workflows/release.yml`: passed
- canonical selected gates: passed

Run 33394476239 built all five Stable package legs, then proved the historical source lacks the removed helper before any tag or draft was created.

Fixes #2997

🤖 Generated by Oh My Pi and posted on behalf of @andrebrait.