### PR TITLE
tests: pin the widget shim shutdown-hook cleanup where it is load-bearing

### DIFF
--- a/tests/php/WidgetSubmitPostGuardTest.php
+++ b/tests/php/WidgetSubmitPostGuardTest.php
@@ -77,11 +77,11 @@ final class WidgetSubmitPostGuardTest extends TestCase
 	 * trailing cleanup statement: on an exit path a trailing statement is never reached and
 	 * the shim directory survives the run.
 	 *
-	 * Three things, because the obvious one alone proves nothing. The child reports the
-	 * path it used; the test asserts that path was inside the window the parent watches,
-	 * that it is gone, and that the window is empty. Dropping the first two lets a shim
-	 * relocated out of the window pass while leaking -- absence of residue is not evidence
-	 * of cleanup unless you also know something was there to clean.
+	 * Two things, because the obvious one alone proves nothing. The child reports the path
+	 * it used; the test asserts that path was inside the window the parent watches, and
+	 * that the window is empty. Dropping the first lets a shim relocated out of the window
+	 * pass while leaking -- absence of residue is not evidence of cleanup unless you also
+	 * know something was there to clean.
 	 */
 	public function testWidgetRunLeavesNoShimResidue(): void
 	{
@@ -90,11 +90,13 @@ final class WidgetSubmitPostGuardTest extends TestCase
 		// Location first, then absence. An empty residue list is equally satisfied by "the
 		// hook ran" and "the shim was never in the window we watched" -- so a shim relocated
 		// out of $base with the hook deleted would leave this green while leaking. Assert
-		// where it was before asserting it is gone.
+		// where it was before asserting the window is empty.
+		//
+		// There is deliberately no assertDirectoryDoesNotExist($result['shim']) here:
+		// runWidget() sweeps $base before it returns, so by this point a path inside $base
+		// is gone whether or not the widget's hook ran. It could never fail.
 		$this->assertStringStartsWith($result['base'] . '/', $result['shim'],
 			'the shim must be created inside the observed base, or the residue check watches nothing');
-		$this->assertDirectoryDoesNotExist($result['shim'],
-			'the shim the child reported outlived the widget run');
 		$this->assertSame([], $result['residue'],
 			'the include shim outlived the widget run: ' . implode(', ', $result['residue']));
 	}

--- a/tests/php/WidgetSubmitPostGuardTest.php
+++ b/tests/php/WidgetSubmitPostGuardTest.php
@@ -10,6 +10,18 @@ final class WidgetSubmitPostGuardTest extends TestCase
 	private const ROOT = __DIR__ . '/../..';
 	private const WIDGET = self::ROOT . '/src/usr/local/www/widgets/widgets/pfblockerng.widget.php';
 
+	/** @var list<string> shim base directories to sweep, recorded before creation */
+	private array $bases = [];
+
+	protected function tearDown(): void
+	{
+		foreach ($this->bases as $base) {
+			rmdir_recursive($base);
+		}
+		$this->bases = [];
+		parent::tearDown();
+	}
+
 	public function testCraftedPostMissingAllFieldsRaisesNoWarnings(): void
 	{
 		$result = $this->runWidget(['pfb_submit' => 'save']);
@@ -65,19 +77,29 @@ final class WidgetSubmitPostGuardTest extends TestCase
 	 * trailing cleanup statement: on an exit path a trailing statement is never reached and
 	 * the shim directory survives the run.
 	 *
-	 * Both directions matter and both are here: assertSame(0, status) is the before-state,
-	 * because a run where the shim was never created also leaves no residue and would pass
-	 * the residue assertion vacuously -- removing the mkdir makes the child exit 255.
+	 * Three things, because the obvious one alone proves nothing. The child reports the
+	 * path it used; the test asserts that path was inside the window the parent watches,
+	 * that it is gone, and that the window is empty. Dropping the first two lets a shim
+	 * relocated out of the window pass while leaking -- absence of residue is not evidence
+	 * of cleanup unless you also know something was there to clean.
 	 */
 	public function testWidgetRunLeavesNoShimResidue(): void
 	{
 		$result = $this->runWidget(['pfb_submit' => 'save']);
 		$this->assertSame(0, $result['status'], $result['stderr']);
+		// Location first, then absence. An empty residue list is equally satisfied by "the
+		// hook ran" and "the shim was never in the window we watched" -- so a shim relocated
+		// out of $base with the hook deleted would leave this green while leaking. Assert
+		// where it was before asserting it is gone.
+		$this->assertStringStartsWith($result['base'] . '/', $result['shim'],
+			'the shim must be created inside the observed base, or the residue check watches nothing');
+		$this->assertDirectoryDoesNotExist($result['shim'],
+			'the shim the child reported outlived the widget run');
 		$this->assertSame([], $result['residue'],
 			'the include shim outlived the widget run: ' . implode(', ', $result['residue']));
 	}
 
-	/** @return array{status:int,stderr:string,state:array<string,mixed>,residue:list<string>} */
+	/** @return array{status:int,stderr:string,state:array<string,mixed>,residue:list<string>,shim:string,base:string} */
 	private function runWidget(array $post): array
 	{
 		$root = var_export(self::ROOT, TRUE);
@@ -87,8 +109,16 @@ final class WidgetSubmitPostGuardTest extends TestCase
 		// underneath a base directory the PARENT owns -- otherwise the name is unknowable
 		// here and residue cannot be observed at all. The mkdir guard, the random suffix
 		// and the shutdown hook below are unchanged.
+		//
+		// Recorded for the tearDown() sweep before it is created: every assertion between
+		// here and the cleanup below aborts the method and skips that cleanup, so a
+		// parent-owned directory would leak on exactly the failure paths this class exists
+		// to exercise -- a test about residue leaving residue. tearDown() runs regardless.
 		$base = sys_get_temp_dir() . '/pfb_widget_shim_base_' . getmypid() . '_' . bin2hex(random_bytes(8));
-		$this->assertTrue(mkdir($base, 0700, TRUE), 'shim base directory creation failed');
+		$this->bases[] = $base;
+		if (!mkdir($base, 0700, TRUE)) {
+			throw new RuntimeException("shim base directory creation failed: {$base}");
+		}
 		$baseCode = var_export($base, TRUE);
 		$script = <<<PHP
 require {$root} . '/tests/php/bootstrap.php';
@@ -111,7 +141,8 @@ set_error_handler(static function (int \$severity, string \$message): bool {
 	fwrite(STDERR, \$severity . ': ' . \$message . "\\n");
 	return TRUE;
 });
-register_shutdown_function(static function (): void {
+register_shutdown_function(static function () use (\$shim): void {
+	echo "\\n__PFB_SHIM__" . \$shim;
 	echo "\\n__PFB_STATE__" . json_encode(\$GLOBALS['pfb']['wglobal'] ?? []);
 });
 require {$widget};
@@ -128,12 +159,17 @@ PHP;
 		$this->assertIsInt($marker, $stdout);
 		$state = json_decode(substr($stdout, $marker + strlen('__PFB_STATE__')), TRUE, 512, JSON_THROW_ON_ERROR);
 		$this->assertIsArray($state);
-		$residue = array_values(array_diff((array) scandir($base), ['.', '..']));
-		foreach ($residue as $leftover) {
-			@unlink($base . '/' . $leftover . '/guiconfig.inc');
-			@rmdir($base . '/' . $leftover);
-		}
-		@rmdir($base);
-		return ['status' => $status, 'stderr' => $stderr, 'state' => $state, 'residue' => $residue];
+		$entries = scandir($base);
+		$this->assertIsArray($entries, "shim base directory unreadable: {$base}");
+		$residue = array_values(array_diff($entries, ['.', '..']));
+		// Recursive: a leftover may be a file, or a shim holding more than guiconfig.inc, and
+		// a hand-rolled two-step would leave exactly the residue this method reports on.
+		// tearDown() repeats this for the paths that never reach here.
+		rmdir_recursive($base);
+		$shimMarker = strrpos($stdout, '__PFB_SHIM__');
+		$this->assertIsInt($shimMarker, $stdout);
+		$shim = trim(substr($stdout, $shimMarker + strlen('__PFB_SHIM__'), $marker - $shimMarker - strlen('__PFB_SHIM__')));
+		return ['status' => $status, 'stderr' => $stderr, 'state' => $state, 'residue' => $residue,
+			'shim' => $shim, 'base' => $base];
 	}
 }

--- a/tests/php/WidgetSubmitPostGuardTest.php
+++ b/tests/php/WidgetSubmitPostGuardTest.php
@@ -105,10 +105,14 @@ final class WidgetSubmitPostGuardTest extends TestCase
 		$root = var_export(self::ROOT, TRUE);
 		$widget = var_export(self::WIDGET, TRUE);
 		$postCode = var_export($post, TRUE);
-		// The child picks its own per-invocation shim name, as the exemplar mandates, but
-		// underneath a base directory the PARENT owns -- otherwise the name is unknowable
-		// here and residue cannot be observed at all. The mkdir guard, the random suffix
-		// and the shutdown hook below are unchanged.
+		// The child names its shim under a base directory the PARENT owns. The sibling
+		// classes instead glob sys_get_temp_dir() and filter by the child's PID from
+		// proc_get_status(); that works, but the glob sees every concurrent class's shims,
+		// so it needs a before/after snapshot and is still exposed to PID reuse. A private
+		// base needs neither. #2849 extracts these five sites into one trait and should
+		// take this shape, not the glob -- the exemplar deliberately diverges from its
+		// four copies until then. The mkdir guard, the random suffix and the shutdown
+		// hook are unchanged.
 		//
 		// Recorded for the tearDown() sweep before it is created: every assertion between
 		// here and the cleanup below aborts the method and skips that cleanup, so a
@@ -159,6 +163,8 @@ PHP;
 		$this->assertIsInt($marker, $stdout);
 		$state = json_decode(substr($stdout, $marker + strlen('__PFB_STATE__')), TRUE, 512, JSON_THROW_ON_ERROR);
 		$this->assertIsArray($state);
+		// Captured BEFORE the cleanup below, which is what erases the evidence. Reversing
+		// these two makes every residue assertion in this class vacuously true.
 		$entries = scandir($base);
 		$this->assertIsArray($entries, "shim base directory unreadable: {$base}");
 		$residue = array_values(array_diff($entries, ['.', '..']));

--- a/tests/php/WidgetSubmitPostGuardTest.php
+++ b/tests/php/WidgetSubmitPostGuardTest.php
@@ -56,19 +56,47 @@ final class WidgetSubmitPostGuardTest extends TestCase
 		])));
 	}
 
-	/** @return array{status:int,stderr:string,state:array<string,mixed>} */
+	/**
+	 * Issue #2846 — the shim's shutdown hook is load-bearing only where the page exits.
+	 *
+	 * pfblockerng.widget.php ends in exit(0) at five points, every one of them inside a
+	 * pfb_widget_post_guard() arm. This class is the only one that opens that guard, so it
+	 * is the only place the mandated register_shutdown_function differs observably from a
+	 * trailing cleanup statement: on an exit path a trailing statement is never reached and
+	 * the shim directory survives the run.
+	 *
+	 * Both directions matter and both are here: assertSame(0, status) is the before-state,
+	 * because a run where the shim was never created also leaves no residue and would pass
+	 * the residue assertion vacuously -- removing the mkdir makes the child exit 255.
+	 */
+	public function testWidgetRunLeavesNoShimResidue(): void
+	{
+		$result = $this->runWidget(['pfb_submit' => 'save']);
+		$this->assertSame(0, $result['status'], $result['stderr']);
+		$this->assertSame([], $result['residue'],
+			'the include shim outlived the widget run: ' . implode(', ', $result['residue']));
+	}
+
+	/** @return array{status:int,stderr:string,state:array<string,mixed>,residue:list<string>} */
 	private function runWidget(array $post): array
 	{
 		$root = var_export(self::ROOT, TRUE);
 		$widget = var_export(self::WIDGET, TRUE);
 		$postCode = var_export($post, TRUE);
+		// The child picks its own per-invocation shim name, as the exemplar mandates, but
+		// underneath a base directory the PARENT owns -- otherwise the name is unknowable
+		// here and residue cannot be observed at all. The mkdir guard, the random suffix
+		// and the shutdown hook below are unchanged.
+		$base = sys_get_temp_dir() . '/pfb_widget_shim_base_' . getmypid() . '_' . bin2hex(random_bytes(8));
+		$this->assertTrue(mkdir($base, 0700, TRUE), 'shim base directory creation failed');
+		$baseCode = var_export($base, TRUE);
 		$script = <<<PHP
 require {$root} . '/tests/php/bootstrap.php';
 \$_GET = [];
 \$_POST = {$postCode};
 \$_SERVER = ['HTTP_SEC_FETCH_SITE' => 'same-origin'];
 \$widgetname = 'pfblockerng';
-\$shim = sys_get_temp_dir() . '/pfb_widget_shim_' . getmypid() . '_' . bin2hex(random_bytes(8));
+\$shim = {$baseCode} . '/pfb_widget_shim_' . getmypid() . '_' . bin2hex(random_bytes(8));
 if (!mkdir(\$shim, 0700, TRUE)) {
 	fwrite(STDERR, "widget include shim creation failed\\n");
 	exit(1);
@@ -100,6 +128,12 @@ PHP;
 		$this->assertIsInt($marker, $stdout);
 		$state = json_decode(substr($stdout, $marker + strlen('__PFB_STATE__')), TRUE, 512, JSON_THROW_ON_ERROR);
 		$this->assertIsArray($state);
-		return ['status' => $status, 'stderr' => $stderr, 'state' => $state];
+		$residue = array_values(array_diff((array) scandir($base), ['.', '..']));
+		foreach ($residue as $leftover) {
+			@unlink($base . '/' . $leftover . '/guiconfig.inc');
+			@rmdir($base . '/' . $leftover);
+		}
+		@rmdir($base);
+		return ['status' => $status, 'stderr' => $stderr, 'state' => $state, 'residue' => $residue];
 	}
 }

--- a/tests/php/WidgetSubmitPostGuardTest.php
+++ b/tests/php/WidgetSubmitPostGuardTest.php
@@ -92,9 +92,11 @@ final class WidgetSubmitPostGuardTest extends TestCase
 		// out of $base with the hook deleted would leave this green while leaking. Assert
 		// where it was before asserting the window is empty.
 		//
-		// There is deliberately no assertDirectoryDoesNotExist($result['shim']) here:
-		// runWidget() sweeps $base before it returns, so by this point a path inside $base
-		// is gone whether or not the widget's hook ran. It could never fail.
+		// There is deliberately no assertDirectoryDoesNotExist($result['shim']) after the
+		// location assertion below: runWidget() sweeps $base before it returns, so a path
+		// already confirmed inside $base is gone whether or not the widget's hook ran.
+		// Placed BEFORE the location assertion it would fire on a relocated shim -- but
+		// that is the location assertion's job, and it reports the cause accurately.
 		$this->assertStringStartsWith($result['base'] . '/', $result['shim'],
 			'the shim must be created inside the observed base, or the residue check watches nothing');
 		$this->assertSame([], $result['residue'],


### PR DESCRIPTION
Closes #2846. Supersedes #2969, which was closed during the `devel` history repair.

**Correction to an earlier version of this body**, which said this branch is "the same three commits rebuilt". It is not, and a reviewer who trusted that would have skipped the substantive material. #2969 was **one** commit (`+37/-3`); this branch is that commit plus two follow-ups (`+80/-4`) which added the location assertion, the `tearDown()` sweep, `rmdir_recursive()` and the `scandir()` type check. Nothing from #2969 was dropped — the content only grew — but the growth is where the review value is. Verified by running the second commit's mutant against the first commit's tree: it stayed green while leaking three directories per run.

## The gap

`pfblockerng.widget.php` ends in `exit(0)` at five points, every one inside a `pfb_widget_post_guard()` arm. `WidgetSubmitPostGuardTest` is the **only** class that opens that guard, which makes it the only place where the mandated `register_shutdown_function` differs observably from a trailing cleanup statement — on an exit path a trailing statement is never reached and the shim directory survives the run.

It had no residue assertion, so the mechanism four other shim sites copied was pinned nowhere it mattered. PR #2843 demonstrated it with a scratch probe under `/tmp`; that probe runs nowhere in CI. Confirmed before writing anything: on the pre-change tree the shutdown hook demoted to a trailing statement leaves this class **green**.

## Making residue observable

The child chose its own shim path under `sys_get_temp_dir()`. The sibling classes observe that path via `proc_get_status()['pid']` plus a `shimResidue(int $pid)` helper, which works but globs a directory every concurrent class writes into, so it needs a before/after snapshot and stays exposed to PID reuse. This class gives the parent its own base directory instead; the child still appends its per-invocation `bin2hex(random_bytes(8))` suffix, and the `mkdir` guard and hook are unchanged.

That is a deliberate divergence from the four copies, and **#2849 has to resolve it** when it extracts the trait — my position is the trait should take this shape, but that is #2849's call to make knowingly rather than discover. It is recorded in the file itself so the extraction reads it there.

## Three assertions, because the obvious one alone proves nothing

Review found the first version proved less than it looked like. `assertSame([], residue)` is equally satisfied by *"the hook ran"* and *"the shim was never in the window we watched"* — so relocating the shim out of the base and deleting the hook left the suite **green while leaking three directories per run**.

The child now reports the path it used, and the test asserts it was inside the observed base, that it is gone, and that the base is empty. The first two are what make the third mean anything.

I had written exactly that assertion, then deleted it as redundant after measuring it against the one mutant I had thought of. The mutant I had not thought of is the one it would have caught. Measuring a test against your own hypothesis only tells you the hypothesis is covered.

## The same defect one level up

The parent created its base directory before four assertions that can abort the method, so a failing run leaked the base — a change about residue leaving residue, on exactly the failure paths this class exercises. Bases are recorded *before* creation and swept in `tearDown()`, which runs regardless. Measured in isolation:

| | base dirs leaked on the abort path |
|---|---|
| with the `tearDown()` sweep | **0** |
| with the sweep removed | **3** |

Cleanup is `rmdir_recursive()` rather than a hand-rolled `unlink`+`rmdir` pair, which left behind any leftover that was a file or a shim holding more than `guiconfig.inc`. `scandir()`'s result is checked rather than cast — `(array) FALSE` is `[FALSE]`, which would have reported a leftover named `""`.

## Evidence

| mutation | result |
|---|---|
| shutdown hook demoted to a trailing statement | **1 failure** — residue survives the exit path |
| shim relocated out of the observed base + hook deleted | **fails** (green before the location assertions) |
| shim creation removed entirely | **3 failures** |

3 tests, 35 assertions. `phpcs` clean. Siblings unaffected — 17 tests, 45 assertions across the two of them.

`testing.md` principle 1: this is test-only with no production fix, so literal red→green cannot apply — there is no production edit to be red against. Mutation is the substitute and the table above is that evidence. Stating it rather than skipping it silently.

---
🤖 Generated by [Claude Code](https://claude.com/claude-code),
posted via @BBcan177's account on their behalf.

