### PR TITLE
tests: recognise escaped-quote delimiters in the theme-safety vocabulary

### DIFF
--- a/tests/php/ThemeSafetyUiTest.php
+++ b/tests/php/ThemeSafetyUiTest.php
@@ -145,6 +145,10 @@ final class ThemeSafetyUiTest extends TestCase
 			// depth was ever resolved and the mask was never consulted. Kept as the issue's
 			// black-box repro; the vocabulary rows in backgroundSyntaxes are what pin the fix.
 			'issue 2952 repro'          => ['$s = "$(x).css({tip: \"}\", \"background-color\": \"#123456\"}); $(y).css({color: \"red\"});";', FALSE],
+			// contextHasForeground() has no element awareness, so a two-arg .css('color', ...)
+			// must stay OUT of its vocabulary: accepting it lets a colour on one element
+			// launder a background on another. Pins the vocabulary's boundary, not a bug.
+			'cross-element .css'        => ["$(a).css('background-color', '#123456');\n$(b).css('color', '#000');", FALSE],
 			// An apostrophe in prose is not a string opener.
 			'apostrophe in prose'       => ["/* don't */ .a { background-color: #123456; } .b { color: red; }", FALSE],
 			'apostrophe, pair below'    => ["/* it's fine */ .a { background-color: #123456;\n color: red; }", TRUE],
@@ -347,9 +351,12 @@ final class ThemeSafetyUiTest extends TestCase
 			'esc quoted key'    => ['{ \"background-color\": \"#fff\" }', '{ \"background-color\": \"#fff\", \"color\": \"#000\" }'],
 			'esc quoted camel'  => ['{ \"backgroundColor\": \"#fff\" }', '{ \"backgroundColor\": \"#fff\", \"color\": \"#000\" }'],
 			'esc js bare key'   => ['{ backgroundColor: \"#fff\" }', '{ backgroundColor: \"#fff\", color: \"#000\" }'],
-			'esc jquery setter' => ['$(x).css(\"background-color\", \"#fff\");', '$(x).css(\"background-color\", \"#fff\"); $(x).css(\"color\", \"#000\");'],
+			'esc jquery setter' => ['$(x).css(\"background-color\", \"#fff\");', '$(x).css({\"background-color\": \"#fff\", \"color\": \"#000\"});'],
 			'esc setProperty'   => ['e.style.setProperty(\"background-color\", \"#fff\");', 'e.style.setProperty(\"background-color\", \"#fff\"); e.style.setProperty(\"color\", \"#000\");'],
 			'esc style assign'  => ['e.style.backgroundColor = \"#fff\";', 'e.style.backgroundColor = \"#fff\"; e.style.color = \"#000\";'],
+			// A quote can carry more than one escape -- JS emitted into a JS string, or a
+			// value that has been json_encode()d twice. $bs is a run, not a single escape.
+			'double-escaped key' => ['{ \\\\"background-color\\\\": \\\\"#fff\\\\" }', '{ \\\\"background-color\\\\": \\\\"#fff\\\\", \\\\"color\\\\": \\\\"#000\\\\" }'],
 			'jquery setter'     => ["\$(x).css('background-color', '#fff');", "\$(x).css({'background-color': '#fff', 'color': '#000'});"],
 			'jquery on a var'   => ["\$el.css('background-color', '#fff');", "\$el.css({'background-color': '#fff', 'color': '#000'});"],
 			'jquery on this'    => ["this.css('background-color', '#fff');", "this.css({'background-color': '#fff', 'color': '#000'});"],
@@ -420,12 +427,16 @@ final class ThemeSafetyUiTest extends TestCase
 	 */
 	public static function foregroundLookalikes(): array
 	{
+		// One row per DISTINCT reason the pattern must reject, not one per spelling: the
+		// pattern has no boundary after `color`, so -scheme / -adjust / ful are the same
+		// check three times. Each row below fails for a reason no other row covers.
 		return [
-			'color-scheme'  => ['e.style.setProperty("color-scheme", "dark");'],
-			'color-adjust'  => ['e.style.setProperty("color-adjust", "exact");'],
-			'colorful'      => ['e.style.setProperty("colorful", "yes");'],
-			'css lookalike' => ['$(x).css("color-scheme", "dark");'],
-			'esc lookalike' => ['e.style.setProperty(\"color-scheme\", \"dark\");'],
+			// the closing delimiter: without it any color-prefixed property pairs
+			'prefix lookalike' => ['e.style.setProperty("color-scheme", "dark");'],
+			// the comma: without it a jQuery/DOM getter, which sets nothing, pairs
+			'getter, no value' => ['e.style.setProperty("color");'],
+			// the lookbehind: without it a method merely ending in setProperty pairs
+			'method suffix'    => ['el.mysetProperty("color", "#000");'],
 		];
 	}
 
@@ -434,8 +445,6 @@ final class ThemeSafetyUiTest extends TestCase
 	{
 		$this->assertNotSame([], self::scan('e.style.backgroundColor = "#123456"; ' . $lookalike),
 			'this must not be accepted as a foreground: ' . $lookalike);
-		$this->assertSame([], self::scan('e.style.backgroundColor = "#123456"; e.style.setProperty("color", "#000");'),
-			'sanity: the real foreground spelling must still pair, or the row above proves nothing');
 	}
 
 	/**
@@ -1305,10 +1314,14 @@ final class ThemeSafetyUiTest extends TestCase
 		// vocabularies are kept in lockstep by testEveryDetectedFormIsAlsoRecognisedWhenPaired.
 		// issue #2952: escaped-quote foregrounds pair escaped-quote backgrounds. Both
 		// delimiters stay required -- dropping the closing one accepts color-scheme.
+		// .css( is deliberately NOT here: this function has no element awareness, so
+		// accepting a two-arg .css('color', ...) would let a colour on a DIFFERENT element
+		// launder a background. The same-element case it would fix does not occur in the
+		// tree (issue #2970); a false negative for a false positive is a bad trade.
 		return (bool)preg_match(
 			'/(?<![A-Za-z0-9_-])color(?:\\\\*["\'])?\s*:'
 			. '|(?<![A-Za-z0-9_-])color\s*='
-			. '|(?:\.css\(|(?<![A-Za-z0-9_])setProperty\()\s*\\\\*["\']color\\\\*["\']\s*,/i',
+			. '|(?<![A-Za-z0-9_])setProperty\(\s*\\\\*["\']color\\\\*["\']\s*,/i',
 			$ctx
 		);
 	}

--- a/tests/php/ThemeSafetyUiTest.php
+++ b/tests/php/ThemeSafetyUiTest.php
@@ -137,14 +137,14 @@ final class ThemeSafetyUiTest extends TestCase
 			'sibling element colour'    => ['$s = "<span style=\"color: black;\"></span><input style=\"background-color: #123456;\">";', FALSE],
 			'same element colour'       => ['$s = "<span style=\"color: black; background-color: #FFFF00;\">x</span>";', TRUE],
 			'single-quoted attribute'   => ['$s = \'<input style="background-color: #123456;">\';', FALSE],
-			// Issue #2952, as filed, claimed a brace inside an escaped-quote span pops the
-			// declaration depth so a neighbour's colour launders the background. Measured
-			// against this tree that is FALSE -- structureMask() blanks the escaped span
-			// and the brace inside it never counts as structure. The real defect was in
-			// scan()'s vocabulary, not the mask, and is covered by backgroundSyntaxes.
-			// These rows pin the behaviour the issue misread, so the claim cannot return.
-			'brace in escaped span'     => ['$s = "<input style=\"background-color: #123456;\" data-t=\"}\">";', FALSE],
-			'brace in escaped, paired'  => ['$s = "<input style=\"background-color: #123456; color: black;\" data-t=\"}\">";', TRUE],
+			// Issue #2952's own reproduction, which the issue read as a masking defect: a `}`
+			// inside an escaped-quote span was said to pop the declaration depth so the
+			// neighbouring css({color: red}) laundered the background. The outcome was real
+			// -- nothing was reported -- but the mechanism was not. The background was never
+			// DETECTED, because its property name is delimited by escaped quotes, so no
+			// depth was ever resolved and the mask was never consulted. Kept as the issue's
+			// black-box repro; the vocabulary rows in backgroundSyntaxes are what pin the fix.
+			'issue 2952 repro'          => ['$s = "$(x).css({tip: \"}\", \"background-color\": \"#123456\"}); $(y).css({color: \"red\"});";', FALSE],
 			// An apostrophe in prose is not a string opener.
 			'apostrophe in prose'       => ["/* don't */ .a { background-color: #123456; } .b { color: red; }", FALSE],
 			'apostrophe, pair below'    => ["/* it's fine */ .a { background-color: #123456;\n color: red; }", TRUE],
@@ -346,6 +346,10 @@ final class ThemeSafetyUiTest extends TestCase
 			'js quoted camel'   => ['{ "backgroundColor": "#fff" }', '{ "backgroundColor": "#fff", "color": "#000" }'],
 			'esc quoted key'    => ['{ \"background-color\": \"#fff\" }', '{ \"background-color\": \"#fff\", \"color\": \"#000\" }'],
 			'esc quoted camel'  => ['{ \"backgroundColor\": \"#fff\" }', '{ \"backgroundColor\": \"#fff\", \"color\": \"#000\" }'],
+			'esc js bare key'   => ['{ backgroundColor: \"#fff\" }', '{ backgroundColor: \"#fff\", color: \"#000\" }'],
+			'esc jquery setter' => ['$(x).css(\"background-color\", \"#fff\");', '$(x).css(\"background-color\", \"#fff\"); $(x).css(\"color\", \"#000\");'],
+			'esc setProperty'   => ['e.style.setProperty(\"background-color\", \"#fff\");', 'e.style.setProperty(\"background-color\", \"#fff\"); e.style.setProperty(\"color\", \"#000\");'],
+			'esc style assign'  => ['e.style.backgroundColor = \"#fff\";', 'e.style.backgroundColor = \"#fff\"; e.style.color = \"#000\";'],
 			'jquery setter'     => ["\$(x).css('background-color', '#fff');", "\$(x).css({'background-color': '#fff', 'color': '#000'});"],
 			'jquery on a var'   => ["\$el.css('background-color', '#fff');", "\$el.css({'background-color': '#fff', 'color': '#000'});"],
 			'jquery on this'    => ["this.css('background-color', '#fff');", "this.css({'background-color': '#fff', 'color': '#000'});"],
@@ -382,10 +386,82 @@ final class ThemeSafetyUiTest extends TestCase
 	 */
 	public function testAnEscapedTranslucentValueIsNotReported(): void
 	{
-		$this->assertSame([], self::scan('{ \"background-color\": \"transparent\" }'),
-			'the escape must not be captured as part of the colour');
+		// [] below is also what an UNDETECTED background returns, so assert the before-state
+		// or the whole test passes with escaped-quote support removed entirely.
+		$this->assertNotSame([], self::scan('{ \"background-color\": \"#123456\" }'),
+			'sanity: an escaped opaque background must be detected, or [] below means nothing');
+		// Every branch that captures a value, not just the object key: the escape is consumed
+		// by the closing delimiter in each, and a branch that gets this wrong reports a
+		// transparent background as an unpaired opaque one.
+		foreach ([
+			'object key'   => '{ \"background-color\": \"transparent\" }',
+			'js bare key'  => '{ backgroundColor: \"transparent\" }',
+			'setProperty'  => 'e.style.setProperty(\"background-color\", \"transparent\");',
+			'style assign' => 'e.style.backgroundColor = \"transparent\";',
+		] as $branch => $source) {
+			$this->assertSame([], self::scan($source),
+				"the escape must not be captured as part of the colour ({$branch})");
+		}
 		$this->assertSame([], self::scan('{ \"background-color\": \"rgba(0, 0, 0, 0.5)\" }'),
 			'an escaped rgba() background is still translucent');
+	}
+
+	/**
+	 * A property whose name merely STARTS with "color" is not a foreground.
+	 *
+	 * contextHasForeground() returning TRUE suppresses a violation, so anything it wrongly
+	 * accepts is a false negative -- unreadable UI shipping unreported, which is the failure
+	 * this guard exists to prevent and the opposite direction from the one the escaped-quote
+	 * work was worried about. Every other foreground test asserts that a real pairing IS
+	 * accepted; this one asserts a non-pairing is REJECTED. color-scheme is live vocabulary
+	 * in this tree, so the setProperty spelling is a plausible next edit.
+	 *
+	 * @return array<string, array{0: string}>
+	 */
+	public static function foregroundLookalikes(): array
+	{
+		return [
+			'color-scheme'  => ['e.style.setProperty("color-scheme", "dark");'],
+			'color-adjust'  => ['e.style.setProperty("color-adjust", "exact");'],
+			'colorful'      => ['e.style.setProperty("colorful", "yes");'],
+			'css lookalike' => ['$(x).css("color-scheme", "dark");'],
+			'esc lookalike' => ['e.style.setProperty(\"color-scheme\", \"dark\");'],
+		];
+	}
+
+	#[DataProvider('foregroundLookalikes')]
+	public function testAPropertyMerelyStartingWithColorDoesNotPair(string $lookalike): void
+	{
+		$this->assertNotSame([], self::scan('e.style.backgroundColor = "#123456"; ' . $lookalike),
+			'this must not be accepted as a foreground: ' . $lookalike);
+		$this->assertSame([], self::scan('e.style.backgroundColor = "#123456"; e.style.setProperty("color", "#000");'),
+			'sanity: the real foreground spelling must still pair, or the row above proves nothing');
+	}
+
+	/**
+	 * A backslash INSIDE a value must not end the value.
+	 *
+	 * Excluding backslashes from the value class keeps \"transparent\" from capturing
+	 * `transparent\`, but hides any value legitimately containing one -- a Windows path in
+	 * url(), a CSS escape like \0023. A lazy value keeps both right.
+	 *
+	 * @return array<string, array{0: string}>
+	 */
+	public static function valuesContainingABackslash(): array
+	{
+		return [
+			'windows path' => ['$(x).css("background", "url(C:\\images\\bg.png)");'],
+			'css escape'   => ['e.style.backgroundColor = "\\0023123456";'],
+			'url escape'   => ['{ "background-color": "url(a\\b.png)" }'],
+			'js bare key'  => ['{ backgroundColor: "url(a\\b.png)" }'],
+		];
+	}
+
+	#[DataProvider('valuesContainingABackslash')]
+	public function testABackslashInsideAValueDoesNotHideTheBackground(string $source): void
+	{
+		$this->assertNotSame([], self::scan($source),
+			'a backslash inside the value must not stop the branch matching: ' . $source);
 	}
 
 	public function testCurrentTreeInventoryMatchesTheDatedTodo(): void
@@ -449,21 +525,19 @@ final class ThemeSafetyUiTest extends TestCase
 		// the bare object key. Named groups, because an alternation numbers groups globally
 		// and a hand-written backreference silently points at the wrong branch.
 		//
-		// issue #2952: each quote may arrive backslash-escaped. JS embedded in a PHP
-		// double-quoted string carries \"background-color\": \"#fff\", and an unescaped-only
-		// vocabulary reads that as no background at all -- the element is then never
-		// examined, so it is silently exempt rather than reported. $bs makes the escape
-		// optional everywhere a quote delimits, and the value classes exclude a backslash
-		// so the captured colour is the colour and not the colour plus its escape.
-		$bs = '\\\\?';
+		// issue #2952: a delimiting quote may arrive backslash-escaped (JS emitted from a
+		// PHP double-quoted string), and an unescaped-only vocabulary reads that as no
+		// background at all -- silently exempt rather than reported. Values are lazy, not
+		// backslash-excluding: a backslash inside url() or a CSS escape is part of the value.
+		$bs = '\\\\*';
 		if (preg_match_all(
 			'/background(?:-color)?\s*:\s*(?<css>[^;}\n]+)'
-			. '|backgroundColor\s*:\s*' . $bs . '(?<jsq>["\'])(?<js>[^"\'\\\\]+)' . $bs . '\k<jsq>'
-			. '|' . $bs . '(?<objq>["\'])background(?:-color|Color)?' . $bs . '\k<objq>\s*:\s*'
-			. $bs . '(?<objvq>["\'])(?<obj>[^"\'\\\\]*+)' . $bs . '\k<objvq>'
+			. '|backgroundColor\s*:\s*' . $bs . '(?<jsq>["\'])(?<js>[^"\']*?)' . $bs . '\k<jsq>'
+			. '|(?<objq>["\'])background(?:-color|Color)?' . $bs . '\k<objq>\s*:\s*'
+			. $bs . '(?<objvq>["\'])(?<obj>[^"\']*?)' . $bs . '\k<objvq>'
 			. '|(?:\.css\(|(?<![A-Za-z0-9_])setProperty\()\s*' . $bs . '(?<setq>["\'])background(?:-color|Color)?' . $bs . '\k<setq>\s*,\s*'
-			. $bs . '(?<setvq>["\'])(?<set>[^"\'\\\\]*+)' . $bs . '\k<setvq>'
-			. '|\.style\.backgroundColor\s*=\s*' . $bs . '(?<domq>["\'])(?<dom>[^"\'\\\\]*+)' . $bs . '\k<domq>/i',
+			. $bs . '(?<setvq>["\'])(?<set>[^"\']*?)' . $bs . '\k<setvq>'
+			. '|\.style\.backgroundColor\s*=\s*' . $bs . '(?<domq>["\'])(?<dom>[^"\']*?)' . $bs . '\k<domq>/i',
 			$source,
 			$matches,
 			PREG_OFFSET_CAPTURE
@@ -1229,13 +1303,12 @@ final class ThemeSafetyUiTest extends TestCase
 		// Every way a foreground can be set must be recognised here, or code paired through
 		// a form scan() detects but this does not reports as a violation. The two
 		// vocabularies are kept in lockstep by testEveryDetectedFormIsAlsoRecognisedWhenPaired.
-		// issue #2952: the escaped-quote forms scan() now detects pair with escaped-quote
-		// foregrounds -- \"color\": \"#000\". Accepting them here is not optional: leaving
-		// them out would make scan() report code that is correctly paired.
+		// issue #2952: escaped-quote foregrounds pair escaped-quote backgrounds. Both
+		// delimiters stay required -- dropping the closing one accepts color-scheme.
 		return (bool)preg_match(
-			'/(?<![A-Za-z0-9_-])color(?:\\\\?["\'])?\s*:'
+			'/(?<![A-Za-z0-9_-])color(?:\\\\*["\'])?\s*:'
 			. '|(?<![A-Za-z0-9_-])color\s*='
-			. '|setProperty\(\s*\\\\?["\']color/i',
+			. '|(?:\.css\(|(?<![A-Za-z0-9_])setProperty\()\s*\\\\*["\']color\\\\*["\']\s*,/i',
 			$ctx
 		);
 	}

--- a/tests/php/ThemeSafetyUiTest.php
+++ b/tests/php/ThemeSafetyUiTest.php
@@ -357,6 +357,14 @@ final class ThemeSafetyUiTest extends TestCase
 			// A quote can carry more than one escape -- JS emitted into a JS string, or a
 			// value that has been json_encode()d twice. $bs is a run, not a single escape.
 			'double-escaped key' => ['{ \\\\"background-color\\\\": \\\\"#fff\\\\" }', '{ \\\\"background-color\\\\": \\\\"#fff\\\\", \\\\"color\\\\": \\\\"#000\\\\" }'],
+			// Every row above is a bare fragment, which is the one context where an escaped
+			// quote cannot actually occur. Inside a real PHP double-quoted literal the match
+			// offset decides the context enclosingString() reads, so a branch that starts ON
+			// the escaped quote reports a correctly-paired object (#3002 review, contract leg).
+			'esc key in php literal' => [
+				'$s = "$(x).css({\\"background-color\\": \\"#123456\\"});";',
+				'$s = "$(x).css({\\"background-color\\": \\"#123456\\", \\"color\\": \\"#000\\"});";',
+			],
 			'jquery setter'     => ["\$(x).css('background-color', '#fff');", "\$(x).css({'background-color': '#fff', 'color': '#000'});"],
 			'jquery on a var'   => ["\$el.css('background-color', '#fff');", "\$el.css({'background-color': '#fff', 'color': '#000'});"],
 			'jquery on this'    => ["this.css('background-color', '#fff');", "this.css({'background-color': '#fff', 'color': '#000'});"],
@@ -437,6 +445,11 @@ final class ThemeSafetyUiTest extends TestCase
 			'getter, no value' => ['e.style.setProperty("color");'],
 			// the lookbehind: without it a method merely ending in setProperty pairs
 			'method suffix'    => ['el.mysetProperty("color", "#000");'],
+			// The three rows above all exercise the setProperty branch. The colon and
+			// assignment branches carry the same boundary and need the same pinning, or a
+			// widening there ships unseen (#3002 review, test-honesty leg).
+			'colon branch'     => ['.a { color-scheme: dark; }'],
+			'assign branch'    => ['e.style.colorScheme = "dark";'],
 		];
 	}
 
@@ -464,6 +477,33 @@ final class ThemeSafetyUiTest extends TestCase
 			'url escape'   => ['{ "background-color": "url(a\\b.png)" }'],
 			'js bare key'  => ['{ backgroundColor: "url(a\\b.png)" }'],
 		];
+	}
+
+	/**
+	 * A PCRE failure must not read as a clean file.
+	 *
+	 * scan() used to fall through to `return []` when preg_match_all() returned FALSE,
+	 * which is indistinguishable from "this source has no violations" -- the fail-open
+	 * shape #3011 closed elsewhere. The lazy value classes can exhaust the backtrack
+	 * limit on a long backslash run after an unterminated quote, so the error path is
+	 * reachable rather than theoretical.
+	 *
+	 * The limit is lowered for the duration rather than feeding scan() a flood, so the
+	 * test asserts the guard and not this machine's pcre.backtrack_limit.
+	 */
+	public function testAScanRegexFailureThrowsInsteadOfReportingNoViolations(): void
+	{
+		$src = '{ "background-color": "#123456" }' . "\n" . 'backgroundColor: "' . str_repeat('\\', 200);
+		$this->assertNotSame([], self::scan($src), 'the violation must be seen at the normal limit');
+
+		$restore = ini_get('pcre.backtrack_limit');
+		ini_set('pcre.backtrack_limit', '100');
+		try {
+			$this->expectException(RuntimeException::class);
+			self::scan($src);
+		} finally {
+			ini_set('pcre.backtrack_limit', $restore === FALSE ? '1000000' : $restore);
+		}
 	}
 
 	#[DataProvider('valuesContainingABackslash')]
@@ -539,10 +579,10 @@ final class ThemeSafetyUiTest extends TestCase
 		// background at all -- silently exempt rather than reported. Values are lazy, not
 		// backslash-excluding: a backslash inside url() or a CSS escape is part of the value.
 		$bs = '\\\\*';
-		if (preg_match_all(
+		$matched = preg_match_all(
 			'/background(?:-color)?\s*:\s*(?<css>[^;}\n]+)'
 			. '|backgroundColor\s*:\s*' . $bs . '(?<jsq>["\'])(?<js>[^"\']*?)' . $bs . '\k<jsq>'
-			. '|(?<objq>["\'])background(?:-color|Color)?' . $bs . '\k<objq>\s*:\s*'
+			. '|' . $bs . '(?<objq>["\'])background(?:-color|Color)?' . $bs . '\k<objq>\s*:\s*'
 			. $bs . '(?<objvq>["\'])(?<obj>[^"\']*?)' . $bs . '\k<objvq>'
 			. '|(?:\.css\(|(?<![A-Za-z0-9_])setProperty\()\s*' . $bs . '(?<setq>["\'])background(?:-color|Color)?' . $bs . '\k<setq>\s*,\s*'
 			. $bs . '(?<setvq>["\'])(?<set>[^"\']*?)' . $bs . '\k<setvq>'
@@ -550,7 +590,15 @@ final class ThemeSafetyUiTest extends TestCase
 			$source,
 			$matches,
 			PREG_OFFSET_CAPTURE
-		) !== FALSE) {
+		);
+		if ($matched === FALSE) {
+			// A PCRE failure is indistinguishable from a clean file, so falling through
+			// would suppress every violation in this source (#3002 review, correctness
+			// leg). Fail loudly instead -- the lazy value classes can exhaust the
+			// backtrack limit on a long backslash run after an unterminated quote.
+			throw new RuntimeException('ThemeSafety scan() regex failed: ' . preg_last_error_msg());
+		}
+		if ($matched > 0) {
 			$count = count($matches[0]);
 			for ($i = 0; $i < $count; $i++) {
 				$full = $matches[0][$i][0];

--- a/tests/php/ThemeSafetyUiTest.php
+++ b/tests/php/ThemeSafetyUiTest.php
@@ -137,6 +137,14 @@ final class ThemeSafetyUiTest extends TestCase
 			'sibling element colour'    => ['$s = "<span style=\"color: black;\"></span><input style=\"background-color: #123456;\">";', FALSE],
 			'same element colour'       => ['$s = "<span style=\"color: black; background-color: #FFFF00;\">x</span>";', TRUE],
 			'single-quoted attribute'   => ['$s = \'<input style="background-color: #123456;">\';', FALSE],
+			// Issue #2952, as filed, claimed a brace inside an escaped-quote span pops the
+			// declaration depth so a neighbour's colour launders the background. Measured
+			// against this tree that is FALSE -- structureMask() blanks the escaped span
+			// and the brace inside it never counts as structure. The real defect was in
+			// scan()'s vocabulary, not the mask, and is covered by backgroundSyntaxes.
+			// These rows pin the behaviour the issue misread, so the claim cannot return.
+			'brace in escaped span'     => ['$s = "<input style=\"background-color: #123456;\" data-t=\"}\">";', FALSE],
+			'brace in escaped, paired'  => ['$s = "<input style=\"background-color: #123456; color: black;\" data-t=\"}\">";', TRUE],
 			// An apostrophe in prose is not a string opener.
 			'apostrophe in prose'       => ["/* don't */ .a { background-color: #123456; } .b { color: red; }", FALSE],
 			'apostrophe, pair below'    => ["/* it's fine */ .a { background-color: #123456;\n color: red; }", TRUE],
@@ -336,6 +344,8 @@ final class ThemeSafetyUiTest extends TestCase
 			'js bare key'       => ['{ backgroundColor: "#fff" }', '{ backgroundColor: "#fff", color: "#000" }'],
 			'js quoted key'     => ['{ "background-color": "#fff" }', '{ "background-color": "#fff", "color": "#000" }'],
 			'js quoted camel'   => ['{ "backgroundColor": "#fff" }', '{ "backgroundColor": "#fff", "color": "#000" }'],
+			'esc quoted key'    => ['{ \"background-color\": \"#fff\" }', '{ \"background-color\": \"#fff\", \"color\": \"#000\" }'],
+			'esc quoted camel'  => ['{ \"backgroundColor\": \"#fff\" }', '{ \"backgroundColor\": \"#fff\", \"color\": \"#000\" }'],
 			'jquery setter'     => ["\$(x).css('background-color', '#fff');", "\$(x).css({'background-color': '#fff', 'color': '#000'});"],
 			'jquery on a var'   => ["\$el.css('background-color', '#fff');", "\$el.css({'background-color': '#fff', 'color': '#000'});"],
 			'jquery on this'    => ["this.css('background-color', '#fff');", "this.css({'background-color': '#fff', 'color': '#000'});"],
@@ -361,6 +371,21 @@ final class ThemeSafetyUiTest extends TestCase
 			'scan() must detect this background syntax: ' . $unpaired);
 		$this->assertSame([], self::scan($paired),
 			'contextHasForeground() must accept the pairing idiom native to this syntax: ' . $paired);
+	}
+
+	/**
+	 * Issue #2952: the escaped-quote branches capture the VALUE too, and the escape must
+	 * not land inside it. With a value class that admits a backslash, \"transparent\"
+	 * captures `transparent\` -- isTranslucent() then does not recognise it, and the guard
+	 * reports a transparent background as an unpaired opaque one. A false positive is the
+	 * one failure this guard cannot afford: it is what teaches people to ignore it.
+	 */
+	public function testAnEscapedTranslucentValueIsNotReported(): void
+	{
+		$this->assertSame([], self::scan('{ \"background-color\": \"transparent\" }'),
+			'the escape must not be captured as part of the colour');
+		$this->assertSame([], self::scan('{ \"background-color\": \"rgba(0, 0, 0, 0.5)\" }'),
+			'an escaped rgba() background is still translucent');
 	}
 
 	public function testCurrentTreeInventoryMatchesTheDatedTodo(): void
@@ -423,13 +448,22 @@ final class ThemeSafetyUiTest extends TestCase
 		// issue #2864: every shape that can set a background, not just the declaration and
 		// the bare object key. Named groups, because an alternation numbers groups globally
 		// and a hand-written backreference silently points at the wrong branch.
+		//
+		// issue #2952: each quote may arrive backslash-escaped. JS embedded in a PHP
+		// double-quoted string carries \"background-color\": \"#fff\", and an unescaped-only
+		// vocabulary reads that as no background at all -- the element is then never
+		// examined, so it is silently exempt rather than reported. $bs makes the escape
+		// optional everywhere a quote delimits, and the value classes exclude a backslash
+		// so the captured colour is the colour and not the colour plus its escape.
+		$bs = '\\\\?';
 		if (preg_match_all(
 			'/background(?:-color)?\s*:\s*(?<css>[^;}\n]+)'
-			. '|backgroundColor\s*:\s*(?<jsq>["\'])(?<js>[^"\']+)\k<jsq>'
-			. '|(?<objq>["\'])background(?:-color|Color)?\k<objq>\s*:\s*(?<objvq>["\'])(?<obj>[^"\']*+)\k<objvq>'
-			. '|(?:\.css\(|(?<![A-Za-z0-9_])setProperty\()\s*(?<setq>["\'])background(?:-color|Color)?\k<setq>\s*,\s*'
-			. '(?<setvq>["\'])(?<set>[^"\']*+)\k<setvq>'
-			. '|\.style\.backgroundColor\s*=\s*(?<domq>["\'])(?<dom>[^"\']*+)\k<domq>/i',
+			. '|backgroundColor\s*:\s*' . $bs . '(?<jsq>["\'])(?<js>[^"\'\\\\]+)' . $bs . '\k<jsq>'
+			. '|' . $bs . '(?<objq>["\'])background(?:-color|Color)?' . $bs . '\k<objq>\s*:\s*'
+			. $bs . '(?<objvq>["\'])(?<obj>[^"\'\\\\]*+)' . $bs . '\k<objvq>'
+			. '|(?:\.css\(|(?<![A-Za-z0-9_])setProperty\()\s*' . $bs . '(?<setq>["\'])background(?:-color|Color)?' . $bs . '\k<setq>\s*,\s*'
+			. $bs . '(?<setvq>["\'])(?<set>[^"\'\\\\]*+)' . $bs . '\k<setvq>'
+			. '|\.style\.backgroundColor\s*=\s*' . $bs . '(?<domq>["\'])(?<dom>[^"\'\\\\]*+)' . $bs . '\k<domq>/i',
 			$source,
 			$matches,
 			PREG_OFFSET_CAPTURE
@@ -1195,10 +1229,13 @@ final class ThemeSafetyUiTest extends TestCase
 		// Every way a foreground can be set must be recognised here, or code paired through
 		// a form scan() detects but this does not reports as a violation. The two
 		// vocabularies are kept in lockstep by testEveryDetectedFormIsAlsoRecognisedWhenPaired.
+		// issue #2952: the escaped-quote forms scan() now detects pair with escaped-quote
+		// foregrounds -- \"color\": \"#000\". Accepting them here is not optional: leaving
+		// them out would make scan() report code that is correctly paired.
 		return (bool)preg_match(
-			'/(?<![A-Za-z0-9_-])color["\']?\s*:'
+			'/(?<![A-Za-z0-9_-])color(?:\\\\?["\'])?\s*:'
 			. '|(?<![A-Za-z0-9_-])color\s*='
-			. '|setProperty\(\s*["\']color["\']/i',
+			. '|setProperty\(\s*\\\\?["\']color/i',
 			$ctx
 		);
 	}


### PR DESCRIPTION
Closes #2952. Replaces #2968, closed during the `devel` history repair; same three commits rebuilt on the repaired base, forbidden `Co-authored-by` trailer removed, each commit signed.

## The defect is not the one the issue describes

I filed #2952 and misdiagnosed it. [The correction is on the issue](https://github.com/pfBlockerNG/pfBlockerNG/issues/2952#issuecomment-5473353467) with the probe that isolated it. The issue blamed `structureMask()` for letting a `}` inside an escaped-quote span pop the declaration depth; that shape is already handled. The real defect is that with the property name in escaped quotes the background gets **zero** regex hits — it is never detected, so the element is never examined. Silently exempt, with no signal anything was skipped. Vocabulary drift (#2864 family), not scope resolution (#2930 family).

## Three review rounds, and the two worst findings were mine

**Round 1 — I introduced a false negative while fixing the reported one.** Adding the optional escape to `contextHasForeground()`'s `setProperty` branch also dropped its closing quote, so `setProperty("color-scheme", …)` counted as a foreground and *suppressed* a real violation. Three of four legs found it independently. The suite could not have: every foreground test asserted a real pairing **is accepted**, none that a non-pairing **is rejected**. `foregroundLookalikes()` closes that asymmetry.

**Round 2 — I did it again while fixing round 1's other finding.** To close a false positive I added `.css(` to the foreground vocabulary. That function has no element awareness, so a colour on element `b` laundered a background on element `a`, and a bare string literal containing `".css('color', "` laundered too. `devel` reports both; my fix did not. The false positive it bought is unreachable here — 11 `.css(` call sites in `src/`, all but one object form (`pfblockerng_log.php:553` is two-arg `.css("overflow", "scroll")`), zero two-arg colour setters, zero `setProperty`. So I removed an unreachable false positive and created a reachable false negative. Reverted, pinned, and the real limitation filed as **#2970**, where it needs element scoping rather than a vocabulary tweak.

**Round 3 — the differential said clean, and it was wrong.** A 1,800-cell battery (15 background syntaxes × 15 foreground spellings × 8 wrappers) found zero cells reporting fewer hits than base, and I read that as "no third fix-induced defect". Independent review found two the battery could not see:

- **A false positive**, which the battery was structurally blind to because it only looked for cells reporting *fewer* hits — this one reports *more*. Round 1's own repair dropped the leading escape run from the object-key branch, on the reasoning that an unanchored alternation never needs to consume a preceding backslash. True for matching, false for the **offset**, which `scan()` feeds to `declarationContext()`. The match then began on the escaped quote, `enclosingString()` read that quote as the enclosing PHP literal's terminator, and a correctly-paired object was reported as a violation. Every `esc …` row tested a bare fragment — the one context where an escaped quote cannot occur — so 112 tests stayed green over it.
- **A reachable fail-open path.** Replacing the possessive value classes with lazy ones made `preg_match_all()` able to exhaust the backtrack limit; `scan()` then fell through to `return []`, which is indistinguishable from a clean file and would suppress every violation in that source.

So the honest count is three fix-induced defects across three rounds, not two. Both are fixed here, each with a fixture that fails when its fix is reverted.

## The change

`$bs` makes the backslash run optional wherever a quote delimits, across all four quote-delimited branches — JS emitted from a PHP double-quoted string escapes every quote, not just the one this issue happened to land on. Values are lazy rather than backslash-excluding: an earlier version excluded backslashes and thereby hid `url(C:\images\bg.png)` and the CSS escape `\0023`, trading one false positive for a class of false negatives against code `devel` handled correctly.

## Evidence

Every mutant that survived an earlier round is now killed. Re-verified on the repaired base:

| mutant | failures |
|---|---|
| re-add `.css(` to the foreground | 1 |
| `$bs` run → single escape | 1 |
| drop `\s*,` from the foreground | 1 |
| drop the foreground closing quote | 2 |

95 → 116 tests, 123 → 158 assertions, measured against `origin/devel` at the current base. `phpcs` clean. (The earlier figures in this body were taken against the pre-history-repair base and were wrong in all four numbers.)

**Honest accounting:** `testABackslashInsideAValueDoesNotHideTheBackground` is green on the base. `testAPropertyMerelyStartingWithColorDoesNotPair` is **not** — grafted onto the base file, two of its rows fail, because the base's `setProperty` foreground branch has neither the comma requirement nor the lookbehind. That commit therefore fixes two pre-existing foreground false negatives beyond #2952's scope, which this body previously accounted for as no-ops. They are regression guards for defects that existed only inside this PR's own history, not evidence that this change fixes #2952. The tests that are red on the base are the six `esc …` syntax rows, the issue's own reproduction row, and the translucent test.

`testing.md` principle 1's freeze/hash cannot apply here: `scan()` and `contextHasForeground()` live in the *same file* as the tests exercising them, so byte-identical freeze between red and green is impossible by construction. I verified the substance by reverting only the code hunks and confirming the new rows go red.

## Known limits, stated rather than left to be found

- **Mismatched escape parity** (`\"key": "value\"`) matches permissively. Every construction for it is either a genuine background or nonsense.
- A value containing an escaped quote (`'a\'b'`) captures only `a`. Not a colour; harmless.
- The two-arg `.css('color', …)` false positive remains open as #2970.
posted via @BBcan177's account on their behalf.

