### PR TITLE
Agent: support foreign Graphify target checkouts

### DIFF
--- a/scripts/agent/ensure-graphify-merge-driver.sh
+++ b/scripts/agent/ensure-graphify-merge-driver.sh
@@ -30,7 +30,11 @@ main() {
 	}
 	# The hook this installs rebuilds the graph, so the override has to be on the
 	# freshly installed package first (issue #2810).
+	# Prefer the requested checkout's own copy, but a foreign target (e.g.
+	# FreeBSD-ports) ships no patch of its own (issue #3004): fall back to the
+	# trusted sibling next to this helper instead of failing the run.
 	patch_graphify=$root/scripts/agent/patch-graphify.sh
+	[ -f "$patch_graphify" ] || patch_graphify=$(dirname "$0")/patch-graphify.sh
 	sh "$patch_graphify" || {
 		echo "ensure-graphify-merge-driver.sh: Graphify language-override patch failed for '$root'" >&2
 		exit 1

--- a/tests/shell/agent_graphify_merge_driver_spec.sh
+++ b/tests/shell/agent_graphify_merge_driver_spec.sh
@@ -70,4 +70,28 @@ PATCH_GRAPHIFY
       The stderr should include 'graphify merge-driver %O %A %B'
     End
   End
+
+  Context 'foreign target without a target-local patch (issue #3004)'
+    # The trusted helper checkout runs the helper against a foreign checkout
+    # (e.g. FreeBSD-ports) that ships no scripts/agent/patch-graphify.sh; the
+    # helper must fall back to its own trusted sibling instead of failing, and
+    # must not create anything inside the foreign checkout.
+    It 'falls back to the trusted sibling patch next to the helper script'
+      helperdir="$fixture/helper/scripts/agent"
+      mkdir -p "$helperdir" "$fixture/helper/scripts/lib"
+      cp "$script_abs" scripts/agent/agent_env.sh "$helperdir/"
+      cp scripts/lib/git-env-scrub.sh "$fixture/helper/scripts/lib/"
+      cat > "$helperdir/patch-graphify.sh" <<'PATCH_GRAPHIFY'
+#!/bin/sh
+printf 'patch-graphify\t%s\n' "$*" >> "$GRAPHIFY_LOG"
+PATCH_GRAPHIFY
+      chmod +x "$helperdir/patch-graphify.sh"
+      rm -rf "$repo/scripts/agent"
+      When run sh "$helperdir/ensure-graphify-merge-driver.sh" "$repo"
+      The status should equal 0
+      The contents of file "$graphify_log" should equal \
+        "$(printf 'patch-graphify\t\n%s\thook install' "$repo")"
+      The value "$(test -e "$repo/scripts/agent" && echo present || echo absent)" should equal "absent"
+    End
+  End
 End


### PR DESCRIPTION
## Summary

- prefer the target checkout's `patch-graphify.sh` when present
- fall back to the trusted helper checkout's sibling patch for foreign targets
- keep Graphify hook/config installation rooted in the target repository

## Evidence

| Frozen RED test | git hash-object | RED run tail |
| --- | --- | --- |
| `tests/shell/agent_graphify_merge_driver_spec.sh` | `96b520879dec302624d3555ed74c28da6383430d` | `4 examples, 1 failure` |

- GREEN: 4 examples, 0 failures with the frozen test unchanged
- Claude verification: PASS, exact base/head replay and no target pollution
- focused `sh -n` and ShellCheck: passed
- full local ShellSpec was blocked only by unavailable macOS `iprange`; attempted Homebrew install, no formula exists; CI ShellSpec passed

Refs pfBlockerNG/pfBlockerNG#3004

🤖 Generated by Oh My Pi and posted on behalf of @andrebrait.