### PR TITLE
agent: keep a package-managed uv from aborting the tool installer

### DIFF
--- a/scripts/agent/setup-agent-tools.sh
+++ b/scripts/agent/setup-agent-tools.sh
@@ -247,12 +247,7 @@ main() {
 	case "$platform" in
 		Linux)
 			if command -v uv >/dev/null 2>&1; then
-				# Maintenance, not a prerequisite: every later use is
-				# `uv tool install --upgrade`, which any uv performs. A uv
-				# that did not come from the standalone installer refuses to
-				# self-update and exits non-zero; under `set -eu` that ends
-				# the run before a single tool is installed.
-				uv self update || :
+				uv self update
 			else
 				install_from_url 'https://astral.sh/uv/install.sh'
 			fi

--- a/scripts/agent/setup-agent-tools.sh
+++ b/scripts/agent/setup-agent-tools.sh
@@ -247,7 +247,12 @@ main() {
 	case "$platform" in
 		Linux)
 			if command -v uv >/dev/null 2>&1; then
-				uv self update
+				# Maintenance, not a prerequisite: every later use is
+				# `uv tool install --upgrade`, which any uv performs. A uv
+				# that did not come from the standalone installer refuses to
+				# self-update and exits non-zero; under `set -eu` that ends
+				# the run before a single tool is installed.
+				uv self update || true
 			else
 				install_from_url 'https://astral.sh/uv/install.sh'
 			fi

--- a/scripts/agent/setup-agent-tools.sh
+++ b/scripts/agent/setup-agent-tools.sh
@@ -247,7 +247,12 @@ main() {
 	case "$platform" in
 		Linux)
 			if command -v uv >/dev/null 2>&1; then
-				uv self update
+				# Maintenance, not a prerequisite: every later use is
+				# `uv tool install --upgrade`, which any uv performs. A uv
+				# that did not come from the standalone installer refuses to
+				# self-update and exits non-zero; under `set -eu` that ends
+				# the run before a single tool is installed.
+				uv self update || :
 			else
 				install_from_url 'https://astral.sh/uv/install.sh'
 			fi

--- a/tests/shell/agent_tools_setup_spec.sh
+++ b/tests/shell/agent_tools_setup_spec.sh
@@ -150,7 +150,12 @@ CURL
 #!/bin/sh
 printf 'uv:%s\n' "$*" >> "$DEBIAN_TOOL_LOG"
 case "$*" in
-  'self update') ;;
+  'self update')
+    # A uv that did not come from the standalone installer refuses to
+    # self-update and exits non-zero (issue: package-managed uv). The
+    # installer must treat that as maintenance, not a prerequisite.
+    if [ -n "${DEBIAN_UV_SELF_UPDATE_FAILS:-}" ]; then exit 1; fi
+    ;;
   'tool install --upgrade serena-agent')
     uv_tool_bin=${UV_TOOL_BIN_DIR:-${XDG_BIN_HOME:-$HOME/.local/bin}}
     mkdir -p "$uv_tool_bin"
@@ -980,6 +985,21 @@ CONFIG
     Assert [ "$(grep -c '^https://github.com/max-sixty/worktrunk/releases/latest/download/worktrunk-installer.sh$' "$curl_log")" -eq 2 ]
     Assert [ "$(grep -c '^setup-hooks:$' "$helper_log")" -eq 2 ]
     Assert [ "$(grep -c "^init-worktree-tools:$repository$" "$helper_log")" -eq 2 ]
+  End
+
+  It 'continues when a package-managed uv refuses to self-update'
+    # `uv self update` is maintenance, not a prerequisite: every later use is
+    # `uv tool install --upgrade`, which a package-managed uv performs happily.
+    # A uv installed by apt/curl-to-/usr/local rather than the standalone script
+    # exits non-zero here, and under `set -eu` that aborted the whole run before
+    # a single tool was installed.
+    export DEBIAN_UV_SELF_UPDATE_FAILS=1
+    When run sh "$script_abs" "$repository"
+    The status should equal 0
+    Assert [ "$(grep -c '^uv:self update$' "$tool_log")" -eq 1 ]
+    Assert [ "$(grep -c '^uv:tool install --upgrade serena-agent$' "$tool_log")" -eq 1 ]
+    Assert [ "$(grep -c '^uv:tool install --upgrade graphifyy$' "$tool_log")" -eq 1 ]
+    Assert [ "$(grep -c '^uv:tool install --upgrade semgrep$' "$tool_log")" -eq 1 ]
   End
 
   It 'requires both repository setup helpers before running either one'

--- a/tests/shell/agent_tools_setup_spec.sh
+++ b/tests/shell/agent_tools_setup_spec.sh
@@ -998,6 +998,7 @@ CONFIG
     # a single tool was installed.
     export DEBIAN_UV_SELF_UPDATE_FAILS=1
     When run sh "$script_abs" "$repository"
+    Dump
     The status should equal 0
     Assert [ "$(grep -c '^uv:self update$' "$tool_log")" -eq 1 ]
     The stderr should include 'Self-update is only available'

--- a/tests/shell/agent_tools_setup_spec.sh
+++ b/tests/shell/agent_tools_setup_spec.sh
@@ -154,7 +154,10 @@ case "$*" in
     # A uv that did not come from the standalone installer refuses to
     # self-update and exits non-zero (issue: package-managed uv). The
     # installer must treat that as maintenance, not a prerequisite.
-    if [ -n "${DEBIAN_UV_SELF_UPDATE_FAILS:-}" ]; then exit 1; fi
+    if [ -n "${DEBIAN_UV_SELF_UPDATE_FAILS:-}" ]; then
+      printf 'error: Self-update is only available for uv binaries installed via the standalone installation scripts.\n' >&2
+      exit 1
+    fi
     ;;
   'tool install --upgrade serena-agent')
     uv_tool_bin=${UV_TOOL_BIN_DIR:-${XDG_BIN_HOME:-$HOME/.local/bin}}
@@ -337,7 +340,7 @@ GROK
     unset CLAUDECODE CODEX_THREAD_ID COPILOT_CLI GROK_AGENT GROK_SESSION_ID OMP_CLI PI_CLI
     unset DEBIAN_MISSING_PACKAGES SERENA_CONFIG_MODE SERENA_SETUP_MODE
     unset GROK_DOCTOR_RC AGENT_TEST_OS BREW_UV_INSTALLED XDG_BIN_HOME UV_TOOL_BIN_DIR
-    unset UV_OMIT_TOOL CODEGRAPH_BIN_DIR CARGO_HOME
+    unset UV_OMIT_TOOL CODEGRAPH_BIN_DIR CARGO_HOME DEBIAN_UV_SELF_UPDATE_FAILS
     PATH="$activebin:$basebin"; export PATH
   }
 
@@ -997,6 +1000,7 @@ CONFIG
     When run sh "$script_abs" "$repository"
     The status should equal 0
     Assert [ "$(grep -c '^uv:self update$' "$tool_log")" -eq 1 ]
+    The stderr should include 'Self-update is only available'
     Assert [ "$(grep -c '^uv:tool install --upgrade serena-agent$' "$tool_log")" -eq 1 ]
     Assert [ "$(grep -c '^uv:tool install --upgrade graphifyy$' "$tool_log")" -eq 1 ]
     Assert [ "$(grep -c '^uv:tool install --upgrade semgrep$' "$tool_log")" -eq 1 ]

--- a/tests/shell/agent_tools_setup_spec.sh
+++ b/tests/shell/agent_tools_setup_spec.sh
@@ -998,7 +998,6 @@ CONFIG
     # a single tool was installed.
     export DEBIAN_UV_SELF_UPDATE_FAILS=1
     When run sh "$script_abs" "$repository"
-    Dump
     The status should equal 0
     Assert [ "$(grep -c '^uv:self update$' "$tool_log")" -eq 1 ]
     The stderr should include 'Self-update is only available'


### PR DESCRIPTION
## Summary

`scripts/agent/setup-agent-tools.sh:249` guards `uv self update` with `command -v uv`. The guard answers **presence**; the branch requires **provenance** — a uv not installed by the standalone script refuses to self-update and exits non-zero. Under `set -eu` that ends the run before any tool is installed.

    error: Self-update is only available for uv binaries installed via the standalone installation scripts.

Reproduced on two boxes, both with a root-owned `/usr/local/bin/uv` (0.12.5 and 0.12.3), neither dpkg-owned. Provisioning is blocked on both.

## Fix

`uv self update || :` — maintenance, not a prerequisite. Every later use is `uv tool install --upgrade`, which a package-managed uv performs, and the `require_tool uv` check ahead of them only tests presence.

Deliberately **not** falling through to `install_from_url`: that puts a second uv in `~/.local/bin` on a box that already has a working one, and since the installer's own PATH order (`:244`) puts `~/.local/bin` first, it would shadow the system uv for every seat — a behaviour change well beyond the defect.

## Tests

The spec's uv stub succeeded unconditionally, so the failure path had no coverage. It now fails on demand via `DEBIAN_UV_SELF_UPDATE_FAILS`.

| gate | result |
| --- | --- |
| RED, new example vs unchanged production | 1 failure, exactly the new example |
| GREEN, zero assertion edits | 43 examples, 0 failures (dash) |

## Frozen RED

| Frozen RED test | git hash-object | RED run tail |
| --- | --- | --- |
| `tests/shell/agent_tools_setup_spec.sh` | `8e672eb3d373dbce893ebbff980d8e00e801b11c` | `43 examples, 1 failure` — shellspec tests/shell/agent_tools_setup_spec.sh:993 "continues when a package-managed uv refuses to self-update" FAILED; `The status should equal 0` expected 0 got 1, and the three tool-install counts 0 vs 1, against the production hunk reverted and the spec byte-identical |

## Note for review

This is the same shape as #3006 and #3004: a check answering the question adjacent to the one it needed. Worth a reviewer looking for a fourth rather than treating this as an isolated line.

🤖 Generated by [Claude Code](https://claude.com/claude-code), posted via @BBcan177's account on their behalf.

