### PR TITLE
Release: include Graphify patch in sparse helper checkout

### DIFF
--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -266,7 +266,9 @@ jobs:
           # destination — checking this out first would wipe it again.
           ref: ${{ github.workflow_sha }}
           repository: pfBlockerNG/pfBlockerNG
-          sparse-checkout: scripts/
+          sparse-checkout: |
+            scripts/
+            .agents/patches/
           sparse-checkout-cone-mode: false
           path: pfblockerng-src
           persist-credentials: false

--- a/tests/test_ci_graphify_merge_driver.py
+++ b/tests/test_ci_graphify_merge_driver.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 import pytest
+import yaml
 
 from tests._workflow_steps import extract_job
 
@@ -237,6 +238,21 @@ def test_exhaustive_push_matrix_has_graphify_driver_before_each_mutation() -> No
         except (AssertionError, ValueError) as error:
             failures.append(str(error))
     assert not failures, "\n" + "\n".join(failures)
+
+
+def test_foreign_target_helper_checkout_includes_graphify_patch_payload() -> None:
+    workflow = yaml.safe_load((WORKFLOWS / "release-published.yml").read_text(encoding="utf-8"))
+    checkouts = [
+        step
+        for step in workflow["jobs"]["sync-ports-fork"]["steps"]
+        if step.get("uses") == "actions/checkout@v6"
+        and step.get("with", {}).get("repository") == "pfBlockerNG/pfBlockerNG"
+        and step["with"].get("ref") == "${{ github.workflow_sha }}"
+        and step["with"].get("path") == "pfblockerng-src"
+    ]
+
+    assert len(checkouts) == 1
+    assert checkouts[0]["with"]["sparse-checkout"].splitlines() == ["scripts/", ".agents/patches/"]
 
 
 _GOOD_FIXTURE = """\


### PR DESCRIPTION
## Summary

- include the vendored Graphify patch payload beside the trusted sparse release helper
- bind the regression to the unique trusted repository/ref/path checkout used by the install command

## Evidence

| Frozen RED test | git hash-object | RED run tail |
| --- | --- | --- |
| `tests/test_ci_graphify_merge_driver.py` | `8c127f38c2e4ec1da466f8087c9bab1ac70d9a5c` | `1 failed, 21 passed: trusted helper checkout contained only scripts/` |

- recovery run 33431988803 failed before port mutation because `.agents/patches/graphify-3075-language-overrides.patch` was absent
- GREEN: 22 Graphify workflow contract tests passed with frozen final test bytes
- actionlint passed for `release-published.yml`
- review fix binds checkout repository, trusted workflow SHA, and `pfblockerng-src` path; duplicate-name decoys no longer satisfy the assertion

Refs #3004

🤖 Generated by Oh My Pi and posted on behalf of @andrebrait.