### PR TITLE
pfblockerng: fail closed when the feed-pass lock cannot be opened

### DIFF
--- a/graphify-out/memory/query_20260831_205833_pfb_feed_pass_acquire_feed_pass_lock_exit_code.md
+++ b/graphify-out/memory/query_20260831_205833_pfb_feed_pass_acquire_feed_pass_lock_exit_code.md
@@ -10,7 +10,7 @@ outcome: "useful"
 
 ## Answer
 
-acquire() is at pfblockerng.inc:19042; its fopen-failure branch returned TRUE (fail-open) while the un-contended flock failure returned FALSE. Callers: begin() plus extra.inc/alerts.php. Fixed to fail closed for #3000.
+acquire() is at pfblockerng.inc:19042; its fopen-failure branch returned TRUE (fail-open) while the un-contended flock failure returned FALSE. Callers: begin() (called by cron.inc, apply.inc, extra.inc) plus direct acquire() in extra.inc and alerts.php. Fixed to fail closed for #3000.
 
 ## Outcome
 

--- a/graphify-out/memory/query_20260831_205833_pfb_feed_pass_acquire_feed_pass_lock_exit_code.md
+++ b/graphify-out/memory/query_20260831_205833_pfb_feed_pass_acquire_feed_pass_lock_exit_code.md
@@ -1,0 +1,17 @@
+---
+type: "query"
+date: "2026-08-31T20:58:33.363671+00:00"
+question: "pfb_feed_pass_acquire feed pass lock exit code"
+contributor: "graphify"
+outcome: "useful"
+---
+
+# Q: pfb_feed_pass_acquire feed pass lock exit code
+
+## Answer
+
+acquire() is at pfblockerng.inc:19042; its fopen-failure branch returned TRUE (fail-open) while the un-contended flock failure returned FALSE. Callers: begin() plus extra.inc/alerts.php. Fixed to fail closed for #3000.
+
+## Outcome
+
+- Signal: useful

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -19050,8 +19050,12 @@ function pfb_feed_pass_acquire(?bool &$contended = NULL): bool {
 	$lockpath = "{$pfb['dbdir']}/pfb_feed_pass.lock";
 	$lock = @fopen($lockpath, 'c');	// 'c': create if absent, no truncate
 	if ($lock === FALSE) {
-		pfb_logger("\nFeed pass lock: open failed [ {$lockpath} ], proceeding unlocked", 2);
-		return TRUE;
+		// issue #3000: fail CLOSED, matching the un-contended flock failure below.
+		// Proceeding unlocked would run the pass with no mutual exclusion over
+		// shared recompute staging, and -- because $contended stays FALSE -- would
+		// report success to the CLI. A refusal is visible in the exit code.
+		pfb_logger("\n Feed pass lock: open failed [ {$lockpath} ]; feed pass aborted.\n", 2);
+		return FALSE;
 	}
 	$would_block = 0;
 	if (!@flock($lock, LOCK_EX | LOCK_NB, $would_block)) {

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -19050,10 +19050,9 @@ function pfb_feed_pass_acquire(?bool &$contended = NULL): bool {
 	$lockpath = "{$pfb['dbdir']}/pfb_feed_pass.lock";
 	$lock = @fopen($lockpath, 'c');	// 'c': create if absent, no truncate
 	if ($lock === FALSE) {
-		// issue #3000: fail CLOSED, matching the un-contended flock failure below.
-		// Proceeding unlocked would run the pass with no mutual exclusion over
-		// shared recompute staging, and -- because $contended stays FALSE -- would
-		// report success to the CLI. A refusal is visible in the exit code.
+		// issue #3000: fail CLOSED like the un-contended flock failure below --
+		// continuing without the lock would run the pass unserialised over shared
+		// recompute staging while still reporting success to the CLI.
 		pfb_logger("\n Feed pass lock: open failed [ {$lockpath} ]; feed pass aborted.\n", 2);
 		return FALSE;
 	}

--- a/tests/php/FeedPassLockTest.php
+++ b/tests/php/FeedPassLockTest.php
@@ -272,6 +272,28 @@ final class FeedPassLockTest extends TestCase
 		}
 	}
 
+	public function testFeedOpenErrorReportsFailureWithoutContention(): void
+	{
+		// issue #3000: the fourth cell of this matrix. The other three rows below
+		// already fail closed; the feed lock's OPEN error used to be the one path
+		// that proceeded WITHOUT mutual exclusion, so two passes could run
+		// unserialised over shared recompute staging while the CLI reported success.
+		// A parent directory that does not exist makes fopen(..., 'c') fail for
+		// every uid -- unlike a chmod fixture, this row also runs as root.
+		$GLOBALS['pfb']['dbdir'] = "{$this->dbdir}/missing/child";
+		$contended = TRUE;
+
+		$this->assertFalse(pfb_feed_pass_acquire($contended),
+			'an unopenable feed lock must abort the pass, never proceed unlocked');
+		$this->assertFalse($contended, 'a feed open error is not contention');
+
+		$log = is_file($GLOBALS['pfb']['log']) ? (string) file_get_contents($GLOBALS['pfb']['log']) : '';
+		$this->assertStringNotContainsString('proceeding unlocked', $log,
+			'the abort must not log the old fail-open wording');
+		$this->assertStringNotContainsString('another pfBlockerNG feed pass is running', $log,
+			'an open error must not masquerade as contention');
+	}
+
 	public function testDispatcherOpenErrorReportsFailureWithoutContention(): void
 	{
 		$GLOBALS['pfb']['schedule_state_dir'] = "{$this->dbdir}/missing/child";
@@ -432,9 +454,13 @@ final class FeedPassLockTest extends TestCase
 			'the outer guarded release (owner flag TRUE) must free the lock');
 	}
 
-	// Hostile row -- lock file unopenable: begin() inherits acquire()'s fail-open
-	// (an unwritable dbdir must never block a legitimate pass).
-	public function testBeginFailsOpenWhenLockFileUnopenable(): void
+	// Hostile row -- lock file unopenable: begin() inherits acquire()'s fail-CLOSED
+	// (issue #3000). This row asserted the opposite on purpose until then: an
+	// unwritable dbdir was allowed through so it could not block a legitimate
+	// pass. That tradeoff is now inverted deliberately -- a pass that cannot
+	// serialise must refuse, because running unserialised corrupts shared
+	// recompute staging silently, while a refusal is visible in the exit code.
+	public function testBeginFailsClosedWhenLockFileUnopenable(): void
 	{
 		if (function_exists('posix_getuid') && posix_getuid() === 0) {
 			$this->markTestSkipped('root bypasses directory permissions; cannot simulate an unwritable dbdir');
@@ -446,8 +472,8 @@ final class FeedPassLockTest extends TestCase
 		chmod($denydir, 0555);
 
 		try {
-			$this->assertTrue(pfb_feed_pass_begin('sync'),
-				'an unwritable dbdir must fail OPEN -- begin() returns TRUE rather than blocking legitimate work');
+			$this->assertFalse(pfb_feed_pass_begin('sync'),
+				'an unwritable dbdir must fail CLOSED -- begin() returns FALSE rather than running a pass with no mutual exclusion');
 		} finally {
 			chmod($denydir, 0755);
 		}

--- a/tests/php/FeedPassLockTest.php
+++ b/tests/php/FeedPassLockTest.php
@@ -274,12 +274,10 @@ final class FeedPassLockTest extends TestCase
 
 	public function testFeedOpenErrorReportsFailureWithoutContention(): void
 	{
-		// issue #3000: the fourth cell of this matrix. The other three rows below
-		// already fail closed; the feed lock's OPEN error used to be the one path
-		// that proceeded WITHOUT mutual exclusion, so two passes could run
-		// unserialised over shared recompute staging while the CLI reported success.
-		// A parent directory that does not exist makes fopen(..., 'c') fail for
-		// every uid -- unlike a chmod fixture, this row also runs as root.
+		// issue #3000: the feed lock's OPEN error, the fourth cell of this matrix.
+		// A missing parent directory makes fopen(..., 'c') fail with ENOENT, which
+		// is an existence error rather than a permission one -- so unlike the
+		// chmod fixture below, this row needs no root skip guard.
 		$GLOBALS['pfb']['dbdir'] = "{$this->dbdir}/missing/child";
 		$contended = TRUE;
 
@@ -290,8 +288,6 @@ final class FeedPassLockTest extends TestCase
 		$log = is_file($GLOBALS['pfb']['log']) ? (string) file_get_contents($GLOBALS['pfb']['log']) : '';
 		$this->assertStringNotContainsString('proceeding unlocked', $log,
 			'the abort must not log the old fail-open wording');
-		$this->assertStringNotContainsString('another pfBlockerNG feed pass is running', $log,
-			'an open error must not masquerade as contention');
 	}
 
 	public function testDispatcherOpenErrorReportsFailureWithoutContention(): void
@@ -455,11 +451,9 @@ final class FeedPassLockTest extends TestCase
 	}
 
 	// Hostile row -- lock file unopenable: begin() inherits acquire()'s fail-CLOSED
-	// (issue #3000). This row asserted the opposite on purpose until then: an
-	// unwritable dbdir was allowed through so it could not block a legitimate
-	// pass. That tradeoff is now inverted deliberately -- a pass that cannot
-	// serialise must refuse, because running unserialised corrupts shared
-	// recompute staging silently, while a refusal is visible in the exit code.
+	// (issue #3000). A pass that cannot serialise must refuse: running unserialised
+	// corrupts shared recompute staging silently, while a refusal is visible in the
+	// exit code.
 	public function testBeginFailsClosedWhenLockFileUnopenable(): void
 	{
 		if (function_exists('posix_getuid') && posix_getuid() === 0) {

--- a/tests/php/SyncGuardLoggingTest.php
+++ b/tests/php/SyncGuardLoggingTest.php
@@ -101,6 +101,7 @@ final class SyncGuardLoggingTest extends TestCase
 
 		$paths = array_merge(
 			glob("{$this->dir}/db/*") ?: [],
+			glob("{$this->dir}/db/.*") ?: [],
 			glob("{$this->dir}/state/*") ?: [],
 			glob("{$this->dir}/cc/*") ?: [],
 			glob("{$this->dir}/cc/.*") ?: [],
@@ -150,18 +151,11 @@ final class SyncGuardLoggingTest extends TestCase
 		// Unrecoverable backup pair: pfb_stage_publish_dir_recover() finds a
 		// '.pfbstagebak2_<name>' backup DIRECTORY whose live target '<name>' already
 		// exists and is NOT a directory, so it cannot restore or discard it and
-		// returns FALSE.
-		//
-		// This row used to vanish dbdir entirely (the scandir(FALSE) path), which
-		// reached this guard only because pfb_feed_pass_acquire() FAILED OPEN: with
-		// dbdir gone its lock fopen() failed and it returned TRUE anyway. Issue #3000
-		// flipped that to fail-closed, so pfb_feed_pass_begin('sync') — which runs
-		// FIRST — now aborts the sync before this guard, exactly as the old comment
-		// here predicted. dbdir must therefore stay present and writable, and the
-		// recovery has to fail on its own terms.
+		// returns FALSE. dbdir must stay present and writable, or issue #3000's
+		// fail-closed lock aborts the sync at pfb_feed_pass_begin() first and this
+		// row stops testing the guard it names.
 		$dbdir = $GLOBALS['pfb']['dbdir'];
-		$this->assertDirectoryExists($dbdir, 'test setup: dbdir must exist so the feed-pass lock can open');
-		$this->assertTrue(mkdir("{$dbdir}/.pfbstagebak2_orphan", 0755, TRUE),
+		$this->assertTrue(mkdir("{$dbdir}/.pfbstagebak2_orphan", 0755),
 			'test setup: could not create the stale stage backup directory');
 		$this->assertNotFalse(file_put_contents("{$dbdir}/orphan", "not a directory\n"),
 			'test setup: could not create the non-directory that blocks recovery');

--- a/tests/php/SyncGuardLoggingTest.php
+++ b/tests/php/SyncGuardLoggingTest.php
@@ -147,16 +147,24 @@ final class SyncGuardLoggingTest extends TestCase
 
 	public function testStagePublishRecoverFailureLogsThePrecondition(): void
 	{
-		// scandir(FALSE) path: dbdir vanished out from under the run.
+		// Unrecoverable backup pair: pfb_stage_publish_dir_recover() finds a
+		// '.pfbstagebak2_<name>' backup DIRECTORY whose live target '<name>' already
+		// exists and is NOT a directory, so it cannot restore or discard it and
+		// returns FALSE.
 		//
-		// This reaches the stage/publish guard only because pfb_feed_pass_acquire()
-		// FAILS OPEN (pfblockerng.inc:17685): with dbdir gone its lock fopen() fails, it
-		// logs "Feed pass lock: open failed [...], proceeding unlocked" and returns TRUE,
-		// so pfb_feed_pass_begin('sync') — which runs FIRST — does not abort the sync.
-		// If that policy ever flips to fail-closed this row goes RED (the log would carry
-		// the feed-pass skip wording instead of stage/publish), which is the correct
-		// signal: the row would no longer be testing what it claims.
-		$GLOBALS['pfb']['dbdir'] = "{$this->dir}/db-nonexistent";
+		// This row used to vanish dbdir entirely (the scandir(FALSE) path), which
+		// reached this guard only because pfb_feed_pass_acquire() FAILED OPEN: with
+		// dbdir gone its lock fopen() failed and it returned TRUE anyway. Issue #3000
+		// flipped that to fail-closed, so pfb_feed_pass_begin('sync') — which runs
+		// FIRST — now aborts the sync before this guard, exactly as the old comment
+		// here predicted. dbdir must therefore stay present and writable, and the
+		// recovery has to fail on its own terms.
+		$dbdir = $GLOBALS['pfb']['dbdir'];
+		$this->assertDirectoryExists($dbdir, 'test setup: dbdir must exist so the feed-pass lock can open');
+		$this->assertTrue(mkdir("{$dbdir}/.pfbstagebak2_orphan", 0755, TRUE),
+			'test setup: could not create the stale stage backup directory');
+		$this->assertNotFalse(file_put_contents("{$dbdir}/orphan", "not a directory\n"),
+			'test setup: could not create the non-directory that blocks recovery');
 
 		$this->assertFalse(sync_package_pfblockerng('noupdates'),
 			'before-state: an unrecoverable stage/publish dir must abort the sync');


### PR DESCRIPTION
Fixes #3000

## What was wrong

`pfb_feed_pass_acquire()` applied opposite failure policies to the two failure paths of the same mutex. An un-lockable lock file aborted the pass; an un-openable one logged a single level-2 line and returned `TRUE`, continuing with no mutual exclusion over shared recompute staging.

That branch also left `$contended` FALSE, so `$deferred_by` stayed `NULL` and `pfb_feed_pass_exit_code()` returned `0`. Two concurrent passes could therefore run unserialised while the CLI reported success. Reachable whenever the lock file cannot be opened for create: `dbdir` absent, wrong permissions, read-only filesystem, `ENOSPC`, `EMFILE`.

## The change

The `fopen` failure now logs and returns `FALSE`, matching the un-contended `flock` failure directly below it.

This completes the matrix the test file already declares under "Row 8 — acquisition errors fail closed without masquerading as contention". Three of its four cells already failed closed (feed flock error, dispatcher open error, dispatcher flock error); the feed **open** error was the only one that did not.

## This inverts a deliberate, previously pinned decision

`testBeginFailsOpenWhenLockFileUnopenable` asserted the fail-open on purpose, so an unwritable `dbdir` could never block a legitimate pass. That tradeoff is accepted and reversed: an unwritable `dbdir` now blocks every feed pass, because a pass that cannot serialise should refuse rather than corrupt shared staging silently — and a refusal is visible in the exit code, where the old behaviour was not.

## Blast radius beyond the issue's stated scope

The issue scoped the change to one assertion. It is two.

`SyncGuardLoggingTest::testStagePublishRecoverFailureLogsThePrecondition` reached its guard *only* via the fail-open — it vanished `dbdir`, which made the lock `fopen()` fail. Its own comment predicted this exact flip and said the row should go red as the correct signal. It now fails recovery on its own terms: a stale `.pfbstagebak2_orphan` backup directory whose live target `orphan` is not a directory, with `dbdir` present and writable.

## Tests (red → green, frozen)

`tests/php/FeedPassLockTest.php` — the inverted row plus a new acquire-level sibling, `testFeedOpenErrorReportsFailureWithoutContention`, which uses a missing parent directory so it also runs as root (unlike the `chmod 0555` fixture, which skips under root).

- RED on untouched production code: both rows failed, `Failed asserting that true is false`.
- Test file frozen byte-identical across the flip: `git hash-object` = `9b9ac530ff9cd7e6278c8899c18b3a99f9c19f79` at both the red and green runs.
- GREEN after the production edit, same file: `OK (22 tests, 87 assertions)`.

Full-suite differential against the same tree with only the production hunk stashed: exactly 2 rows fixed, exactly 1 row newly red (the `SyncGuardLoggingTest` row above, then repaired), 76 unchanged failures.

Those 76 are environmental on this box, not from this branch: `php-intl` is absent, so every IDN row dies on `Call to undefined function idn_to_ascii()`. They fail identically on untouched `origin/devel` here.

## Gates

`scripts/agent/run-gates.sh`: coverage-pairing, composer-vendor, php -l, phpcs, markdownlint and the policy checkers all pass. PHPStan clean (`No errors`). PHPUnit locally carries only the pre-existing `intl` failures described above; CI is the authoritative verdict on the PHP suite.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Feed synchronization now stops safely when its lock file cannot be opened, preventing operations from proceeding without protection.
  * Updated logging clearly reports when a feed pass is aborted.
  * Synchronization recovery failures are handled and reported more reliably.

* **Tests**
  * Added coverage for lock-file access failures and fail-closed synchronization behavior.
  * Improved cleanup and recovery test scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->