### PR TITLE
tests: recognise JS template-literal interpolation in ThemeSafety

### DIFF
--- a/tests/php/ThemeSafetyUiTest.php
+++ b/tests/php/ThemeSafetyUiTest.php
@@ -82,8 +82,7 @@ final class ThemeSafetyUiTest extends TestCase
 			'EditorView.theme({ "&": { backgroundColor: "#fff", color: "#212121" } })',
 			'td style=\'font-size:10px; color: red; background-color: rgba(128, 128, 128, 0.2);\'',
 			'setAttribute(\'style\', "background: {$pfb[$u_key]}")',
-			// issue #2962: the JS mirror of the PHP row above. scan() reads .js files,
-			// where interpolation is ${...} inside a template literal, not {$...}.
+			// issue #2962: the JS mirror of the PHP row above -- scan() reads .js too.
 			'const s = `background-color: ${theme.bg}`;',
 			'colors: { background: null, segmentStroke: "#ffffff" }',
 		];
@@ -1180,8 +1179,7 @@ final class ThemeSafetyUiTest extends TestCase
 
 	private static function isInterpolated(string $value): bool
 	{
-		// '{$' is PHP's complex interpolation; '${' is a JS template-literal
-		// placeholder, and scan() reads .js as well as .php (issue #2962).
+		// '{$' is PHP, '${' a JS template literal -- scan() reads both (issue #2962).
 		return str_contains($value, '{$')
 			|| str_contains($value, '${')
 			|| (bool)preg_match('/\$[a-zA-Z_]/', $value);

--- a/tests/php/ThemeSafetyUiTest.php
+++ b/tests/php/ThemeSafetyUiTest.php
@@ -82,6 +82,9 @@ final class ThemeSafetyUiTest extends TestCase
 			'EditorView.theme({ "&": { backgroundColor: "#fff", color: "#212121" } })',
 			'td style=\'font-size:10px; color: red; background-color: rgba(128, 128, 128, 0.2);\'',
 			'setAttribute(\'style\', "background: {$pfb[$u_key]}")',
+			// issue #2962: the JS mirror of the PHP row above. scan() reads .js files,
+			// where interpolation is ${...} inside a template literal, not {$...}.
+			'const s = `background-color: ${theme.bg}`;',
 			'colors: { background: null, segmentStroke: "#ffffff" }',
 		];
 		foreach ($good as $src) {
@@ -1177,7 +1180,10 @@ final class ThemeSafetyUiTest extends TestCase
 
 	private static function isInterpolated(string $value): bool
 	{
+		// '{$' is PHP's complex interpolation; '${' is a JS template-literal
+		// placeholder, and scan() reads .js as well as .php (issue #2962).
 		return str_contains($value, '{$')
+			|| str_contains($value, '${')
 			|| (bool)preg_match('/\$[a-zA-Z_]/', $value);
 	}
 


### PR DESCRIPTION
Fixes #2962

## Defect

`ThemeSafetyUiTest::isInterpolated()` recognised PHP interpolation only:

```php
return str_contains($value, '{$')
    || (bool)preg_match('/\$[a-zA-Z_]/', $value);
```

`scan()` also reads `.js`, where interpolation is `${...}` inside a template literal. Neither existing form matches it — `{$` is the reverse order, and `\$[a-zA-Z_]` cannot match because the character following `$` is `{`. A computed JS background was graded as a hardcoded colour and reported as an unpaired opaque background.

## Change

One added alternative, `str_contains($value, '${')`, as the issue's own suggested fix describes. `${` is also valid (if deprecated) PHP interpolation, so the addition is consistent across both languages `scan()` reads.

## Test

The reproduction row is the JS mirror of the PHP interpolation row already present in `testTranslucentOrPairedForegroundIsNotAViolation`'s `$good` list, placed directly beside it.

- RED on untouched code: `Failed asserting that two arrays are identical`, reporting `'excerpt' => 'background-color: ${theme.bg'` as a violation — the exact defect.
- GREEN after the one-line change, test row byte-identical (verified by diff: the row appears only as an addition, never altered between runs).
- `OK (94 tests, 118 assertions)`.

## Direction of the fix

This defect errs toward the false-positive side — noise on correct code, not a laundered violation — which is why the issue was deferred rather than fixed inline at the time. The fix removes the noise without widening what the guard accepts: `isInterpolated()` only ever suppresses grading a value as a *hardcoded* colour, so no previously-reported violation can be laundered by it unless the value genuinely contains a placeholder.

## Gates

`scripts/agent/run-gates.sh`: all pass except PHPUnit, whose failures are pre-existing on this box and reproduce on pristine `devel`. Zero ThemeSafety rows fail. CI is authoritative for the PHP suite.

The failing set is 76 rows and is **not** all one cause — an earlier revision of this body said "76 IDN failures", which was wrong:

- **61** IDN/Unicode rows — `php-intl` is absent here (`Call to undefined function idn_to_ascii()`).
- **15** non-IDN rows — `DownloadExtractedPayloadSanityTest` (6), `DownloadGeoipStagePublishTest` (5), `NoEmptyOnStringRuleTest` (2), `DownloadRejectValidatorClearTest` (1), `SourceScanningWiringPolicyTest` (1); archive/tooling and lint-rule environment gaps, unrelated to this diff.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved theme safety checks to correctly recognize background colors interpolated in JavaScript template literals.
  * Prevented valid interpolated color usage from being incorrectly reported as a violation.

* **Tests**
  * Added coverage for JavaScript template-literal color interpolation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->