### PR TITLE
tests: exercise ThemeSafety's CSS scan path and pin the extension filter

### DIFF
--- a/tests/php/ThemeSafetyUiTest.php
+++ b/tests/php/ThemeSafetyUiTest.php
@@ -442,14 +442,10 @@ final class ThemeSafetyUiTest extends TestCase
 	}
 
 	/**
-	 * The 'css' entry in scanTree()'s extension list matches no file under any scan
-	 * root, and never has (issue #2963). Two readings were possible: aspirational, so
-	 * a stylesheet added later is scanned automatically; or stale, so the entry is
-	 * dead. The entry is KEPT as aspirational, and this row is what makes that a
-	 * decision rather than a guess -- it builds a throwaway root, puts a stylesheet
-	 * with an unpaired opaque background under one of the four scanned directories,
-	 * and asserts scanTree() reports it. The second assertion pins the filter's
-	 * other side, so widening the list to everything fails the row too.
+	 * Pins scanTree()'s 'css' entry as aspirational rather than stale (issue #2963):
+	 * a .css probe under a scanned root must be reported, and an unlisted .scss with
+	 * identical content skipped -- so widening the list to everything fails the row
+	 * too. The rationale for keeping the entry lives on the list itself.
 	 */
 	public function testScanTreeReadsAStylesheetAndSkipsAnUnlistedExtension(): void
 	{
@@ -459,17 +455,15 @@ final class ThemeSafetyUiTest extends TestCase
 		try {
 			// Inside the try so a partially created tree is still torn down.
 			$this->assertTrue(mkdir($dir, 0755, TRUE), 'test setup: could not create the scan root');
-			file_put_contents("{$dir}/pfb_probe.css", $rule);
-			// Asserted, unlike the .css write: a silent failure here would make the
-			// assertArrayNotHasKey below pass vacuously.
+			$this->assertNotFalse(file_put_contents("{$dir}/pfb_probe.css", $rule),
+				'test setup: could not write the stylesheet');
 			$this->assertNotFalse(file_put_contents("{$dir}/pfb_probe.scss", $rule),
 				'test setup: could not write the unlisted-extension file');
 
 			$found = self::scanTree($root);
 
 			$this->assertArrayHasKey('src/usr/local/www/pfblockerng/pfb_probe.css', $found,
-				'scanTree() must reach and scan a .css file under a scan root -- if this fails '
-				. 'while the background-syntax rows still pass, the extension list is the cause');
+				'a .css file under a scan root must be scanned -- css is in the extension list');
 			$this->assertArrayNotHasKey('src/usr/local/www/pfblockerng/pfb_probe.scss', $found,
 				'an extension absent from the list must be skipped, identical content notwithstanding');
 		} finally {
@@ -506,9 +500,8 @@ final class ThemeSafetyUiTest extends TestCase
 					continue;
 				}
 				$ext = strtolower(pathinfo($path, PATHINFO_EXTENSION));
-				// 'css' matches nothing under these roots today; kept deliberately for a
-				// stylesheet that lands later, and pinned by
-				// testScanTreeReadsAStylesheetAndSkipsAnUnlistedExtension() (issue #2963).
+				// 'css' matches nothing under these roots today; kept for a stylesheet that
+				// lands later, pinned by testScanTreeReadsAStylesheet...() (issue #2963).
 				if (!in_array($ext, ['php', 'inc', 'js', 'css'], TRUE)) {
 					continue;
 				}

--- a/tests/php/ThemeSafetyUiTest.php
+++ b/tests/php/ThemeSafetyUiTest.php
@@ -448,37 +448,32 @@ final class ThemeSafetyUiTest extends TestCase
 	 * dead. The entry is KEPT as aspirational, and this row is what makes that a
 	 * decision rather than a guess -- it builds a throwaway root, puts a stylesheet
 	 * with an unpaired opaque background under one of the four scanned directories,
-	 * and asserts scanTree() reports it.
-	 *
-	 * The second assertion pins the filter's other side: an extension absent from the
-	 * list is skipped despite identical content. Without it the row would still pass
-	 * if the list were widened to accept everything.
+	 * and asserts scanTree() reports it. The second assertion pins the filter's
+	 * other side, so widening the list to everything fails the row too.
 	 */
 	public function testScanTreeReadsAStylesheetAndSkipsAnUnlistedExtension(): void
 	{
 		$root = sys_get_temp_dir() . '/pfb_themesafety_scantree_' . uniqid('', TRUE);
 		$dir = "{$root}/src/usr/local/www/pfblockerng";
-		$this->assertTrue(mkdir($dir, 0755, TRUE), 'test setup: could not create the scan root');
-
 		$rule = ".pfb-generated { background-color: #f0f0f0; }\n";
 		try {
-			$this->assertNotFalse(file_put_contents("{$dir}/pfb_probe.css", $rule),
-				'test setup: could not write the stylesheet');
+			// Inside the try so a partially created tree is still torn down.
+			$this->assertTrue(mkdir($dir, 0755, TRUE), 'test setup: could not create the scan root');
+			file_put_contents("{$dir}/pfb_probe.css", $rule);
+			// Asserted, unlike the .css write: a silent failure here would make the
+			// assertArrayNotHasKey below pass vacuously.
 			$this->assertNotFalse(file_put_contents("{$dir}/pfb_probe.scss", $rule),
 				'test setup: could not write the unlisted-extension file');
 
 			$found = self::scanTree($root);
 
 			$this->assertArrayHasKey('src/usr/local/www/pfblockerng/pfb_probe.css', $found,
-				'a .css file under a scan root must be scanned -- css is in the extension list');
+				'scanTree() must reach and scan a .css file under a scan root -- if this fails '
+				. 'while the background-syntax rows still pass, the extension list is the cause');
 			$this->assertArrayNotHasKey('src/usr/local/www/pfblockerng/pfb_probe.scss', $found,
 				'an extension absent from the list must be skipped, identical content notwithstanding');
 		} finally {
-			@unlink("{$dir}/pfb_probe.css");
-			@unlink("{$dir}/pfb_probe.scss");
-			for ($d = $dir; str_starts_with($d, $root); $d = dirname($d)) {
-				@rmdir($d);
-			}
+			rmdir_recursive($root);
 		}
 	}
 
@@ -511,6 +506,9 @@ final class ThemeSafetyUiTest extends TestCase
 					continue;
 				}
 				$ext = strtolower(pathinfo($path, PATHINFO_EXTENSION));
+				// 'css' matches nothing under these roots today; kept deliberately for a
+				// stylesheet that lands later, and pinned by
+				// testScanTreeReadsAStylesheetAndSkipsAnUnlistedExtension() (issue #2963).
 				if (!in_array($ext, ['php', 'inc', 'js', 'css'], TRUE)) {
 					continue;
 				}

--- a/tests/php/ThemeSafetyUiTest.php
+++ b/tests/php/ThemeSafetyUiTest.php
@@ -442,6 +442,47 @@ final class ThemeSafetyUiTest extends TestCase
 	}
 
 	/**
+	 * The 'css' entry in scanTree()'s extension list matches no file under any scan
+	 * root, and never has (issue #2963). Two readings were possible: aspirational, so
+	 * a stylesheet added later is scanned automatically; or stale, so the entry is
+	 * dead. The entry is KEPT as aspirational, and this row is what makes that a
+	 * decision rather than a guess -- it builds a throwaway root, puts a stylesheet
+	 * with an unpaired opaque background under one of the four scanned directories,
+	 * and asserts scanTree() reports it.
+	 *
+	 * The second assertion pins the filter's other side: an extension absent from the
+	 * list is skipped despite identical content. Without it the row would still pass
+	 * if the list were widened to accept everything.
+	 */
+	public function testScanTreeReadsAStylesheetAndSkipsAnUnlistedExtension(): void
+	{
+		$root = sys_get_temp_dir() . '/pfb_themesafety_scantree_' . uniqid('', TRUE);
+		$dir = "{$root}/src/usr/local/www/pfblockerng";
+		$this->assertTrue(mkdir($dir, 0755, TRUE), 'test setup: could not create the scan root');
+
+		$rule = ".pfb-generated { background-color: #f0f0f0; }\n";
+		try {
+			$this->assertNotFalse(file_put_contents("{$dir}/pfb_probe.css", $rule),
+				'test setup: could not write the stylesheet');
+			$this->assertNotFalse(file_put_contents("{$dir}/pfb_probe.scss", $rule),
+				'test setup: could not write the unlisted-extension file');
+
+			$found = self::scanTree($root);
+
+			$this->assertArrayHasKey('src/usr/local/www/pfblockerng/pfb_probe.css', $found,
+				'a .css file under a scan root must be scanned -- css is in the extension list');
+			$this->assertArrayNotHasKey('src/usr/local/www/pfblockerng/pfb_probe.scss', $found,
+				'an extension absent from the list must be skipped, identical content notwithstanding');
+		} finally {
+			@unlink("{$dir}/pfb_probe.css");
+			@unlink("{$dir}/pfb_probe.scss");
+			for ($d = $dir; str_starts_with($d, $root); $d = dirname($d)) {
+				@rmdir($d);
+			}
+		}
+	}
+
+	/**
 	 * @return array<string, list<array{line:int, excerpt:string}>>
 	 */
 	public static function scanTree(string $root): array


### PR DESCRIPTION
Fixes #2963

## The decision this PR makes

`scanTree()` accepts `['php', 'inc', 'js', 'css']` and there are zero `.css` files under any of its four scan roots. The issue set out two readings that want opposite fixes:

- **aspirational** — `.css` is there so a stylesheet added later is scanned automatically; then it is correct and should stay, but nothing proves it works;
- **stale** — CSS moved elsewhere or never shipped from these roots; then the entry is dead and should go.

This PR takes the **aspirational** reading and supplies the missing proof. That is the smaller, reversible choice: keeping the entry costs one test, whereas dropping it silently removes coverage the first time a `.css` file lands under a scan root, and nothing would flag its absence.

## Change

One test row, plus the comment recording which reading applies — since "a reader cannot tell which of the two it is" was the defect, not the extension list itself.

The row builds a throwaway root, writes a stylesheet with an unpaired opaque background under one of the four scanned directories, and asserts `scanTree()` reports it. A second assertion pins the filter's other side: a `.scss` file with byte-identical content is skipped.

## No red-first run, and why

This is behaviour-preserving coverage — `css` was already in the list, so the row passes on untouched code. `.agents/policy/testing.md` covers exactly this case: behaviour-preserving work pins existing behaviour as its oracle and stays green across the change.

That makes "does it have teeth" the only question worth answering, so both assertions were mutated:

| Mutation | Result |
| --- | --- |
| drop `'css'` from the extension list (the stale reading) | **RED** — `a .css file under a scan root must be scanned` |
| widen the filter to accept every extension | **RED** — `an extension absent from the list must be skipped` |
| restored | `OK (95 tests, 122 assertions)` |

The second mutation matters: without that assertion the row would still pass if the list were widened to everything, so it is what stops this being a one-sided test.

The fixture cleans up after itself — zero `/tmp/pfb_themesafety_scantree_*` directories remain after a run.

## Gates

`scripts/agent/run-gates.sh`: all pass except PHPUnit, whose failures are pre-existing on this box and reproduce on pristine `devel`. Zero ThemeSafety rows fail. CI is authoritative for the PHP suite.

The failing set is 76 rows and is **not** all one cause — an earlier revision of this body said "76 IDN failures", which was wrong:

- **61** IDN/Unicode rows — `php-intl` is absent here (`Call to undefined function idn_to_ascii()`).
- **15** non-IDN rows — `DownloadExtractedPayloadSanityTest` (6), `DownloadGeoipStagePublishTest` (5), `NoEmptyOnStringRuleTest` (2), `DownloadRejectValidatorClearTest` (1), `SourceScanningWiringPolicyTest` (1); archive/tooling and lint-rule environment gaps, unrelated to this diff.

A 77th row, `CountLinesTest::testManyTimesOneChunkStaysWithinBoundedMemory`, fails intermittently with `Failed asserting that 1006848 is identical to 2097152` — a truncated fixture write, because `/tmp` on this host is a 3.9 GB tmpfs currently at 100%. Environmental, and reproduced on pristine `devel`.
