### PR TITLE
Tooling: enforce Graphify patch for every contributor

### DIFF
--- a/.agents/context/repository-intelligence.md
+++ b/.agents/context/repository-intelligence.md
@@ -20,8 +20,8 @@ Load when: every agent session, from `AGENTS.md`.
   installs or upgrades `graphifyy>=0.9.51` with `uv` and runs
   `scripts/agent/patch-graphify.sh`, before activating `.githooks`. Missing `uv`,
   a wrapper launcher without a Python shebang, or an interpreter that cannot import
-  the selected Graphify package fails closed. `setup-agent-tools.sh` uses the same
-  shared installer; its later setup-hooks call is intentionally idempotent.
+  the selected Graphify package fails closed. `setup-agent-tools.sh` runs this canonical
+  setup at Graphify's install-order slot, before ast-grep and semgrep.
 - Initialize a checkout with `sh scripts/agent/init-worktree-tools.sh .`. It runs
   `scripts/agent/ensure-codegraph.sh` for the exact-root CodeGraph index, reapplies
   the Graphify patch, then runs `graphify update <root>` when the root graph exists.

--- a/.agents/context/repository-intelligence.md
+++ b/.agents/context/repository-intelligence.md
@@ -15,36 +15,30 @@ Load when: every agent session, from `AGENTS.md`.
   release wait on a repository commit and downgrades a host that is already ahead.
   When a setup script fails because a dependency is absent, that missing dependency is
   installed the same way, never pinned to whatever version the failure happened to name.
-- Initialize a checkout with `sh scripts/agent/init-worktree-tools.sh .`.
-  `work-branch.sh --worktree` runs the same initializer after creating a worktree and
-  removes the new worktree and branch if initialization fails; it uses Git directly
-  and does not require Worktrunk. For `wt --yes switch --create <branch>`, the tracked
-  `.config/wt.toml` runs the initializer as its `pre-start` hook and prunes worktree metadata after
-  Worktrunk merge and remove operations.
-- CodeGraph and Graphify are mandatory. The initializer runs
-  `scripts/agent/ensure-codegraph.sh` for the exact-root CodeGraph index first,
-  then runs `graphify update <root>` when the root graph already exists. When the
-  root graph is absent the initializer prints a notice and builds nothing: the
-  first build's scope is a judgement call, so create it with a `/graphify` run in
-  an AI assistant. Install or refresh Graphify in one command with
-  `uv tool install --upgrade 'graphifyy>=0.9.51'` — a floor, never an exact pin, so a
-  fresh host and an outdated one both land on the current release.
-- Graphify's suffix map parses `.inc` as Pascal, so this repository's PHP includes
-  extract as roughly 30 incidental nodes instead of roughly 767 while extraction still
-  reports success. Until upstream releases Graphify-Labs/graphify#3075, that fix rides
-  as `.agents/patches/graphify-3075-language-overrides.patch`, applied to the installed
-  package by `scripts/agent/patch-graphify.sh` from its two call sites:
-  `ensure-graphify-merge-driver.sh` (the entry point seven branch/content mutation workflows use) and
-  `init-worktree-tools.sh`, before it refreshes the graph. It patches only the package
-  owned by the interpreter named on the `graphify` shebang, so a `pip --user` or
-  PYTHONPATH-only Graphify is skipped rather than patched — caught by the tracked
-  graph's include-node floor in `tests/test_cross_agent_tooling.py`. Because it patches
-  the installed package, a bare `uv tool upgrade graphifyy` reverts it; the next
-  bootstrap, worktree cut, or CI run re-applies it. The tracked `.graphifyrc`
-  (`language.inc=php`) is inert on an unpatched Graphify, so a contributor who never
-  runs these scripts sees the old Pascal parse, not breakage. Delete the patch, the
-  script, its two call sites, and their tests once a released graphifyy carries the
-  change.
+- CodeGraph and Graphify are mandatory. Canonical post-clone setup is
+  `sh scripts/setup-hooks.sh`: it calls `scripts/agent/ensure-graphify.sh`, which
+  installs or upgrades `graphifyy>=0.9.51` with `uv` and runs
+  `scripts/agent/patch-graphify.sh`, before activating `.githooks`. Missing `uv`,
+  a wrapper launcher without a Python shebang, or an interpreter that cannot import
+  the selected Graphify package fails closed. `setup-agent-tools.sh` uses the same
+  shared installer; its later setup-hooks call is intentionally idempotent.
+- Initialize a checkout with `sh scripts/agent/init-worktree-tools.sh .`. It runs
+  `scripts/agent/ensure-codegraph.sh` for the exact-root CodeGraph index, reapplies
+  the Graphify patch, then runs `graphify update <root>` when the root graph exists.
+  When the graph is absent it prints a notice and builds nothing; first-build scope
+  is a judgement call handled by a `/graphify` run. `work-branch.sh --worktree`
+  routes through this initializer and rolls back a failed cut;
+  `wt --yes switch --create <branch>` runs it from `.config/wt.toml`.
+- Graphify's suffix map parses `.inc` as Pascal, collapsing this repository's PHP
+  includes from roughly 767 nodes to roughly 30 while extraction still succeeds.
+  Until a release includes Graphify-Labs/graphify#3075, the fix rides as
+  `.agents/patches/graphify-3075-language-overrides.patch`. The tracked
+  `.graphifyrc` (`language.inc=php`) activates it. `ensure-graphify-merge-driver.sh`
+  delegates to the shared installer before `graphify hook install`;
+  `init-worktree-tools.sh` patches before update; and `.githooks/pre-commit` patches
+  before its no-staged-files exit, repairing a bare Graphify upgrade before the
+  post-commit rebuild. The include-node floor in `tests/test_cross_agent_tooling.py`
+  remains the final graph guard. Delete this machinery once the upstream change ships.
 - Every worktree owns its `.codegraph/` index: run `codegraph init` when it is absent,
   and never borrow a parent or sibling tree's index. Before Serena symbolic edits,
   verify that its active project root equals `git rev-parse --show-toplevel`; after a

--- a/.agents/context/repository-intelligence.md
+++ b/.agents/context/repository-intelligence.md
@@ -19,9 +19,10 @@ Load when: every agent session, from `AGENTS.md`.
   `sh scripts/setup-hooks.sh`: it calls `scripts/agent/ensure-graphify.sh`, which
   installs or upgrades `graphifyy>=0.9.51` with `uv` and runs
   `scripts/agent/patch-graphify.sh`, before activating `.githooks`.
-  `scripts/agent/resolve-graphify.sh` prefers the launcher selected by `PATH` and only
-  when none exists resolves `uv tool dir --bin/graphify`; an arbitrary PATH wrapper
-  remains authoritative and fails closed. A Python shebang is used directly. Only the
+  `scripts/agent/resolve-graphify.sh` prefers the launcher selected by `PATH`,
+  physically absolutizes a relative selection before returning it, and only when none
+  exists resolves `uv tool dir --bin/graphify`; an arbitrary PATH wrapper remains
+  authoritative and fails closed. A Python shebang is used directly. Only the
   exact uv-owned launcher may use uv's `/bin/sh` trampoline, in which case the resolver
   validates and uses the `graphifyy` tool environment's Python. Missing `uv` or a
   launcher/interpreter that cannot import its selected Graphify package fails closed.
@@ -39,9 +40,10 @@ Load when: every agent session, from `AGENTS.md`.
   Until a release includes Graphify-Labs/graphify#3075, the fix rides as
   `.agents/patches/graphify-3075-language-overrides.patch`. The tracked
   `.graphifyrc` (`language.inc=php`) activates it. `ensure-graphify.sh` emits the
-  validated executable launcher path; `ensure-graphify-merge-driver.sh` captures and
-  quotes that path for target-rooted `hook install`; `init-worktree-tools.sh` resolves
-  the same launcher for update; and `.githooks/pre-commit` resolves and patches again
+  validated absolute executable launcher path; `ensure-graphify-merge-driver.sh`
+  captures and quotes that path for target-rooted `hook install`;
+  `init-worktree-tools.sh` resolves the same launcher for update; and
+  `.githooks/pre-commit` resolves and patches again
   before its no-staged-files exit, repairing a bare Graphify upgrade in a fresh process
   before the post-commit rebuild. The include-node floor in
   `tests/test_cross_agent_tooling.py`

--- a/.agents/context/repository-intelligence.md
+++ b/.agents/context/repository-intelligence.md
@@ -18,10 +18,15 @@ Load when: every agent session, from `AGENTS.md`.
 - CodeGraph and Graphify are mandatory. Canonical post-clone setup is
   `sh scripts/setup-hooks.sh`: it calls `scripts/agent/ensure-graphify.sh`, which
   installs or upgrades `graphifyy>=0.9.51` with `uv` and runs
-  `scripts/agent/patch-graphify.sh`, before activating `.githooks`. Missing `uv`,
-  a wrapper launcher without a Python shebang, or an interpreter that cannot import
-  the selected Graphify package fails closed. `setup-agent-tools.sh` runs this canonical
-  setup at Graphify's install-order slot, before ast-grep and semgrep.
+  `scripts/agent/patch-graphify.sh`, before activating `.githooks`.
+  `scripts/agent/resolve-graphify.sh` prefers the launcher selected by `PATH` and only
+  when none exists resolves `uv tool dir --bin/graphify`; an arbitrary PATH wrapper
+  remains authoritative and fails closed. A Python shebang is used directly. Only the
+  exact uv-owned launcher may use uv's `/bin/sh` trampoline, in which case the resolver
+  validates and uses the `graphifyy` tool environment's Python. Missing `uv` or a
+  launcher/interpreter that cannot import its selected Graphify package fails closed.
+  `setup-agent-tools.sh` runs this canonical setup at Graphify's install-order slot,
+  before ast-grep and semgrep.
 - Initialize a checkout with `sh scripts/agent/init-worktree-tools.sh .`. It runs
   `scripts/agent/ensure-codegraph.sh` for the exact-root CodeGraph index, reapplies
   the Graphify patch, then runs `graphify update <root>` when the root graph exists.
@@ -33,11 +38,13 @@ Load when: every agent session, from `AGENTS.md`.
   includes from roughly 767 nodes to roughly 30 while extraction still succeeds.
   Until a release includes Graphify-Labs/graphify#3075, the fix rides as
   `.agents/patches/graphify-3075-language-overrides.patch`. The tracked
-  `.graphifyrc` (`language.inc=php`) activates it. `ensure-graphify-merge-driver.sh`
-  delegates to the shared installer before `graphify hook install`;
-  `init-worktree-tools.sh` patches before update; and `.githooks/pre-commit` patches
-  before its no-staged-files exit, repairing a bare Graphify upgrade before the
-  post-commit rebuild. The include-node floor in `tests/test_cross_agent_tooling.py`
+  `.graphifyrc` (`language.inc=php`) activates it. `ensure-graphify.sh` emits the
+  validated executable launcher path; `ensure-graphify-merge-driver.sh` captures and
+  quotes that path for target-rooted `hook install`; `init-worktree-tools.sh` resolves
+  the same launcher for update; and `.githooks/pre-commit` resolves and patches again
+  before its no-staged-files exit, repairing a bare Graphify upgrade in a fresh process
+  before the post-commit rebuild. The include-node floor in
+  `tests/test_cross_agent_tooling.py`
   remains the final graph guard. Delete this machinery once the upstream change ships.
 - Every worktree owns its `.codegraph/` index: run `codegraph init` when it is absent,
   and never borrow a parent or sibling tree's index. Before Serena symbolic edits,

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -48,13 +48,17 @@ step() { printf '[pre-commit] %s\n' "$1"; }
 failed() { printf '[pre-commit] FAILED: %s\n' "$1" >&2; fail=1; }
 skip() { skipped="${skipped}${skipped:+,} $1"; }
 
+# A bare Graphify upgrade replaces site-packages; repair it before any early exit.
+sh scripts/agent/patch-graphify.sh || failed 'Graphify .inc language override'
+[ "$fail" -ne 0 ] || step 'Graphify .inc language override'
+
 # --- Commit identity & signing prerequisites (issue #2982): fail-closed gate
 #     before the no-staged exit, so allow-empty commits are covered too. Resolved
 #     relative to $0 because core.hooksPath is the absolute shared path (linked
 #     release worktrees must reach the same checker). Missing/non-executable
 #     checker fails closed; a checker failure joins the other `fail` results
 #     without suppressing them. Git's own signing stays the cryptographic proof. ---
-step 'commit identity & signing prerequisites'
+[ "$fail" -ne 0 ] || step 'commit identity & signing prerequisites'
 identity_checker=$(dirname -- "$0")/check-commit-identity.sh
 if [ ! -x "$identity_checker" ]; then
 	failed "commit identity checker missing or not executable: $identity_checker"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ repo. This guide is the *how-to* (setup, subsystems, build, test, release); `CLA
   [pfBlockerNG/FreeBSD-ports](https://github.com/pfBlockerNG/FreeBSD-ports), branch
   `pfblockerng/use-github` (the build-input branch carrying our port; ADR-17 self-hosted
   distribution — we do **not** use the upstream `pfsense/FreeBSD-ports`)
-- The developer toolchain below (Python via `uv`, PHP, and the pinned shell/workflow linters)
+- The developer toolchain below (`uv`, PHP, and the pinned shell/workflow linters)
 
 ### Toolchain setup
 
@@ -127,11 +127,10 @@ The repository ships hooks in `.githooks/` — a tracked directory, so they are
 shared and reviewed (the default `.git/hooks` is local-only and cannot be
 committed):
 
-- **`pre-commit`** runs the fast linters and the unit suites (Ruff, pytest,
-  markdownlint, ShellCheck + `sh -n`, shellspec, `php -l`; PHPStan and PHPUnit
-  only when `vendor/` is present) and blocks the commit on any failure. A check
-  whose tool is not installed is skipped (CI is the hard gate); bypass with
-  `git commit --no-verify`.
+- **`pre-commit`** reapplies the temporary Graphify `.inc=php` compatibility patch,
+  then runs the fast linters and policy checks. Patch failure blocks even an empty
+  commit; a missing optional lint tool is skipped (CI is the hard gate). Agents do
+  not bypass hooks with `git commit --no-verify`.
 - **`pre-push`** enforces the release tag scheme before anything is pushed (single source:
   [`scripts/release-version.sh`](scripts/release-version.sh)):
 
@@ -143,11 +142,16 @@ committed):
 | Malformed or mismatched trailer | push is rejected |
 
 Activate the hooks once after cloning (git cannot auto-apply a committed hooks
-path):
+path). This command requires `uv`, installs or upgrades Graphify, and applies the
+temporary [Graphify-Labs/graphify#3075](https://github.com/Graphify-Labs/graphify/pull/3075)
+`.inc=php` patch before enabling the hooks:
 
 ```sh
-sh scripts/setup-hooks.sh    # sets core.hooksPath to .githooks
+sh scripts/setup-hooks.sh
 ```
+
+Until a Graphify release includes that upstream change, setup and every commit
+must apply the patch; an installation that cannot be patched fails closed.
 
 These are local client-side guards. CI enforces the same checks (and the tag
 rules) server-side, so anything that bypasses a hook is still caught by GitHub

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -244,7 +244,7 @@ in `read-version-matrix.sh`.
 | [`deploy.sh`](deploy.sh) | Fast code update of an **already-installed** pfBlockerNG: rsync `src/` + restart unbound/nginx. |
 | [`setup-hooks.sh`](setup-hooks.sh) | Mandatory post-clone setup: install/patch Graphify, point git at `.githooks`, and initialize CodeGraph when installed. |
 | [`agent/ensure-graphify.sh`](agent/ensure-graphify.sh) | Shared Graphify install/upgrade plus temporary `.inc=php` patch entry point. |
-| [`agent/resolve-graphify.sh`](agent/resolve-graphify.sh) | Prefer the PATH-selected Graphify launcher, otherwise resolve uv's direct launcher and validate its owning Python without trusting arbitrary wrappers. |
+| [`agent/resolve-graphify.sh`](agent/resolve-graphify.sh) | Prefer and physically absolutize the PATH-selected Graphify launcher; otherwise resolve uv's direct launcher and validate its owning Python without trusting arbitrary wrappers. |
 | [`agent/patch-graphify.sh`](agent/patch-graphify.sh) | Idempotently apply Graphify-Labs/graphify#3075; fails closed when the selected launcher cannot identify its package. |
 | [`agent/ensure-codegraph.sh`](agent/ensure-codegraph.sh) | Idempotently create an exact-root CodeGraph index for one checkout. |
 | [`git-no-docs.sh`](git-no-docs.sh) | Local doc-free history views: run a read-only git command (default `log -p`) with the `.gitattributes` `linguist-documentation` trees (`legacy/ADRs/`, `docs/`) excluded from its pathspec. |

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -244,6 +244,7 @@ in `read-version-matrix.sh`.
 | [`deploy.sh`](deploy.sh) | Fast code update of an **already-installed** pfBlockerNG: rsync `src/` + restart unbound/nginx. |
 | [`setup-hooks.sh`](setup-hooks.sh) | Mandatory post-clone setup: install/patch Graphify, point git at `.githooks`, and initialize CodeGraph when installed. |
 | [`agent/ensure-graphify.sh`](agent/ensure-graphify.sh) | Shared Graphify install/upgrade plus temporary `.inc=php` patch entry point. |
+| [`agent/resolve-graphify.sh`](agent/resolve-graphify.sh) | Prefer the PATH-selected Graphify launcher, otherwise resolve uv's direct launcher and validate its owning Python without trusting arbitrary wrappers. |
 | [`agent/patch-graphify.sh`](agent/patch-graphify.sh) | Idempotently apply Graphify-Labs/graphify#3075; fails closed when the selected launcher cannot identify its package. |
 | [`agent/ensure-codegraph.sh`](agent/ensure-codegraph.sh) | Idempotently create an exact-root CodeGraph index for one checkout. |
 | [`git-no-docs.sh`](git-no-docs.sh) | Local doc-free history views: run a read-only git command (default `log -p`) with the `.gitattributes` `linguist-documentation` trees (`legacy/ADRs/`, `docs/`) excluded from its pathspec. |

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -242,7 +242,9 @@ in `read-version-matrix.sh`.
 | --- | --- |
 | [`install-from-repo.sh`](install-from-repo.sh) | **First-time install** onto a clean pfSense from `src/` — no Netgate pkg. |
 | [`deploy.sh`](deploy.sh) | Fast code update of an **already-installed** pfBlockerNG: rsync `src/` + restart unbound/nginx. |
-| [`setup-hooks.sh`](setup-hooks.sh) | Point git at `.githooks` and initialize CodeGraph when installed (run once after cloning). |
+| [`setup-hooks.sh`](setup-hooks.sh) | Mandatory post-clone setup: install/patch Graphify, point git at `.githooks`, and initialize CodeGraph when installed. |
+| [`agent/ensure-graphify.sh`](agent/ensure-graphify.sh) | Shared Graphify install/upgrade plus temporary `.inc=php` patch entry point. |
+| [`agent/patch-graphify.sh`](agent/patch-graphify.sh) | Idempotently apply Graphify-Labs/graphify#3075; fails closed when the selected launcher cannot identify its package. |
 | [`agent/ensure-codegraph.sh`](agent/ensure-codegraph.sh) | Idempotently create an exact-root CodeGraph index for one checkout. |
 | [`git-no-docs.sh`](git-no-docs.sh) | Local doc-free history views: run a read-only git command (default `log -p`) with the `.gitattributes` `linguist-documentation` trees (`legacy/ADRs/`, `docs/`) excluded from its pathspec. |
 | [`update-pfsense-stubs.py`](update-pfsense-stubs.py) | Regenerate `stubs/pfsense/` after a CE bump. |

--- a/scripts/agent/ensure-graphify-merge-driver.sh
+++ b/scripts/agent/ensure-graphify-merge-driver.sh
@@ -24,11 +24,11 @@ main() {
 	}
 
 	# The hook rebuilds the graph, so the shared installer applies the override first.
-	sh "$(dirname "$0")/ensure-graphify.sh" "$root" || {
+	graphify_bin=$(sh "$(dirname "$0")/ensure-graphify.sh" "$root") || {
 		echo "ensure-graphify-merge-driver.sh: Graphify setup failed for '$root'" >&2
 		exit 1
 	}
-	(cd "$root" && graphify hook install) || {
+	(cd "$root" && "$graphify_bin" hook install) || {
 		echo "ensure-graphify-merge-driver.sh: Graphify hook installation failed in '$root'" >&2
 		exit 1
 	}

--- a/scripts/agent/ensure-graphify-merge-driver.sh
+++ b/scripts/agent/ensure-graphify-merge-driver.sh
@@ -12,7 +12,6 @@ main() {
 	scrub_git_env "$0"
 	[ "$#" -le 1 ] || usage
 	require_tool git
-	require_tool uv
 
 	target=${1:-.}
 	root=$(git -C "$target" rev-parse --show-toplevel 2>/dev/null) || {
@@ -24,19 +23,9 @@ main() {
 		exit 2
 	}
 
-	uv tool install --upgrade 'graphifyy>=0.9.51' || {
-		echo "ensure-graphify-merge-driver.sh: Graphify installation failed" >&2
-		exit 1
-	}
-	# The hook this installs rebuilds the graph, so the override has to be on the
-	# freshly installed package first (issue #2810).
-	# Prefer the requested checkout's own copy, but a foreign target (e.g.
-	# FreeBSD-ports) ships no patch of its own (issue #3004): fall back to the
-	# trusted sibling next to this helper instead of failing the run.
-	patch_graphify=$root/scripts/agent/patch-graphify.sh
-	[ -f "$patch_graphify" ] || patch_graphify=$(dirname "$0")/patch-graphify.sh
-	sh "$patch_graphify" || {
-		echo "ensure-graphify-merge-driver.sh: Graphify language-override patch failed for '$root'" >&2
+	# The hook rebuilds the graph, so the shared installer applies the override first.
+	sh "$(dirname "$0")/ensure-graphify.sh" "$root" || {
+		echo "ensure-graphify-merge-driver.sh: Graphify setup failed for '$root'" >&2
 		exit 1
 	}
 	(cd "$root" && graphify hook install) || {

--- a/scripts/agent/ensure-graphify.sh
+++ b/scripts/agent/ensure-graphify.sh
@@ -39,6 +39,14 @@ main() {
 		fail "required target or trusted sibling patch-graphify.sh is missing"
 
 	uv tool install --upgrade 'graphifyy>=0.9.51' || fail 'Graphify installation failed'
+	if ! command -v graphify >/dev/null 2>&1; then
+		uv_tool_bin=$(uv tool dir --bin) ||
+			fail 'cannot resolve uv tool executable directory'
+		[ -x "$uv_tool_bin/graphify" ] ||
+			fail "Graphify launcher '$uv_tool_bin/graphify' is not executable after installation"
+		PATH="$uv_tool_bin:$PATH"
+		export PATH
+	fi
 	sh "$patch_graphify" || fail "Graphify language-override patch failed for '$root'"
 }
 

--- a/scripts/agent/ensure-graphify.sh
+++ b/scripts/agent/ensure-graphify.sh
@@ -17,6 +17,8 @@ fail() {
 main() {
 	# shellcheck source=scripts/agent/agent_env.sh
 	. "$(dirname "$0")/agent_env.sh"
+	# shellcheck source=scripts/agent/resolve-graphify.sh
+	. "$(dirname "$0")/resolve-graphify.sh"
 	scrub_git_env "$0"
 	[ "$#" -le 1 ] || usage
 	require_tool git
@@ -38,16 +40,13 @@ main() {
 	[ -f "$patch_graphify" ] ||
 		fail "required target or trusted sibling patch-graphify.sh is missing"
 
-	uv tool install --upgrade 'graphifyy>=0.9.51' || fail 'Graphify installation failed'
-	if ! command -v graphify >/dev/null 2>&1; then
-		uv_tool_bin=$(uv tool dir --bin) ||
-			fail 'cannot resolve uv tool executable directory'
-		[ -x "$uv_tool_bin/graphify" ] ||
-			fail "Graphify launcher '$uv_tool_bin/graphify' is not executable after installation"
-		PATH="$uv_tool_bin:$PATH"
-		export PATH
-	fi
-	sh "$patch_graphify" || fail "Graphify language-override patch failed for '$root'"
+	uv tool install --upgrade 'graphifyy>=0.9.51' 1>&2 ||
+		fail 'Graphify installation failed'
+	graphify_bin=$(resolve_graphify_launcher) ||
+		fail 'cannot resolve the installed Graphify launcher'
+	sh "$patch_graphify" ||
+		fail "Graphify language-override patch failed for '$root'"
+	printf '%s\n' "$graphify_bin"
 }
 
 main "$@"

--- a/scripts/agent/ensure-graphify.sh
+++ b/scripts/agent/ensure-graphify.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+# Install or upgrade Graphify and apply this checkout's temporary .inc=php patch.
+# Usage: ensure-graphify.sh [REPOSITORY]
+
+set -eu
+
+usage() {
+	echo "usage: ensure-graphify.sh [REPOSITORY]" >&2
+	exit 2
+}
+
+fail() {
+	echo "ensure-graphify.sh: $*" >&2
+	exit 1
+}
+
+main() {
+	# shellcheck source=scripts/agent/agent_env.sh
+	. "$(dirname "$0")/agent_env.sh"
+	scrub_git_env "$0"
+	[ "$#" -le 1 ] || usage
+	require_tool git
+	require_tool uv
+
+	target=${1:-.}
+	root=$(git -C "$target" rev-parse --show-toplevel 2>/dev/null) || {
+		echo "ensure-graphify.sh: '$target' is not a git worktree" >&2
+		exit 2
+	}
+	root=$(CDPATH='' cd "$root" && pwd -P) || {
+		echo "ensure-graphify.sh: cannot resolve Git root '$root'" >&2
+		exit 2
+	}
+	# Prefer the target checkout's policy; foreign targets fall back to this
+	# trusted helper checkout without receiving repository files of their own.
+	patch_graphify=$root/scripts/agent/patch-graphify.sh
+	[ -f "$patch_graphify" ] || patch_graphify=$(dirname "$0")/patch-graphify.sh
+	[ -f "$patch_graphify" ] ||
+		fail "required target or trusted sibling patch-graphify.sh is missing"
+
+	uv tool install --upgrade 'graphifyy>=0.9.51' || fail 'Graphify installation failed'
+	sh "$patch_graphify" || fail "Graphify language-override patch failed for '$root'"
+}
+
+main "$@"

--- a/scripts/agent/init-worktree-tools.sh
+++ b/scripts/agent/init-worktree-tools.sh
@@ -9,11 +9,12 @@ usage() {
 main() {
 	# shellcheck source=scripts/agent/agent_env.sh
 	. "$(dirname "$0")/agent_env.sh"
+	# shellcheck source=scripts/agent/resolve-graphify.sh
+	. "$(dirname "$0")/resolve-graphify.sh"
 	scrub_git_env "$0"
 	[ "$#" -le 1 ] || usage
 	require_tool git
 	require_tool codegraph
-	require_tool graphify
 
 	target=${1:-.}
 	root=$(git -C "$target" rev-parse --show-toplevel 2>/dev/null) || {
@@ -21,6 +22,7 @@ main() {
 		exit 2
 	}
 	root=$(CDPATH='' cd "$root" && pwd -P) || exit 2
+	graphify_bin=$(resolve_graphify_launcher) || exit 1
 
 	sh "$(dirname "$0")/ensure-codegraph.sh" "$root" || exit $?
 	# Before any extraction: an unpatched Graphify parses this repository's PHP .inc
@@ -31,7 +33,7 @@ main() {
 	# its cost, what .graphifyignore allows) is a judgement call, so defer it to an
 	# AI-assisted `/graphify` run rather than picking a default unattended.
 	if [ -f "$root/graphify-out/graph.json" ]; then
-		graphify update "$root" || exit $?
+		"$graphify_bin" update "$root" || exit $?
 	else
 		echo "No Graphify root graph in $root; run /graphify in your AI assistant to build one." >&2
 	fi

--- a/scripts/agent/patch-graphify.sh
+++ b/scripts/agent/patch-graphify.sh
@@ -32,6 +32,8 @@ fail() {
 main() {
 	# shellcheck source=scripts/agent/agent_env.sh
 	. "$(dirname "$0")/agent_env.sh"
+	# shellcheck source=scripts/agent/resolve-graphify.sh
+	. "$(dirname "$0")/resolve-graphify.sh"
 
 	# The script and its patch always ship together, so the patch comes from this
 	# script's own checkout -- a worktree cut from a branch that predates the patch
@@ -41,17 +43,13 @@ main() {
 	[ -f "$patch_file" ] || fail "vendored patch '$patch_file' is missing"
 
 	require_tool sed
-	graphify_bin=$(command -v graphify) ||
-		fail "Graphify is not installed; run 'uv tool install --upgrade graphifyy' first"
-	# The interpreter that owns the package is read off the CLI's own shebang -- never
-	# hardcoded, and never the ambient python3. A wrapper or shim must fail closed:
-	# another interpreter could patch an unrelated package and report success.
-	interpreter=$(sed -n '1s/^#![[:space:]]*//p' "$graphify_bin")
-	interpreter=${interpreter%% *}
-	case "$interpreter" in
-		/*python*) ;;
-		*) fail "'$graphify_bin' does not name a Python interpreter on its shebang; reinstall the direct uv launcher with 'uv tool install --reinstall graphifyy'" ;;
-	esac
+	graphify_bin=$(resolve_graphify_launcher) || exit 1
+	# Direct Python shebangs identify their owning environment. uv emits a precise
+	# /bin/sh trampoline when that environment path contains spaces; the shared
+	# resolver accepts only uv's selected launcher and derives its interpreter from
+	# the graphifyy tool directory. Arbitrary wrappers remain authoritative and fail.
+	interpreter=$(resolve_graphify_interpreter "$graphify_bin") ||
+		fail "'$graphify_bin' does not name a Python interpreter on its shebang or a validated uv trampoline; reinstall it with 'uv tool install --reinstall graphifyy'"
 
 	# Both probes run isolated (-I), which since Python 3.4 keeps the caller's directory
 	# off sys.path and, by implying -E and -s, keeps PYTHONPATH and the user site

--- a/scripts/agent/patch-graphify.sh
+++ b/scripts/agent/patch-graphify.sh
@@ -7,8 +7,8 @@
 # reports success (issue #2810). Upstream fixes that in Graphify-Labs/graphify#3075,
 # which is unreleased, so the patch rides in .agents/patches/ and is re-applied after
 # every install: a bare `uv tool upgrade graphifyy` replaces site-packages and reverts
-# it. Delete this script, its patch, and its two call sites once a released graphifyy
-# provides the override API -- this script no-ops from that release on.
+# it. Delete this script, its patch, and its bootstrap call sites once a released
+# graphifyy provides the override API -- this script no-ops from that release on.
 #
 # No repository is touched and no cache is purged: the patch salts the AST cache key
 # with the remapped language (rcfile.cache_salt, cache._salted_key, salt= threaded
@@ -28,12 +28,6 @@ fail() {
 	exit 1
 }
 
-# A Graphify this script cannot reach is a skip, never a dead worktree cut and never a
-# guess. The tracked graph's include-node floor catches a real install that got skipped.
-skip() {
-	echo "patch-graphify.sh: $*; skipping the $UPSTREAM override" >&2
-	exit 0
-}
 
 main() {
 	# shellcheck source=scripts/agent/agent_env.sh
@@ -49,16 +43,14 @@ main() {
 	require_tool sed
 	graphify_bin=$(command -v graphify) ||
 		fail "Graphify is not installed; run 'uv tool install --upgrade graphifyy' first"
-	# A uv tool venv carries its Python minor version in the site-packages path, so the
-	# interpreter that owns the package is read off the CLI's own shebang -- never
-	# hardcoded, and never the ambient python3: a different interpreter imports a
-	# DIFFERENT graphify, so falling back patches an unrelated package and reports
-	# success. A wrapper or shim that hides the interpreter is therefore a skip.
+	# The interpreter that owns the package is read off the CLI's own shebang -- never
+	# hardcoded, and never the ambient python3. A wrapper or shim must fail closed:
+	# another interpreter could patch an unrelated package and report success.
 	interpreter=$(sed -n '1s/^#![[:space:]]*//p' "$graphify_bin")
 	interpreter=${interpreter%% *}
 	case "$interpreter" in
 		/*python*) ;;
-		*) skip "'$graphify_bin' does not name a Python interpreter on its shebang" ;;
+		*) fail "'$graphify_bin' does not name a Python interpreter on its shebang; reinstall the direct uv launcher with 'uv tool install --reinstall graphifyy'" ;;
 	esac
 
 	# Both probes run isolated (-I), which since Python 3.4 keeps the caller's directory
@@ -69,7 +61,7 @@ main() {
 	# interpreter already resolves its own graphify.
 	package=$("$interpreter" -I -c \
 		'import graphify, os; print(os.path.dirname(graphify.__file__))' 2>/dev/null) || package=''
-	[ -n "$package" ] || skip "cannot locate an importable Graphify package for '$graphify_bin'"
+	[ -n "$package" ] || fail "cannot locate an importable Graphify package for '$graphify_bin'; reinstall it with 'uv tool install --reinstall graphifyy'"
 	[ -d "$package" ] || fail "Graphify package directory '$package' does not exist"
 	site=$(CDPATH='' cd "$package/.." && pwd -P) || exit 2
 

--- a/scripts/agent/resolve-graphify.sh
+++ b/scripts/agent/resolve-graphify.sh
@@ -1,0 +1,57 @@
+#!/bin/sh
+# Shared POSIX resolver for the Graphify launcher and its owning interpreter.
+# Safe to source: functions only, with all results written to stdout.
+
+resolve_graphify_launcher() {
+	_graphify_launcher=$(command -v graphify 2>/dev/null) &&
+		[ -n "$_graphify_launcher" ] && {
+			printf '%s\n' "$_graphify_launcher"
+			return 0
+		}
+
+	command -v uv >/dev/null 2>&1 || {
+		echo "resolve-graphify.sh: Graphify is not installed; run 'uv tool install --upgrade graphifyy' first" >&2
+		return 1
+	}
+	_graphify_uv_bin=$(uv tool dir --bin 2>/dev/null) || {
+		echo 'resolve-graphify.sh: cannot resolve uv tool executable directory' >&2
+		return 1
+	}
+	_graphify_launcher=$_graphify_uv_bin/graphify
+	[ -x "$_graphify_launcher" ] || {
+		echo "resolve-graphify.sh: Graphify launcher '$_graphify_launcher' is not executable" >&2
+		return 1
+	}
+	printf '%s\n' "$_graphify_launcher"
+}
+
+resolve_graphify_interpreter() {
+	[ "$#" -eq 1 ] || return 2
+	_graphify_launcher=$1
+	_graphify_interpreter=$(sed -n '1s/^#![[:space:]]*//p' "$_graphify_launcher" 2>/dev/null)
+	_graphify_interpreter=${_graphify_interpreter%% *}
+	case "$_graphify_interpreter" in
+		/*python*)
+			printf '%s\n' "$_graphify_interpreter"
+			return 0
+			;;
+	esac
+
+	# Only uv's own selected launcher may use its shell trampoline. Never parse or
+	# follow a shell wrapper selected anywhere else on PATH.
+	command -v uv >/dev/null 2>&1 || return 1
+	_graphify_uv_bin=$(uv tool dir --bin 2>/dev/null) || return 1
+	[ "$_graphify_launcher" = "$_graphify_uv_bin/graphify" ] || return 1
+	_graphify_uv_tools=$(uv tool dir 2>/dev/null) || return 1
+	_graphify_interpreter=$_graphify_uv_tools/graphifyy/bin/python
+	[ -x "$_graphify_interpreter" ] || return 1
+
+	_graphify_line1=$(sed -n '1p' "$_graphify_launcher")
+	_graphify_line2=$(sed -n '2p' "$_graphify_launcher")
+	_graphify_line3=$(sed -n '3p' "$_graphify_launcher")
+	[ "$_graphify_line1" = '#!/bin/sh' ] || return 1
+	[ "$_graphify_line2" = "'''exec' '$_graphify_interpreter' \"\$0\" \"\$@\"" ] || return 1
+	[ "$_graphify_line3" = "' '''" ] || return 1
+	"$_graphify_interpreter" -I -c 'import graphify' >/dev/null 2>&1 || return 1
+	printf '%s\n' "$_graphify_interpreter"
+}

--- a/scripts/agent/resolve-graphify.sh
+++ b/scripts/agent/resolve-graphify.sh
@@ -2,38 +2,45 @@
 # Shared POSIX resolver for the Graphify launcher and its owning interpreter.
 # Safe to source: functions only, with all results written to stdout.
 
-resolve_graphify_launcher() {
-	_graphify_launcher=$(command -v graphify 2>/dev/null) &&
-		[ -n "$_graphify_launcher" ] && {
-			case "$_graphify_launcher" in
-				/*) ;;
-				*)
-					_graphify_name=${_graphify_launcher##*/}
-					_graphify_dir=${_graphify_launcher%/*}
-					[ "$_graphify_dir" != "$_graphify_launcher" ] || _graphify_dir=.
-					case "$_graphify_dir" in
-						-*) _graphify_dir=./$_graphify_dir ;;
-					esac
-					_graphify_dir=$(CDPATH='' cd -P "$_graphify_dir" 2>/dev/null && pwd -P) || {
-						echo "resolve-graphify.sh: cannot resolve PATH-selected launcher directory '$_graphify_dir'" >&2
-						return 1
-					}
-					_graphify_launcher=$_graphify_dir/$_graphify_name
-					;;
+absolutize_graphify_launcher() {
+	[ "$#" -eq 1 ] || return 2
+	_graphify_launcher=$1
+	case "$_graphify_launcher" in
+		/*) ;;
+		*)
+			_graphify_name=${_graphify_launcher##*/}
+			_graphify_dir=${_graphify_launcher%/*}
+			[ "$_graphify_dir" != "$_graphify_launcher" ] || _graphify_dir=.
+			case "$_graphify_dir" in
+				-*) _graphify_dir=./$_graphify_dir ;;
 			esac
-			printf '%s\n' "$_graphify_launcher"
-			return 0
-		}
+			_graphify_dir=$(CDPATH='' cd -P "$_graphify_dir" 2>/dev/null && pwd -P) || {
+				echo "resolve-graphify.sh: cannot resolve selected launcher directory '$_graphify_dir'" >&2
+				return 1
+			}
+			_graphify_launcher=$_graphify_dir/$_graphify_name
+			;;
+	esac
+	printf '%s\n' "$_graphify_launcher"
+}
 
-	command -v uv >/dev/null 2>&1 || {
-		echo "resolve-graphify.sh: Graphify is not installed; run 'uv tool install --upgrade graphifyy' first" >&2
-		return 1
-	}
-	_graphify_uv_bin=$(uv tool dir --bin 2>/dev/null) || {
-		echo 'resolve-graphify.sh: cannot resolve uv tool executable directory' >&2
-		return 1
-	}
-	_graphify_launcher=$_graphify_uv_bin/graphify
+resolve_graphify_launcher() {
+	if _graphify_launcher=$(command -v graphify 2>/dev/null) &&
+		[ -n "$_graphify_launcher" ]; then
+		:
+	else
+		command -v uv >/dev/null 2>&1 || {
+			echo "resolve-graphify.sh: Graphify is not installed; run 'uv tool install --upgrade graphifyy' first" >&2
+			return 1
+		}
+		_graphify_uv_bin=$(uv tool dir --bin 2>/dev/null) || {
+			echo 'resolve-graphify.sh: cannot resolve uv tool executable directory' >&2
+			return 1
+		}
+		_graphify_launcher=$_graphify_uv_bin/graphify
+	fi
+
+	_graphify_launcher=$(absolutize_graphify_launcher "$_graphify_launcher") || return 1
 	[ -x "$_graphify_launcher" ] || {
 		echo "resolve-graphify.sh: Graphify launcher '$_graphify_launcher' is not executable" >&2
 		return 1
@@ -57,7 +64,8 @@ resolve_graphify_interpreter() {
 	# follow a shell wrapper selected anywhere else on PATH.
 	command -v uv >/dev/null 2>&1 || return 1
 	_graphify_uv_bin=$(uv tool dir --bin 2>/dev/null) || return 1
-	[ "$_graphify_launcher" = "$_graphify_uv_bin/graphify" ] || return 1
+	_graphify_uv_launcher=$(absolutize_graphify_launcher "$_graphify_uv_bin/graphify") || return 1
+	[ "$_graphify_launcher" = "$_graphify_uv_launcher" ] || return 1
 	_graphify_uv_tools=$(uv tool dir 2>/dev/null) || return 1
 	_graphify_interpreter=$_graphify_uv_tools/graphifyy/bin/python
 	[ -x "$_graphify_interpreter" ] || return 1

--- a/scripts/agent/resolve-graphify.sh
+++ b/scripts/agent/resolve-graphify.sh
@@ -70,11 +70,12 @@ resolve_graphify_interpreter() {
 	_graphify_interpreter=$_graphify_uv_tools/graphifyy/bin/python
 	[ -x "$_graphify_interpreter" ] || return 1
 
+	_graphify_interpreter_token=$("$_graphify_interpreter" -I -c 'import shlex, sys; print(shlex.quote(sys.argv[1]))' "$_graphify_interpreter") || return 1
 	_graphify_line1=$(sed -n '1p' "$_graphify_launcher")
 	_graphify_line2=$(sed -n '2p' "$_graphify_launcher")
 	_graphify_line3=$(sed -n '3p' "$_graphify_launcher")
 	[ "$_graphify_line1" = '#!/bin/sh' ] || return 1
-	[ "$_graphify_line2" = "'''exec' '$_graphify_interpreter' \"\$0\" \"\$@\"" ] || return 1
+	[ "$_graphify_line2" = "'''exec' $_graphify_interpreter_token \"\$0\" \"\$@\"" ] || return 1
 	[ "$_graphify_line3" = "' '''" ] || return 1
 	"$_graphify_interpreter" -I -c 'import graphify' >/dev/null 2>&1 || return 1
 	printf '%s\n' "$_graphify_interpreter"

--- a/scripts/agent/resolve-graphify.sh
+++ b/scripts/agent/resolve-graphify.sh
@@ -5,6 +5,22 @@
 resolve_graphify_launcher() {
 	_graphify_launcher=$(command -v graphify 2>/dev/null) &&
 		[ -n "$_graphify_launcher" ] && {
+			case "$_graphify_launcher" in
+				/*) ;;
+				*)
+					_graphify_name=${_graphify_launcher##*/}
+					_graphify_dir=${_graphify_launcher%/*}
+					[ "$_graphify_dir" != "$_graphify_launcher" ] || _graphify_dir=.
+					case "$_graphify_dir" in
+						-*) _graphify_dir=./$_graphify_dir ;;
+					esac
+					_graphify_dir=$(CDPATH='' cd -P "$_graphify_dir" 2>/dev/null && pwd -P) || {
+						echo "resolve-graphify.sh: cannot resolve PATH-selected launcher directory '$_graphify_dir'" >&2
+						return 1
+					}
+					_graphify_launcher=$_graphify_dir/$_graphify_name
+					;;
+			esac
 			printf '%s\n' "$_graphify_launcher"
 			return 0
 		}

--- a/scripts/agent/setup-agent-tools.sh
+++ b/scripts/agent/setup-agent-tools.sh
@@ -174,7 +174,7 @@ setup_serena_client() {
 
 setup_graphify_client() {
 	# Integration and platform-skill installers are separate update surfaces.
-	(cd "$HOME" && graphify "$1" install && graphify install --platform "$1")
+	(cd "$HOME" && "$graphify_bin" "$1" install && "$graphify_bin" install --platform "$1")
 }
 
 configure_agents() {
@@ -189,9 +189,9 @@ configure_agents() {
 		setup_graphify_client codex
 	fi
 	if command -v grok >/dev/null 2>&1; then
-		(cd "$HOME" && graphify agents install)
+		(cd "$HOME" && "$graphify_bin" agents install)
 		setup_serena_client grok grok
-		(cd "$HOME" && graphify install --platform agents)
+		(cd "$HOME" && "$graphify_bin" install --platform agents)
 		if ! grok mcp doctor codegraph --json >/dev/null 2>&1; then
 			grok mcp remove codegraph >/dev/null 2>&1 || true
 			grok mcp add codegraph -- codegraph serve --mcp
@@ -211,6 +211,8 @@ main() {
 
 	# shellcheck source=scripts/agent/agent_env.sh
 	. "$(dirname "$0")/agent_env.sh"
+	# shellcheck source=scripts/agent/resolve-graphify.sh
+	. "$(dirname "$0")/resolve-graphify.sh"
 	scrub_git_env "$0"
 	require_tool uname
 	platform=$(uname -s)
@@ -276,7 +278,8 @@ main() {
 	uv tool install --upgrade ast-grep-cli
 	uv tool install --upgrade semgrep
 	require_tool serena
-	require_tool graphify
+	graphify_bin=$(resolve_graphify_launcher) ||
+		fail 'cannot resolve the installed Graphify launcher'
 	require_tool ast-grep
 	require_tool semgrep
 

--- a/scripts/agent/setup-agent-tools.sh
+++ b/scripts/agent/setup-agent-tools.sh
@@ -272,7 +272,7 @@ main() {
 	esac
 	require_tool uv
 	uv tool install --upgrade serena-agent
-	sh "$ensure_graphify" "$root"
+	(cd "$root" && sh "$setup_hooks")
 	uv tool install --upgrade ast-grep-cli
 	uv tool install --upgrade semgrep
 	require_tool serena
@@ -297,7 +297,6 @@ main() {
 	disable_serena_dashboard
 	configure_agents
 
-	(cd "$root" && sh "$setup_hooks")
 	sh "$init_tools" "$root"
 }
 

--- a/scripts/agent/setup-agent-tools.sh
+++ b/scripts/agent/setup-agent-tools.sh
@@ -227,8 +227,10 @@ main() {
 		fail "'$target' is not a git worktree"
 	root=$(CDPATH='' cd "$root" && pwd -P) || exit 2
 	setup_hooks=$root/scripts/setup-hooks.sh
+	ensure_graphify=$root/scripts/agent/ensure-graphify.sh
 	init_tools=$root/scripts/agent/init-worktree-tools.sh
 	[ -f "$setup_hooks" ] || fail "required repository helper '$setup_hooks' is missing"
+	[ -f "$ensure_graphify" ] || fail "required repository helper '$ensure_graphify' is missing"
 	[ -f "$init_tools" ] || fail "required repository helper '$init_tools' is missing"
 
 	if [ -n "${XDG_BIN_HOME:-}" ]; then
@@ -270,7 +272,7 @@ main() {
 	esac
 	require_tool uv
 	uv tool install --upgrade serena-agent
-	uv tool install --upgrade graphifyy
+	sh "$ensure_graphify" "$root"
 	uv tool install --upgrade ast-grep-cli
 	uv tool install --upgrade semgrep
 	require_tool serena

--- a/scripts/setup-hooks.sh
+++ b/scripts/setup-hooks.sh
@@ -14,7 +14,7 @@ set -eu
 
 root=$(git rev-parse --show-toplevel)
 script_dir=$(CDPATH='' cd "$(dirname "$0")" && pwd -P)
-sh "$script_dir/agent/ensure-graphify.sh" "$root"
+sh "$script_dir/agent/ensure-graphify.sh" "$root" >/dev/null
 git -C "$root" config core.hooksPath .githooks
 
 if command -v codegraph >/dev/null 2>&1; then

--- a/scripts/setup-hooks.sh
+++ b/scripts/setup-hooks.sh
@@ -1,22 +1,23 @@
 #!/bin/sh
-# One-time developer setup: activate tracked Git hooks and bootstrap CodeGraph.
+# One-time developer setup: patch Graphify, activate tracked hooks, and bootstrap CodeGraph.
 #
 # Run once after cloning:
 #   sh scripts/setup-hooks.sh
 #
 # git cannot auto-apply a committed core.hooksPath (by design — cloning a repo
 # must not silently install executable hooks), so this single explicit opt-in is
-# the closest to "automatic". After running it, .githooks/pre-commit and
-# .githooks/pre-push are active in this clone. When CodeGraph is installed, the
-# same command also creates this checkout's exact-root index.
+# the closest to "automatic". The setup installs and patches Graphify before
+# activating .githooks; when CodeGraph is installed, it also creates this
+# checkout's exact-root index.
 
 set -eu
 
 root=$(git rev-parse --show-toplevel)
+script_dir=$(CDPATH='' cd "$(dirname "$0")" && pwd -P)
+sh "$script_dir/agent/ensure-graphify.sh" "$root"
 git -C "$root" config core.hooksPath .githooks
 
 if command -v codegraph >/dev/null 2>&1; then
-	script_dir=$(CDPATH='' cd "$(dirname "$0")" && pwd -P)
 	sh "$script_dir/agent/ensure-codegraph.sh" "$root"
 fi
 

--- a/tests/shell/agent_codegraph_spec.sh
+++ b/tests/shell/agent_codegraph_spec.sh
@@ -104,8 +104,21 @@ case "$1" in
   *) exit 9 ;;
 esac
 CODEGRAPH
-    cat > "$stubdir/graphify" <<'GRAPHIFY'
+    graphify_package="$fixture/toolvenv/package/graphify"
+    mkdir -p "$graphify_package"
+    interpreter="$fixture/toolvenv/bin/python3"
+    mkdir -p "$fixture/toolvenv/bin"
+    cat > "$interpreter" <<'INTERPRETER'
 #!/bin/sh
+case "$*" in
+  *os.path.dirname*) printf '%s\n' "$CODEGRAPH_GRAPHIFY_PACKAGE"; exit 0 ;;
+  *activate_language_overrides*) exit 0 ;;
+esac
+exec sh "$@"
+INTERPRETER
+    chmod +x "$interpreter"
+    printf '#!%s\n' "$interpreter" > "$stubdir/graphify"
+    cat >> "$stubdir/graphify" <<'GRAPHIFY'
 [ "$#" -eq 3 ] && [ "$1" = extract ] && [ "$3" = --code-only ] || exit 9
 mkdir -p "$2/graphify-out"
 true > "$2/graphify-out/graph.json"
@@ -116,7 +129,7 @@ GRAPHIFY
 exit 0
 SERENA
     chmod +x "$stubdir/codegraph" "$stubdir/graphify" "$stubdir/serena"
-    export CODEGRAPH_LOG="$codegraph_log"
+    export CODEGRAPH_LOG="$codegraph_log" CODEGRAPH_GRAPHIFY_PACKAGE="$graphify_package"
     PATH="$stubdir:$PATH"; export PATH
   }
   cleanup() { rm -rf "$fixture"; }

--- a/tests/shell/agent_graphify_merge_driver_spec.sh
+++ b/tests/shell/agent_graphify_merge_driver_spec.sh
@@ -1,13 +1,25 @@
 #shellcheck shell=sh
 
 Describe 'ensure-graphify-merge-driver.sh'
-  script_abs="${SHELLSPEC_PROJECT_ROOT:-$PWD}/scripts/agent/ensure-graphify-merge-driver.sh"
 
   setup() {
     . "${SHELLSPEC_PROJECT_ROOT:-$PWD}/scripts/lib/git-env-scrub.sh"
     pfb_scrub_git_env
     fixture=$(mktemp -d "${TMPDIR:-/tmp}/graphify_driver_spec.XXXXXX") || return 1
     fixture=$(cd "$fixture" && pwd -P) || return 1
+    script_home="$fixture/suite/scripts/agent"
+    mkdir -p "$script_home" "$fixture/suite/scripts/lib"
+    cp "${SHELLSPEC_PROJECT_ROOT:-$PWD}/scripts/lib/git-env-scrub.sh" "$fixture/suite/scripts/lib/"
+    cp "${SHELLSPEC_PROJECT_ROOT:-$PWD}/scripts/agent/ensure-graphify-merge-driver.sh" "$script_home/"
+    cp "${SHELLSPEC_PROJECT_ROOT:-$PWD}/scripts/agent/ensure-graphify.sh" "$script_home/ensure-graphify-real.sh"
+    cp "${SHELLSPEC_PROJECT_ROOT:-$PWD}/scripts/agent/agent_env.sh" "$script_home/"
+    script_abs="$script_home/ensure-graphify-merge-driver.sh"
+    cat > "$script_home/ensure-graphify.sh" <<'ENSURE_GRAPHIFY'
+#!/bin/sh
+[ -f "$1/scripts/agent/patch-graphify.sh" ] &&
+  printf 'ensure-graphify\t%s\n' "$*" >> "$GRAPHIFY_LOG"
+exec sh "$(dirname "$0")/ensure-graphify-real.sh" "$@"
+ENSURE_GRAPHIFY
     repo="$fixture/requested-root"
     git_fixture init -q "$repo" || return 1
     stubdir="$fixture/bin"
@@ -52,7 +64,7 @@ PATCH_GRAPHIFY
     The status should equal 0
     The contents of file "$uv_log" should equal 'tool install --upgrade graphifyy>=0.9.51'
     The contents of file "$graphify_log" should equal \
-      "$(printf 'patch-graphify\t\n%s\thook install' "$repo")"
+      "$(printf 'ensure-graphify\t%s\npatch-graphify\t\n%s\thook install' "$repo" "$repo")"
     The value "$(git_fixture -C "$repo" config --get merge.graphify.driver)" should include 'graphify merge-driver %O %A %B'
   End
 
@@ -79,7 +91,8 @@ PATCH_GRAPHIFY
     It 'falls back to the trusted sibling patch next to the helper script'
       helperdir="$fixture/helper/scripts/agent"
       mkdir -p "$helperdir" "$fixture/helper/scripts/lib"
-      cp "$script_abs" scripts/agent/agent_env.sh "$helperdir/"
+      cp "$script_abs" "$script_home/ensure-graphify.sh" "$script_home/ensure-graphify-real.sh" \
+        scripts/agent/agent_env.sh "$helperdir/"
       cp scripts/lib/git-env-scrub.sh "$fixture/helper/scripts/lib/"
       cat > "$helperdir/patch-graphify.sh" <<'PATCH_GRAPHIFY'
 #!/bin/sh

--- a/tests/shell/agent_graphify_merge_driver_spec.sh
+++ b/tests/shell/agent_graphify_merge_driver_spec.sh
@@ -11,15 +11,9 @@ Describe 'ensure-graphify-merge-driver.sh'
     mkdir -p "$script_home" "$fixture/suite/scripts/lib"
     cp "${SHELLSPEC_PROJECT_ROOT:-$PWD}/scripts/lib/git-env-scrub.sh" "$fixture/suite/scripts/lib/"
     cp "${SHELLSPEC_PROJECT_ROOT:-$PWD}/scripts/agent/ensure-graphify-merge-driver.sh" "$script_home/"
-    cp "${SHELLSPEC_PROJECT_ROOT:-$PWD}/scripts/agent/ensure-graphify.sh" "$script_home/ensure-graphify-real.sh"
+    cp "${SHELLSPEC_PROJECT_ROOT:-$PWD}/scripts/agent/ensure-graphify.sh" "$script_home/"
     cp "${SHELLSPEC_PROJECT_ROOT:-$PWD}/scripts/agent/agent_env.sh" "$script_home/"
     script_abs="$script_home/ensure-graphify-merge-driver.sh"
-    cat > "$script_home/ensure-graphify.sh" <<'ENSURE_GRAPHIFY'
-#!/bin/sh
-[ -f "$1/scripts/agent/patch-graphify.sh" ] &&
-  printf 'ensure-graphify\t%s\n' "$*" >> "$GRAPHIFY_LOG"
-exec sh "$(dirname "$0")/ensure-graphify-real.sh" "$@"
-ENSURE_GRAPHIFY
     repo="$fixture/requested-root"
     git_fixture init -q "$repo" || return 1
     stubdir="$fixture/bin"
@@ -64,7 +58,7 @@ PATCH_GRAPHIFY
     The status should equal 0
     The contents of file "$uv_log" should equal 'tool install --upgrade graphifyy>=0.9.51'
     The contents of file "$graphify_log" should equal \
-      "$(printf 'ensure-graphify\t%s\npatch-graphify\t\n%s\thook install' "$repo" "$repo")"
+      "$(printf 'patch-graphify\t\n%s\thook install' "$repo")"
     The value "$(git_fixture -C "$repo" config --get merge.graphify.driver)" should include 'graphify merge-driver %O %A %B'
   End
 
@@ -91,8 +85,7 @@ PATCH_GRAPHIFY
     It 'falls back to the trusted sibling patch next to the helper script'
       helperdir="$fixture/helper/scripts/agent"
       mkdir -p "$helperdir" "$fixture/helper/scripts/lib"
-      cp "$script_abs" "$script_home/ensure-graphify.sh" "$script_home/ensure-graphify-real.sh" \
-        scripts/agent/agent_env.sh "$helperdir/"
+      cp "$script_abs" "$script_home/ensure-graphify.sh" scripts/agent/agent_env.sh "$helperdir/"
       cp scripts/lib/git-env-scrub.sh "$fixture/helper/scripts/lib/"
       cat > "$helperdir/patch-graphify.sh" <<'PATCH_GRAPHIFY'
 #!/bin/sh

--- a/tests/shell/agent_graphify_merge_driver_spec.sh
+++ b/tests/shell/agent_graphify_merge_driver_spec.sh
@@ -13,6 +13,9 @@ Describe 'ensure-graphify-merge-driver.sh'
     cp "${SHELLSPEC_PROJECT_ROOT:-$PWD}/scripts/agent/ensure-graphify-merge-driver.sh" "$script_home/"
     cp "${SHELLSPEC_PROJECT_ROOT:-$PWD}/scripts/agent/ensure-graphify.sh" "$script_home/"
     cp "${SHELLSPEC_PROJECT_ROOT:-$PWD}/scripts/agent/agent_env.sh" "$script_home/"
+    if [ -f "${SHELLSPEC_PROJECT_ROOT:-$PWD}/scripts/agent/resolve-graphify.sh" ]; then
+      cp "${SHELLSPEC_PROJECT_ROOT:-$PWD}/scripts/agent/resolve-graphify.sh" "$script_home/"
+    fi
     script_abs="$script_home/ensure-graphify-merge-driver.sh"
     repo="$fixture/requested-root"
     git_fixture init -q "$repo" || return 1
@@ -23,7 +26,17 @@ Describe 'ensure-graphify-merge-driver.sh'
 
     cat > "$stubdir/uv" <<'UV'
 #!/bin/sh
-printf '%s\n' "$*" >> "$UV_LOG"
+case "$*" in
+  'tool install --upgrade graphifyy>=0.9.51')
+    printf '%s\n' "$*" >> "$UV_LOG"
+    if [ "${UV_PROGRESS_FIXTURE:-0}" = 1 ]; then printf '%s\n' 'uv progress'; fi
+    ;;
+  'tool dir --bin')
+    [ -n "${UV_TOOL_BIN_FIXTURE:-}" ] || exit 9
+    printf '%s\n' "$UV_TOOL_BIN_FIXTURE"
+    ;;
+  *) exit 9 ;;
+esac
 UV
     cat > "$stubdir/graphify" <<'GRAPHIFY'
 #!/bin/sh
@@ -86,6 +99,9 @@ PATCH_GRAPHIFY
       helperdir="$fixture/helper/scripts/agent"
       mkdir -p "$helperdir" "$fixture/helper/scripts/lib"
       cp "$script_abs" "$script_home/ensure-graphify.sh" scripts/agent/agent_env.sh "$helperdir/"
+      if [ -f "$script_home/resolve-graphify.sh" ]; then
+        cp "$script_home/resolve-graphify.sh" "$helperdir/"
+      fi
       cp scripts/lib/git-env-scrub.sh "$fixture/helper/scripts/lib/"
       cat > "$helperdir/patch-graphify.sh" <<'PATCH_GRAPHIFY'
 #!/bin/sh
@@ -97,6 +113,39 @@ PATCH_GRAPHIFY
       The status should equal 0
       The contents of file "$graphify_log" should equal \
         "$(printf 'patch-graphify\t\n%s\thook install' "$repo")"
+      The value "$(test -e "$repo/scripts/agent" && echo present || echo absent)" should equal "absent"
+    End
+
+    It 'uses the off-PATH launcher returned by setup for a foreign target'
+      helperdir="$fixture/off-path-helper/scripts/agent"
+      mkdir -p "$helperdir" "$fixture/off-path-helper/scripts/lib"
+      cp "$script_abs" "$script_home/ensure-graphify.sh" scripts/agent/agent_env.sh "$helperdir/"
+      if [ -f "$script_home/resolve-graphify.sh" ]; then
+        cp "$script_home/resolve-graphify.sh" "$helperdir/"
+      fi
+      cp scripts/lib/git-env-scrub.sh "$fixture/off-path-helper/scripts/lib/"
+      cat > "$helperdir/patch-graphify.sh" <<'PATCH_GRAPHIFY'
+#!/bin/sh
+printf 'patch-graphify\t%s\n' "$*" >> "$GRAPHIFY_LOG"
+PATCH_GRAPHIFY
+      chmod +x "$helperdir/patch-graphify.sh"
+      rm -rf "$repo/scripts/agent"
+      uv_tool_bin="$fixture/uv tool bin"
+      mkdir -p "$uv_tool_bin"
+      cp "$stubdir/graphify" "$uv_tool_bin/graphify"
+      off_path="$fixture/off path"
+      mkdir -p "$off_path"
+      for tool in dirname git sh; do
+        ln -s "$(command -v "$tool")" "$off_path/$tool"
+      done
+      ln -s "$stubdir/uv" "$off_path/uv"
+      When run env PATH="$off_path" UV_TOOL_BIN_FIXTURE="$uv_tool_bin" \
+        UV_PROGRESS_FIXTURE=1 sh "$helperdir/ensure-graphify-merge-driver.sh" "$repo"
+      The status should equal 0
+      The stderr should include 'uv progress'
+      The contents of file "$graphify_log" should equal \
+        "$(printf 'patch-graphify\t\n%s\thook install' "$repo")"
+      The value "$(git_fixture -C "$repo" config --get merge.graphify.driver)" should include 'graphify merge-driver %O %A %B'
       The value "$(test -e "$repo/scripts/agent" && echo present || echo absent)" should equal "absent"
     End
   End

--- a/tests/shell/agent_graphify_merge_driver_spec.sh
+++ b/tests/shell/agent_graphify_merge_driver_spec.sh
@@ -157,37 +157,15 @@ PATCH_GRAPHIFY
       cp scripts/lib/git-env-scrub.sh "$fixture/relative-helper/scripts/lib/"
       cat > "$helperdir/patch-graphify.sh" <<'PATCH_GRAPHIFY'
 #!/bin/sh
-. "$(dirname "$0")/resolve-graphify.sh"
-graphify_bin=$(resolve_graphify_launcher) || exit 1
-interpreter=$(resolve_graphify_interpreter "$graphify_bin") || exit 1
-"$interpreter" -I -c 'pass' || exit 1
-printf 'patch-graphify\t%s\n' "$graphify_bin" >> "$GRAPHIFY_LOG"
+printf 'patch-graphify\t%s\n' "$*" >> "$GRAPHIFY_LOG"
 PATCH_GRAPHIFY
       chmod +x "$helperdir/patch-graphify.sh"
       rm -rf "$repo/scripts/agent"
 
       caller="$fixture/caller"
       relative_bin="$caller/relbin"
-      original_interpreter=$(command -v python3)
       mkdir -p "$relative_bin"
-      {
-        printf '#!%s\n' "$original_interpreter"
-        cat <<'PYTHON'
-import os
-import subprocess
-import sys
-
-with open(os.environ["GRAPHIFY_LOG"], "a", encoding="utf-8") as log:
-    log.write(f"original\t{os.getcwd()}\t{' '.join(sys.argv[1:])}\n")
-if sys.argv[1:] != ["hook", "install"]:
-    raise SystemExit(91)
-subprocess.run(
-    ["git", "config", "--local", "merge.graphify.driver", "graphify merge-driver %O %A %B"],
-    check=True,
-)
-PYTHON
-      } > "$relative_bin/graphify"
-      chmod +x "$relative_bin/graphify"
+      cp "$stubdir/graphify" "$relative_bin/graphify"
 
       decoy_marker="$fixture/decoy-executed"
       mkdir -p "$repo/relbin"
@@ -201,7 +179,7 @@ DECOY
 
       tool_path="$fixture/relative-tools"
       mkdir -p "$tool_path"
-      for tool in dirname git sed touch; do
+      for tool in dirname git touch; do
         ln -s "$(command -v "$tool")" "$tool_path/$tool"
       done
       ln -s "$(command -v dash || command -v sh)" "$tool_path/sh"
@@ -211,7 +189,53 @@ DECOY
         "$caller" "$helperdir/ensure-graphify-merge-driver.sh" "$repo"
       The status should equal 0
       The contents of file "$graphify_log" should equal \
-        "$(printf 'patch-graphify\t%s\noriginal\t%s\thook install' "$relative_bin/graphify" "$repo")"
+        "$(printf 'patch-graphify\t\n%s\thook install' "$repo")"
+      The path "$decoy_marker" should not be exist
+      The value "$(git_fixture -C "$repo" config --get merge.graphify.driver)" should include 'graphify merge-driver %O %A %B'
+    End
+
+    It 'absolutizes a relative uv fallback before entering a foreign target'
+      helperdir="$fixture/relative-uv-helper/scripts/agent"
+      mkdir -p "$helperdir" "$fixture/relative-uv-helper/scripts/lib"
+      cp "$script_abs" "$script_home/ensure-graphify.sh" "$script_home/resolve-graphify.sh" \
+        scripts/agent/agent_env.sh "$helperdir/"
+      cp scripts/lib/git-env-scrub.sh "$fixture/relative-uv-helper/scripts/lib/"
+      cat > "$helperdir/patch-graphify.sh" <<'PATCH_GRAPHIFY'
+#!/bin/sh
+printf 'patch-graphify\t%s\n' "$*" >> "$GRAPHIFY_LOG"
+PATCH_GRAPHIFY
+      chmod +x "$helperdir/patch-graphify.sh"
+      rm -rf "$repo/scripts/agent"
+
+      caller="$fixture/uv-caller"
+      relative_bin="$caller/relbin"
+      mkdir -p "$relative_bin"
+      cp "$stubdir/graphify" "$relative_bin/graphify"
+
+      decoy_marker="$fixture/uv-decoy-executed"
+      mkdir -p "$repo/relbin"
+      cat > "$repo/relbin/graphify" <<'DECOY'
+#!/bin/sh
+printf 'decoy\t%s\t%s\n' "$PWD" "$*" >> "$GRAPHIFY_LOG"
+touch "$DECOY_MARKER"
+"$GIT_TOOL" config --local merge.graphify.driver 'graphify merge-driver %O %A %B'
+DECOY
+      chmod +x "$repo/relbin/graphify"
+
+      tool_path="$fixture/relative-uv-tools"
+      mkdir -p "$tool_path"
+      for tool in dirname git touch; do
+        ln -s "$(command -v "$tool")" "$tool_path/$tool"
+      done
+      ln -s "$(command -v dash || command -v sh)" "$tool_path/sh"
+      ln -s "$stubdir/uv" "$tool_path/uv"
+      When run env PATH="$tool_path" UV_TOOL_BIN_FIXTURE=relbin \
+        GIT_TOOL="$tool_path/git" DECOY_MARKER="$decoy_marker" \
+        sh -c 'cd "$1" && exec sh "$2" "$3"' _ \
+        "$caller" "$helperdir/ensure-graphify-merge-driver.sh" "$repo"
+      The status should equal 0
+      The contents of file "$graphify_log" should equal \
+        "$(printf 'patch-graphify\t\n%s\thook install' "$repo")"
       The path "$decoy_marker" should not be exist
       The value "$(git_fixture -C "$repo" config --get merge.graphify.driver)" should include 'graphify merge-driver %O %A %B'
     End

--- a/tests/shell/agent_graphify_merge_driver_spec.sh
+++ b/tests/shell/agent_graphify_merge_driver_spec.sh
@@ -148,5 +148,72 @@ PATCH_GRAPHIFY
       The value "$(git_fixture -C "$repo" config --get merge.graphify.driver)" should include 'graphify merge-driver %O %A %B'
       The value "$(test -e "$repo/scripts/agent" && echo present || echo absent)" should equal "absent"
     End
+
+    It 'absolutizes a relative PATH launcher before entering a foreign target'
+      helperdir="$fixture/relative-helper/scripts/agent"
+      mkdir -p "$helperdir" "$fixture/relative-helper/scripts/lib"
+      cp "$script_abs" "$script_home/ensure-graphify.sh" "$script_home/resolve-graphify.sh" \
+        scripts/agent/agent_env.sh "$helperdir/"
+      cp scripts/lib/git-env-scrub.sh "$fixture/relative-helper/scripts/lib/"
+      cat > "$helperdir/patch-graphify.sh" <<'PATCH_GRAPHIFY'
+#!/bin/sh
+. "$(dirname "$0")/resolve-graphify.sh"
+graphify_bin=$(resolve_graphify_launcher) || exit 1
+interpreter=$(resolve_graphify_interpreter "$graphify_bin") || exit 1
+"$interpreter" -I -c 'pass' || exit 1
+printf 'patch-graphify\t%s\n' "$graphify_bin" >> "$GRAPHIFY_LOG"
+PATCH_GRAPHIFY
+      chmod +x "$helperdir/patch-graphify.sh"
+      rm -rf "$repo/scripts/agent"
+
+      caller="$fixture/caller"
+      relative_bin="$caller/relbin"
+      original_interpreter=$(command -v python3)
+      mkdir -p "$relative_bin"
+      {
+        printf '#!%s\n' "$original_interpreter"
+        cat <<'PYTHON'
+import os
+import subprocess
+import sys
+
+with open(os.environ["GRAPHIFY_LOG"], "a", encoding="utf-8") as log:
+    log.write(f"original\t{os.getcwd()}\t{' '.join(sys.argv[1:])}\n")
+if sys.argv[1:] != ["hook", "install"]:
+    raise SystemExit(91)
+subprocess.run(
+    ["git", "config", "--local", "merge.graphify.driver", "graphify merge-driver %O %A %B"],
+    check=True,
+)
+PYTHON
+      } > "$relative_bin/graphify"
+      chmod +x "$relative_bin/graphify"
+
+      decoy_marker="$fixture/decoy-executed"
+      mkdir -p "$repo/relbin"
+      cat > "$repo/relbin/graphify" <<'DECOY'
+#!/bin/sh
+printf 'decoy\t%s\t%s\n' "$PWD" "$*" >> "$GRAPHIFY_LOG"
+touch "$DECOY_MARKER"
+"$GIT_TOOL" config --local merge.graphify.driver 'graphify merge-driver %O %A %B'
+DECOY
+      chmod +x "$repo/relbin/graphify"
+
+      tool_path="$fixture/relative-tools"
+      mkdir -p "$tool_path"
+      for tool in dirname git sed touch; do
+        ln -s "$(command -v "$tool")" "$tool_path/$tool"
+      done
+      ln -s "$(command -v dash || command -v sh)" "$tool_path/sh"
+      ln -s "$stubdir/uv" "$tool_path/uv"
+      When run env PATH="relbin:$tool_path" GIT_TOOL="$tool_path/git" \
+        DECOY_MARKER="$decoy_marker" sh -c 'cd "$1" && exec sh "$2" "$3"' _ \
+        "$caller" "$helperdir/ensure-graphify-merge-driver.sh" "$repo"
+      The status should equal 0
+      The contents of file "$graphify_log" should equal \
+        "$(printf 'patch-graphify\t%s\noriginal\t%s\thook install' "$relative_bin/graphify" "$repo")"
+      The path "$decoy_marker" should not be exist
+      The value "$(git_fixture -C "$repo" config --get merge.graphify.driver)" should include 'graphify merge-driver %O %A %B'
+    End
   End
 End

--- a/tests/shell/agent_tools_setup_spec.sh
+++ b/tests/shell/agent_tools_setup_spec.sh
@@ -51,6 +51,7 @@ ENSURE_GRAPHIFY
     cat > "$repository/scripts/setup-hooks.sh" <<'SETUP_HOOKS'
 #!/bin/sh
 printf 'setup-hooks:%s\n' "$*" >> "$DEBIAN_HELPER_LOG"
+sh "$(dirname "$0")/agent/ensure-graphify.sh" "$PWD"
 SETUP_HOOKS
     cat > "$repository/scripts/agent/init-worktree-tools.sh" <<'INIT_WORKTREE'
 #!/bin/sh
@@ -589,7 +590,7 @@ UNMANAGED_UV
       '  demo:' \
       '    web_dashboard: true')"
     The contents of file "$helper_log" should equal \
-      "$(printf 'ensure-graphify:%s\nsetup-hooks:\ninit-worktree-tools:%s' "$repository" "$repository")"
+      "$(printf 'setup-hooks:\nensure-graphify:%s\ninit-worktree-tools:%s' "$repository" "$repository")"
     The contents of file "$tool_log" should include 'serena:init'
     The contents of file "$tool_log" should include 'wt:config shell install --yes'
     The contents of file "$tool_log" should include 'codegraph:install -l global -y -t auto'
@@ -603,7 +604,8 @@ UNMANAGED_UV
       'projects:' \
       '  demo:' \
       '    web_dashboard: true')"
-    The contents of file "$helper_log" should equal "$(printf 'ensure-graphify:%s' "$repository")"
+    The contents of file "$helper_log" should equal \
+      "$(printf 'setup-hooks:\nensure-graphify:%s' "$repository")"
     The contents of file "$tool_log" should include 'codegraph:install -l global -y -t auto'
   End
 
@@ -914,7 +916,8 @@ CONFIG
     The contents of file "$worktrunk_config" should equal "$(cat "$worktrunk_multiline_expected")"
     The value "$(wc -c < "$worktrunk_config" | tr -d '[:space:]')" should equal \
       "$(wc -c < "$worktrunk_multiline_expected" | tr -d '[:space:]')"
-    The contents of file "$helper_log" should equal "$(printf 'ensure-graphify:%s' "$repository")"
+    The contents of file "$helper_log" should equal \
+      "$(printf 'setup-hooks:\nensure-graphify:%s' "$repository")"
   End
 
   It 'inserts only the global Worktrunk key while preserving hostile comments, tables, and nested paths byte-for-byte'

--- a/tests/shell/agent_tools_setup_spec.sh
+++ b/tests/shell/agent_tools_setup_spec.sh
@@ -43,6 +43,11 @@ POLICY_MARKER
     cp "$policy_marker" "$fixture/policy.before"
 
     helper_log="$fixture/helpers.log"
+    cat > "$repository/scripts/agent/ensure-graphify.sh" <<'ENSURE_GRAPHIFY'
+#!/bin/sh
+printf 'ensure-graphify:%s\n' "$1" >> "$DEBIAN_HELPER_LOG"
+uv tool install --upgrade graphifyy
+ENSURE_GRAPHIFY
     cat > "$repository/scripts/setup-hooks.sh" <<'SETUP_HOOKS'
 #!/bin/sh
 printf 'setup-hooks:%s\n' "$*" >> "$DEBIAN_HELPER_LOG"
@@ -574,7 +579,7 @@ UNMANAGED_UV
     The path "$home/.serena/serena_config.yml" should not be exist
   End
 
-  It 'disables only the root Serena dashboard key and calls both repository helpers for the default repository'
+  It 'disables only the root Serena dashboard key and calls every repository helper for the default repository'
     When run sh -c 'cd "$1" && exec sh "$2"' _ "$repository" "$script_abs"
     The status should equal 0
     The contents of file "$home/.serena/serena_config.yml" should equal "$(printf '%s\n' \
@@ -583,7 +588,8 @@ UNMANAGED_UV
       'projects:' \
       '  demo:' \
       '    web_dashboard: true')"
-    The contents of file "$helper_log" should equal "$(printf 'setup-hooks:\ninit-worktree-tools:%s' "$repository")"
+    The contents of file "$helper_log" should equal \
+      "$(printf 'ensure-graphify:%s\nsetup-hooks:\ninit-worktree-tools:%s' "$repository" "$repository")"
     The contents of file "$tool_log" should include 'serena:init'
     The contents of file "$tool_log" should include 'wt:config shell install --yes'
     The contents of file "$tool_log" should include 'codegraph:install -l global -y -t auto'
@@ -597,7 +603,7 @@ UNMANAGED_UV
       'projects:' \
       '  demo:' \
       '    web_dashboard: true')"
-    The file "$helper_log" should not be exist
+    The contents of file "$helper_log" should equal "$(printf 'ensure-graphify:%s' "$repository")"
     The contents of file "$tool_log" should include 'codegraph:install -l global -y -t auto'
   End
 
@@ -908,7 +914,7 @@ CONFIG
     The contents of file "$worktrunk_config" should equal "$(cat "$worktrunk_multiline_expected")"
     The value "$(wc -c < "$worktrunk_config" | tr -d '[:space:]')" should equal \
       "$(wc -c < "$worktrunk_multiline_expected" | tr -d '[:space:]')"
-    The file "$helper_log" should not be exist
+    The contents of file "$helper_log" should equal "$(printf 'ensure-graphify:%s' "$repository")"
   End
 
   It 'inserts only the global Worktrunk key while preserving hostile comments, tables, and nested paths byte-for-byte'
@@ -986,6 +992,7 @@ CONFIG
     Assert [ "$(grep -c '^codegraph:install -l global -y -t auto$' "$tool_log")" -eq 2 ]
     Assert [ "$(grep -c '^wt:config shell install --yes$' "$tool_log")" -eq 2 ]
     Assert [ "$(grep -c '^https://github.com/max-sixty/worktrunk/releases/latest/download/worktrunk-installer.sh$' "$curl_log")" -eq 2 ]
+    Assert [ "$(grep -c "^ensure-graphify:$repository$" "$helper_log")" -eq 2 ]
     Assert [ "$(grep -c '^setup-hooks:$' "$helper_log")" -eq 2 ]
     Assert [ "$(grep -c "^init-worktree-tools:$repository$" "$helper_log")" -eq 2 ]
   End
@@ -1006,12 +1013,21 @@ CONFIG
     Assert [ "$(grep -c '^uv:tool install --upgrade semgrep$' "$tool_log")" -eq 1 ]
   End
 
-  It 'requires both repository setup helpers before running either one'
+  It 'requires every repository setup helper before running any of them'
     rm -f "$repository/scripts/agent/init-worktree-tools.sh"
     When run sh "$script_abs" "$repository"
     The status should not equal 0
     The stderr should include 'init-worktree-tools.sh'
     The file "$helper_log" should not be exist
+  End
+
+  It 'fails before tool installation when the shared Graphify helper is missing'
+    rm -f "$repository/scripts/agent/ensure-graphify.sh"
+    When run sh "$script_abs" "$repository"
+    The status should not equal 0
+    The stderr should include 'ensure-graphify.sh'
+    The file "$helper_log" should not be exist
+    The file "$tool_log" should not be exist
   End
 
   It 'rejects more than one repository argument'

--- a/tests/shell/agent_work_branch_spec.sh
+++ b/tests/shell/agent_work_branch_spec.sh
@@ -91,8 +91,21 @@ case "$1" in
   *) exit 9 ;;
 esac
 CODEGRAPH
-    cat > "$stubdir/graphify" <<'GRAPHIFY'
+    graphify_package="$fixture/toolvenv/package/graphify"
+    mkdir -p "$graphify_package"
+    interpreter="$fixture/toolvenv/bin/python3"
+    mkdir -p "$fixture/toolvenv/bin"
+    cat > "$interpreter" <<'INTERPRETER'
 #!/bin/sh
+case "$*" in
+  *os.path.dirname*) printf '%s\n' "$WB_GRAPHIFY_PACKAGE"; exit 0 ;;
+  *activate_language_overrides*) exit 0 ;;
+esac
+exec sh "$@"
+INTERPRETER
+    chmod +x "$interpreter"
+    printf '#!%s\n' "$interpreter" > "$stubdir/graphify"
+    cat >> "$stubdir/graphify" <<'GRAPHIFY'
 case "$1" in
   update)
     [ "$#" -eq 2 ] || exit 9
@@ -114,7 +127,7 @@ GIT
     chmod +x "$stubdir/git"
     export WB_TOOL_EVENTS="$events"
     default_tool_log="$fixture/default-tools"
-    export WB_DEFAULT_TOOL_LOG="$default_tool_log"
+    export WB_DEFAULT_TOOL_LOG="$default_tool_log" WB_GRAPHIFY_PACKAGE="$graphify_package"
     export PFB_INIT_WORKTREE_TOOLS="$stubdir/init-worktree-tools"
     PATH="$stubdir:$PATH"; export PATH
   }

--- a/tests/shell/agent_worktree_tools_spec.sh
+++ b/tests/shell/agent_worktree_tools_spec.sh
@@ -25,6 +25,13 @@ Describe 'init-worktree-tools.sh'
         commit -q --allow-empty -m init || return 1
     stubdir="$fixture/bin"; mkdir -p "$stubdir"
     tool_log="$fixture/tools.log"
+    graphify_package="$fixture/toolvenv/package/graphify"
+    mkdir -p "$graphify_package"
+    true > "$graphify_package/__init__.py"
+    cat > "$graphify_package/rcfile.py" <<'RCFILE'
+def activate_language_overrides(root):
+    return {}
+RCFILE
 
     cat > "$stubdir/codegraph" <<'CODEGRAPH'
 #!/bin/sh
@@ -41,19 +48,20 @@ case "$1" in
   *) exit 9 ;;
 esac
 CODEGRAPH
-    # patch-graphify.sh finds the package to patch through the interpreter named on the
-    # shebang of the `graphify` on PATH, so this stub's shebang names a wrapper sitting
-    # where a uv tool venv keeps its own interpreter. The wrapper logs the patch
-    # script's probe -- which is what pins the patch call's position in this chain --
-    # and then fails it, so the patch script skips and the real installed Graphify is
-    # never touched from here. Anything that is not that probe is the stub below being
-    # executed through this shebang, so it runs as the /bin/sh script it is.
+    # patch-graphify.sh finds the package through the interpreter named on the
+    # `graphify` shebang. This fixture interpreter reports an already-patched package
+    # and logs the location probe, so no real installed Graphify is touched.
     interpreter="$fixture/toolvenv/bin/python3"
     mkdir -p "$fixture/toolvenv/bin"
     cat > "$interpreter" <<'INTERPRETER'
 #!/bin/sh
-case "$1" in
-  -I) printf 'patch-graphify:probe\n' >> "$WORKTREE_TOOL_LOG"; exit 1 ;;
+case "$*" in
+  *os.path.dirname*)
+    printf 'patch-graphify:probe\n' >> "$WORKTREE_TOOL_LOG"
+    printf '%s\n' "$WORKTREE_GRAPHIFY_PACKAGE"
+    exit 0
+    ;;
+  *activate_language_overrides*) exit 0 ;;
 esac
 exec sh "$@"
 INTERPRETER
@@ -90,7 +98,7 @@ SERENA
     ln -s "$stubdir/codegraph" "$no_serena/codegraph"
     ln -s "$stubdir/graphify" "$no_serena/graphify"
 
-    export WORKTREE_TOOL_LOG="$tool_log"
+    export WORKTREE_TOOL_LOG="$tool_log" WORKTREE_GRAPHIFY_PACKAGE="$graphify_package"
     # The initializer applies the vendored .inc language-override patch (issue #2810)
     # before refreshing the graph, so every log below carries `patch-graphify:probe`
     # between the CodeGraph line and the Graphify one.
@@ -116,12 +124,12 @@ SERENA
     The stderr should include 'run /graphify'
   End
 
-  It 'runs the vendored Graphify language override before refreshing the graph, and a stubbed graphify is a skip'
+  It 'runs the vendored Graphify language override before refreshing an existing graph'
     mkdir -p "$worktree/graphify-out"
     true > "$worktree/graphify-out/graph.json"
     When run env OMP_CLI=1 sh "$script_abs" "$worktree"
     The status should equal 0
-    The stderr should include 'cannot locate'
+    The stderr should include 'already provides'
     The contents of file "$tool_log" should equal \
       "$(printf 'codegraph:init:%s\npatch-graphify:probe\ngraphify:update:%s' "$worktree" "$worktree")"
     The stderr should include 'Initializing CodeGraph in'

--- a/tests/shell/graphify_language_patch_spec.sh
+++ b/tests/shell/graphify_language_patch_spec.sh
@@ -21,10 +21,12 @@ Describe 'patch-graphify.sh'
   # answer is read back off the package tree, so it flips exactly when a run patches
   # it -- an already-provided override and a fresh apply cannot both be faked.
   make_interpreter() {
+    python3_bin=$(command -v python3) || return 1
     mkdir -p "$(dirname "$1")"
     cat > "$1" <<INTERPRETER
 #!/bin/sh
 case "\$*" in
+  *shlex.quote*) exec "$python3_bin" "\$@" ;;
   *os.path.dirname*) printf '%s\n' '$package' ;;
   *activate_language_overrides*)
     grep -q 'def activate_language_overrides' '$package/rcfile.py' 2>/dev/null || exit 1
@@ -37,28 +39,32 @@ INTERPRETER
   }
 
   make_uv_trampoline_fixture() {
-    uv_tool_dir="$fixture/home with spaces/.local/share/uv/tools"
-    uv_tool_bin="$fixture/home with spaces/.local/bin"
+    uv_home=${1:-"$fixture/home with spaces"}
+    uv_tool_dir="$uv_home/.local/share/uv/tools"
+    uv_tool_bin="$uv_home/.local/bin"
     uv_python="$uv_tool_dir/graphifyy/bin/python"
     make_interpreter "$uv_python"
+    uv_python_token=$("$uv_python" -I -c 'import shlex, sys; print(shlex.quote(sys.argv[1]))' "$uv_python") || return 1
     mkdir -p "$uv_tool_bin"
     {
       printf '#!/bin/sh\n'
-      printf "'''exec' '%s' \"\$0\" \"\$@\"\n" "$uv_python"
+      printf "'''exec' %s \"\$0\" \"\$@\"\n" "$uv_python_token"
       printf "' '''\n"
       printf 'exit 0\n'
     } > "$uv_tool_bin/graphify"
     chmod +x "$uv_tool_bin/graphify"
     resolver_path="$fixture/resolver path"
     mkdir -p "$resolver_path"
-    for tool in dirname grep patch sed sh; do
+    for tool in cat dirname grep patch sed sh; do
       ln -s "$(command -v "$tool")" "$resolver_path/$tool"
     done
-    cat > "$resolver_path/uv" <<UV
+    printf '%s\n' "$uv_tool_bin" > "$resolver_path/uv-bin.out"
+    printf '%s\n' "$uv_tool_dir" > "$resolver_path/uv-tools.out"
+    cat > "$resolver_path/uv" <<'UV'
 #!/bin/sh
-case "\$*" in
-  'tool dir --bin') printf '%s\n' '$uv_tool_bin' ;;
-  'tool dir') printf '%s\n' '$uv_tool_dir' ;;
+case "$*" in
+  'tool dir --bin') cat "$(dirname "$0")/uv-bin.out" ;;
+  'tool dir') cat "$(dirname "$0")/uv-tools.out" ;;
   *) exit 9 ;;
 esac
 UV
@@ -223,6 +229,18 @@ RCFILE
     The stderr should include "$package"
     The contents of file "$package/rcfile.py" should include 'activate_language_overrides'
     The contents of file "$package/extract.py" should include 'SUFFIX_OVERRIDES = True'
+  End
+
+  It "patches through uv's real apostrophe quoting without evaluating launcher text"
+    injection_marker="$fixture/PWNED"
+    make_uv_trampoline_fixture "$fixture/home O'Brien \$(touch PWNED)"
+    When run env PATH="$resolver_path" sh -c 'cd "$1" && exec sh "$2"' _ "$fixture" "$script_abs"
+    The status should equal 0
+    The stderr should include 'applied Graphify-Labs/graphify#3075'
+    The stderr should include "$package"
+    The contents of file "$package/rcfile.py" should include 'activate_language_overrides'
+    The contents of file "$package/extract.py" should include 'SUFFIX_OVERRIDES = True'
+    The path "$injection_marker" should not be exist
   End
 
   Context 'uv-owned shell trampoline shape validation'

--- a/tests/shell/graphify_language_patch_spec.sh
+++ b/tests/shell/graphify_language_patch_spec.sh
@@ -29,6 +29,7 @@ case "\$*" in
   *activate_language_overrides*)
     grep -q 'def activate_language_overrides' '$package/rcfile.py' 2>/dev/null || exit 1
     ;;
+  *'import graphify'*) : ;;
   *) exit 9 ;;
 esac
 INTERPRETER
@@ -62,6 +63,9 @@ INTERPRETER
     mkdir -p "$checkout/scripts/agent" "$checkout/.agents/patches" || return 1
     cp "$project_root/scripts/agent/patch-graphify.sh" "$checkout/scripts/agent/" || return 1
     cp "$project_root/scripts/agent/agent_env.sh" "$checkout/scripts/agent/" || return 1
+    if [ -f "$project_root/scripts/agent/resolve-graphify.sh" ]; then
+      cp "$project_root/scripts/agent/resolve-graphify.sh" "$checkout/scripts/agent/" || return 1
+    fi
     script_abs="$checkout/scripts/agent/patch-graphify.sh"
 
     cat > "$checkout/.agents/patches/graphify-3075-language-overrides.patch" <<'PATCH'
@@ -181,6 +185,41 @@ RCFILE
     Assert [ -z "$(find "$fixture/site packages" \( -name '*.~[0-9]*~' -o \( -name '*.orig' ! -name 'with.orig' \) \) -print)" ]
   End
 
+
+  It 'patches through a real-shape uv shell trampoline under a tool path with spaces'
+    uv_tool_dir="$fixture/home with spaces/.local/share/uv/tools"
+    uv_tool_bin="$fixture/home with spaces/.local/bin"
+    uv_python="$uv_tool_dir/graphifyy/bin/python"
+    make_interpreter "$uv_python"
+    mkdir -p "$uv_tool_bin"
+    {
+      printf '#!/bin/sh\n'
+      printf "'''exec' '%s' \"\$0\" \"\$@\"\n" "$uv_python"
+      printf "' '''\n"
+      printf 'exit 0\n'
+    } > "$uv_tool_bin/graphify"
+    chmod +x "$uv_tool_bin/graphify"
+    resolver_path="$fixture/resolver path"
+    mkdir -p "$resolver_path"
+    for tool in dirname grep patch sed sh; do
+      ln -s "$(command -v "$tool")" "$resolver_path/$tool"
+    done
+    cat > "$resolver_path/uv" <<UV
+#!/bin/sh
+case "\$*" in
+  'tool dir --bin') printf '%s\n' '$uv_tool_bin' ;;
+  'tool dir') printf '%s\n' '$uv_tool_dir' ;;
+  *) exit 9 ;;
+esac
+UV
+    chmod +x "$resolver_path/uv"
+    When run env PATH="$resolver_path" sh "$script_abs"
+    The status should equal 0
+    The stderr should include 'applied Graphify-Labs/graphify#3075'
+    The stderr should include "$package"
+    The contents of file "$package/rcfile.py" should include 'activate_language_overrides'
+    The contents of file "$package/extract.py" should include 'SUFFIX_OVERRIDES = True'
+  End
   It 'fails closed when the graphify shebang does not name a Python interpreter'
     # The ambient python3 is NOT a fallback: another interpreter imports another
     # graphify, so falling back patches an unrelated package and reports success. A

--- a/tests/shell/graphify_language_patch_spec.sh
+++ b/tests/shell/graphify_language_patch_spec.sh
@@ -181,28 +181,29 @@ RCFILE
     Assert [ -z "$(find "$fixture/site packages" \( -name '*.~[0-9]*~' -o \( -name '*.orig' ! -name 'with.orig' \) \) -print)" ]
   End
 
-  It 'skips with a warning when the graphify shebang does not name a Python interpreter'
+  It 'fails closed when the graphify shebang does not name a Python interpreter'
     # The ambient python3 is NOT a fallback: another interpreter imports another
     # graphify, so falling back patches an unrelated package and reports success. A
     # working python3 sits on PATH here precisely to prove nothing reaches for it.
     printf '#!/bin/sh\nexit 0\n' > "$stubdir/graphify"
     make_interpreter "$stubdir/python3"
     When run sh "$script_abs"
-    The status should equal 0
+    The status should not equal 0
     The stderr should include 'does not name a Python interpreter'
     The path "$package/rcfile.py" should not be exist
     Assert [ "$(cmp -s "$package/extract.py" "$fixture/extract.py.before"; printf '%s' "$?")" -eq 0 ]
   End
 
-  It 'skips with a warning when the shebang interpreter cannot import graphify'
+  It 'fails closed when the shebang interpreter cannot import graphify'
     printf '#!/bin/sh\nexit 1\n' > "$interpreter"
     When run sh "$script_abs"
-    The status should equal 0
+    The status should not equal 0
     The stderr should include 'cannot locate'
     The path "$package/rcfile.py" should not be exist
+    Assert [ "$(cmp -s "$package/extract.py" "$fixture/extract.py.before"; printf '%s' "$?")" -eq 0 ]
   End
 
-  It 'ignores a hostile module in the working directory it is called from'
+  It 'fails closed while ignoring a hostile module in the working directory'
     # Both probes run isolated (-I), which keeps the caller's directory off sys.path, so
     # a graphify.py beside the caller can neither answer for the installed package nor
     # execute at all.
@@ -216,7 +217,7 @@ __file__ = '$hostile/graphify.py'
 HOSTILE
     printf '#!%s\nexit 0\n' "$(command -v python3)" > "$stubdir/graphify"
     When run sh -c 'cd "$1" && exec sh "$2"' _ "$hostile" "$script_abs"
-    The status should equal 0
+    The status should not equal 0
     The stderr should include 'cannot locate'
     The path "$hostile/executed" should not be exist
     The path "$hostile/rcfile.py" should not be exist

--- a/tests/shell/graphify_language_patch_spec.sh
+++ b/tests/shell/graphify_language_patch_spec.sh
@@ -36,6 +36,35 @@ INTERPRETER
     chmod +x "$1"
   }
 
+  make_uv_trampoline_fixture() {
+    uv_tool_dir="$fixture/home with spaces/.local/share/uv/tools"
+    uv_tool_bin="$fixture/home with spaces/.local/bin"
+    uv_python="$uv_tool_dir/graphifyy/bin/python"
+    make_interpreter "$uv_python"
+    mkdir -p "$uv_tool_bin"
+    {
+      printf '#!/bin/sh\n'
+      printf "'''exec' '%s' \"\$0\" \"\$@\"\n" "$uv_python"
+      printf "' '''\n"
+      printf 'exit 0\n'
+    } > "$uv_tool_bin/graphify"
+    chmod +x "$uv_tool_bin/graphify"
+    resolver_path="$fixture/resolver path"
+    mkdir -p "$resolver_path"
+    for tool in dirname grep patch sed sh; do
+      ln -s "$(command -v "$tool")" "$resolver_path/$tool"
+    done
+    cat > "$resolver_path/uv" <<UV
+#!/bin/sh
+case "\$*" in
+  'tool dir --bin') printf '%s\n' '$uv_tool_bin' ;;
+  'tool dir') printf '%s\n' '$uv_tool_dir' ;;
+  *) exit 9 ;;
+esac
+UV
+    chmod +x "$resolver_path/uv"
+  }
+
   # A real uv tool venv, built for the decoy example, which needs a REAL interpreter: a
   # stub can neither honour nor ignore -I, so no example resting on one can observe the
   # isolation. A symlinked python3 plus a pyvenv.cfg naming its home makes that
@@ -187,38 +216,46 @@ RCFILE
 
 
   It 'patches through a real-shape uv shell trampoline under a tool path with spaces'
-    uv_tool_dir="$fixture/home with spaces/.local/share/uv/tools"
-    uv_tool_bin="$fixture/home with spaces/.local/bin"
-    uv_python="$uv_tool_dir/graphifyy/bin/python"
-    make_interpreter "$uv_python"
-    mkdir -p "$uv_tool_bin"
-    {
-      printf '#!/bin/sh\n'
-      printf "'''exec' '%s' \"\$0\" \"\$@\"\n" "$uv_python"
-      printf "' '''\n"
-      printf 'exit 0\n'
-    } > "$uv_tool_bin/graphify"
-    chmod +x "$uv_tool_bin/graphify"
-    resolver_path="$fixture/resolver path"
-    mkdir -p "$resolver_path"
-    for tool in dirname grep patch sed sh; do
-      ln -s "$(command -v "$tool")" "$resolver_path/$tool"
-    done
-    cat > "$resolver_path/uv" <<UV
-#!/bin/sh
-case "\$*" in
-  'tool dir --bin') printf '%s\n' '$uv_tool_bin' ;;
-  'tool dir') printf '%s\n' '$uv_tool_dir' ;;
-  *) exit 9 ;;
-esac
-UV
-    chmod +x "$resolver_path/uv"
+    make_uv_trampoline_fixture
     When run env PATH="$resolver_path" sh "$script_abs"
     The status should equal 0
     The stderr should include 'applied Graphify-Labs/graphify#3075'
     The stderr should include "$package"
     The contents of file "$package/rcfile.py" should include 'activate_language_overrides'
     The contents of file "$package/extract.py" should include 'SUFFIX_OVERRIDES = True'
+  End
+
+  Context 'uv-owned shell trampoline shape validation'
+    Parameters
+      1
+      2
+      3
+    End
+
+    It "fails closed when uv-owned trampoline line $1 is malformed"
+      make_uv_trampoline_fixture
+      line1='#!/bin/sh'
+      line2="'''exec' '$uv_python' \"\$0\" \"\$@\""
+      line3="' '''"
+      case "$1" in
+        1) line1='#!/bin/sh -e' ;;
+        2) line2="'''exec' '$uv_python' \"\$0\" \"\$*\"" ;;
+        3) line3="' ''" ;;
+      esac
+      {
+        printf '%s\n' "$line1"
+        printf '%s\n' "$line2"
+        printf '%s\n' "$line3"
+        printf 'exit 0\n'
+      } > "$uv_tool_bin/graphify"
+      chmod +x "$uv_tool_bin/graphify"
+      cp -R "$package" "$fixture/package.before"
+      When run env PATH="$resolver_path" sh "$script_abs"
+      The status should not equal 0
+      The stderr should include 'does not name a Python interpreter on its shebang or a validated uv trampoline'
+      The path "$package/rcfile.py" should not be exist
+      Assert [ -z "$(diff -r "$fixture/package.before" "$package")" ]
+    End
   End
   It 'fails closed when the graphify shebang does not name a Python interpreter'
     # The ambient python3 is NOT a fallback: another interpreter imports another

--- a/tests/shell/precommit_composer_vendor_spec.sh
+++ b/tests/shell/precommit_composer_vendor_spec.sh
@@ -15,10 +15,11 @@ Describe '.githooks/pre-commit Composer vendor guard'
     gitc config gpg.format ssh
     true > "$repo/key.pub"
     gitc config user.signingkey "$repo/key.pub"
-    mkdir -p "$repo/.githooks" "$repo/scripts" "$repo/src" "$repo/vendor/bin"
+    mkdir -p "$repo/.githooks" "$repo/scripts/agent" "$repo/src" "$repo/vendor/bin"
     cp "$PFB_ROOT/.githooks/pre-commit" "$repo/.githooks/pre-commit"
     cp "$PFB_ROOT/.githooks/check-commit-identity.sh" "$repo/.githooks/" \
       && chmod +x "$repo/.githooks/check-commit-identity.sh"
+    printf '#!/bin/sh\nexit 0\n' > "$repo/scripts/agent/patch-graphify.sh"
     printf '<?php echo 1;\n' > "$repo/src/a.php"
     gitc add src/a.php
 

--- a/tests/shell/precommit_githooks_exempt_spec.sh
+++ b/tests/shell/precommit_githooks_exempt_spec.sh
@@ -32,10 +32,11 @@ scripts/agent/check-agent-config-parity.sh'
     gitc config gpg.format ssh
     true > "$repo/key.pub"
     gitc config user.signingkey "$repo/key.pub"
-    mkdir -p "$repo/.githooks" "$repo/scripts" "$repo/src" "$repo/vendor/bin"
+    mkdir -p "$repo/.githooks" "$repo/scripts/agent" "$repo/src" "$repo/vendor/bin"
     cp "$PFB_ROOT/.githooks/pre-commit" "$repo/.githooks/pre-commit"
     cp "$PFB_ROOT/.githooks/check-commit-identity.sh" "$repo/.githooks/" \
       && chmod +x "$repo/.githooks/check-commit-identity.sh"
+    printf '#!/bin/sh\nexit 0\n' > "$repo/scripts/agent/patch-graphify.sh"
     printf '<?php echo 1;\n' > "$repo/src/a.php"
     gitc add src/a.php
 

--- a/tests/shell/precommit_hostile_path_spec.sh
+++ b/tests/shell/precommit_hostile_path_spec.sh
@@ -21,10 +21,11 @@ Describe '.githooks/pre-commit with a C-quoted path'
     gitc config gpg.format ssh
     true > "$repo/key.pub"
     gitc config user.signingkey "$repo/key.pub"
-    mkdir -p "$repo/.githooks" "$repo/src" "$repo/vendor/bin"
+    mkdir -p "$repo/.githooks" "$repo/scripts/agent" "$repo/src" "$repo/vendor/bin"
     cp "$PFB_ROOT/.githooks/pre-commit" "$repo/.githooks/pre-commit"
     cp "$PFB_ROOT/.githooks/check-commit-identity.sh" "$repo/.githooks/" \
       && chmod +x "$repo/.githooks/check-commit-identity.sh"
+    printf '#!/bin/sh\nexit 0\n' > "$repo/scripts/agent/patch-graphify.sh"
     # The staged checker makes staged_sh=1, so the shell gates run; create their
     # scan roots so the sandbox stays silent (the spec pins classification only).
     mkdir -p "$repo/scripts" "$repo/tests" "$repo/.claude/hooks"

--- a/tests/shell/precommit_identity_spec.sh
+++ b/tests/shell/precommit_identity_spec.sh
@@ -34,7 +34,7 @@ Describe '.githooks/check-commit-identity.sh + pre-commit wiring (issue #2982)'
   }
   cleanup() {
     rm -rf "$repo" "$stubdir"
-    unset GIT_CONFIG_GLOBAL GIT_CONFIG_SYSTEM
+    unset GIT_CONFIG_GLOBAL GIT_CONFIG_SYSTEM PATCH_GRAPHIFY_LOG PATCH_GRAPHIFY_RC
   }
   Before 'make_repo'
   After 'cleanup'
@@ -354,7 +354,14 @@ scripts/agent/check-agent-config-parity.sh'
   # gate decides the hook verdict.
   make_wired_repo() {
     make_repo
-    mkdir -p "$repo/src" "$repo/scripts" "$repo/tests" "$repo/.claude/hooks"
+    mkdir -p "$repo/src" "$repo/scripts/agent" "$repo/tests" "$repo/.claude/hooks"
+    patch_graphify_log="$repo/patch-graphify.log"
+    export PATCH_GRAPHIFY_LOG="$patch_graphify_log"
+    cat > "$repo/scripts/agent/patch-graphify.sh" <<'PATCH_GRAPHIFY'
+#!/bin/sh
+printf '%s\n' patch-graphify >> "$PATCH_GRAPHIFY_LOG"
+exit "${PATCH_GRAPHIFY_RC:-0}"
+PATCH_GRAPHIFY
     printf '%s\n' "$ALL_CHECKERS" > "$repo/.githooks-exempt"
     # Commit the manifest so the index starts EMPTY: the allow-empty example
     # below must exercise the hook's no-staged exit, not a staged manifest
@@ -405,6 +412,23 @@ scripts/agent/check-agent-config-parity.sh'
     The status should equal 1
     The stderr should include '[pre-commit] FAILED: commit identity checker missing or not executable: '
     The output should include '[pre-commit] commit identity & signing prerequisites'
+  End
+
+  It 'runs the Graphify patch guard before the no-staged-files exit'
+    make_wired_repo
+    When run sh -c "cd '$repo' && sh .githooks/pre-commit"
+    The status should equal 0
+    The output should include '[pre-commit] Graphify .inc language override'
+    The contents of file "$patch_graphify_log" should equal 'patch-graphify'
+  End
+
+  It 'fails closed when the Graphify patch guard fails with an empty index'
+    make_wired_repo
+    export PATCH_GRAPHIFY_RC=17
+    When run sh -c "cd '$repo' && sh .githooks/pre-commit"
+    The status should equal 1
+    The stderr should include '[pre-commit] FAILED: Graphify .inc language override'
+    The contents of file "$patch_graphify_log" should equal 'patch-graphify'
   End
 
   It 'does not suppress the other staged gates when the identity check fails'

--- a/tests/shell/setup_hooks_spec.sh
+++ b/tests/shell/setup_hooks_spec.sh
@@ -1,7 +1,8 @@
 #shellcheck shell=sh
-# setup-hooks.sh also bootstraps CodeGraph for the main checkout when available.
+# setup-hooks.sh installs and patches Graphify before activating hooks, then bootstraps
+# CodeGraph for the main checkout when available.
 
-Describe 'setup-hooks.sh CodeGraph bootstrap'
+Describe 'setup-hooks.sh contributor bootstrap'
   script_abs="${SHELLSPEC_PROJECT_ROOT:-$PWD}/scripts/setup-hooks.sh"
 
   setup() {
@@ -17,10 +18,23 @@ Describe 'setup-hooks.sh CodeGraph bootstrap'
         commit -q --allow-empty -m init || return 1
     stubdir="$fixture/bin"; mkdir -p "$stubdir"
     codegraph_log="$fixture/codegraph.log"
+    graphify_log="$fixture/graphify.log"
     missing_codegraph_path="$fixture/no-codegraph"; mkdir -p "$missing_codegraph_path"
-    for tool in sh git basename; do
+    missing_uv_path="$fixture/no-uv"; mkdir -p "$missing_uv_path"
+    for tool in sh git basename dirname; do
       ln -s "$(command -v "$tool")" "$missing_codegraph_path/$tool"
+      ln -s "$(command -v "$tool")" "$missing_uv_path/$tool"
     done
+    cat > "$stubdir/uv" <<'UV'
+#!/bin/sh
+printf '%s\n' "$*" >> "$GRAPHIFY_LOG"
+UV
+    ln -s "$stubdir/uv" "$missing_codegraph_path/uv"
+    mkdir -p "$primary/scripts/agent"
+    cat > "$primary/scripts/agent/patch-graphify.sh" <<'PATCH_GRAPHIFY'
+#!/bin/sh
+printf '%s\n' patch-graphify >> "$GRAPHIFY_LOG"
+PATCH_GRAPHIFY
     cat > "$stubdir/codegraph" <<'CODEGRAPH'
 #!/bin/sh
 case "$1" in
@@ -35,8 +49,8 @@ case "$1" in
   *) exit 9 ;;
 esac
 CODEGRAPH
-    chmod +x "$stubdir/codegraph"
-    export CODEGRAPH_LOG="$codegraph_log"
+    chmod +x "$stubdir/uv" "$stubdir/codegraph"
+    export CODEGRAPH_LOG="$codegraph_log" GRAPHIFY_LOG="$graphify_log"
     PATH="$stubdir:$PATH"; export PATH
   }
   cleanup() { rm -rf "$fixture"; }
@@ -49,6 +63,8 @@ CODEGRAPH
     The output should include 'core.hooksPath set to: .githooks'
     The stderr should include 'Initializing CodeGraph'
     The contents of file "$codegraph_log" should equal "init $primary"
+    The contents of file "$graphify_log" should equal \
+      "$(printf '%s\n%s' 'tool install --upgrade graphifyy>=0.9.51' patch-graphify)"
     Assert [ -f "$primary/.codegraph/codegraph.db" ]
   End
 
@@ -56,7 +72,16 @@ CODEGRAPH
     When run env PATH="$missing_codegraph_path" sh -c 'cd "$1" && exec sh "$2"' _ "$primary" "$script_abs"
     The status should equal 0
     The output should include 'core.hooksPath set to: .githooks'
-    The stderr should equal ''
+    The contents of file "$graphify_log" should equal \
+      "$(printf '%s\n%s' 'tool install --upgrade graphifyy>=0.9.51' patch-graphify)"
     The file "$codegraph_log" should not be exist
+  End
+
+  It 'fails before activating hooks when uv is unavailable'
+    When run env PATH="$missing_uv_path" sh -c 'cd "$1" && exec sh "$2"' _ "$primary" "$script_abs"
+    The status should equal 4
+    The stderr should include 'TOOL-MISSING: uv'
+    The value "$(git_fixture -C "$primary" config --get core.hooksPath 2>/dev/null || true)" should equal ''
+    The file "$graphify_log" should not be exist
   End
 End

--- a/tests/shell/setup_hooks_spec.sh
+++ b/tests/shell/setup_hooks_spec.sh
@@ -4,6 +4,7 @@
 
 Describe 'setup-hooks.sh contributor bootstrap'
   script_abs="${SHELLSPEC_PROJECT_ROOT:-$PWD}/scripts/setup-hooks.sh"
+  precommit_abs="${SHELLSPEC_PROJECT_ROOT:-$PWD}/.githooks/pre-commit"
 
   setup() {
     . "${SHELLSPEC_PROJECT_ROOT:-$PWD}/scripts/lib/git-env-scrub.sh"
@@ -21,7 +22,7 @@ Describe 'setup-hooks.sh contributor bootstrap'
     graphify_log="$fixture/graphify.log"
     missing_codegraph_path="$fixture/no-codegraph"; mkdir -p "$missing_codegraph_path"
     missing_uv_path="$fixture/no-uv"; mkdir -p "$missing_uv_path"
-    for tool in basename cat chmod dirname git mkdir sh; do
+    for tool in basename cat chmod dirname git grep mkdir sh tr; do
       ln -s "$(command -v "$tool")" "$missing_codegraph_path/$tool"
       ln -s "$(command -v "$tool")" "$missing_uv_path/$tool"
     done
@@ -45,10 +46,18 @@ esac
 UV
     ln -s "$stubdir/uv" "$missing_codegraph_path/uv"
     mkdir -p "$primary/scripts/agent"
+    if [ -f "${SHELLSPEC_PROJECT_ROOT:-$PWD}/scripts/agent/resolve-graphify.sh" ]; then
+      cp "${SHELLSPEC_PROJECT_ROOT:-$PWD}/scripts/agent/resolve-graphify.sh" "$primary/scripts/agent/"
+    fi
     cat > "$primary/scripts/agent/patch-graphify.sh" <<'PATCH_GRAPHIFY'
 #!/bin/sh
-if [ -n "${EXPECTED_GRAPHIFY_BIN:-}" ]; then
+if [ -f "$(dirname "$0")/resolve-graphify.sh" ]; then
+  . "$(dirname "$0")/resolve-graphify.sh"
+  graphify_bin=$(resolve_graphify_launcher) || exit 17
+else
   graphify_bin=$(command -v graphify) || exit 17
+fi
+if [ -n "${EXPECTED_GRAPHIFY_BIN:-}" ]; then
   printf 'patch-graphify:%s\n' "$graphify_bin" >> "$GRAPHIFY_LOG"
   [ "$graphify_bin" = "$EXPECTED_GRAPHIFY_BIN" ] || exit 18
 else
@@ -111,6 +120,26 @@ CODEGRAPH
     The contents of file "$graphify_log" should equal \
       "$(printf '%s\n%s' 'tool install --upgrade graphifyy>=0.9.51' "patch-graphify:$uv_tool_bin/graphify")"
     The value "$(git_fixture -C "$primary" config --get core.hooksPath)" should equal '.githooks'
+  End
+
+  It 'repairs through pre-commit in a fresh process with the original off-PATH environment'
+    uv_tool_bin="$fixture/uv tool bin"
+    cp "$precommit_abs" "$primary/.githooks/pre-commit"
+    cat > "$primary/.githooks/check-commit-identity.sh" <<'IDENTITY'
+#!/bin/sh
+exit 0
+IDENTITY
+    chmod +x "$primary/.githooks/check-commit-identity.sh"
+    When run env \
+      PATH="$missing_codegraph_path" \
+      UV_TOOL_BIN_FIXTURE="$uv_tool_bin" \
+      UV_TOOL_BIN_DIR="$uv_tool_bin" \
+      EXPECTED_GRAPHIFY_BIN="$uv_tool_bin/graphify" \
+      sh -c 'cd "$1" && sh "$2" && exec sh .githooks/pre-commit' _ "$primary" "$script_abs"
+    The status should equal 0
+    The output should include '[pre-commit] Graphify .inc language override'
+    The contents of file "$graphify_log" should equal \
+      "$(printf '%s\n%s\n%s' 'tool install --upgrade graphifyy>=0.9.51' "patch-graphify:$uv_tool_bin/graphify" "patch-graphify:$uv_tool_bin/graphify")"
   End
 
   It 'does not bypass a Graphify wrapper already selected by PATH'

--- a/tests/shell/setup_hooks_spec.sh
+++ b/tests/shell/setup_hooks_spec.sh
@@ -21,19 +21,39 @@ Describe 'setup-hooks.sh contributor bootstrap'
     graphify_log="$fixture/graphify.log"
     missing_codegraph_path="$fixture/no-codegraph"; mkdir -p "$missing_codegraph_path"
     missing_uv_path="$fixture/no-uv"; mkdir -p "$missing_uv_path"
-    for tool in sh git basename dirname; do
+    for tool in basename cat chmod dirname git mkdir sh; do
       ln -s "$(command -v "$tool")" "$missing_codegraph_path/$tool"
       ln -s "$(command -v "$tool")" "$missing_uv_path/$tool"
     done
     cat > "$stubdir/uv" <<'UV'
 #!/bin/sh
-printf '%s\n' "$*" >> "$GRAPHIFY_LOG"
+case "$*" in
+  'tool install --upgrade graphifyy>=0.9.51')
+    printf '%s\n' "$*" >> "$GRAPHIFY_LOG"
+    if [ -n "${UV_TOOL_BIN_FIXTURE:-}" ]; then
+      mkdir -p "$UV_TOOL_BIN_FIXTURE"
+      printf '#!/bin/sh\nexit 0\n' > "$UV_TOOL_BIN_FIXTURE/graphify"
+      chmod +x "$UV_TOOL_BIN_FIXTURE/graphify"
+    fi
+    ;;
+  'tool dir --bin')
+    [ -n "${UV_TOOL_BIN_FIXTURE:-}" ] || exit 9
+    printf '%s\n' "$UV_TOOL_BIN_FIXTURE"
+    ;;
+  *) exit 9 ;;
+esac
 UV
     ln -s "$stubdir/uv" "$missing_codegraph_path/uv"
     mkdir -p "$primary/scripts/agent"
     cat > "$primary/scripts/agent/patch-graphify.sh" <<'PATCH_GRAPHIFY'
 #!/bin/sh
-printf '%s\n' patch-graphify >> "$GRAPHIFY_LOG"
+if [ -n "${EXPECTED_GRAPHIFY_BIN:-}" ]; then
+  graphify_bin=$(command -v graphify) || exit 17
+  printf 'patch-graphify:%s\n' "$graphify_bin" >> "$GRAPHIFY_LOG"
+  [ "$graphify_bin" = "$EXPECTED_GRAPHIFY_BIN" ] || exit 18
+else
+  printf '%s\n' patch-graphify >> "$GRAPHIFY_LOG"
+fi
 PATCH_GRAPHIFY
     cat > "$stubdir/codegraph" <<'CODEGRAPH'
 #!/bin/sh
@@ -50,7 +70,9 @@ case "$1" in
 esac
 CODEGRAPH
     chmod +x "$stubdir/uv" "$stubdir/codegraph"
-    export CODEGRAPH_LOG="$codegraph_log" GRAPHIFY_LOG="$graphify_log"
+    uv_tool_bin_fixture="$fixture/default uv tool bin"
+    export CODEGRAPH_LOG="$codegraph_log" GRAPHIFY_LOG="$graphify_log" \
+      UV_TOOL_BIN_FIXTURE="$uv_tool_bin_fixture"
     PATH="$stubdir:$PATH"; export PATH
   }
   cleanup() { rm -rf "$fixture"; }
@@ -75,6 +97,36 @@ CODEGRAPH
     The contents of file "$graphify_log" should equal \
       "$(printf '%s\n%s' 'tool install --upgrade graphifyy>=0.9.51' patch-graphify)"
     The file "$codegraph_log" should not be exist
+  End
+
+  It 'patches a fresh uv install when the uv tool bin is absent from PATH'
+    uv_tool_bin="$fixture/uv tool bin"
+    When run env \
+      PATH="$missing_codegraph_path" \
+      UV_TOOL_BIN_FIXTURE="$uv_tool_bin" \
+      EXPECTED_GRAPHIFY_BIN="$uv_tool_bin/graphify" \
+      sh -c 'cd "$1" && exec sh "$2"' _ "$primary" "$script_abs"
+    The status should equal 0
+    The output should include 'core.hooksPath set to: .githooks'
+    The contents of file "$graphify_log" should equal \
+      "$(printf '%s\n%s' 'tool install --upgrade graphifyy>=0.9.51' "patch-graphify:$uv_tool_bin/graphify")"
+    The value "$(git_fixture -C "$primary" config --get core.hooksPath)" should equal '.githooks'
+  End
+
+  It 'does not bypass a Graphify wrapper already selected by PATH'
+    wrapper="$missing_codegraph_path/graphify"
+    printf '#!/bin/sh\nexit 0\n' > "$wrapper"
+    chmod +x "$wrapper"
+    uv_tool_bin="$fixture/uv tool bin"
+    When run env \
+      PATH="$missing_codegraph_path" \
+      UV_TOOL_BIN_FIXTURE="$uv_tool_bin" \
+      EXPECTED_GRAPHIFY_BIN="$wrapper" \
+      sh -c 'cd "$1" && exec sh "$2"' _ "$primary" "$script_abs"
+    The status should equal 0
+    The output should include 'core.hooksPath set to: .githooks'
+    The contents of file "$graphify_log" should equal \
+      "$(printf '%s\n%s' 'tool install --upgrade graphifyy>=0.9.51' "patch-graphify:$wrapper")"
   End
 
   It 'fails before activating hooks when uv is unavailable'

--- a/tests/test_cross_agent_tooling.py
+++ b/tests/test_cross_agent_tooling.py
@@ -402,44 +402,38 @@ def test_graphify_inc_language_override_rides_as_a_local_patch() -> None:
     # PHP includes extract as a handful of incidental nodes (issue #2810). The fix is
     # upstream in Graphify-Labs/graphify#3075 and unreleased, so it rides as a patch
     # applied to the installed package after every install. When upstream releases it,
-    # the patch, the script, its two call sites, and this test go away together.
+    # the patch, shared installer, universal call sites, and this test go away together.
     patch = (ROOT / ".agents/patches/graphify-3075-language-overrides.patch").read_text(encoding="utf-8")
     assert "Graphify-Labs/graphify#3075" in patch, "the vendored patch must name its upstream PR"
     assert "+++ b/graphify/rcfile.py" in patch, "the vendored patch must carry the .graphifyrc parser"
 
-    # Two call sites, each pinned by the line that RUNS the patch. Their ORDER -- the
-    # patch before that site's first use of Graphify, or that step's output is
-    # Pascal-parsed -- is asserted behaviourally by the specs that execute these
-    # scripts: agent_graphify_merge_driver_spec.sh pins the patch before
-    # `graphify hook install`, agent_worktree_tools_spec.sh before `graphify update`.
-    # setup-agent-tools.sh has no call of its own -- it ends by running
-    # init-worktree-tools.sh, which patches.
-    for install, invocation in (
-        ("scripts/agent/ensure-graphify-merge-driver.sh", 'sh "$patch_graphify" || {'),
-        (
-            "scripts/agent/init-worktree-tools.sh",
-            'sh "$(dirname "$0")/patch-graphify.sh" || exit $?',
-        ),
-    ):
-        # The invocation carries no repository argument: the script derives everything
-        # it needs from its own path and from the `graphify` on PATH.
-        source = (ROOT / install).read_text(encoding="utf-8")
-        assert invocation in source, f"{install} does not run patch-graphify.sh with no argument"
+    installer_path = "scripts/agent/ensure-graphify.sh"
+    installer = (ROOT / installer_path).read_text(encoding="utf-8")
+    install_command = "uv tool install --upgrade 'graphifyy>=0.9.51'"
+    assert install_command in installer, "the shared Graphify installer lost its install/upgrade floor"
+    assert 'sh "$patch_graphify"' in installer, "the shared Graphify installer does not apply the patch"
 
-    bootstrap = (ROOT / "scripts/agent/setup-agent-tools.sh").read_text(encoding="utf-8")
-    assert "patch-graphify.sh" not in bootstrap, (
-        "setup-agent-tools.sh regained a patch-graphify.sh call: it already reaches the "
-        "patch through init-worktree-tools.sh"
-    )
+    callers = {
+        "scripts/setup-hooks.sh": 'sh "$script_dir/agent/ensure-graphify.sh" "$root"',
+        ".githooks/pre-commit": "sh scripts/agent/patch-graphify.sh || failed 'Graphify .inc language override'",
+        "scripts/agent/init-worktree-tools.sh": 'sh "$(dirname "$0")/patch-graphify.sh" || exit $?',
+        "scripts/agent/ensure-graphify-merge-driver.sh": 'sh "$(dirname "$0")/ensure-graphify.sh" "$root"',
+        "scripts/agent/setup-agent-tools.sh": 'sh "$ensure_graphify" "$root"',
+    }
+    for caller, invocation in callers.items():
+        source = (ROOT / caller).read_text(encoding="utf-8")
+        assert invocation in source, f"{caller} lost mandatory Graphify install/patch reachability"
+        assert install_command not in source, f"{caller} duplicates the shared Graphify installation convention"
 
     rc = (ROOT / ".graphifyrc").read_text(encoding="utf-8").splitlines()
     assert "language.inc=php" in rc, ".graphifyrc must declare the PHP include override"
 
     routing = (ROOT / ".agents/context/repository-intelligence.md").read_text(encoding="utf-8")
-    # Identifiers only. A prose pin fails on a pure line rewrap that changes nothing, so
-    # the document's sentences stay the reader's rather than this test's.
     for contract in (
+        "scripts/agent/ensure-graphify.sh",
         "scripts/agent/patch-graphify.sh",
+        "scripts/setup-hooks.sh",
+        ".githooks/pre-commit",
         "Graphify-Labs/graphify#3075",
         "language.inc=php",
         "include-node floor",

--- a/tests/test_cross_agent_tooling.py
+++ b/tests/test_cross_agent_tooling.py
@@ -401,8 +401,7 @@ def test_graphify_inc_language_override_rides_as_a_local_patch() -> None:
     # Graphify's suffix map sends .inc to the Pascal extractor, so this repository's
     # PHP includes extract as a handful of incidental nodes (issue #2810). The fix is
     # upstream in Graphify-Labs/graphify#3075 and unreleased, so it rides as a patch
-    # applied to the installed package after every install. When upstream releases it,
-    # the patch, shared installer, universal call sites, and this test go away together.
+    # applied to the installed package after every install.
     patch = (ROOT / ".agents/patches/graphify-3075-language-overrides.patch").read_text(encoding="utf-8")
     assert "Graphify-Labs/graphify#3075" in patch, "the vendored patch must name its upstream PR"
     assert "+++ b/graphify/rcfile.py" in patch, "the vendored patch must carry the .graphifyrc parser"
@@ -412,6 +411,13 @@ def test_graphify_inc_language_override_rides_as_a_local_patch() -> None:
     install_command = "uv tool install --upgrade 'graphifyy>=0.9.51'"
     assert install_command in installer, "the shared Graphify installer lost its install/upgrade floor"
     assert 'sh "$patch_graphify"' in installer, "the shared Graphify installer does not apply the patch"
+
+    resolver = (ROOT / "scripts/agent/resolve-graphify.sh").read_text(encoding="utf-8")
+    quote_probe = (
+        '"$_graphify_interpreter" -I -c \'import shlex, sys; print(shlex.quote(sys.argv[1]))\' "$_graphify_interpreter"'
+    )
+    assert quote_probe in resolver, "uv trampoline validation lost isolated POSIX quoting by its owning interpreter"
+    assert "eval" not in resolver, "Graphify launcher validation must not evaluate launcher text"
 
     callers = {
         "scripts/setup-hooks.sh": 'sh "$script_dir/agent/ensure-graphify.sh" "$root"',

--- a/tests/test_cross_agent_tooling.py
+++ b/tests/test_cross_agent_tooling.py
@@ -418,12 +418,15 @@ def test_graphify_inc_language_override_rides_as_a_local_patch() -> None:
         ".githooks/pre-commit": "sh scripts/agent/patch-graphify.sh || failed 'Graphify .inc language override'",
         "scripts/agent/init-worktree-tools.sh": 'sh "$(dirname "$0")/patch-graphify.sh" || exit $?',
         "scripts/agent/ensure-graphify-merge-driver.sh": 'sh "$(dirname "$0")/ensure-graphify.sh" "$root"',
-        "scripts/agent/setup-agent-tools.sh": 'sh "$ensure_graphify" "$root"',
+        "scripts/agent/setup-agent-tools.sh": '(cd "$root" && sh "$setup_hooks")',
     }
     for caller, invocation in callers.items():
         source = (ROOT / caller).read_text(encoding="utf-8")
         assert invocation in source, f"{caller} lost mandatory Graphify install/patch reachability"
         assert install_command not in source, f"{caller} duplicates the shared Graphify installation convention"
+
+    agent_setup = (ROOT / "scripts/agent/setup-agent-tools.sh").read_text(encoding="utf-8")
+    assert 'sh "$ensure_graphify" "$root"' not in agent_setup, "agent setup duplicates canonical Graphify setup"
 
     rc = (ROOT / ".graphifyrc").read_text(encoding="utf-8").splitlines()
     assert "language.inc=php" in rc, ".graphifyrc must declare the PHP include override"


### PR DESCRIPTION
## Summary

- add one shared `ensure-graphify.sh` installer/patch owner for contributor and agent setup paths
- resolve one authoritative Graphify launcher across fresh processes, off-PATH uv installs, and uv's spaced-path shell trampoline
- accept uv's POSIX-safe apostrophe quoting by deriving the expected interpreter token with that interpreter's isolated stdlib `shlex.quote`
- make canonical setup install/upgrade and patch Graphify before hooks activate
- make pre-commit reapply the temporary `.inc=php` patch and fail closed before early exit
- keep merge-driver setup target-rooted while invoking the exact launcher returned by setup
- preserve #3007 target-local patch precedence, trusted-sibling fallback, and foreign-target no-pollution behavior

## Launcher contract

`scripts/agent/resolve-graphify.sh` prefers `command -v graphify` and physically absolutizes a relative PATH result in the caller's directory before validation or emission. Only when no launcher is selected does it resolve executable `uv tool dir --bin/graphify`. Existing PATH wrappers remain authoritative and fail closed. Python shebang launchers are used directly. Only the exact uv-owned launcher may use uv's `/bin/sh` trampoline; its interpreter is derived from `uv tool dir`, required executable/importable under `-I`, and asked under `-I` to produce its POSIX shell token with stdlib `shlex.quote`. The resolver then compares the exact three-line uv trampoline shape without `eval`.

`patch-graphify.sh` resolves independently in every process. `ensure-graphify.sh` writes exactly the validated absolute executable launcher path on stdout, and `ensure-graphify-merge-driver.sh` captures and invokes that quoted path in the target checkout.

## #3007 integration

1. A target-local `scripts/agent/patch-graphify.sh` remains preferred.
2. A foreign target without that helper uses the trusted sibling beside `ensure-graphify.sh`.
3. Graphify hook and merge-driver configuration remain rooted in the foreign target, with no repository files planted there.

## Frozen RED evidence

| Frozen RED test | git hash-object | RED run tail |
| --- | --- | --- |
| `tests/shell/agent_codegraph_spec.sh` | `e42d484d968aeb4af65e4a5abe25fbb9975d5de2` | `FAILED non-Python fixture launcher was rejected by mandatory patching` |
| `tests/shell/agent_graphify_merge_driver_spec.sh` | `307031eda7784656826b120722d2bd8885264b3f` | `FAILED relative uv fallback crossed the target cd and executed its decoy` |
| `tests/shell/agent_tools_setup_spec.sh` | `f5a745f730721640ac0c6a85941aeecc09d2f9ac` | `FAILED 10 examples rejected duplicate Graphify installation/order` |
| `tests/shell/agent_work_branch_spec.sh` | `abb3b0bedb7ccd83ab7b98616cf9a869d4d018e5` | `FAILED non-Python fixture launcher was rejected by mandatory patching` |
| `tests/shell/agent_worktree_tools_spec.sh` | `90e5ee2b603fba58afbc353593e3acfb8ff18e44` | `FAILED worktree Graphify launcher could not satisfy fail-closed patching` |
| `tests/shell/graphify_language_patch_spec.sh` | `56d57dcb87d9136f091eb59d4ca703074ab86566` | `FAILED valid apostrophe-quoted uv trampoline was rejected before patching` |
| `tests/shell/precommit_composer_vendor_spec.sh` | `7dbbf5fb2d1aad730faeaf63fa094c39a02a70d1` | `FAILED sandbox lacked the mandatory Graphify patch helper` |
| `tests/shell/precommit_githooks_exempt_spec.sh` | `4c035f6ae18d1c7b0853a700197c3747599f47fb` | `FAILED sandbox lacked the mandatory Graphify patch helper` |
| `tests/shell/precommit_hostile_path_spec.sh` | `86e6810e2ffafb78ec495bd823338c6db98f6e4a` | `FAILED sandbox lacked the mandatory Graphify patch helper` |
| `tests/shell/precommit_identity_spec.sh` | `f477aeae3a720119ea7795284ea6ea8fc750de77` | `FAILED pre-commit lacked mandatory Graphify repair and failure propagation` |
| `tests/shell/setup_hooks_spec.sh` | `260fa86ae951892486a0324dcf1a718d3dfa373d` | `FAILED fresh pre-commit process could not resolve the off-PATH launcher` |
| `tests/test_cross_agent_tooling.py` | `2e3a774de0adf8d59150c696fac6287316eef29b` | `FAILED resolver lacked isolated stdlib POSIX quoting by the uv-owned interpreter` |

With the resolver's uv fallback disabled, the three round-2 frozen rows ran `3 examples, 3 failures`. Restoring production with byte-identical tests ran `3 examples, 0 failures`. In round 3, the frozen relative-PATH row ran `1 example, 1 failure` against prior production: the resolver emitted `relbin/graphify` and the foreign-target decoy executed. Deleting only the six trampoline-shape guard lines made the three frozen malformed-line rows run `3 examples, 3 failures`, create `rcfile.py`, and alter package bytes. Restoring production with the same final test hashes ran all four rows `4 examples, 0 failures`. Earlier rows retain their original evidence in the implementation and review reports. In round 4, the final frozen merge-driver bytes ran the relative-uv fallback row over prior `e7333067` production as `1 example, 1 failure`: the uv stub returned `relbin`, the helper crossed into the foreign target, and its decoy ran. The same bytes at current production ran `1 example, 0 failures`. The simplified relative-PATH row retained its teeth: over pre-F3 `09f0fe72` production it ran `1 example, 1 failure`, while current production passed.

For final Grok F5, the frozen real-shape row uses a tool/interpreter path containing spaces, `O'Brien`, and the literal injection canary `$(touch PWNED)`. Prior/raw-path production rejected the valid launcher (`1 example, 1 failure`); exact production patches successfully and leaves `PWNED` absent (`1 example, 0 failures`). Replacing only the quoted-token comparison with the prior raw-path comparison reproduces the same failure. The structural row separately pins the uv-owned interpreter's `-I`/`shlex.quote` call and forbids `eval`.

## Verification

- Existing arbitrary PATH-wrapper regressions: `2 examples, 0 failures`
- Focused trampoline/setup/merge-driver ShellSpec under dash: `28 examples, 0 failures`
- Structural pytest: `19 passed`
- Shell syntax and production ShellCheck `--severity=info`: clean
- Canonical gates: all change-relevant gates pass; host-wide pytest is blocked only by Node 26's changed native JUnit suite name in unrelated `test_native_node_canary_report_is_rejected_with_exact_skip_semantics` (`5836 passed, 2 skipped, 1 failed`)
- Exact-head GitHub checks: `PASS` pinned to `c8cb7123fc22646adcd4680df9a363454b0b11f4`
- Graphify output restored; worktree clean

## Commit identity

- Head: `c8cb7123fc22646adcd4680df9a363454b0b11f4`
- Signature: good ED25519 Git signature for `andrebrait@gmail.com`, key `SHA256:TWOpw6FOQreHf+1JiNmNsjK/bXvpJwOOyoLdWv0v/VE`
- Remote PR head verified byte-identical

Closes #3006
Refs #3004 and #3007
