### PR TITLE
Release: use signed HTTP catalogues in live gates

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -507,7 +507,7 @@ jobs:
     with:
       pytest_marker: repo
       pytest_filter: test_install_from_live_nightly_url
-      smoke_nightly_live_url: https://pkg.pfblockerng.com/nightly
+      smoke_nightly_live_url: http://pkg.pfblockerng.com/nightly
       smoke_nightly_expected_source_sha: ${{ needs.prepare.outputs.source_sha }}
       smoke_nightly_expected_version: ${{ needs.prepare.outputs.pkg_version }}
     secrets: inherit

--- a/.github/workflows/pkg-tagged-ingest.yml
+++ b/.github/workflows/pkg-tagged-ingest.yml
@@ -153,7 +153,7 @@ jobs:
       extra_pkgs: ${{ toJson(matrix.extra_pkgs) }}
       pytest_marker: repo
       pytest_filter: test_install_from_live_pages_url
-      smoke_repo_live_url: https://pkg.pfblockerng.com/${{ needs.stage-pkg.outputs.staging_prefix }}/${{ matrix.channel }}
+      smoke_repo_live_url: http://pkg.pfblockerng.com/${{ needs.stage-pkg.outputs.staging_prefix }}/${{ matrix.channel }}
       smoke_repo_expected_source_sha: ${{ inputs.source_sha }}
       smoke_repo_expected_version: ${{ inputs.portversion }}
       smoke_repo_expected_channel: ${{ inputs.channel }}

--- a/tests/smoke/test_nightly_install.py
+++ b/tests/smoke/test_nightly_install.py
@@ -60,6 +60,7 @@ from .test_repo_install import (
     repo_priority,
     restore_pages_hosts,
     reversion_pkg,
+    write_live_repo_conf,
 )
 
 pytestmark = pytest.mark.repo
@@ -80,7 +81,7 @@ CONF = "/usr/local/etc/pkg/repos/pfb_nightly_smoke.conf"
 # Phase-5d — live nightly Pages URL check (dispatch-only; gated on SMOKE_NIGHTLY_LIVE_URL).
 # Unset -> SKIP (the file:// VM-acceptance above is the always-on proof).
 LIVE_NIGHTLY_URL_ENV = "SMOKE_NIGHTLY_LIVE_URL"
-DEFAULT_LIVE_NIGHTLY_URL = "https://pkg.pfblockerng.com/nightly"
+DEFAULT_LIVE_NIGHTLY_URL = "http://pkg.pfblockerng.com/nightly"
 NIGHTLY_LIVE_CONF = "/usr/local/etc/pkg/repos/pfb_nightly_live_smoke.conf"
 
 # The rc.packages install hook aborts with one of these when the registration name
@@ -325,7 +326,7 @@ def _live_nightly_url() -> str | None:
     """The live nightly Pages base to test against, or None to SKIP.
 
     Gated on ``SMOKE_NIGHTLY_LIVE_URL``: set it to the deployed nightly base
-    (e.g. ``https://pkg.pfblockerng.com/nightly``) after a nightly publish
+    (e.g. ``http://pkg.pfblockerng.com/nightly``) after a nightly publish
     dispatch; leave it unset and the test SKIPS.  A bare ``1``/``true`` selects
     the default base.
     """
@@ -340,7 +341,7 @@ def _live_nightly_url() -> str | None:
 @pytest.mark.timeout(900)
 def test_install_from_live_nightly_url(smoke_vm: SmokeVM) -> None:
     """A real pfSense box installs the canonical package from the
-    deployed nightly Pages catalog over its public HTTPS URL (no ``-f``).
+    deployed nightly Pages catalogue over its public URL (no ``-f``).
 
     DISPATCH-ONLY + GATED on ``SMOKE_NIGHTLY_LIVE_URL`` (unset -> SKIP). The
     always-on proof is the ``file://`` VM-acceptance above; this exercises the
@@ -356,7 +357,7 @@ def test_install_from_live_nightly_url(smoke_vm: SmokeVM) -> None:
       (NO ``-r``, NO ``-f``),
     Then the install comes from our nightly repo (``pkg query %R`` ==
       ``pfblockerng-nightly``) with deps resolved and the .pkg checksum validated —
-      the deployed nightly Pages catalog is real + installable over HTTPS.
+      the deployed nightly Pages catalogue is real + installable over HTTP.
     """
     base_url = _live_nightly_url()
     if base_url is None:
@@ -373,7 +374,7 @@ def test_install_from_live_nightly_url(smoke_vm: SmokeVM) -> None:
     assert host, f"could not parse a host from {base_url!r}"
 
     # BACKSTOP: prove the deploy actually serves the nightly catalog from the runner
-    # first (independent of the guest) — polls through first-deploy / DNS / cert lag.
+    # first (independent of the guest) — polls through first-deploy / DNS lag.
     # The varver to poll is read from the BOX itself via the _box_real_varver oracle:
     # the guest, not the matrix, is the authority for which release line this leg
     # runs. This base already ends in /nightly,
@@ -388,7 +389,7 @@ def test_install_from_live_nightly_url(smoke_vm: SmokeVM) -> None:
     # nightly_vm module fixture's file:// catalog, same NIGHTLY_REPO name) sorts AFTER
     # "pfb_nightly_live_smoke.conf" (this test's conf, written below) — so a stale copy
     # left by a fixture that errored mid-setup would silently win and this test would
-    # never actually touch the live HTTPS URL. Clear it unconditionally before proceeding.
+    # never actually touch the live catalogue URL. Clear it unconditionally before proceeding.
     smoke_vm.ssh("/bin/rm", "-f", CONF, timeout=60.0)
 
     # GIVEN: Pages IPs pinned (guest DNS is sandboxed), nightly package absent, our
@@ -398,28 +399,16 @@ def test_install_from_live_nightly_url(smoke_vm: SmokeVM) -> None:
         pfsense_prio = repo_priority(smoke_vm, "pfSense")
         pkg_delete(smoke_vm, CANONICAL_PKG_NAME)
 
-        # Write the production nightly conf: pfblockerng-nightly, HTTPS live URL, NONE-signed.
-        # The URL is fully resolved (arch-less, NO_ARCH — issue #1806): no ${ABI} pkg(8)
-        # variable any more, just the box's own varver under the nightly base.
-        conf = (
-            f"{NIGHTLY_REPO}: {{\n"
-            f'  url: "{base_url}/{varver}",\n'
-            "  mirror_type: none,\n"
-            "  signature_type: none,\n"
-            f"  priority: {pfsense_prio + 100},\n"
-            "  enabled: yes\n"
-            "}\n"
+        # Use the production generator so the HTTP catalogue is authenticated by
+        # the shipped ECDSA fingerprint, matching every other live channel gate.
+        write_live_repo_conf(
+            smoke_vm,
+            base_url,
+            varver,
+            priority=pfsense_prio + 100,
+            channel="nightly",
+            conf_path=NIGHTLY_LIVE_CONF,
         )
-        r = subprocess.run(
-            smoke_vm.ssh_argv("tee", NIGHTLY_LIVE_CONF),
-            input=conf,
-            capture_output=True,
-            text=True,
-            timeout=60.0,
-            check=False,
-        )
-        if r.returncode != 0:
-            raise RuntimeError(f"write nightly live conf failed: rc={r.returncode} {r.stderr!r}")
 
         # WHEN: pkg update reads the live nightly catalog.
         pkg_update(smoke_vm)

--- a/tests/smoke/test_repo_install.py
+++ b/tests/smoke/test_repo_install.py
@@ -149,7 +149,7 @@ PORTABLE_REPO_ROOT = f"{GUEST_SPIKE_DIR}/portable_catalog"  # where the flat por
 RC_D_HOOK_SRC = Path(__file__).resolve().parents[2] / "src/usr/local/etc/rc.d/pfblockerng_repo_generate.sh"
 
 # The caller supplies a selected channel root beneath the project Pages URL through
-# SMOKE_REPO_LIVE_URL; when unset, the live HTTPS check is skipped.
+# SMOKE_REPO_LIVE_URL; when unset, the live catalogue check is skipped.
 LIVE_BASE_URL_ENV = "SMOKE_REPO_LIVE_URL"
 LIVE_NIGHTLY_URL_ENV = "SMOKE_NIGHTLY_LIVE_URL"
 LIVE_EXPECTED_SOURCE_SHA_ENV = "SMOKE_REPO_EXPECTED_SOURCE_SHA"
@@ -157,12 +157,12 @@ LIVE_EXPECTED_VERSION_ENV = "SMOKE_REPO_EXPECTED_VERSION"
 LIVE_EXPECTED_CHANNEL_ENV = "SMOKE_REPO_EXPECTED_CHANNEL"
 NIGHTLY_EXPECTED_SOURCE_SHA_ENV = "SMOKE_NIGHTLY_EXPECTED_SOURCE_SHA"
 NIGHTLY_EXPECTED_VERSION_ENV = "SMOKE_NIGHTLY_EXPECTED_VERSION"
-DEFAULT_LIVE_BASE_URL = "https://pkg.pfblockerng.com/stable"
+DEFAULT_LIVE_BASE_URL = "http://pkg.pfblockerng.com/stable"
 # GitHub Pages' anycast IPs. The smoke harness sandboxes guest DNS to a mock that
-# only answers `uuid-*.com`, so `pkg.pfblockerng.com` does not resolve on the guest. Pinning
-# the Pages IPs in the guest /etc/hosts lets `pkg`'s HTTPS fetch reach Pages by name
-# (TLS SNI still presents `pkg.pfblockerng.com`, validated by the Pages custom-domain cert) without
-# touching the resolver. Egress is OPEN for this flow (_ensure_egress_open).
+# only answers `uuid-*.com`, so `pkg.pfblockerng.com` does not resolve on the guest.
+# Pinning the Pages IPs in the guest /etc/hosts lets `pkg`'s catalogue fetch reach
+# Pages by name without touching the resolver. Egress is OPEN for this flow
+# (_ensure_egress_open).
 PAGES_IPS = ("185.199.108.153", "185.199.109.153", "185.199.110.153", "185.199.111.153")
 
 
@@ -568,8 +568,8 @@ def write_repo_conf(
     flow runs with egress open so they are reachable); callers set ours/decoy
     priorities a clear margin ABOVE the pfSense repo (see ``repo_priority``) so the
     real Netgate repo never wins regardless of what it offers. ``signature_type:
-    none`` (pfSense honors per-repo ``none``; trust = the local ``file://`` path
-    here, HTTPS in production).
+    none`` (pfSense honors per-repo ``none``; trust here is the local ``file://``
+    path, while production uses a signed catalogue over plain HTTP).
     """
     conf = _repo_block(OURS_REPO_NAME, ours_dir, ours_priority)
     if decoy_dir is not None:
@@ -1224,7 +1224,7 @@ def _live_base_url() -> str | None:
     """The live Pages base to test against, or None to SKIP.
 
     Gated on ``SMOKE_REPO_LIVE_URL``: set it to the deployed base (e.g.
-    ``https://pkg.pfblockerng.com/stable``, or a staged
+    ``http://pkg.pfblockerng.com/stable``, or a staged
     ``.../pkg/staging/<seg>/<channel>`` root pre-promote, issue #2389) to run the live
     check after a publish dispatch; leave it unset and the test SKIPS (the always-on
     proof is the file:// VM-acceptance above). A bare ``1``/``true`` selects the
@@ -1239,7 +1239,7 @@ def _live_base_url() -> str | None:
 
 
 def poll_catalog_served(base_url: str, catalog_path: str, *, attempts: int = 30, delay: float = 10.0) -> None:
-    """Poll the live ``<base>/<catalog_path>/meta.conf`` until it serves (first deploy + DNS/cert lag).
+    """Poll the live ``<base>/<catalog_path>/meta.conf`` until it serves (first deploy + DNS lag).
 
     Arch-less (NO_ARCH — issue #1806): a published catalog is keyed by varver alone,
     no ``${ABI}``/CPU segment. ``catalog_path`` is the caller's full subtree under
@@ -1255,7 +1255,7 @@ def poll_catalog_served(base_url: str, catalog_path: str, *, attempts: int = 30,
         try:
             for fname in ("meta.conf", "packagesite.pkg"):
                 url = f"{base_url}/{catalog_path}/{fname}"
-                with urllib.request.urlopen(url, timeout=15) as resp:  # noqa: S310 (fixed https Pages URL)
+                with urllib.request.urlopen(url, timeout=15) as resp:  # noqa: S310 (controlled Pages URL)
                     if resp.status != 200:
                         raise RuntimeError(f"{url} -> HTTP {resp.status}")
                     if not resp.read(1):
@@ -1272,8 +1272,8 @@ def pin_pages_hosts(vm: SmokeVM, host: str, *, timeout: float = 60.0) -> str:
 
     The smoke harness sandboxes guest DNS to a mock answering only ``uuid-*.com``,
     so the Pages host does not resolve on the box. A static ``/etc/hosts`` entry
-    routes ``pkg``'s HTTPS fetch to Pages by IP while TLS SNI still presents ``host``
-    (GitHub's *.github.io cert validates). Idempotent: the entry is removed first.
+    routes ``pkg``'s catalogue fetch to Pages by IP. Idempotent: the entry is
+    removed first.
 
     Returns the pre-pin ``/etc/hosts`` content — pass it to :func:`restore_pages_hosts`
     in the caller's ``finally`` so the pin never outlives the test (issue #582: it
@@ -1285,7 +1285,7 @@ def pin_pages_hosts(vm: SmokeVM, host: str, *, timeout: float = 60.0) -> str:
 
     # Drop any prior line carrying this host as a whitespace-separated field (not
     # just a line-ending match, so stale aliases/comments don't survive), then pin
-    # ALL the Pages IPs (resilient to a single-IP failure; pkg follows the cert).
+    # ALL the Pages IPs (resilient to a single-IP failure).
     # Atomic via a tmp file + mv.
     strip = f"grep -Ev '[[:space:]]{re.escape(host)}([[:space:]]|$)' /etc/hosts > /etc/hosts.pfb 2>/dev/null"
     script = (
@@ -1467,7 +1467,7 @@ def _cleanup_live_pages(vm: SmokeVM, prior_hosts: str) -> None:
     _raise_live_pages_errors("live Pages teardown failed", errors)
 
 
-@pytest.mark.timeout(900)  # live deploy/DNS/cert can lag + pkg update + install over the public URL.
+@pytest.mark.timeout(900)  # live deploy/DNS can lag + pkg update + install over the public URL.
 def test_install_from_live_pages_url(repo_vm: SmokeVM) -> None:
     """Install the canonical package from the selected live Pages repository."""
     base_url = _live_base_url()
@@ -1485,7 +1485,7 @@ def test_install_from_live_pages_url(repo_vm: SmokeVM) -> None:
     assert host, f"could not parse a host from {base_url!r}"
 
     # BACKSTOP: prove the deploy actually serves the catalog from the RUNNER first
-    # (independent of the guest) — polls through first-deploy / DNS / cert lag. The
+    # (independent of the guest) — polls through first-deploy / DNS lag. The
     # varver to poll is read from the BOX itself via the _box_real_varver oracle: the
     # guest, not the matrix, is the authority for which release line this leg runs.
     # The caller passes a selected channel root, so the subtree is the bare varver.
@@ -1500,8 +1500,8 @@ def test_install_from_live_pages_url(repo_vm: SmokeVM) -> None:
         _ensure_live_pages_packages_absent(repo_vm)
         write_live_repo_conf(repo_vm, base_url, varver, priority=pfsense_prio + 100)
 
-        # WHEN: pkg update must ACCEPT the live HTTPS catalog (a rejected catalog — bad
-        # meta.conf, malformed packagesite, mismatched sum, or an unreachable URL — fails here).
+        # WHEN: pkg update must ACCEPT the signed live catalogue (a rejected catalogue —
+        # bad meta.conf, malformed packagesite, mismatched sum, or an unreachable URL — fails here).
         pkg_update(repo_vm)
         assert pkg_installed_version_of(repo_vm, CANONICAL_PKG_NAME) is None, (
             f"{CANONICAL_PKG_NAME} unexpectedly present before the live-URL install"
@@ -2300,7 +2300,7 @@ def _read_conf_url_on_guest(vm: SmokeVM, conf_path: str) -> str:
     # POSIX class [[:space:]] — NOT GNU \s: BSD grep -E (FreeBSD/pfSense) treats \s as a
     # literal 's', so ^\s*url: would not match the space-indented `  url:` conf line.
     result = _ssh_check(vm, "grep", "-E", r"^[[:space:]]*url:", conf_path)
-    # url: "https://..."  -> strip the key, whitespace, and surrounding quotes.
+    # url: "http://..."  -> strip the key, whitespace, and surrounding quotes.
     raw = result.stdout.strip()
     match = re.search(r'url:\s*"([^"]+)"', raw)
     if not match:

--- a/tests/test_issue2456_pkg_ownership.py
+++ b/tests/test_issue2456_pkg_ownership.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
+import ast
 import os
 import subprocess
 import textwrap
 import unittest
 from pathlib import Path
+
+import yaml
 
 from tests._workflow_steps import extract_after, extract_before, extract_job, extract_step
 
@@ -14,6 +17,8 @@ PUBLISHED = (WORKFLOWS / "release-published.yml").read_text(encoding="utf-8")
 REPUBLISH = (WORKFLOWS / "pkg-republish.yml").read_text(encoding="utf-8")
 TAGGED = WORKFLOWS / "pkg-tagged-ingest.yml"
 NIGHTLY = (WORKFLOWS / "nightly.yml").read_text(encoding="utf-8")
+REPO_SMOKE = (ROOT / "tests" / "smoke" / "test_repo_install.py").read_text(encoding="utf-8")
+NIGHTLY_SMOKE = (ROOT / "tests" / "smoke" / "test_nightly_install.py").read_text(encoding="utf-8")
 REPO_INSTALL = (WORKFLOWS / "repo-install.yml").read_text(encoding="utf-8")
 README = (ROOT / "README.md").read_text(encoding="utf-8")
 
@@ -70,6 +75,52 @@ class SourcePublicationBoundaryTests(unittest.TestCase):
             self.assertIn(needle, NIGHTLY)
         ingest = extract_job(NIGHTLY, "ingest-pkg")
         live = extract_job(NIGHTLY, "validate-live-pages-install")
+        live_inputs = yaml.safe_load(NIGHTLY)["jobs"]["validate-live-pages-install"]["with"]
+        self.assertEqual(live_inputs["smoke_nightly_live_url"], "http://pkg.pfblockerng.com/nightly")
+
+        smoke_tree = ast.parse(NIGHTLY_SMOKE)
+        defaults = [
+            node
+            for node in smoke_tree.body
+            if isinstance(node, ast.Assign)
+            and any(isinstance(target, ast.Name) and target.id == "DEFAULT_LIVE_NIGHTLY_URL" for target in node.targets)
+        ]
+        self.assertEqual(len(defaults), 1)
+        self.assertEqual(ast.literal_eval(defaults[0].value), "http://pkg.pfblockerng.com/nightly")
+        functions = [
+            node
+            for node in smoke_tree.body
+            if isinstance(node, ast.FunctionDef) and node.name == "test_install_from_live_nightly_url"
+        ]
+        self.assertEqual(len(functions), 1)
+        all_helper_calls = [
+            node
+            for node in ast.walk(functions[0])
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == "write_live_repo_conf"
+        ]
+        try_blocks = [node for node in functions[0].body if isinstance(node, ast.Try)]
+        self.assertEqual(len(try_blocks), 1)
+        direct_helper_calls = [
+            statement.value
+            for statement in try_blocks[0].body
+            if isinstance(statement, ast.Expr)
+            and isinstance(statement.value, ast.Call)
+            and isinstance(statement.value.func, ast.Name)
+            and statement.value.func.id == "write_live_repo_conf"
+        ]
+        self.assertEqual(len(all_helper_calls), 1)
+        self.assertEqual(direct_helper_calls, all_helper_calls)
+        keywords = {keyword.arg: keyword.value for keyword in direct_helper_calls[0].keywords}
+        self.assertEqual(ast.literal_eval(keywords["channel"]), "nightly")
+        conf_path = keywords["conf_path"]
+        assert isinstance(conf_path, ast.Name)
+        self.assertEqual(conf_path.id, "NIGHTLY_LIVE_CONF")
+        self.assertFalse(
+            any(
+                isinstance(node, ast.Constant) and isinstance(node.value, str) and "signature_type: none" in node.value
+                for node in ast.walk(functions[0])
+            )
+        )
         cleanup = extract_job(NIGHTLY, "cleanup-nightly-oci")
         digest = "needs.publish-nightly-oci.outputs.artifact_ref"
         self.assertIn("needs: [prepare, publish-nightly-oci]", ingest)
@@ -95,16 +146,26 @@ class SourcePublicationBoundaryTests(unittest.TestCase):
             "fail-fast: false",
             "pytest_marker: repo",
             "pytest_filter: test_install_from_live_pages_url",
-            (
-                "smoke_repo_live_url: https://pkg.pfblockerng.com/"
-                "${{ needs.stage-pkg.outputs.staging_prefix }}/${{ matrix.channel }}"
-            ),
             "smoke_repo_expected_source_sha: ${{ inputs.source_sha }}",
             "smoke_repo_expected_version: ${{ inputs.portversion }}",
             "smoke_repo_expected_channel: ${{ inputs.channel }}",
             "checkout_ref: ${{ github.workflow_sha }}",
         ):
             self.assertIn(contract, live)
+        live_inputs = yaml.safe_load(tagged)["jobs"]["validate-live-pages-install"]["with"]
+        self.assertEqual(
+            live_inputs["smoke_repo_live_url"],
+            "http://pkg.pfblockerng.com/${{ needs.stage-pkg.outputs.staging_prefix }}/${{ matrix.channel }}",
+        )
+        smoke_tree = ast.parse(REPO_SMOKE)
+        defaults = [
+            node
+            for node in smoke_tree.body
+            if isinstance(node, ast.Assign)
+            and any(isinstance(target, ast.Name) and target.id == "DEFAULT_LIVE_BASE_URL" for target in node.targets)
+        ]
+        self.assertEqual(len(defaults), 1)
+        self.assertEqual(ast.literal_eval(defaults[0].value), "http://pkg.pfblockerng.com/stable")
         self.assertIn("needs: [stage-pkg, prepare-live-gate]", live)
         self.assertIn(
             "needs: [stage-pkg, prepare-live-gate, validate-live-pages-install]",


### PR DESCRIPTION
## Summary

- validate staged tagged catalogues over the plain HTTP transport used by real pfSense clients
- align Nightly and tagged live-smoke defaults with the ECDSA-signed catalogue contract
- make the Nightly live gate unconditionally use the same generated fingerprint trust path as tagged channels
- preserve HTTPS for fetching the unsigned root installer script

## Evidence

| Frozen RED test | git hash-object | RED run tail |
| --- | --- | --- |
| `tests/test_issue2456_pkg_ownership.py` | `ffa4217cfb01f3b4ee3b5e684b877f5b89528b8e` | `final three-file overlay on base: 2 failed / 11 passed for effective HTTPS workflow URLs` |
| `tests/smoke/test_nightly_install.py` | `38adb80617af05649ad373f710edb83817b8c1ea` | `final three-file overlay on base: 2 failed / 11 passed` |
| `tests/smoke/test_repo_install.py` | `a70d7beeed1f4af927a27d114d92337caeeae34e` | `final three-file overlay on base: 2 failed / 11 passed` |

- recovery run 33446894022: all four pfSense Plus live legs failed before package installation because the GitHub Pages YR1 / Root YR chain was rejected; CE legs passed
- HTTP `pkg.pfblockerng.com` responds directly without redirect
- GREEN: 13 focused publication-boundary tests passed; focused mypy passed
- Nightly uses an unconditional direct `write_live_repo_conf(..., channel="nightly")` call, which emits fingerprint verification and installs the shipped ECDSA trust anchor
- workflow inputs are parsed as YAML and smoke constants/helper calls as Python AST; comment, identifier-suffix, nested/dead-code spoofs cannot satisfy the regression test
- stable/testing/edge/Nightly covered; unsigned installer bootstrap remains HTTPS

Refs #3004

🤖 Generated by Oh My Pi and posted on behalf of @andrebrait.