### PR TITLE
Release: distinguish live routes in smoke concurrency

### DIFF
--- a/.github/workflows/smoke-single.yml
+++ b/.github/workflows/smoke-single.yml
@@ -278,7 +278,7 @@ permissions:
   packages: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ inputs.image_name }}-${{ inputs.pfsense_version }}-${{ inputs.shard }}-${{ inputs.checkout_ref || github.ref }}
+  group: ${{ github.workflow }}-${{ inputs.image_name }}-${{ inputs.pfsense_version }}-${{ inputs.shard }}-${{ inputs.checkout_ref || github.ref }}-${{ inputs.smoke_repo_live_url || inputs.smoke_nightly_live_url || 'non-live' }}
   cancel-in-progress: false
 
 jobs:

--- a/tests/test_issue2456_pkg_ownership.py
+++ b/tests/test_issue2456_pkg_ownership.py
@@ -16,6 +16,7 @@ WORKFLOWS = ROOT / ".github" / "workflows"
 PUBLISHED = (WORKFLOWS / "release-published.yml").read_text(encoding="utf-8")
 REPUBLISH = (WORKFLOWS / "pkg-republish.yml").read_text(encoding="utf-8")
 TAGGED = WORKFLOWS / "pkg-tagged-ingest.yml"
+SMOKE_SINGLE = (WORKFLOWS / "smoke-single.yml").read_text(encoding="utf-8")
 NIGHTLY = (WORKFLOWS / "nightly.yml").read_text(encoding="utf-8")
 REPO_SMOKE = (ROOT / "tests" / "smoke" / "test_repo_install.py").read_text(encoding="utf-8")
 NIGHTLY_SMOKE = (ROOT / "tests" / "smoke" / "test_nightly_install.py").read_text(encoding="utf-8")
@@ -137,6 +138,18 @@ class SourcePublicationBoundaryTests(unittest.TestCase):
         self.assertNotRegex(ingest, r"artifact_ref:\s*ghcr\.io/.+:(?:latest|nightly)")
         self.assertLess(NIGHTLY.index("operation=nightly"), NIGHTLY.index("test_install_from_live_nightly_url"))
         self.assertLess(NIGHTLY.index("test_install_from_live_nightly_url"), NIGHTLY.index("operation=nightly-cleanup"))
+
+    def test_live_catalogue_routes_are_part_of_smoke_concurrency_identity(self) -> None:
+        concurrency = yaml.safe_load(SMOKE_SINGLE)["concurrency"]
+        self.assertEqual(
+            concurrency["group"],
+            (
+                "${{ github.workflow }}-${{ inputs.image_name }}-${{ inputs.pfsense_version }}-"
+                "${{ inputs.shard }}-${{ inputs.checkout_ref || github.ref }}-"
+                "${{ inputs.smoke_repo_live_url || inputs.smoke_nightly_live_url || 'non-live' }}"
+            ),
+        )
+        self.assertIs(concurrency["cancel-in-progress"], False)
 
     def test_tagged_finalize_depends_on_the_live_gate_and_discards_failure(self) -> None:
         tagged = TAGGED.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

- include the effective live catalogue route in `smoke-single` concurrency identity
- keep existing non-live serialization through an explicit fallback
- preserve `cancel-in-progress: false`

## Evidence

| Frozen RED test | git hash-object | RED run tail |
| --- | --- | --- |
| `tests/test_issue2456_pkg_ownership.py` | `94948891d47f5c756fa9d73a6f873518ace82b4d` | `1 failed, 13 passed: concurrency identity omitted live route` |

- recovery 33451468403 cancelled exactly four zero-second build jobs, one per image/version tuple; every started live gate passed
- root cause: stable/testing/edge siblings shared one concurrency group, where GitHub retains one running plus one pending and replaces the older pending
- GREEN: 14 focused publication-boundary tests passed
- independent Codex verifier: PASS; repo URL, Nightly URL, fallback, and cancel-in-progress mutants killed; five route identities distinct

Refs #3004

🤖 Generated by Oh My Pi and posted on behalf of @andrebrait.