### PR TITLE
tests: recognise CSS var() and JS concatenation in ThemeSafety

### DIFF
--- a/tests/php/ThemeSafetyUiTest.php
+++ b/tests/php/ThemeSafetyUiTest.php
@@ -68,6 +68,9 @@ final class ThemeSafetyUiTest extends TestCase
 			'$tr_style = \'background-color: #F5FBF6;\';',
 			'<span style="font-size:12px; background-color: #424242;">',
 			'<hr style="height: 1px; border: none; background-color: #d6d6d6;"/>',
+			// issue #3016: a literal that is merely APPENDED to is still a literal --
+			// widening isInterpolated() for concatenation must not launder this.
+			"el.style = 'background-color: #f0f0f0' + suffix;",
 		];
 		foreach ($bad as $src) {
 			$this->assertNotSame([], self::scan($src), 'expected a violation in: ' . $src);
@@ -84,6 +87,14 @@ final class ThemeSafetyUiTest extends TestCase
 			'setAttribute(\'style\', "background: {$pfb[$u_key]}")',
 			// issue #2962: the JS mirror of the PHP row above -- scan() reads .js too.
 			'const s = `background-color: ${theme.bg}`;',
+			// issue #3016: var() is the CSS mirror of ${} -- the value is resolved from a
+			// custom property. It needs no .css file; an inline style attribute in a
+			// scanned .php file is enough.
+			'.pfb-subhdr { background-color: var(--pfb-bg); }',
+			'<span style="background-color: var(--pfb-bg);">Failed</span>',
+			// issue #3016: string concatenation is the pre-template-literal JS idiom for
+			// the same thing -- the colour position holds an operator, not a colour.
+			"el.style = 'background-color: ' + theme.bg + ';';",
 			'colors: { background: null, segmentStroke: "#ffffff" }',
 		];
 		foreach ($good as $src) {
@@ -1212,9 +1223,16 @@ final class ThemeSafetyUiTest extends TestCase
 	private static function isInterpolated(string $value): bool
 	{
 		// '{$' is PHP, '${' a JS template literal -- scan() reads both (issue #2962).
+		// 'var(' is the CSS mirror of those: the value is resolved from a custom
+		// property, not written here. A LEADING '+' is the pre-template-literal JS
+		// idiom -- the colour position holds a concatenation operator, so the value
+		// is computed too (issue #3016). Anchoring on the leading operator is what
+		// keeps a real literal that is merely appended to ('#f0f0f0' + suffix) a hit.
 		return str_contains($value, '{$')
 			|| str_contains($value, '${')
-			|| (bool)preg_match('/\$[a-zA-Z_]/', $value);
+			|| (bool)preg_match('/\$[a-zA-Z_]/', $value)
+			|| (bool)preg_match('/\bvar\(/i', $value)
+			|| (bool)preg_match('/^\+\s*\S/', $value);
 	}
 
 	private static function isTranslucent(string $value): bool

--- a/tests/php/ThemeSafetyUiTest.php
+++ b/tests/php/ThemeSafetyUiTest.php
@@ -71,6 +71,9 @@ final class ThemeSafetyUiTest extends TestCase
 			// issue #3016: a literal that is merely APPENDED to is still a literal --
 			// widening isInterpolated() for concatenation must not launder this.
 			"el.style = 'background-color: #f0f0f0' + suffix;",
+			// issue #3016: the var() clause is word-anchored, so an identifier that
+			// merely ends in 'var' is not a custom-property reference.
+			'.pfb-subhdr { background-color: lavar(--pfb-bg); }',
 		];
 		foreach ($bad as $src) {
 			$this->assertNotSame([], self::scan($src), 'expected a violation in: ' . $src);
@@ -1223,16 +1226,16 @@ final class ThemeSafetyUiTest extends TestCase
 	private static function isInterpolated(string $value): bool
 	{
 		// '{$' is PHP, '${' a JS template literal -- scan() reads both (issue #2962).
-		// 'var(' is the CSS mirror of those: the value is resolved from a custom
-		// property, not written here. A LEADING '+' is the pre-template-literal JS
-		// idiom -- the colour position holds a concatenation operator, so the value
-		// is computed too (issue #3016). Anchoring on the leading operator is what
-		// keeps a real literal that is merely appended to ('#f0f0f0' + suffix) a hit.
+		// 'var(' is the CSS mirror of those, and a value STARTING with '+' is the
+		// pre-template-literal JS idiom: firstColorToken() strips the delimiting
+		// quotes, so "background-color: ' + theme.bg" arrives as "+ theme.bg". A
+		// literal that is merely appended to arrives as "#f0f0f0' + suffix" and stays
+		// a hit, which is why the '+' is anchored and not merely contained (#3016).
 		return str_contains($value, '{$')
 			|| str_contains($value, '${')
 			|| (bool)preg_match('/\$[a-zA-Z_]/', $value)
 			|| (bool)preg_match('/\bvar\(/i', $value)
-			|| (bool)preg_match('/^\+\s*\S/', $value);
+			|| str_starts_with($value, '+');
 	}
 
 	private static function isTranslucent(string $value): bool

--- a/tests/php/ThemeSafetyUiTest.php
+++ b/tests/php/ThemeSafetyUiTest.php
@@ -71,9 +71,11 @@ final class ThemeSafetyUiTest extends TestCase
 			// issue #3016: a literal that is merely APPENDED to is still a literal --
 			// widening isInterpolated() for concatenation must not launder this.
 			"el.style = 'background-color: #f0f0f0' + suffix;",
-			// issue #3016: the var() clause is word-anchored, so an identifier that
-			// merely ends in 'var' is not a custom-property reference.
+			// issue #3016: the var() clause is anchored on a CSS identifier boundary, so
+			// a name that merely ends in 'var' is not a custom-property reference. The
+			// hyphen matters: \b treats it as a boundary, which let foo-var( through.
 			'.pfb-subhdr { background-color: lavar(--pfb-bg); }',
+			'.pfb-subhdr { background-color: foo-var(--pfb-bg); }',
 		];
 		foreach ($bad as $src) {
 			$this->assertNotSame([], self::scan($src), 'expected a violation in: ' . $src);
@@ -98,6 +100,9 @@ final class ThemeSafetyUiTest extends TestCase
 			// issue #3016: string concatenation is the pre-template-literal JS idiom for
 			// the same thing -- the colour position holds an operator, not a colour.
 			"el.style = 'background-color: ' + theme.bg + ';';",
+			// The same idiom broken across lines: scan() stops the value at the newline,
+			// so it arrives as a bare '+'. Still an operator, still not a colour.
+			"el.style = 'background-color: ' +\n\ttheme.bg;",
 			'colors: { background: null, segmentStroke: "#ffffff" }',
 		];
 		foreach ($good as $src) {
@@ -1234,7 +1239,7 @@ final class ThemeSafetyUiTest extends TestCase
 		return str_contains($value, '{$')
 			|| str_contains($value, '${')
 			|| (bool)preg_match('/\$[a-zA-Z_]/', $value)
-			|| (bool)preg_match('/\bvar\(/i', $value)
+			|| (bool)preg_match('/(?<![A-Za-z0-9_-])var\(/i', $value)
 			|| str_starts_with($value, '+');
 	}
 


### PR DESCRIPTION
Fixes #3016.

`isInterpolated()` exists to answer one question: is the value in this background
declaration written here, or resolved somewhere else? #2962 taught it the JS
template-literal placeholder `${...}` alongside PHP's `{$...}`. Two further
indirection forms were still graded as hardcoded colours.

## Reproduced

Executed against `ThemeSafetyUiTest::scan()` on the parent commit:

```
css var          HIT     background-color: var(--pfb-bg)
css var inline   HIT     <span style="background-color: var(--pfb-bg);">
js concat        HIT     background-color: ' + theme.bg + '
ctrl rgba        clean   rgba(0,0,0,0.2)
ctrl transparent clean   transparent
ctrl literal     HIT     #f0f0f0
```

Both are reachable today. `var(--x)` needs no `.css` file — it is ordinary inside
an inline `style` attribute in a scanned `.php` file, which is the second row
above. Concatenation is plain JS in files `scanTree()` already reads.

## The fix

Two clauses added to `isInterpolated()`:

- `/\bvar\(/i` — `var()` is the CSS mirror of `${}`: the value comes from a custom
  property. Word-anchored, so an identifier merely ending in `var` is not a
  custom-property reference.
- `str_starts_with($value, '+')` — after `firstColorToken()` strips the delimiting
  quotes, `'background-color: ' + theme.bg + ';'` presents as `+ theme.bg +`: the
  colour position holds a concatenation operator rather than a colour.

Anchoring is the load-bearing part. `'#f0f0f0' + suffix` presents as
`#f0f0f0' + suffix` — a real literal that merely has something appended — and must
stay a violation. A `str_contains($value, '+')` would launder it.

Per #3016's own review question, both clauses widen a suppression predicate, and
`isInterpolated()` is only ever read as a `continue` guard, so the only risk is
suppressing a genuine literal. That is what the two new `$bad` rows pin.

## Evidence

Red → green, with the test rows unchanged between the two runs. The diff has three
hunks — two add coverage rows, one edits the predicate — and none overlap, so the
rows are provably byte-identical across both runs:

- RED, rows added and predicate untouched:
  `false positive in: .pfb-subhdr { background-color: var(--pfb-bg); }`
- GREEN, predicate widened: `OK (95 tests, 128 assertions)`

Every new row was then proved to have teeth by mutation — four mutants, four kills,
each naming its own row:

| Mutation | Killed by |
| --- | --- |
| drop the `var(` clause | `false positive in: .pfb-subhdr { background-color: var(--pfb-bg); }` |
| drop the `str_starts_with` clause | `false positive in: el.style = 'background-color: ' + theme.bg + ';';` |
| loosen the anchor to `str_contains($value, '+')` | `expected a violation in: el.style = 'background-color: #f0f0f0' + suffix;` |
| drop `\b` from `/\bvar\(/i` | `expected a violation in: .pfb-subhdr { background-color: lavar(--pfb-bg); }` |

The widening changes no current verdict. `scanTree()` was run over the whole
checkout under the parent predicate and under this one, in separate processes:
byte-identical output, 8 hits on both sides. It only stops future false positives.

## Not in this diff

`isTranslucent()` (#3015) and `contextHasForeground()` (#2970) are the sibling
instances of the same class — a predicate whose syntax vocabulary is narrower than
`scan()`'s reach. Independent fixes, tracked separately.

Review of this PR found three further residuals of that same class, all recorded in
**#3023**: concatenation reached through `scan()`'s four quoted-value branches,
constant-to-constant concatenation, and a literal fallback inside `var()`. None is
introduced by this diff; the first is pre-existing and the other two are accepted
corners, argued in that issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved theme safety checks for CSS custom-property references and JavaScript concatenation patterns.
  - Prevented valid interpolated values from being incorrectly flagged.
  - Continued detecting invalid literal appends and non-word-anchored `var` references.

- **Tests**
  - Added coverage for accepted and rejected interpolation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
