### PR TITLE
tests: stop eight fixture teardowns stranding their temp directories

### DIFF
--- a/tests/php/AlertsDnsblLoggedFieldsRenderTest.php
+++ b/tests/php/AlertsDnsblLoggedFieldsRenderTest.php
@@ -85,22 +85,7 @@ final class AlertsDnsblLoggedFieldsRenderTest extends TestCase
 				$GLOBALS[$g] = $v;
 			}
 		}
-		$this->rrmdir($this->tmp);
-	}
-
-	private function rrmdir(string $dir): void
-	{
-		if (!is_dir($dir)) {
-			return;
-		}
-		foreach (scandir($dir) as $f) {
-			if ($f === '.' || $f === '..') {
-				continue;
-			}
-			$p = "{$dir}/{$f}";
-			is_dir($p) ? $this->rrmdir($p) : @unlink($p);
-		}
-		@rmdir($dir);
+		rmdir_recursive($this->tmp);
 	}
 
 	/** Seed the OLD grep path's data file with one NDJSON row for $domain (schema v1). */

--- a/tests/php/CountryNetworksCountGuardTest.php
+++ b/tests/php/CountryNetworksCountGuardTest.php
@@ -16,10 +16,7 @@ final class CountryNetworksCountGuardTest extends TestCase
 
 	protected function tearDown(): void
 	{
-		foreach (glob($this->dir . '/*') ?: [] as $file) {
-			@unlink($file);
-		}
-		@rmdir($this->dir);
+		rmdir_recursive($this->dir);
 	}
 
 	public function testCountReadFailureUsesNonPlaceholderHeader(): void

--- a/tests/php/DnsblLogEventQueryAttributionTest.php
+++ b/tests/php/DnsblLogEventQueryAttributionTest.php
@@ -97,26 +97,11 @@ final class DnsblLogEventQueryAttributionTest extends TestCase
 			}
 		} finally {
 			$GLOBALS['pfb'] = $this->savedPfb;
-			$this->rrmdir($this->tmp);
+			rmdir_recursive($this->tmp);
 		}
 		if ($failure !== null) {
 			throw $failure;
 		}
-	}
-
-	private function rrmdir(string $dir): void
-	{
-		if (!is_dir($dir)) {
-			return;
-		}
-		foreach (scandir($dir) as $f) {
-			if ($f === '.' || $f === '..') {
-				continue;
-			}
-			$p = "{$dir}/{$f}";
-			is_dir($p) ? $this->rrmdir($p) : @unlink($p);
-		}
-		@rmdir($dir);
 	}
 
 	/** Seed the OLD grep path's data file with one NDJSON row for $domain (schema v1). */

--- a/tests/php/DnsblipMarkerFolderTest.php
+++ b/tests/php/DnsblipMarkerFolderTest.php
@@ -31,6 +31,7 @@ final class DnsblipMarkerFolderTest extends TestCase
 {
 	/** @var array<string,array{bool,mixed}> Saved globals to restore. */
 	private array $saved = [];
+	private string $base;
 
 	private string $denydir;
 	private string $nativedir;
@@ -64,6 +65,7 @@ final class DnsblipMarkerFolderTest extends TestCase
 
 		// Real, isolated temp dirs so we can assert the marker file's actual location.
 		$base = sys_get_temp_dir() . '/pfb_marker_' . uniqid('', TRUE);
+		$this->base     = $base;
 		$this->denydir   = "{$base}/deny";
 		$this->nativedir = "{$base}/native";
 		$this->dnsdir    = "{$base}/dns";
@@ -100,6 +102,7 @@ final class DnsblipMarkerFolderTest extends TestCase
 				unset($GLOBALS[$g]);
 			}
 		}
+		rmdir_recursive($this->base);
 	}
 
 	/** @return list<string> */

--- a/tests/php/DueLedgerTest.php
+++ b/tests/php/DueLedgerTest.php
@@ -98,9 +98,7 @@ final class DueLedgerTest extends TestCase
 
 	protected function tearDown(): void
 	{
-		@unlink($this->dir . '/pfb_due_ledger.json');
-		@unlink($this->dir . '/pfb_due_ledger.json.tmp');
-		@rmdir($this->dir);
+		rmdir_recursive($this->dir);
 	}
 
 	// -----------------------------------------------------------------------

--- a/tests/php/IpRecomputeSnapshotTest.php
+++ b/tests/php/IpRecomputeSnapshotTest.php
@@ -46,13 +46,7 @@ final class IpRecomputeSnapshotTest extends TestCase
 		if (in_array('pfbtrunc', stream_get_wrappers(), TRUE)) {
 			stream_wrapper_unregister('pfbtrunc');
 		}
-		foreach ([$this->snapdir, $this->denydir, $this->origdir] as $d) {
-			foreach (@glob("{$d}/*") ?: [] as $f) {
-				@unlink($f);
-			}
-			@rmdir($d);
-		}
-		@rmdir($this->root);
+		rmdir_recursive($this->root);
 	}
 
 	public function testSnapshotPathIsBasenameDotSnapAndRoundTripsTheHeader(): void

--- a/tests/php/PfbSyncStatusLedgerTest.php
+++ b/tests/php/PfbSyncStatusLedgerTest.php
@@ -75,10 +75,7 @@ final class PfbSyncStatusLedgerTest extends TestCase
 		// Restore a writable mode in case testUnwritableLedgerDirFailsSafely ran
 		// (chmod 0555), so the recursive cleanup below can actually delete it.
 		@chmod($this->dir, 0777);
-		foreach (glob($this->dir . '/*') ?: [] as $file) {
-			@unlink($file);
-		}
-		@rmdir($this->dir);
+		rmdir_recursive($this->dir);
 	}
 
 	private static function clockAt(int $ts): callable

--- a/tests/php/QuietHoursApplyTest.php
+++ b/tests/php/QuietHoursApplyTest.php
@@ -68,9 +68,7 @@ final class QuietHoursApplyTest extends TestCase
 
 	protected function tearDown(): void
 	{
-		@unlink($this->dir . '/pfb_due_ledger.json');
-		@unlink($this->dir . '/pfb_due_ledger.json.tmp');
-		@rmdir($this->dir);
+		rmdir_recursive($this->dir);
 	}
 
 	// -----------------------------------------------------------------------

--- a/tests/php/TempDirLeakGuardTest.php
+++ b/tests/php/TempDirLeakGuardTest.php
@@ -10,8 +10,7 @@ use PHPUnit\Framework\TestCase;
  * Hand-rolled teardowns removed a fixture tree by naming the files they expected
  * to find — a glob, or a list of unlink() calls, followed by one rmdir(). Anything
  * else the test wrote (a dotfile, a nested directory) made that rmdir() fail, and
- * the whole tree survived every run until /tmp filled and unrelated tests began
- * failing with code-shaped errors.
+ * the whole tree survived every run.
  *
  * The suite already ships rmdir_recursive() (tests/php/pfsense_doubles.php), which
  * recurses with scandir() and so removes exactly what the hand-rolled versions miss.
@@ -22,7 +21,6 @@ final class TempDirLeakGuardTest extends TestCase
 {
 	/**
 	 * Test files whose teardown stranded its fixture directory before #3018.
-	 * Measured leak per run on the parent commit: 22, 18, 7, 5, 4, 1, 1, 1.
 	 *
 	 * @var list<string>
 	 */
@@ -63,23 +61,22 @@ final class TempDirLeakGuardTest extends TestCase
 			// fixture below $tmp and its residue is exactly what survives teardown.
 			$process = proc_open(
 				$command,
-				[1 => ['pipe', 'w'], 2 => ['pipe', 'w']],
+				// stderr redirected into stdout: draining one pipe fully before the
+				// other deadlocks if the nested run fills the second (issue #3018).
+				[1 => ['pipe', 'w'], 2 => ['redirect', 1]],
 				$pipes,
 				$root,
 				array_merge(getenv(), ['TMPDIR' => $tmp])
 			);
 			$this->assertIsResource($process);
 			$stdout = stream_get_contents($pipes[1]);
-			$stderr = stream_get_contents($pipes[2]);
 			fclose($pipes[1]);
-			fclose($pipes[2]);
 			$status = proc_close($process);
 
 			$this->assertSame(0, $status, sprintf(
 				"the nested fixture-teardown run FAILED; every name and message below belongs to "
-				. "that nested run, not to this guard:\n%s\n%s",
-				$stdout,
-				$stderr
+				. "that nested run, not to this guard:\n%s",
+				$stdout
 			));
 
 			$residue = array_values(array_diff(scandir($tmp) ?: [], ['.', '..']));

--- a/tests/php/TempDirLeakGuardTest.php
+++ b/tests/php/TempDirLeakGuardTest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Regression guard for issue #3018.
+ *
+ * Hand-rolled teardowns removed a fixture tree by naming the files they expected
+ * to find — a glob, or a list of unlink() calls, followed by one rmdir(). Anything
+ * else the test wrote (a dotfile, a nested directory) made that rmdir() fail, and
+ * the whole tree survived every run until /tmp filled and unrelated tests began
+ * failing with code-shaped errors.
+ *
+ * The suite already ships rmdir_recursive() (tests/php/pfsense_doubles.php), which
+ * recurses with scandir() and so removes exactly what the hand-rolled versions miss.
+ * This guard runs the previously-leaking files in a nested PHPUnit process with a
+ * private TMPDIR and asserts that process left nothing behind.
+ */
+final class TempDirLeakGuardTest extends TestCase
+{
+	/**
+	 * Test files whose teardown stranded its fixture directory before #3018.
+	 * Measured leak per run on the parent commit: 22, 18, 7, 5, 4, 1, 1, 1.
+	 *
+	 * @var list<string>
+	 */
+	private const LEAKED_BEFORE_3018 = [
+		'DueLedgerTest.php',
+		'DnsblipMarkerFolderTest.php',
+		'TickCronInstallTest.php',
+		'TickCronTest.php',
+		'QuietHoursApplyTest.php',
+		'PfbSyncStatusLedgerTest.php',
+		'IpRecomputeSnapshotTest.php',
+		'CountryNetworksCountGuardTest.php',
+	];
+
+	public function testFixtureTeardownsLeaveNothingUnderTmpdir(): void
+	{
+		$root = dirname(__DIR__, 2);
+		$tmp  = sys_get_temp_dir() . '/pfb_leak_guard_' . getmypid() . '_' . bin2hex(random_bytes(8));
+		$this->assertTrue(mkdir($tmp, 0700, TRUE), "leak-guard TMPDIR creation failed: {$tmp}");
+
+		$tests = [];
+		foreach (self::LEAKED_BEFORE_3018 as $file) {
+			$path = "{$root}/tests/php/{$file}";
+			$this->assertFileExists($path, 'the guard names a test file that no longer exists');
+			$tests[] = $path;
+		}
+
+		$command = array_merge([
+			PHP_BINARY,
+			"{$root}/vendor/bin/phpunit",
+			'--configuration',
+			"{$root}/phpunit.xml",
+			'--do-not-cache-result',
+		], $tests);
+
+		try {
+			// sys_get_temp_dir() reads TMPDIR, so the nested run allocates every
+			// fixture below $tmp and its residue is exactly what survives teardown.
+			$process = proc_open(
+				$command,
+				[1 => ['pipe', 'w'], 2 => ['pipe', 'w']],
+				$pipes,
+				$root,
+				array_merge(getenv(), ['TMPDIR' => $tmp])
+			);
+			$this->assertIsResource($process);
+			$stdout = stream_get_contents($pipes[1]);
+			$stderr = stream_get_contents($pipes[2]);
+			fclose($pipes[1]);
+			fclose($pipes[2]);
+			$status = proc_close($process);
+
+			$this->assertSame(0, $status, sprintf(
+				"the nested fixture-teardown run FAILED; every name and message below belongs to "
+				. "that nested run, not to this guard:\n%s\n%s",
+				$stdout,
+				$stderr
+			));
+
+			$residue = array_values(array_diff(scandir($tmp) ?: [], ['.', '..']));
+			sort($residue);
+			$this->assertSame([], $residue, sprintf(
+				"fixture teardown stranded %d path(s) under TMPDIR (#3018). Use rmdir_recursive() "
+				. "rather than a glob or a list of unlink() calls:\n  %s",
+				count($residue),
+				implode("\n  ", $residue)
+			));
+		} finally {
+			rmdir_recursive($tmp);
+		}
+	}
+}

--- a/tests/php/TickCronInstallTest.php
+++ b/tests/php/TickCronInstallTest.php
@@ -39,10 +39,7 @@ final class TickCronInstallTest extends TestCase
 
 	protected function tearDown(): void
 	{
-		foreach (glob("{$this->tmp}/*") ?: [] as $f) {
-			is_dir($f) ? @rmdir($f) : @unlink($f);
-		}
-		@rmdir($this->tmp);
+		rmdir_recursive($this->tmp);
 	}
 
 	private function cronCommands(): array

--- a/tests/php/TickCronTest.php
+++ b/tests/php/TickCronTest.php
@@ -66,9 +66,7 @@ final class TickCronTest extends TestCase
 
 	protected function tearDown(): void
 	{
-		@unlink($this->dir . '/pfb_due_ledger.json');
-		@unlink($this->dir . '/pfb_due_ledger.json.tmp');
-		@rmdir($this->dir);
+		rmdir_recursive($this->dir);
 	}
 
 	// -----------------------------------------------------------------------


### PR DESCRIPTION
Refs #3018. Deliberately **not** `Fixes` — see "What this does not close".

## The leak

Eight test classes strand their fixture directory on every run. Measured per class against the parent commit, each run against a clean snapshot:

| class | dirs stranded per run | prefix |
| --- | --- | --- |
| `DueLedgerTest` | 22 | `pfb_ledger_test_` |
| `DnsblipMarkerFolderTest` | 18 | `pfb_marker_` |
| `TickCronInstallTest` | 7 | `pfb_cron_disable_` |
| `TickCronTest` | 5 | `pfb_tick_test_` |
| `QuietHoursApplyTest` | 4 | `pfb_qh_test_` |
| `PfbSyncStatusLedgerTest` | 1 | `pfb_sync_status_test_` |
| `IpRecomputeSnapshotTest` | 1 | `pfb_rec_snap_` |
| `CountryNetworksCountGuardTest` | 1 | `pfb_country_networks_` |
| | **59** | |

## Two mechanisms, one fix

A `glob()` + `unlink()` loop misses dotfiles. It also cannot remove a **nested directory**, which strands most of these:

- `CountryNetworksCountGuardTest` creates `not-a-file/` inside its fixture directory.
- `DueLedgerTest` creates two nested directories.
- `IpRecomputeSnapshotTest` writes its logs into the parent it then tries to `rmdir()`.
- `TickCronInstallTest` globs one level and calls `@rmdir` on a directory entry, which fails when that entry is non-empty.
- `DnsblipMarkerFolderTest` restored globals and removed nothing at all.

`rmdir_recursive()` handles both halves. It already exists at `tests/php/pfsense_doubles.php`, is loaded unconditionally by the bootstrap, and is used by dozens of test files — including the bootstrap's own shutdown handler. This is reuse, not new machinery.

Also folded the two private `rrmdir()` copies in `AlertsDnsblLoggedFieldsRenderTest` and `DnsblLogEventQueryAttributionTest` onto the shared helper.

Nineteen further files **that name a private tree remover** (`removeTree()`/`rrmdir()`) were measured clean — they recurse via `scandir()` or `RecursiveDirectoryIterator` with `SKIP_DOTS`, both of which include dotfiles. That is duplication, not a defect, and it stays out of a bug fix.

**That sweep was scoped to the symbol names, not to the defect, and it should not be read as complete.** Review found **73 test files that call `glob()` inside `tearDown()`** — for example `AliasDeltaApplyTest.php:112`, `DnsblFeedCountTest.php:29`, `PfbDnsblipRebuildCheckTest.php:36`, each doing `array_map('unlink', glob("{$dir}/*"))` followed by `@rmdir`. That is the same latent shape as the eight fixed here; they survive only because their fixtures happen to contain neither a dotfile nor a nested directory today, which the residue measurement confirms — none appears among the survivors. Rewriting 73 teardowns does not belong in a bug fix, but the class is real and larger than this diff.

## Why it is not cosmetic

A full `/tmp` produces failures that read as code defects. On a host where `/tmp` had filled, `CountLinesTest::testManyTimesOneChunkStaysWithinBoundedMemory` failed with `Failed asserting that 1006848 is identical to 2097152` — a truncated fixture write, not an off-by-half counting bug, and it reproduced on pristine `devel`. `scripts/agent/run-gates.sh` writes its JUnit reports under `/tmp`, PHPStan caches there and pytest builds fixtures there, so an exhausted `/tmp` can corrupt a gate verdict in a shape that reads as authoritative.

## Regression pin

`TempDirLeakGuardTest` re-runs these eight files under a private `TMPDIR` and fails if any path survives, naming the file that stranded it. Its coverage is the explicit list of the eight files fixed here — it will not catch a newly-leaking file, which is a deliberate limit rather than an oversight.

## Evidence

Whole suite, private `TMPDIR`, same worktree, stash out / stash in:

| | residue | tests | errors | failures |
| --- | --- | --- | --- | --- |
| parent | **66** | 6381 | 61 | 13 |
| with this change | **7** | 6382 | 61 | 13 |

Errors and failures are identical either way, so nothing here changes a test verdict; the extra test is the guard. The eight classes in isolation go from 59 stranded directories to 0, with `OK (156 tests, 484 assertions)` both ways.

## What this does not close

Seven paths survive. Two are tool-owned and out of scope: `phpstan` and `phpunit_*`. Five are real:

```
pfb_pfctl_checked_op_<pid>
pfb_pfctl_calls_<rand>
pfb_log_event_dnslog_<rand>.applied   (x2)
pfb_family_
```

These appear **only when the whole suite runs** — each is cleaned when its file runs alone — so they are a different mechanism from the glob/dotfile/nested-directory one, and `rmdir_recursive()` will not close them. #3018 stays open for that remainder rather than being closed on a partial fix.

