### PR TITLE
Release: lead smoke concurrency with live route

### DIFF
--- a/.github/workflows/smoke-single.yml
+++ b/.github/workflows/smoke-single.yml
@@ -278,7 +278,7 @@ permissions:
   packages: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ inputs.image_name }}-${{ inputs.pfsense_version }}-${{ inputs.shard }}-${{ inputs.checkout_ref || github.ref }}-${{ inputs.smoke_repo_live_url || inputs.smoke_nightly_live_url || 'non-live' }}
+  group: ${{ inputs.smoke_repo_live_url || inputs.smoke_nightly_live_url || 'non-live' }}-${{ github.workflow }}-${{ inputs.image_name }}-${{ inputs.pfsense_version }}-${{ inputs.shard }}-${{ inputs.checkout_ref || github.ref }}
   cancel-in-progress: false
 
 jobs:

--- a/tests/test_issue2456_pkg_ownership.py
+++ b/tests/test_issue2456_pkg_ownership.py
@@ -141,14 +141,12 @@ class SourcePublicationBoundaryTests(unittest.TestCase):
 
     def test_live_catalogue_routes_are_part_of_smoke_concurrency_identity(self) -> None:
         concurrency = yaml.safe_load(SMOKE_SINGLE)["concurrency"]
-        self.assertEqual(
-            concurrency["group"],
-            (
-                "${{ github.workflow }}-${{ inputs.image_name }}-${{ inputs.pfsense_version }}-"
-                "${{ inputs.shard }}-${{ inputs.checkout_ref || github.ref }}-"
-                "${{ inputs.smoke_repo_live_url || inputs.smoke_nightly_live_url || 'non-live' }}"
-            ),
+        route_expression = "${{ inputs.smoke_repo_live_url || inputs.smoke_nightly_live_url || 'non-live' }}"
+        shared_axes = (
+            "${{ github.workflow }}-${{ inputs.image_name }}-${{ inputs.pfsense_version }}-"
+            "${{ inputs.shard }}-${{ inputs.checkout_ref || github.ref }}"
         )
+        self.assertEqual(concurrency["group"], f"{route_expression}-{shared_axes}")
         self.assertIs(concurrency["cancel-in-progress"], False)
 
     def test_tagged_finalize_depends_on_the_live_gate_and_discards_failure(self) -> None:


### PR DESCRIPTION
## Summary

- move the existing live-route discriminator to the beginning of `smoke-single` concurrency identity
- keep every existing workflow/image/version/shard/ref axis
- preserve repo-live, Nightly-live, non-live precedence and `cancel-in-progress: false`

## Evidence

| Frozen RED test | git hash-object | RED run tail |
| --- | --- | --- |
| `tests/test_issue2456_pkg_ownership.py` | `ca13203f69ca53f955e22f8bcd03fdb50348f0eb` | `1 failed: merged suffix ordering did not put route identity before shared axes` |

- recovery 33454563081 ran the merged suffix fix but still cancelled exactly four zero-second builds, one per image/version tuple; every started live gate passed
- live URLs were non-empty; runtime disproved missing-input and confirmed the trailing discriminator was ineffective after the long shared prefix
- GREEN: 14 focused publication-boundary tests passed
- effective YAML exact equality pins route-first order, repo/Nightly operands, fallback, all shared axes, and boolean false
- independent Codex verifier: PASS; suffix regression, repo/Nightly operands, fallback, and cancel flag mutants killed

Refs #3004

🤖 Generated by Oh My Pi and posted on behalf of @andrebrait.