### PR TITLE
ci: update checkout and setup-uv actions

### DIFF
--- a/.github/workflows/agent-config.yml
+++ b/.github/workflows/agent-config.yml
@@ -55,7 +55,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
 

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -111,7 +111,7 @@ jobs:
       py_flavor: ${{ steps.lookup.outputs.py_flavor }}
     steps:
       - name: Checkout (for scripts/read-version-matrix.sh)
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
 
@@ -162,7 +162,7 @@ jobs:
       version: ${{ inputs.pfsense_ce_version }}
     steps:
       - name: Checkout (for scripts/)
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
 
@@ -313,7 +313,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
 

--- a/.github/workflows/build-pkg-linux.yml
+++ b/.github/workflows/build-pkg-linux.yml
@@ -131,14 +131,14 @@ jobs:
       - name: Checkout the branch under test
         # This checkout IS --local-src: the builder packages this exact tree
         # (the way the FreeBSD path pins the port's USE_GITHUB fetch to the SHA).
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
 
       - name: Set up uv and the pinned Python
         # build-leg.sh shells out to `python3`; .python-version pins the same minor
         # the appliance carries, and uv provisions + activates it.
-        uses: astral-sh/setup-uv@v7 # v7.6.0
+        uses: astral-sh/setup-uv@v10.0.1
         with:
           version: "0.12.6"
           activate-environment: true

--- a/.github/workflows/coderabbit-cli.yml
+++ b/.github/workflows/coderabbit-cli.yml
@@ -34,7 +34,7 @@ jobs:
             exit 1
           fi
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/context-budget.yml
+++ b/.github/workflows/context-budget.yml
@@ -61,7 +61,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
 

--- a/.github/workflows/hsts-refresh.yml
+++ b/.github/workflows/hsts-refresh.yml
@@ -62,13 +62,13 @@ jobs:
       BRANCH: hsts-refresh/auto
       DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           persist-credentials: true   # need to push the automation branch via git push --force
           ref: devel
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v10.0.1
 
       - name: Install the Graphify merge driver
         run: sh scripts/agent/ensure-graphify-merge-driver.sh .

--- a/.github/workflows/image-refresh.yml
+++ b/.github/workflows/image-refresh.yml
@@ -121,7 +121,7 @@ jobs:
       count: ${{ steps.plan.outputs.count }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
 
@@ -228,13 +228,13 @@ jobs:
       matrix: ${{ fromJSON(needs.plan.outputs.matrix) }}
     steps:
       - name: Checkout (for scripts/ + tests/smoke/)
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           persist-credentials: true   # the activation step pushes tracker/* branches (issue #1837)
           fetch-depth: 0              # reach the ci-metadata orphan ref
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v10.0.1
 
       - name: Install the Graphify merge driver
         run: sh scripts/agent/ensure-graphify-merge-driver.sh .

--- a/.github/workflows/module-durations.yml
+++ b/.github/workflows/module-durations.yml
@@ -55,14 +55,14 @@ jobs:
        github.event.workflow_run.event == 'schedule')
     steps:
       - name: Checkout devel
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           persist-credentials: true   # need to push the refreshed table to devel via git push
           ref: devel
           fetch-depth: 0   # full history so the pre-push rebase can replay cleanly
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v10.0.1
 
       - name: Install the Graphify merge driver
         run: sh scripts/agent/ensure-graphify-merge-driver.sh .

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -50,7 +50,7 @@ jobs:
       source_date_epoch: ${{ steps.plan.outputs.source_date_epoch }}
     steps:
       - name: Checkout trusted workflow tools
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: devel
           fetch-depth: 0
@@ -58,7 +58,7 @@ jobs:
           path: trusted
 
       - name: Checkout explicit source ref as package input
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ env.SOURCE_REF }}
           fetch-depth: 0
@@ -197,7 +197,7 @@ jobs:
         include: ${{ fromJson(needs.prepare.outputs.build_matrix) }}
     steps:
       - name: Checkout trusted workflow tools
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ needs.prepare.outputs.tools_sha }}
           fetch-depth: 0
@@ -205,7 +205,7 @@ jobs:
           path: trusted
 
       - name: Checkout pinned source as package input
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ needs.prepare.outputs.source_sha }}
           fetch-depth: 0
@@ -213,7 +213,7 @@ jobs:
           path: source
 
       - name: Set up the pinned dependency-package toolchain
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v10.0.1
         with:
           version: "0.12.6"
 
@@ -355,7 +355,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout trusted workflow tools for handoff validation
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ needs.prepare.outputs.tools_sha }}
           fetch-depth: 0
@@ -472,7 +472,7 @@ jobs:
     needs: [prepare, publish-nightly-oci]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           ref: ${{ needs.prepare.outputs.tools_sha }}
           fetch-depth: 1
@@ -518,7 +518,7 @@ jobs:
     needs: [prepare, publish-nightly-oci, validate-live-pages-install]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           ref: ${{ needs.prepare.outputs.tools_sha }}
           fetch-depth: 1

--- a/.github/workflows/pkg-republish.yml
+++ b/.github/workflows/pkg-republish.yml
@@ -33,7 +33,7 @@ jobs:
       channel: ${{ steps.resolve.outputs.channel }}
       portversion: ${{ steps.resolve.outputs.portversion }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           ref: ${{ github.workflow_sha }}
           repository: pfBlockerNG/pfBlockerNG

--- a/.github/workflows/pkg-tagged-ingest.yml
+++ b/.github/workflows/pkg-tagged-ingest.yml
@@ -42,7 +42,7 @@ jobs:
       touched: ${{ steps.result.outputs.touched }}
       noop: ${{ steps.result.outputs.noop }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           ref: ${{ github.workflow_sha }}
           fetch-depth: 1
@@ -92,7 +92,7 @@ jobs:
     outputs:
       matrix: ${{ steps.build.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           ref: ${{ github.workflow_sha }}
           fetch-depth: 1
@@ -166,7 +166,7 @@ jobs:
     needs: [stage-pkg, prepare-live-gate, validate-live-pages-install]
     if: always() && needs.stage-pkg.result == 'success' && needs.stage-pkg.outputs.noop != 'true'
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           ref: ${{ github.workflow_sha }}
           fetch-depth: 1

--- a/.github/workflows/psl-refresh.yml
+++ b/.github/workflows/psl-refresh.yml
@@ -62,13 +62,13 @@ jobs:
       BRANCH: psl-refresh/auto
       DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           persist-credentials: true   # need to push the automation branch via git push --force
           ref: devel
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v10.0.1
 
       - name: Install the Graphify merge driver
         run: sh scripts/agent/ensure-graphify-merge-driver.sh .

--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -122,7 +122,7 @@ jobs:
           print(f"Resolved Release {resolved_tag} (id {resolved_id}, prerelease={prerelease_text})")
           '
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           # SECURITY: release-version.sh below is EXECUTED AS SHELL, so this checkout
           # must pin the revision the workflow itself came from — never a ref an
@@ -234,7 +234,7 @@ jobs:
           permission-contents: write
 
       - name: Checkout the FreeBSD-ports fork (use-github branch)
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           repository: pfBlockerNG/FreeBSD-ports
           ref: pfblockerng/use-github
@@ -253,7 +253,7 @@ jobs:
           sparse-checkout-cone-mode: true
 
       - name: Checkout pfBlockerNG (the release helper — TRUSTED ref, sparse)
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           # SECURITY: portrevision-rebuild.sh below is EXECUTED AS SHELL in a job that
           # holds an App token able to push to pfblockerng/use-github. It must therefore
@@ -274,7 +274,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v10.0.1
 
       - name: Install the Graphify merge driver
         run: sh "${GITHUB_WORKSPACE}/pfblockerng-src/scripts/agent/ensure-graphify-merge-driver.sh" .

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -151,13 +151,13 @@ jobs:
             *) echo "::error::dry_run input must be exactly 'true' or 'false' (got: '${INPUT_DRY}')"; exit 1 ;;
           esac
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0          # full history: tag ancestry + log range
           persist-credentials: false
 
       - name: Check out the release helpers (TRUSTED ref, sparse)
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           # SECURITY: this job holds contents:write AND a GH_TOKEN, and it executes
           # release-version.sh + release-ci-gate.sh AS SHELL. The next step resets the
@@ -497,7 +497,7 @@ jobs:
       # and by tag-release's gate.
       run_suites:   ${{ steps.channel.outputs.run_suites }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0   # need full history to reach ci-metadata ref and tag
           persist-credentials: false
@@ -620,7 +620,7 @@ jobs:
 
       - name: Check out pinned dependency-builder source
         if: steps.pins.outputs.has_dependencies == 'true'
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.event.inputs.source == 'release/3.3' && github.workflow_sha || steps.destinations.outputs.source_sha }}
           fetch-depth: 1
@@ -725,7 +725,7 @@ jobs:
       created: ${{ steps.stamp.outputs.created }}
       commit:  ${{ steps.stamp.outputs.commit }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           # issue #1855: the PINNED release commit (prepare-release), not the tag —
           # nothing is tagged yet at this point. Empty on dry-run (prepare-release is
@@ -778,7 +778,7 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           ref: ${{ needs.prepare-release.outputs.sha }}
           fetch-depth: 0             # full history + tags: the resume check below
@@ -865,7 +865,7 @@ jobs:
       source_sha:        ${{ needs.prepare-release.outputs.sha }}
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           # The PINNED release commit — identical content to the tag tag-release just
           # pushed onto it, without depending on the tag having propagated.
@@ -874,7 +874,7 @@ jobs:
           persist-credentials: false
 
       - name: Check out the release helpers (TRUSTED ref, sparse)
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           # SECURITY: same rule as prepare-release. This job holds
           # contents:write and executes release-version.sh AS SHELL (the metadata step
@@ -1211,7 +1211,7 @@ jobs:
 
     steps:
       - name: Checkout the pinned release source
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           # issue #1855: build from prepare-release's PINNED SHA — the channel-branch
           # tip including the committed changelog. The tag is created LATER, on this
@@ -1237,7 +1237,7 @@ jobs:
 
       - name: Set up the pinned dependency-package toolchain
         if: steps.extras.outputs.extra_pkgs != '[]'
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v10.0.1
         with:
           version: "0.12.6"
           activate-environment: true
@@ -1480,7 +1480,7 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
 

--- a/.github/workflows/repo-install.yml
+++ b/.github/workflows/repo-install.yml
@@ -89,7 +89,7 @@ jobs:
       ci_matrix: ${{ steps.read.outputs.ci_matrix }}
       leg_count: ${{ steps.count.outputs.leg_count }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
           fetch-depth: 0

--- a/.github/workflows/smoke-single.yml
+++ b/.github/workflows/smoke-single.yml
@@ -368,7 +368,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           # issue #1859: the test code comes from the ref the caller names — for a
           # release that is the pinned release SHA, so the suite verifies the source
@@ -653,7 +653,7 @@ jobs:
         # activate-environment puts the project environment on PATH, so the `python3`
         # scripts/run-smoke.sh shells out to is the synced interpreter (.python-version
         # pins the same minor the appliance carries).
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v10.0.1
         with:
           enable-cache: true
           activate-environment: true

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -184,7 +184,7 @@ jobs:
       pytest_marker: ${{ steps.filter.outputs.pytest_marker }}
       pytest_filter: ${{ steps.filter.outputs.pytest_filter }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
           fetch-depth: 0   # reach the ci-metadata orphan ref + branch history (impacted diff)

--- a/.github/workflows/test-version-matrix.yml
+++ b/.github/workflows/test-version-matrix.yml
@@ -23,7 +23,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout (for scripts/read-version-matrix.sh)
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,7 +82,7 @@ jobs:
       php_versions: ${{ steps.matrix.outputs.php_versions }}
     steps:
       - name: Checkout (for scripts/read-version-matrix.sh + the action)
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
 
@@ -113,7 +113,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
 
@@ -133,7 +133,7 @@ jobs:
       - name: Install uv
         # astral-sh/setup-uv publishes no floating major tag past v7 — later majors ship
         # exact versions only. enable-cache persists uv's download cache between runs.
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v10.0.1
         with:
           enable-cache: true
 
@@ -180,14 +180,14 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
 
       - name: Install uv
         # astral-sh/setup-uv publishes no floating major tag past v7 — later majors ship
         # exact versions only. enable-cache persists uv's download cache between runs.
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v10.0.1
         with:
           enable-cache: true
 
@@ -208,14 +208,14 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
 
       - name: Install uv
         # astral-sh/setup-uv publishes no floating major tag past v7 — later majors ship
         # exact versions only. enable-cache persists uv's download cache between runs.
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v10.0.1
         with:
           enable-cache: true
 
@@ -237,7 +237,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
 
@@ -363,7 +363,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           persist-credentials: false # lint-only job; no git writes
 
@@ -458,7 +458,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
 
@@ -664,7 +664,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
 
@@ -691,7 +691,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
 
@@ -747,7 +747,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
 
@@ -799,7 +799,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
 
@@ -808,7 +808,7 @@ jobs:
         # charset_normalizer"` and SKIPS without it, so this job needs the locked
         # environment even though it is a PHP leg. activate-environment puts the venv
         # python first on PATH, which is what the test's `command -v python3` finds.
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v10.0.1
         with:
           enable-cache: true
           activate-environment: true
@@ -907,7 +907,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
 
@@ -932,7 +932,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
 
@@ -957,7 +957,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
 
@@ -1012,14 +1012,14 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
 
       - name: Install uv
         # astral-sh/setup-uv publishes no floating major tag past v7 — later majors ship
         # exact versions only. enable-cache persists uv's download cache between runs.
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v10.0.1
         with:
           enable-cache: true
 
@@ -1085,7 +1085,7 @@ jobs:
       pull-requests: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
           fetch-depth: 0 # need the merge-base with the PR base ref for the three-dot diff
@@ -1173,7 +1173,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
           fetch-depth: 0 # need the merge-base with the PR base ref for the three-dot diff

--- a/.github/workflows/tld-refresh.yml
+++ b/.github/workflows/tld-refresh.yml
@@ -61,13 +61,13 @@ jobs:
       BRANCH: tld-refresh/auto
       DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           persist-credentials: true   # need to push the automation branch via git push --force
           ref: devel
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v10.0.1
 
       - name: Install the Graphify merge driver
         run: sh scripts/agent/ensure-graphify-merge-driver.sh .

--- a/.github/workflows/top1m-healthcheck.yml
+++ b/.github/workflows/top1m-healthcheck.yml
@@ -39,7 +39,7 @@ jobs:
     outputs:
       matrix: ${{ steps.extract.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
 
@@ -75,7 +75,7 @@ jobs:
       matrix:
         include: ${{ fromJson(needs.discover.outputs.matrix) }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
 
@@ -189,7 +189,7 @@ jobs:
       # See the "check" job -- same secret, same derivation rule.
       CLOUDFLARE_RADAR_TOKEN: ${{ secrets.CLOUDFLARE_RADAR_TOKEN }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
 

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -246,7 +246,7 @@ jobs:
       leg_count: ${{ steps.gen.outputs.leg_count }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0   # need history to detect "commits in the last day" for the schedule guard
           persist-credentials: false
@@ -375,7 +375,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           # issue #1859: the test code comes from the ref the caller names — for a
           # release that is the pinned release SHA, so the suite verifies the source
@@ -615,7 +615,7 @@ jobs:
         # activate-environment puts the project environment on PATH, so the `python3`
         # scripts/run-smoke.sh shells out to is the synced interpreter (.python-version
         # pins the same minor the appliance carries).
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v10.0.1
         with:
           enable-cache: true
           activate-environment: true

--- a/.github/workflows/version-tracker.yml
+++ b/.github/workflows/version-tracker.yml
@@ -73,7 +73,7 @@ jobs:
       build_matrix: ${{ steps.read.outputs.build_matrix }}
       ci_matrix: ${{ steps.read.outputs.ci_matrix }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
           fetch-depth: 0   # need history to reach the ci-metadata orphan ref
@@ -127,7 +127,7 @@ jobs:
       packages: read
       actions: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
           fetch-depth: 0
@@ -270,13 +270,13 @@ jobs:
       actions: write         # dispatch image-refresh.yml direct legs
       packages: read         # oras pull/manifest-fetch of the smoke images
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           persist-credentials: true   # push the tracker/* matrix-PR branches
           fetch-depth: 0
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v10.0.1
 
       - name: Install the Graphify merge driver
         run: sh scripts/agent/ensure-graphify-merge-driver.sh .

--- a/tests/test_ci_action_version_guard.py
+++ b/tests/test_ci_action_version_guard.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+
+import tests.test_ci_checkout_persist_credentials as guard
+
+
+def test_version_guard_rejects_inline_quoted_and_hash_suffix_pins(tmp_path: Path) -> None:
+    module = guard.__dict__
+    original = module["WORKFLOWS_DIR"]
+    module["WORKFLOWS_DIR"] = tmp_path
+    try:
+        (tmp_path / "inline.yml").write_text(
+            "jobs:\n"
+            "  demo:\n"
+            "    steps:\n"
+            "      - uses: actions/checkout@v6\n"
+            '      - uses: "actions/checkout@v6"\n'
+            "      - uses: actions/checkout@v7#junk\n"
+            "      - uses: astral-sh/setup-uv@v7\n",
+            encoding="utf-8",
+        )
+
+        seen, offenders = module["_action_version_offenders"]()
+        assert seen == {"actions/checkout", "astral-sh/setup-uv"}
+        report = "\n".join(offenders)
+        assert "checkout@v6" in report
+        assert "checkout@v7#junk" in report
+        assert "setup-uv@v7" in report
+    finally:
+        module["WORKFLOWS_DIR"] = original

--- a/tests/test_ci_action_version_guard.py
+++ b/tests/test_ci_action_version_guard.py
@@ -3,27 +3,38 @@ from pathlib import Path
 import tests.test_ci_checkout_persist_credentials as guard
 
 
-def test_version_guard_rejects_inline_quoted_and_hash_suffix_pins(tmp_path: Path) -> None:
-    module = guard.__dict__
-    original = module["WORKFLOWS_DIR"]
-    module["WORKFLOWS_DIR"] = tmp_path
-    try:
-        (tmp_path / "inline.yml").write_text(
-            "jobs:\n"
-            "  demo:\n"
-            "    steps:\n"
-            "      - uses: actions/checkout@v6\n"
-            '      - uses: "actions/checkout@v6"\n'
-            "      - uses: actions/checkout@v7#junk\n"
-            "      - uses: astral-sh/setup-uv@v7\n",
-            encoding="utf-8",
-        )
+def _workflow(path: Path, uses: str) -> Path:
+    path.write_text(f"jobs:\n  demo:\n    steps:\n      {uses}\n", encoding="utf-8")
+    return path
 
-        seen, offenders = module["_action_version_offenders"]()
-        assert seen == {"actions/checkout", "astral-sh/setup-uv"}
-        report = "\n".join(offenders)
-        assert "checkout@v6" in report
-        assert "checkout@v7#junk" in report
-        assert "setup-uv@v7" in report
-    finally:
-        module["WORKFLOWS_DIR"] = original
+
+def test_version_guard_rejects_each_hostile_pin_shape(tmp_path: Path) -> None:
+    scan = guard.__dict__["_action_version_offenders"]
+    cases = (
+        ("- uses: actions/checkout@v6", "actions/checkout", "actions/checkout@v6"),
+        ('- uses: "actions/checkout@v6"', "actions/checkout", "actions/checkout@v6"),
+        ("- uses : actions/checkout@v6", "actions/checkout", "actions/checkout@v6"),
+        ("- uses: actions/checkout@v7#junk", "actions/checkout", "actions/checkout@v7#junk"),
+        ("- uses: 'astral-sh/setup-uv@v7\"'", "astral-sh/setup-uv", 'astral-sh/setup-uv@v7"'),
+        ("- uses: actions/checkout@v7 junk", "actions/checkout", "actions/checkout@v7 junk"),
+        ("- uses: actions/checkout@ v6", "actions/checkout", "actions/checkout@ v6"),
+    )
+    for index, (uses, action, value) in enumerate(cases):
+        seen, offenders = scan([_workflow(tmp_path / f"bad-{index}.yml", uses)])
+        assert seen == {action}, f"scanner skipped target action: {uses}"
+        assert len(offenders) == 1, f"scanner accepted hostile pin: {uses}"
+        assert value in offenders[0]
+
+
+def test_version_guard_accepts_valid_yaml_scalar_shapes(tmp_path: Path) -> None:
+    scan = guard.__dict__["_action_version_offenders"]
+    cases = (
+        ("- uses: actions/checkout@v7", "actions/checkout"),
+        ("- uses : actions/checkout@v7", "actions/checkout"),
+        ('- uses: "actions/checkout@v7" # comment', "actions/checkout"),
+        ("- uses: 'astral-sh/setup-uv@v10.0.1' # comment", "astral-sh/setup-uv"),
+    )
+    for index, (uses, action) in enumerate(cases):
+        seen, offenders = scan([_workflow(tmp_path / f"good-{index}.yml", uses)])
+        assert seen == {action}, f"scanner skipped valid pin: {uses}"
+        assert not offenders, f"scanner rejected valid pin: {uses}"

--- a/tests/test_ci_checkout_persist_credentials.py
+++ b/tests/test_ci_checkout_persist_credentials.py
@@ -33,6 +33,11 @@ _WORKFLOW_GLOBS = ("*.yml", "*.yaml")
 _STEP_ITEM_RE = re.compile(r"^(?P<indent>[ ]*)-\s")
 _STEP_MARKER_RE = re.compile(r"^[ ]*-[ ]+")  # the sequence marker only, never the key that follows
 _CHECKOUT_RE = re.compile(r"uses:\s*actions/checkout@")
+_EXPECTED_ACTION_VERSIONS = {"actions/checkout": "v7", "astral-sh/setup-uv": "v10.0.1"}
+_ACTION_USES_RE = re.compile(
+    r"""^(?:-\s+)?uses:\s*(?P<quote>["']?)(?P<action>actions/checkout|astral-sh/setup-uv)@"""
+    r"""(?P<version>[^\s"']+)(?P=quote)(?:\s+#.*)?$"""
+)
 _PERSIST_RE = re.compile(r"^[ ]*persist-credentials:\s*(?P<value>true|false)\b(?P<comment>.*)$")
 _JOB_KEY_RE = re.compile(r"^ {2}[A-Za-z0-9_.-]+:\s*(#.*)?$")
 _WITH_KEY_RE = re.compile(r"^(?P<indent>[ ]*)with:\s*(#.*)?$")
@@ -207,21 +212,26 @@ def test_enumeration_is_non_vacuous() -> None:
     )
 
 
-def test_checkout_and_setup_uv_versions_are_current() -> None:
-    expected = {"actions/checkout": "v7", "astral-sh/setup-uv": "v10.0.1"}
+def _action_version_offenders() -> tuple[set[str], list[str]]:
     seen: set[str] = set()
     offenders: list[str] = []
     for path in _workflow_files():
         for line_number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
-            action_line = line.split("#", 1)[0].strip()
-            for action, version in expected.items():
-                prefix = f"uses: {action}@"
-                if action_line.startswith(prefix):
-                    seen.add(action)
-                    if action_line != f"{prefix}{version}":
-                        offenders.append(f"{path.name}:{line_number}: {action_line}")
+            match = _ACTION_USES_RE.fullmatch(line.strip())
+            if match is None:
+                continue
+            action = match.group("action")
+            seen.add(action)
+            if match.group("version") != _EXPECTED_ACTION_VERSIONS[action]:
+                offenders.append(f"{path.name}:{line_number}: {line.strip()}")
+    return seen, offenders
 
-    assert seen == expected.keys(), f"expected action pins not found: {sorted(expected.keys() - seen)}"
+
+def test_checkout_and_setup_uv_versions_are_current() -> None:
+    seen, offenders = _action_version_offenders()
+    assert seen == _EXPECTED_ACTION_VERSIONS.keys(), (
+        f"expected action pins not found: {sorted(_EXPECTED_ACTION_VERSIONS.keys() - seen)}"
+    )
     assert not offenders, "outdated GitHub Action pins:\n  " + "\n  ".join(offenders)
 
 

--- a/tests/test_ci_checkout_persist_credentials.py
+++ b/tests/test_ci_checkout_persist_credentials.py
@@ -182,7 +182,7 @@ def _raw_checkout_line_count() -> int:
     inventing one the regex doesn't). Comment lines are excluded here -- the
     same predicate _find_checkout_sites applies when picking a block's
     checkout line -- so a documentation example like `# uses:
-    actions/checkout@v6` can never make the two sides disagree; a REAL
+    actions/checkout@v7` can never make the two sides disagree; a REAL
     duplicate `uses:` key inside one step is invalid YAML and out of scope."""
     count = 0
     for path in _workflow_files():
@@ -205,6 +205,24 @@ def test_enumeration_is_non_vacuous() -> None:
         f"found zero actions/checkout sites under {WORKFLOWS_DIR} (globs: {_WORKFLOW_GLOBS}) -- "
         f"a broken enumeration must never silently pass by finding nothing."
     )
+
+
+def test_checkout_and_setup_uv_versions_are_current() -> None:
+    expected = {"actions/checkout": "v7", "astral-sh/setup-uv": "v10.0.1"}
+    seen: set[str] = set()
+    offenders: list[str] = []
+    for path in _workflow_files():
+        for line_number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+            action_line = line.split("#", 1)[0].strip()
+            for action, version in expected.items():
+                prefix = f"uses: {action}@"
+                if action_line.startswith(prefix):
+                    seen.add(action)
+                    if action_line != f"{prefix}{version}":
+                        offenders.append(f"{path.name}:{line_number}: {action_line}")
+
+    assert seen == expected.keys(), f"expected action pins not found: {sorted(expected.keys() - seen)}"
+    assert not offenders, "outdated GitHub Action pins:\n  " + "\n  ".join(offenders)
 
 
 def test_walker_count_matches_raw_checkout_line_count() -> None:
@@ -259,7 +277,7 @@ def test_only_a_direct_child_of_the_with_block_counts_as_a_declaration(tmp_path:
         "  demo:\n"
         "    steps:\n"
         "      - name: Checkout\n"
-        "        uses: actions/checkout@v6\n"
+        "        uses: actions/checkout@v7\n"
         "        with:\n"
         "          ref: |\n"
         "            persist-credentials: false\n",
@@ -278,7 +296,7 @@ def test_only_a_direct_child_of_the_with_block_counts_as_a_declaration(tmp_path:
         "  demo:\n"
         "    steps:\n"
         "      - name: Checkout\n"
-        "        uses: actions/checkout@v6\n"
+        "        uses: actions/checkout@v7\n"
         "        with:\n"
         "          ref: main\n"
         "          persist-credentials: false\n",
@@ -301,7 +319,7 @@ def test_a_decoy_with_block_inside_another_keys_scalar_is_not_the_input_mapping(
         "  demo:\n"
         "    steps:\n"
         "      - name: Checkout\n"
-        "        uses: actions/checkout@v6\n"
+        "        uses: actions/checkout@v7\n"
         "        env:\n"
         "          NOTES: |\n"
         "            with:\n"
@@ -324,7 +342,7 @@ def test_a_decoy_with_block_inside_another_keys_scalar_is_not_the_input_mapping(
         "  demo:\n"
         "    steps:\n"
         "      - -weird: x\n"
-        "        uses: actions/checkout@v6\n"
+        "        uses: actions/checkout@v7\n"
         "        env: |\n"
         "         with:\n"
         "           persist-credentials: false\n",

--- a/tests/test_ci_checkout_persist_credentials.py
+++ b/tests/test_ci_checkout_persist_credentials.py
@@ -26,6 +26,8 @@ import re
 from dataclasses import dataclass
 from pathlib import Path
 
+import yaml
+
 ROOT = Path(__file__).resolve().parents[1]
 WORKFLOWS_DIR = ROOT / ".github" / "workflows"
 _WORKFLOW_GLOBS = ("*.yml", "*.yaml")
@@ -34,10 +36,6 @@ _STEP_ITEM_RE = re.compile(r"^(?P<indent>[ ]*)-\s")
 _STEP_MARKER_RE = re.compile(r"^[ ]*-[ ]+")  # the sequence marker only, never the key that follows
 _CHECKOUT_RE = re.compile(r"uses:\s*actions/checkout@")
 _EXPECTED_ACTION_VERSIONS = {"actions/checkout": "v7", "astral-sh/setup-uv": "v10.0.1"}
-_ACTION_USES_RE = re.compile(
-    r"""^(?:-\s+)?uses:\s*(?P<quote>["']?)(?P<action>actions/checkout|astral-sh/setup-uv)@"""
-    r"""(?P<version>[^\s"']+)(?P=quote)(?:\s+#.*)?$"""
-)
 _PERSIST_RE = re.compile(r"^[ ]*persist-credentials:\s*(?P<value>true|false)\b(?P<comment>.*)$")
 _JOB_KEY_RE = re.compile(r"^ {2}[A-Za-z0-9_.-]+:\s*(#.*)?$")
 _WITH_KEY_RE = re.compile(r"^(?P<indent>[ ]*)with:\s*(#.*)?$")
@@ -212,23 +210,26 @@ def test_enumeration_is_non_vacuous() -> None:
     )
 
 
-def _action_version_offenders() -> tuple[set[str], list[str]]:
+def _action_version_offenders(files: list[Path]) -> tuple[set[str], list[str]]:
     seen: set[str] = set()
     offenders: list[str] = []
-    for path in _workflow_files():
-        for line_number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
-            match = _ACTION_USES_RE.fullmatch(line.strip())
-            if match is None:
-                continue
-            action = match.group("action")
-            seen.add(action)
-            if match.group("version") != _EXPECTED_ACTION_VERSIONS[action]:
-                offenders.append(f"{path.name}:{line_number}: {line.strip()}")
+    for path in files:
+        workflow = yaml.safe_load(path.read_text(encoding="utf-8"))
+        for job_name, job in workflow.get("jobs", {}).items():
+            for step_index, step in enumerate(job.get("steps", [])):
+                action_ref = step.get("uses")
+                if not isinstance(action_ref, str):
+                    continue
+                for action, version in _EXPECTED_ACTION_VERSIONS.items():
+                    if action_ref.startswith(f"{action}@"):
+                        seen.add(action)
+                        if action_ref != f"{action}@{version}":
+                            offenders.append(f"{path.name}:{job_name}:step-{step_index}: uses: {action_ref}")
     return seen, offenders
 
 
 def test_checkout_and_setup_uv_versions_are_current() -> None:
-    seen, offenders = _action_version_offenders()
+    seen, offenders = _action_version_offenders(_workflow_files())
     assert seen == _EXPECTED_ACTION_VERSIONS.keys(), (
         f"expected action pins not found: {sorted(_EXPECTED_ACTION_VERSIONS.keys() - seen)}"
     )

--- a/tests/test_ci_graphify_merge_driver.py
+++ b/tests/test_ci_graphify_merge_driver.py
@@ -13,7 +13,7 @@ from tests._workflow_steps import extract_job
 
 ROOT = Path(__file__).resolve().parents[1]
 WORKFLOWS = ROOT / ".github" / "workflows"
-_SETUP_UV = "uses: astral-sh/setup-uv@v7"
+_SETUP_UV = "uses: astral-sh/setup-uv@v10.0.1"
 _DRIVER = "ensure-graphify-merge-driver.sh"
 _STEP_RE = re.compile(r"^      - [A-Za-z_][A-Za-z0-9_-]*:", re.MULTILINE)
 _JOB_RE = re.compile(r"^  ([A-Za-z0-9_-]+):\s*(?:#.*)?$", re.MULTILINE)
@@ -46,42 +46,42 @@ PUSH_JOBS = (
         "refresh",
         "sh scripts/agent/ensure-graphify-merge-driver.sh .",
         'git push --force origin "$BRANCH"',
-        checkout_groups=(("uses: actions/checkout@v6", "ref: devel"),),
+        checkout_groups=(("uses: actions/checkout@v7", "ref: devel"),),
     ),
     PushJob(
         "psl-refresh.yml",
         "refresh",
         "sh scripts/agent/ensure-graphify-merge-driver.sh .",
         'git push --force origin "$BRANCH"',
-        checkout_groups=(("uses: actions/checkout@v6", "ref: devel"),),
+        checkout_groups=(("uses: actions/checkout@v7", "ref: devel"),),
     ),
     PushJob(
         "tld-refresh.yml",
         "refresh",
         "sh scripts/agent/ensure-graphify-merge-driver.sh .",
         'git push --force origin "$BRANCH"',
-        checkout_groups=(("uses: actions/checkout@v6", "ref: devel"),),
+        checkout_groups=(("uses: actions/checkout@v7", "ref: devel"),),
     ),
     PushJob(
         "image-refresh.yml",
         "refresh",
         "sh scripts/agent/ensure-graphify-merge-driver.sh .",
         'git -C "$WT" push --force origin "$BR"',
-        checkout_groups=(("name: Checkout (for scripts/ + tests/smoke/)", "uses: actions/checkout@v6"),),
+        checkout_groups=(("name: Checkout (for scripts/ + tests/smoke/)", "uses: actions/checkout@v7"),),
     ),
     PushJob(
         "module-durations.yml",
         "refresh",
         "sh scripts/agent/ensure-graphify-merge-driver.sh .",
         "until git push origin HEAD:devel; do",
-        checkout_groups=(("uses: actions/checkout@v6", "ref: devel"),),
+        checkout_groups=(("uses: actions/checkout@v7", "ref: devel"),),
     ),
     PushJob(
         "version-tracker.yml",
         "reconcile",
         "sh scripts/agent/ensure-graphify-merge-driver.sh .",
         'git push --force origin "$1"',
-        checkout_groups=(("uses: actions/checkout@v6",),),
+        checkout_groups=(("uses: actions/checkout@v7",),),
     ),
     PushJob(
         "release-published.yml",
@@ -91,12 +91,12 @@ PUSH_JOBS = (
         checkout_groups=(
             (
                 "name: Checkout the FreeBSD-ports fork (use-github branch)",
-                "uses: actions/checkout@v6",
+                "uses: actions/checkout@v7",
                 "repository: pfBlockerNG/FreeBSD-ports",
                 "ref: pfblockerng/use-github",
             ),
             (
-                "uses: actions/checkout@v6",
+                "uses: actions/checkout@v7",
                 "repository: pfBlockerNG/pfBlockerNG",
                 "ref: ${{ github.workflow_sha }}",
                 "path: pfblockerng-src",
@@ -173,10 +173,10 @@ def _assert_job_contract(job: str, spec: PushJob) -> None:
         checkout_steps.append(matches[0])
     setup_uv_steps = [index for index, step in enumerate(steps) if _has_step_line(step, _SETUP_UV)]
     assert len(setup_uv_steps) == 1, (
-        f"{label}: expected exactly one setup-uv step pinned to v7, found {len(setup_uv_steps)}"
+        f"{label}: expected exactly one setup-uv step pinned to v10.0.1, found {len(setup_uv_steps)}"
     )
     setup_uv = setup_uv_steps[0]
-    assert _SETUP_UV in steps[setup_uv], f"{label}: setup-uv must be pinned to v7"
+    assert _SETUP_UV in steps[setup_uv], f"{label}: setup-uv must be pinned to v10.0.1"
 
     ensure = _command_step(steps, spec.ensure_command, label)
     assert _DRIVER in steps[ensure]
@@ -185,7 +185,7 @@ def _assert_job_contract(job: str, spec: PushJob) -> None:
     mutation_step, mutation_command = mutation
     assert mutation_command == spec.first_mutation, f"{label}: first qualifying mutation changed: {mutation_command!r}"
     assert max(checkout_steps) < setup_uv, f"{label}: setup-uv must run after every relevant checkout"
-    assert setup_uv < ensure, f"{label}: setup-uv v7 must run before merge-driver setup"
+    assert setup_uv < ensure, f"{label}: setup-uv v10.0.1 must run before merge-driver setup"
     assert ensure < mutation_step, f"{label}: merge-driver setup must run before {mutation_command!r}"
 
 
@@ -245,7 +245,7 @@ def test_foreign_target_helper_checkout_includes_graphify_patch_payload() -> Non
     checkouts = [
         step
         for step in workflow["jobs"]["sync-ports-fork"]["steps"]
-        if step.get("uses") == "actions/checkout@v6"
+        if step.get("uses") == "actions/checkout@v7"
         and step.get("with", {}).get("repository") == "pfBlockerNG/pfBlockerNG"
         and step["with"].get("ref") == "${{ github.workflow_sha }}"
         and step["with"].get("path") == "pfblockerng-src"
@@ -257,13 +257,13 @@ def test_foreign_target_helper_checkout_includes_graphify_patch_payload() -> Non
 
 _GOOD_FIXTURE = """\
       - name: Checkout tools
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Checkout target
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           path: pkg-repo
       - name: Set up uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v10.0.1
       - name: Install Graphify merge driver
         run: sh scripts/agent/ensure-graphify-merge-driver.sh pkg-repo
       - name: Publish
@@ -271,7 +271,7 @@ _GOOD_FIXTURE = """\
 """
 _SETUP_FIXTURE = """\
       - name: Set up uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v10.0.1
 """
 _PUBLISH_FIXTURE = """\
       - name: Publish
@@ -283,8 +283,8 @@ _FIXTURE_SPEC = PushJob(
     "sh scripts/agent/ensure-graphify-merge-driver.sh pkg-repo",
     "sh scripts/publish-pkg-repo.sh",
     checkout_groups=(
-        ("name: Checkout tools", "uses: actions/checkout@v6"),
-        ("name: Checkout target", "uses: actions/checkout@v6", "path: pkg-repo"),
+        ("name: Checkout tools", "uses: actions/checkout@v7"),
+        ("name: Checkout target", "uses: actions/checkout@v7", "path: pkg-repo"),
     ),
 )
 
@@ -309,8 +309,8 @@ def test_guard_rejects_planted_missing_or_late_setup(broken: str) -> None:
 
 def test_comments_cannot_spoof_tool_pins_or_checkout_paths() -> None:
     wrong_uv = _GOOD_FIXTURE.replace(
-        "        uses: astral-sh/setup-uv@v7",
-        "        uses: astral-sh/setup-uv@v6\n        # uses: astral-sh/setup-uv@v7",
+        "        uses: astral-sh/setup-uv@v10.0.1",
+        "        uses: astral-sh/setup-uv@v9\n        # uses: astral-sh/setup-uv@v10.0.1",
     )
     with pytest.raises(AssertionError, match="setup-uv"):
         _assert_job_contract(wrong_uv, _FIXTURE_SPEC)

--- a/tests/test_issue2143_callback_destinations.py
+++ b/tests/test_issue2143_callback_destinations.py
@@ -34,7 +34,7 @@ def test_manual_callback_validates_published_release_and_derives_tuple() -> None
 
 
 def test_published_callback_uses_full_history_for_branch_ancestry() -> None:
-    checkout = extract_between(PUBLISHED, "uses: actions/checkout@v6", "      - name: Classify")
+    checkout = extract_between(PUBLISHED, "uses: actions/checkout@v7", "      - name: Classify")
     assert "fetch-depth: 0" in checkout
 
 

--- a/tests/test_issue2231_workflow_hygiene.py
+++ b/tests/test_issue2231_workflow_hygiene.py
@@ -2296,7 +2296,7 @@ jobs:
   consume:
     needs: [resolve, prepare-release]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           ref: ${{ needs.prepare-release.outputs.sha || needs.resolve.outputs.source_sha }}
 """,

--- a/tests/test_issue2245_stateless_nightly.py
+++ b/tests/test_issue2245_stateless_nightly.py
@@ -667,10 +667,10 @@ jobs:
   build:
     needs: prepare
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           ref: ${{ needs.prepare.outputs.source_sha }}
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           ref: ${{ needs.prepare.outputs.source_sha || github.ref }}
 """
@@ -738,7 +738,7 @@ jobs:
     env:
       SOURCE_SHA: ${{ needs.prepare.outputs.source_sha || github.ref }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           ref: ${{ needs.prepare.outputs.source_sha }}
       - run: git checkout "$SOURCE_SHA"
@@ -763,7 +763,7 @@ jobs:
     env:
       PORTS_SHA: ${{ needs.prepare.outputs.ports_sha || github.ref }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           ref: ${{ needs.prepare.outputs.ports_sha }}
       - run: sh scripts/build-leg.sh --ports-ref "$PORTS_SHA"
@@ -788,7 +788,7 @@ jobs:
     env:
       PORTS_SHA: ${{ needs.prepare.outputs.ports_sha || github.ref }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           ref: ${{ needs.prepare.outputs.ports_sha }}
       - run: sh scripts/build-leg.sh --ports-ref=$PORTS_SHA

--- a/tests/test_release_ci_path_consistency.py
+++ b/tests/test_release_ci_path_consistency.py
@@ -144,7 +144,7 @@ def test_issue_2387_tagged_build_uses_one_pinned_route_and_ports_identity() -> N
     assert "dependency_packages: ${{ steps.dependencies.outputs.dependency_packages || '{}' }}" in read_matrix
     assert read_matrix.count("git ls-remote https://github.com/pfBlockerNG/FreeBSD-ports") == 1
     builder_checkout = extract_step(release, "Check out pinned dependency-builder source")
-    assert "uses: actions/checkout@v6" in builder_checkout
+    assert "uses: actions/checkout@v7" in builder_checkout
     assert (
         "ref: ${{ github.event.inputs.source == 'release/3.3' && github.workflow_sha || "
         "steps.destinations.outputs.source_sha }}" in builder_checkout

--- a/tests/test_ui_release_gate_wiring.py
+++ b/tests/test_ui_release_gate_wiring.py
@@ -532,7 +532,7 @@ def test_release_dependency_builder_receives_structured_reproducibility_inputs()
     assert build_steps.index(extras) < build_steps.index(setup) < build_steps.index(sync)
     assert setup["if"] == "steps.extras.outputs.extra_pkgs != '[]'"
     assert sync["if"] == "steps.extras.outputs.extra_pkgs != '[]'"
-    assert pinned_builder["uses"] == "actions/checkout@v6"
+    assert pinned_builder["uses"] == "actions/checkout@v7"
     assert pinned_builder["with"]["ref"] == (
         "${{ github.event.inputs.source == 'release/3.3' && github.workflow_sha || "
         "steps.destinations.outputs.source_sha }}"


### PR DESCRIPTION
## Summary

- update every `actions/checkout@v6` reference to `actions/checkout@v7`
- update every `astral-sh/setup-uv@v7` reference to `astral-sh/setup-uv@v10.0.1`
- add a YAML-parsed whole-workflow version contract covering exact and hostile scalar forms

## Verification

Primary RED command:

`uv run pytest tests/test_ci_checkout_persist_credentials.py tests/test_ci_graphify_merge_driver.py tests/test_issue2143_callback_destinations.py tests/test_issue2231_workflow_hygiene.py tests/test_issue2245_stateless_nightly.py tests/test_release_ci_path_consistency.py tests/test_ui_release_gate_wiring.py`

| Frozen RED test | git hash-object | RED run tail |
| --- | --- | --- |
| `tests/test_ci_action_version_guard.py` | `789f8703233cd271182f4a378ba49cb344f24655` | hostile and valid YAML-shape rows failed under the text scanner |
| `tests/test_ci_checkout_persist_credentials.py` | `97e2d718ce040b9b03a289a30046fce530e644c7` | final YAML-parsed broad contract rejected all 83 restored retired pins |
| `tests/test_ci_graphify_merge_driver.py` | `12b6860e03cbb0b12b4054db39248dbd3686ab05` | Graphify checkout and setup-uv contracts failed on retired pins |
| `tests/test_issue2143_callback_destinations.py` | `d50a6b9dfa3aafa7b6af9de9fc463604ce0b95bb` | `test_published_callback_uses_full_history_for_branch_ancestry` failed |
| `tests/test_issue2231_workflow_hygiene.py` | `cc7abac028c9d23280d4c2dbf7097af50f5a7896` | primary RED run completed with six expected failures |
| `tests/test_issue2245_stateless_nightly.py` | `0a961e59ecb9d3970eb0866ec4570ac5887a0a2f` | primary RED run completed with six expected failures |
| `tests/test_release_ci_path_consistency.py` | `94d8b198cdce37065553955e84d73f2967247b92` | `test_issue_2387_tagged_build_uses_one_pinned_route_and_ports_identity` failed |
| `tests/test_ui_release_gate_wiring.py` | `22a4437e2d87e4b012a68d41904504bc7ab741c3` | `test_release_dependency_builder_receives_structured_reproducibility_inputs` failed |

- Primary RED: 6 failed, 237 passed; unchanged-hash GREEN: 243 passed.
- Final scanner RED: 2 failed; unchanged-hash GREEN: 9 passed.
- Final focused workflow contracts: 245 passed.
- `actionlint`; Ruff check and format check; mypy passed.
- Full local canonical pytest: 5,835 passed, 2 skipped, 1 unrelated Node 26 JUnit-format failure tracked by #2983.
- Repository-wide searches confirm zero retired action pins.

Fixes #3027

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated workflows to use newer, pinned versions of checkout and Python environment setup actions.
  * Improved consistency and security across build, test, release, refresh, and validation workflows.

* **Tests**
  * Added coverage to validate action version pins and checkout credential settings.
  * Updated workflow test fixtures and expectations for the newer action versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->