### PR TITLE
Release: pass explicit live smoke concurrency keys

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -507,6 +507,7 @@ jobs:
     with:
       pytest_marker: repo
       pytest_filter: test_install_from_live_nightly_url
+      concurrency_key: nightly
       smoke_nightly_live_url: http://pkg.pfblockerng.com/nightly
       smoke_nightly_expected_source_sha: ${{ needs.prepare.outputs.source_sha }}
       smoke_nightly_expected_version: ${{ needs.prepare.outputs.pkg_version }}

--- a/.github/workflows/pkg-tagged-ingest.yml
+++ b/.github/workflows/pkg-tagged-ingest.yml
@@ -153,6 +153,7 @@ jobs:
       extra_pkgs: ${{ toJson(matrix.extra_pkgs) }}
       pytest_marker: repo
       pytest_filter: test_install_from_live_pages_url
+      concurrency_key: ${{ matrix.channel }}
       smoke_repo_live_url: http://pkg.pfblockerng.com/${{ needs.stage-pkg.outputs.staging_prefix }}/${{ matrix.channel }}
       smoke_repo_expected_source_sha: ${{ inputs.source_sha }}
       smoke_repo_expected_version: ${{ inputs.portversion }}

--- a/.github/workflows/smoke-single.yml
+++ b/.github/workflows/smoke-single.yml
@@ -199,6 +199,11 @@ on:
         required: false
         type: string
         default: "1"
+      concurrency_key:
+        description: "Short caller-supplied concurrency identity for live gates; non-live callers share the default."
+        required: false
+        type: string
+        default: "non-live"
       smoke_nightly_live_url:
         description: "Live nightly Pages base URL for test_install_from_live_nightly_url. Blank -> SKIP."
         required: false
@@ -278,7 +283,7 @@ permissions:
   packages: read
 
 concurrency:
-  group: ${{ inputs.smoke_repo_live_url || inputs.smoke_nightly_live_url || 'non-live' }}-${{ github.workflow }}-${{ inputs.image_name }}-${{ inputs.pfsense_version }}-${{ inputs.shard }}-${{ inputs.checkout_ref || github.ref }}
+  group: ${{ inputs.concurrency_key || 'non-live' }}-${{ github.workflow }}-${{ inputs.image_name }}-${{ inputs.pfsense_version }}-${{ inputs.shard }}-${{ inputs.checkout_ref || github.ref }}
   cancel-in-progress: false
 
 jobs:

--- a/tests/test_issue2456_pkg_ownership.py
+++ b/tests/test_issue2456_pkg_ownership.py
@@ -140,14 +140,29 @@ class SourcePublicationBoundaryTests(unittest.TestCase):
         self.assertLess(NIGHTLY.index("test_install_from_live_nightly_url"), NIGHTLY.index("operation=nightly-cleanup"))
 
     def test_live_catalogue_routes_are_part_of_smoke_concurrency_identity(self) -> None:
-        concurrency = yaml.safe_load(SMOKE_SINGLE)["concurrency"]
-        route_expression = "${{ inputs.smoke_repo_live_url || inputs.smoke_nightly_live_url || 'non-live' }}"
+        smoke = yaml.safe_load(SMOKE_SINGLE)
+        triggers = smoke[True]  # PyYAML 1.1 resolves the plain `on` key to True.
+        concurrency_input = triggers["workflow_call"]["inputs"]["concurrency_key"]
+        self.assertIs(concurrency_input["required"], False)
+        self.assertEqual(concurrency_input["type"], "string")
+        self.assertEqual(concurrency_input["default"], "non-live")
+        self.assertNotIn("concurrency_key", triggers["workflow_dispatch"]["inputs"])
+
+        concurrency = smoke["concurrency"]
+        key_expression = "${{ inputs.concurrency_key || 'non-live' }}"
         shared_axes = (
             "${{ github.workflow }}-${{ inputs.image_name }}-${{ inputs.pfsense_version }}-"
             "${{ inputs.shard }}-${{ inputs.checkout_ref || github.ref }}"
         )
-        self.assertEqual(concurrency["group"], f"{route_expression}-{shared_axes}")
+        self.assertEqual(concurrency["group"], f"{key_expression}-{shared_axes}")
         self.assertIs(concurrency["cancel-in-progress"], False)
+
+        tagged_inputs = yaml.safe_load(TAGGED.read_text(encoding="utf-8"))["jobs"]["validate-live-pages-install"][
+            "with"
+        ]
+        nightly_inputs = yaml.safe_load(NIGHTLY)["jobs"]["validate-live-pages-install"]["with"]
+        self.assertEqual(tagged_inputs["concurrency_key"], "${{ matrix.channel }}")
+        self.assertEqual(nightly_inputs["concurrency_key"], "nightly")
 
     def test_tagged_finalize_depends_on_the_live_gate_and_discards_failure(self) -> None:
         tagged = TAGGED.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

- add a short explicit `concurrency_key` to the reusable `workflow_call` surface
- pass `matrix.channel` for tagged stable/testing/edge gates and `nightly` for Nightly
- keep direct dispatch within GitHub's 25-input limit; direct/non-live runs use the group fallback
- keep live URLs for transport while non-live callers retain `non-live`

## Evidence

| Frozen RED test | git hash-object | RED run tail |
| --- | --- | --- |
| `tests/test_issue2456_pkg_ownership.py` | `2f0722031540572ad98b71a80ed62f11e5b33fad` | `explicit-key RED plus dispatch-capacity RED: workflow lacked key, then exceeded GitHub's 25-input limit` |

- runs 33451468403, 33454563081, and 33456765915 each cancelled exactly four zero-second builds despite baseline, URL-suffix, and URL-prefix groups; every started live gate passed
- runtime disproved URL-derived concurrency identity at called-workflow evaluation
- GREEN: 14 focused publication-boundary tests passed; actionlint passed
- independent Codex verifier: PASS; reusable input, tagged/Nightly callers, fallback/default, wrong type, hardcoded stable, URL regression, and cancel flag mutations covered

Refs #3004

🤖 Generated by Oh My Pi and posted on behalf of @andrebrait.