### PR TITLE
Release: distinguish nested live build artifacts

### DIFF
--- a/.github/workflows/smoke-single.yml
+++ b/.github/workflows/smoke-single.yml
@@ -129,7 +129,7 @@ on:
         required: false
         default: "[]"
       dep_artifact:
-        description: "Name of a pre-built dep-pkgs artifact to download instead of building one here. The smoke.yml fan-out composes this (same pattern as pkg_artifact); blank = this workflow's own build-pkg job built it (self-build path), named pfBlockerNG-deppkgs-<image_name>-<pfsense_version>-s<shard>."
+        description: "Name of a pre-built dep-pkgs artifact to download instead of building one here. The smoke.yml fan-out composes this (same pattern as pkg_artifact); blank = this workflow's own build-pkg job built it (self-build path), named pfBlockerNG-deppkgs-<concurrency_key-or-non-live>-<image_name>-<pfsense_version>-s<shard>."
         required: false
         default: ""
       checkout_ref:
@@ -260,7 +260,7 @@ on:
         type: string
         default: "[]"
       dep_artifact:
-        description: "Name of a pre-built dep-pkgs artifact to download instead of building one here. The smoke.yml fan-out composes this (same pattern as pkg_artifact); blank = this workflow's own build-pkg job built it (self-build path), named pfBlockerNG-deppkgs-<image_name>-<pfsense_version>-s<shard>."
+        description: "Name of a pre-built dep-pkgs artifact to download instead of building one here. The smoke.yml fan-out composes this (same pattern as pkg_artifact); blank = this workflow's own build-pkg job built it (self-build path), named pfBlockerNG-deppkgs-<concurrency_key-or-non-live>-<image_name>-<pfsense_version>-s<shard>."
         required: false
         type: string
         default: ""
@@ -329,7 +329,7 @@ jobs:
       # artifact_name input; the dep download below repeats the dep literal), so the
       # major-collapse naming that matters for cross-workflow/cross-run consumers
       # (release.yml/smoke.yml) buys nothing here.
-      artifact_name: pfBlockerNG-pkg-${{ inputs.image_name }}-${{ inputs.pfsense_version }}-s${{ inputs.shard }}
+      artifact_name: pfBlockerNG-pkg-${{ inputs.concurrency_key || 'non-live' }}-${{ inputs.image_name }}-${{ inputs.pfsense_version }}-s${{ inputs.shard }}
       # Optional Option-A validation: point the .pkg build at a FreeBSD-ports branch
       # carrying a new plist entry. Blank -> build-pkg-linux's own defaults
       # (pfBlockerNG/FreeBSD-ports @ pfblockerng/use-github), so a normal run is unchanged.
@@ -341,11 +341,10 @@ jobs:
       # uploads its dep artifact, which the "Download dep packages" step below
       # (same workflow, same run) then downloads.
       extra_pkgs: ${{ inputs.extra_pkgs }}
-      # W1: mirror artifact_name's OWN discriminator (image_name + pfsense_version + shard) — this
-      # build-pkg job's matrix (indirectly, one invocation per caller-side leg)
-      # can share a run with sibling invocations of THIS reusable workflow (e.g.
-      # repo-install.yml's fan-out); the plain per-major default would collide.
-      dep_artifact_name: pfBlockerNG-deppkgs-${{ inputs.image_name }}-${{ inputs.pfsense_version }}-s${{ inputs.shard }}
+      # W1: mirror artifact_name's route + image + version + shard identity.
+      # Sibling channels share a run, so route-blind names collide in the
+      # nested build workflow.
+      dep_artifact_name: pfBlockerNG-deppkgs-${{ inputs.concurrency_key || 'non-live' }}-${{ inputs.image_name }}-${{ inputs.pfsense_version }}-s${{ inputs.shard }}
 
   smoke:
     name: pytest -m smoke (live pfSense VM)
@@ -612,7 +611,7 @@ jobs:
         if: ${{ inputs.extra_pkgs != '' && inputs.extra_pkgs != '[]' }}
         uses: actions/download-artifact@v7
         with:
-          name: ${{ inputs.dep_artifact != '' && inputs.dep_artifact || format('pfBlockerNG-deppkgs-{0}-{1}-s{2}', inputs.image_name, inputs.pfsense_version, inputs.shard) }}
+          name: ${{ inputs.dep_artifact != '' && inputs.dep_artifact || format('pfBlockerNG-deppkgs-{0}-{1}-{2}-s{3}', inputs.concurrency_key || 'non-live', inputs.image_name, inputs.pfsense_version, inputs.shard) }}
           path: deppkgs
 
       - name: Export SMOKE_DEP_PKGS

--- a/tests/test_issue2453_smoke_single_artifact_names.py
+++ b/tests/test_issue2453_smoke_single_artifact_names.py
@@ -1,10 +1,12 @@
-"""Pin issue #2453: smoke-single.yml's self-build (pkg_artifact blank) path must key its
-pkg / dep-pkgs artifact names on pfsense_version too, not only image_name + shard.
+"""Pin issue #2453: smoke-single.yml's self-build path must key pkg / dep-pkgs
+artifact names on live route and pfsense_version, not only image_name + shard.
 
 repo-install.yml fans smoke-single.yml out over the ci-metadata matrix, and CE 2.8 / CE 2.9
 share image_name=pfsense-ce (Plus legs share pfsense-plus). With image_name-only names two
 per-version legs of ONE run upload the same artifact name and the CE 2.9 leg can download the
 CE 2.8 (FreeBSD:15) .pkg -> `pkg: wrong architecture: FreeBSD:15:* instead of FreeBSD:16:amd64`.
+Tagged publication also runs stable/testing/edge siblings for one version, so their nested
+build artifacts need the explicit route key used by build-pkg-linux concurrency.
 """
 
 from __future__ import annotations
@@ -14,9 +16,14 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 SMOKE_SINGLE_WORKFLOW = ROOT / ".github/workflows/smoke-single.yml"
 
-PKG_NAME = "pfBlockerNG-pkg-${{ inputs.image_name }}-${{ inputs.pfsense_version }}-s${{ inputs.shard }}"
-DEP_NAME = "pfBlockerNG-deppkgs-${{ inputs.image_name }}-${{ inputs.pfsense_version }}-s${{ inputs.shard }}"
-DEP_DOWNLOAD = "format('pfBlockerNG-deppkgs-{0}-{1}-s{2}', inputs.image_name, inputs.pfsense_version, inputs.shard)"
+ROUTE_KEY = "${{ inputs.concurrency_key || 'non-live' }}"
+ARTIFACT_AXES = "${{ inputs.image_name }}-${{ inputs.pfsense_version }}-s${{ inputs.shard }}"
+PKG_NAME = f"pfBlockerNG-pkg-{ROUTE_KEY}-{ARTIFACT_AXES}"
+DEP_NAME = f"pfBlockerNG-deppkgs-{ROUTE_KEY}-{ARTIFACT_AXES}"
+DEP_DOWNLOAD = (
+    "format('pfBlockerNG-deppkgs-{0}-{1}-{2}-s{3}', inputs.concurrency_key || 'non-live', "
+    "inputs.image_name, inputs.pfsense_version, inputs.shard)"
+)
 
 
 def _lines() -> list[str]:
@@ -63,9 +70,11 @@ def test_legacy_forms_are_what_the_pre_fix_workflow_carried() -> None:
     a typo in a legacy pattern cannot turn the sweep vacuous."""
     text = SMOKE_SINGLE_WORKFLOW.read_text(encoding="utf-8")
     pre_fix = (
-        text.replace("-${{ inputs.pfsense_version }}-s${{", "-s${{")
+        text.replace(f"pfBlockerNG-pkg-{ROUTE_KEY}-", "pfBlockerNG-pkg-")
+        .replace(f"pfBlockerNG-deppkgs-{ROUTE_KEY}-", "pfBlockerNG-deppkgs-")
+        .replace("-${{ inputs.pfsense_version }}-s${{", "-s${{")
         .replace(DEP_DOWNLOAD, "format('pfBlockerNG-deppkgs-{0}-s{1}', inputs.image_name, inputs.shard)")
-        .replace("<image_name>-<pfsense_version>-s<shard>", "<image_name>-s<shard>")
+        .replace("<concurrency_key-or-non-live>-<image_name>-<pfsense_version>-s<shard>", "<image_name>-s<shard>")
     )
     assert pre_fix != text
     for legacy in LEGACY_FORMS:

--- a/tests/test_issue2456_pkg_ownership.py
+++ b/tests/test_issue2456_pkg_ownership.py
@@ -157,6 +157,35 @@ class SourcePublicationBoundaryTests(unittest.TestCase):
         self.assertEqual(concurrency["group"], f"{key_expression}-{shared_axes}")
         self.assertIs(concurrency["cancel-in-progress"], False)
 
+        build_inputs = smoke["jobs"]["build-pkg"]["with"]
+        artifact_axes = "${{ inputs.image_name }}-${{ inputs.pfsense_version }}-s${{ inputs.shard }}"
+        self.assertEqual(build_inputs["artifact_name"], f"pfBlockerNG-pkg-{key_expression}-{artifact_axes}")
+        self.assertEqual(build_inputs["dep_artifact_name"], f"pfBlockerNG-deppkgs-{key_expression}-{artifact_axes}")
+
+        nested_build = yaml.safe_load((WORKFLOWS / "build-pkg-linux.yml").read_text(encoding="utf-8"))
+        self.assertEqual(
+            nested_build["concurrency"]["group"],
+            "${{ github.workflow }}-${{ inputs.artifact_name }}-${{ github.ref }}",
+        )
+        pkg_download = next(
+            step
+            for step in smoke["jobs"]["smoke"]["steps"]
+            if step.get("name") == "Download the built pfBlockerNG package"
+        )
+        self.assertEqual(
+            pkg_download["with"]["name"],
+            "${{ inputs.pkg_artifact != '' && inputs.pkg_artifact || needs.build-pkg.outputs.artifact }}",
+        )
+        dep_download = next(
+            step for step in smoke["jobs"]["smoke"]["steps"] if step.get("name") == "Download dep packages"
+        )
+        self.assertEqual(
+            dep_download["with"]["name"],
+            "${{ inputs.dep_artifact != '' && inputs.dep_artifact || "
+            "format('pfBlockerNG-deppkgs-{0}-{1}-{2}-s{3}', inputs.concurrency_key || 'non-live', "
+            "inputs.image_name, inputs.pfsense_version, inputs.shard) }}",
+        )
+
         tagged_inputs = yaml.safe_load(TAGGED.read_text(encoding="utf-8"))["jobs"]["validate-live-pages-install"][
             "with"
         ]


### PR DESCRIPTION
## Summary

- add the explicit live-route key to nested package and dependency artifact names
- make `build-pkg-linux` concurrency distinguish stable/testing/edge siblings through `inputs.artifact_name`
- keep package and dependency producer/consumer identities exact

## Evidence

| Frozen RED test | git hash-object | RED run tail |
| --- | --- | --- |
| `tests/test_issue2456_pkg_ownership.py` | `9738a61a1f9ecaf2fdf038da59e7c24069402551` | `route-blind producer/consumer RED on parent` |
| `tests/test_issue2453_smoke_single_artifact_names.py` | `21eb981ad6f78b0dc0eee985fa003c7bdd9b9b00` | `pre-update contract: 4 failed when artifact names gained route identity` |

- run 33459034962 used explicit parent concurrency keys but still cancelled exactly four nested `build-pkg` jobs; every started live gate passed
- nested `build-pkg-linux.yml` concurrency keys on `inputs.artifact_name`; prior smoke artifact names were route-blind
- GREEN: 19 focused artifact/publication contract tests passed; actionlint passed
- package consumer follows `needs.build-pkg.outputs.artifact`; dependency keyed fallback is character-identical to its producer
- independent Codex verifier: PASS after producer/consumer fix; main/dep producer, main/dep consumer, fallback, nested linkage, and route mutants covered

Refs #3004

🤖 Generated by Oh My Pi and posted on behalf of @andrebrait.