### PR TITLE
Release: align dependency builder with lock

### DIFF
--- a/scripts/build-dep-pkg-portable.py
+++ b/scripts/build-dep-pkg-portable.py
@@ -80,8 +80,8 @@ _REPO_ROOT = _THIS_DIR.parent
 _BUILD_TOOLCHAIN = {
     "python": "3.11.15",
     "pip": "26.2.1",
-    "setuptools": "75.6.0",
-    "wheel": "0.45.1",
+    "setuptools": "83.0.0",
+    "wheel": "0.46.2",
     "zstandard": "0.25.0",
 }
 _UV_VERSION = "0.12.6"

--- a/tests/test_build_dep_pkg_portable.py
+++ b/tests/test_build_dep_pkg_portable.py
@@ -1457,3 +1457,8 @@ def test_dependency_build_group_and_lock_use_exact_pins() -> None:
         "wheel": "0.46.2",
         "zstandard": "0.25.0",
     }
+    assert bdp._BUILD_TOOLCHAIN == {
+        "python": (root / ".python-version").read_text(encoding="utf-8").strip(),
+        **{name: versions[name] for name in ("pip", "setuptools", "wheel", "zstandard")},
+    }
+    assert bdp._UV_VERSION == versions["uv"]


### PR DESCRIPTION
## Summary

- align dependency-package runtime guards with exact setuptools and wheel versions already pinned in pyproject and uv.lock
- bind script, Python, project, lock, and uv versions in one existing parity test

## Evidence

| Frozen RED test | git hash-object | RED run tail |
| --- | --- | --- |
| `tests/test_build_dep_pkg_portable.py` | `a13ae6cfb9c12d1858d91ed10b264574447919e4` | `setuptools RED: 75.6.0 vs locked 83.0.0; rebased wheel RED: 0.45.1 vs locked 0.46.2` |

- run 33462423266 started all 12 nested builds; all six Plus empty-extra builds passed, while all six CE dependency builds failed at the stale setuptools guard
- concurrent devel advanced wheel to 0.46.2; the frozen parity test caught the same stale runtime-guard class during rebase
- pyproject and uv.lock exact-pin setuptools 83.0.0 and wheel 0.46.2
- GREEN: eight focused toolchain parity/drift tests passed
- independent Codex verifier: PASS; isolated locked environment validated Python and exact tool versions before rebase; post-rebase parity rerun passed

Refs #3004

🤖 Generated by Oh My Pi and posted on behalf of @andrebrait.