### PR TITLE
tests: make dependency pin guard version-agnostic

### DIFF
--- a/tests/test_build_dep_pkg_portable.py
+++ b/tests/test_build_dep_pkg_portable.py
@@ -30,6 +30,7 @@ from typing import Any
 
 import pfb_pkg
 import pytest
+from packaging.version import Version
 
 from scripts import tagged_release_handoff as trh
 from tests.gitenv import scrubbed_git_env
@@ -1441,22 +1442,27 @@ def test_dependency_build_group_and_lock_use_exact_pins() -> None:
     root = bdp._REPO_ROOT
     assert (root / ".python-version").read_text(encoding="utf-8") == "3.11.15\n"
     project = tomllib.loads((root / "pyproject.toml").read_text(encoding="utf-8"))
-    assert project["dependency-groups"]["dep-pkg-build"] == [
-        "pip==26.2.1",
-        "setuptools==83.0.0",
-        "wheel==0.46.2",
-        "zstandard==0.25.0",
-        "uv==0.12.6",
-    ]
+    pins: dict[str, str] = {}
+    for requirement in project["dependency-groups"]["dep-pkg-build"]:
+        name, separator, version = requirement.partition("==")
+        assert separator and name and version, f"{requirement!r} is not an exact == pin"
+        assert name not in pins, f"duplicate dep-pkg-build pin: {name}"
+        assert not any(char.isspace() for char in version), f"{requirement!r} is not an exact == pin"
+        pins[name] = str(Version(version))
+    assert set(pins) == {"pip", "setuptools", "uv", "wheel", "zstandard"}
+
     lock = tomllib.loads((root / "uv.lock").read_text(encoding="utf-8"))
-    versions = {package["name"]: package["version"] for package in lock["package"]}
-    assert {name: versions[name] for name in ("pip", "setuptools", "uv", "wheel", "zstandard")} == {
-        "pip": "26.2.1",
-        "setuptools": "83.0.0",
-        "uv": "0.12.6",
-        "wheel": "0.46.2",
-        "zstandard": "0.25.0",
+    root_package = next(package for package in lock["package"] if package["name"] == project["project"]["name"])
+    locked_dependencies = root_package["dev-dependencies"]["dep-pkg-build"]
+    assert len(locked_dependencies) == len(pins)
+    assert {dependency["name"] for dependency in locked_dependencies} == set(pins)
+    locked_requirements = root_package["metadata"]["requires-dev"]["dep-pkg-build"]
+    assert len(locked_requirements) == len(pins)
+    assert {requirement["name"]: requirement["specifier"] for requirement in locked_requirements} == {
+        name: f"=={version}" for name, version in pins.items()
     }
+    versions = {package["name"]: package["version"] for package in lock["package"]}
+    assert {name: versions[name] for name in pins} == pins
     assert bdp._BUILD_TOOLCHAIN == {
         "python": (root / ".python-version").read_text(encoding="utf-8").strip(),
         **{name: versions[name] for name in ("pip", "setuptools", "wheel", "zstandard")},


### PR DESCRIPTION
## Summary

- Derive `dep-pkg-build` versions from `pyproject.toml` instead of duplicating version literals in the guard.
- Keep the exact five-package set across both project and lock dependency membership.
- Require lock metadata specifiers and resolved versions to match canonical PEP 440 project pins.
- Continue rejecting ranges, compatible-release specifiers, wildcards, markers, malformed versions, and duplicate package pins.

Follow-up to #3025.

## Verification

- RED: changed the lock membership from `wheel` to `packaging`; the unchanged guard failed with `packaging` extra and `wheel` missing.
- GREEN: restored `wheel`; the same guard passed. Final test-file hash remained `454678aec1a0e10d9dfbe33c3ae979116bf848b2` across RED and GREEN.
- Positive normalization: changed the project pin to `wheel==0.046.2` while the lock retained canonical `0.46.2`; `uv lock --check` and the unchanged guard both passed.
- `uv run --locked --python 3.11 pytest tests/test_build_dep_pkg_portable.py -q`: 77 passed.
- Ruff check/format and mypy passed.
- Full local pytest has one pre-existing Node 26.8.1 JUnit suite-name failure reproduced unchanged on `origin/devel`; tracked by #2983. CI remains authoritative.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved dependency validation coverage by parsing declared package requirements directly.
  * Added checks that development dependencies use exact, unique version pins with consistent lockfile metadata.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->