### PR TITLE
pfblockerng: tell a feed-pass acquisition error apart from contention

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -7987,11 +7987,9 @@ function pfb_alerts_ip_action($action, string $ip, string $table, string $descr,
 				$savemsg2 = ' : An update/reload pass is currently in progress, suppression will apply at the next reload';
 				break;
 			case 'lock_error':
-				// Wording mirrors the 'busy' arm's shape: the caller splices
-				// " and added to the ... customlist" onto the end of this string,
-				// so it must read as a clause that a conjunction can follow.
-				$savemsg2 = ' : The feed-pass lock could not be acquired (see the pfBlockerNG log),'
-					. ' suppression will apply at the next reload';
+				$savemsg2 = "Host IP address {$ip} was added to the IPv{$family} Suppression customlist, "
+					. 'but live suppression was deferred because the feed-pass lock could not be acquired; '
+					. 'see the pfBlockerNG log. It will apply at the next reload.';
 				break;
 			default:
 				$savemsg2 = " : Live punch failed [ {$apply['fail']} ], suppression will still apply at the next reload";
@@ -8015,7 +8013,9 @@ function pfb_alerts_ip_action($action, string $ip, string $table, string $descr,
 			if (!empty($descr)) {
 				$supp_dat .= " # {$descr}";
 			}
-			$result['savemsg'] = gettext("Host IP address {$ip}") . gettext($savemsg2) . gettext(" and added to the IPv{$family} Suppression customlist.");
+			$result['savemsg'] = $apply['status'] === 'lock_error'
+				? gettext($savemsg2)
+				: gettext("Host IP address {$ip}") . gettext($savemsg2) . gettext(" and added to the IPv{$family} Suppression customlist.");
 			$data = '';
 			foreach ($supp_data as $line) {
 				$data .= "{$line}";

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -6292,6 +6292,7 @@ function pfblockerng_tick(
 			|| !is_resource($GLOBALS['pfb_schedule_dispatch_lock']);
 		$feed_pass_owner = !isset($GLOBALS['pfb_feed_pass_lock'])
 			|| !is_resource($GLOBALS['pfb_feed_pass_lock']);
+		$pfb_tick_contended = FALSE;
 		if (!pfb_schedule_dispatch_begin()) {
 			logger(LOG_INFO, localize_text('Tick: scheduled work deferred (another tick is running).'), LOG_PREFIX_PKG_PFBLOCKERNG);
 		} elseif (!pfb_feed_pass_begin('scheduled', $pfb_tick_contended)) {
@@ -7986,8 +7987,11 @@ function pfb_alerts_ip_action($action, string $ip, string $table, string $descr,
 				$savemsg2 = ' : An update/reload pass is currently in progress, suppression will apply at the next reload';
 				break;
 			case 'lock_error':
-				$savemsg2 = ' : The feed-pass lock could not be acquired, suppression will apply at the next reload'
-					. ' -- see the pfBlockerNG log; retrying will not clear this';
+				// Wording mirrors the 'busy' arm's shape: the caller splices
+				// " and added to the ... customlist" onto the end of this string,
+				// so it must read as a clause that a conjunction can follow.
+				$savemsg2 = ' : The feed-pass lock could not be acquired (see the pfBlockerNG log),'
+					. ' suppression will apply at the next reload';
 				break;
 			default:
 				$savemsg2 = " : Live punch failed [ {$apply['fail']} ], suppression will still apply at the next reload";

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -5675,7 +5675,13 @@ function pfb_schedule_cache_regenerate(): bool
 	}
 	$feed_pass_owner = !isset($GLOBALS['pfb_feed_pass_lock'])
 		|| !is_resource($GLOBALS['pfb_feed_pass_lock']);
-	if (!pfb_feed_pass_begin('schedule-cache')) {
+	$contended = FALSE;
+	if (!pfb_feed_pass_begin('schedule-cache', $contended)) {
+		// issue #3012: begin() logs its own skip line only for contention, so an
+		// acquisition error would otherwise leave no record naming schedule cache regeneration.
+		if (!$contended) {
+			pfb_logger("\n Schedule cache regeneration skipped: the feed pass lock could not be acquired.\n", 1);
+		}
 		if ($dispatch_owner) {
 			pfb_schedule_dispatch_release();
 		}
@@ -5707,7 +5713,13 @@ function pfb_extras_process_begin(): bool
 			LOG_PREFIX_PKG_PFBLOCKERNG);
 		return FALSE;
 	}
-	if (!pfb_feed_pass_begin('extras')) {
+	$contended = FALSE;
+	if (!pfb_feed_pass_begin('extras', $contended)) {
+		// issue #3012: begin() logs its own skip line only for contention, so an
+		// acquisition error would otherwise leave no record naming extras processing.
+		if (!$contended) {
+			pfb_logger("\n Extras processing skipped: the feed pass lock could not be acquired.\n", 1);
+		}
 		if ($dispatch_owner) {
 			pfb_schedule_dispatch_release();
 		}
@@ -6282,8 +6294,11 @@ function pfblockerng_tick(
 			|| !is_resource($GLOBALS['pfb_feed_pass_lock']);
 		if (!pfb_schedule_dispatch_begin()) {
 			logger(LOG_INFO, localize_text('Tick: scheduled work deferred (another tick is running).'), LOG_PREFIX_PKG_PFBLOCKERNG);
-		} elseif (!pfb_feed_pass_begin('scheduled')) {
-			logger(LOG_INFO, localize_text('Tick: scheduled work deferred (another feed pass is running).'), LOG_PREFIX_PKG_PFBLOCKERNG);
+		} elseif (!pfb_feed_pass_begin('scheduled', $pfb_tick_contended)) {
+			logger(LOG_INFO, $pfb_tick_contended
+				? localize_text('Tick: scheduled work deferred (another feed pass is running).')
+				: localize_text('Tick: scheduled work skipped -- the feed-pass lock could not be acquired; see the pfBlockerNG log.'),
+				LOG_PREFIX_PKG_PFBLOCKERNG);
 			if ($dispatch_owner) {
 				pfb_schedule_dispatch_release();
 			}
@@ -7844,7 +7859,10 @@ function pfb_pfctl_checked_op(string $pfctl, string $table, string $op, string $
  * @param  string $table    The pf table name (caller-validated).
  * @param  string $ip       The host to carve out (v4 or v6).
  * @return array{status: string, fail: ?string, del_cnt: int, add_cnt: int}
- *         status is one of 'applied'|'not_blocked'|'busy'|'failed'; 'fail'
+ *         status is one of 'applied'|'not_blocked'|'busy'|'lock_error'|'failed';
+ *         'busy' is contention (another pass holds the feed lock) while
+ *         'lock_error' is an acquisition failure that retrying will not clear
+ *         (issue #3012); 'fail'
  *         names the cause for 'failed' (NULL otherwise, prefixed
  *         "snapshot: " for a capture failure); the counts are 0 outside
  *         'applied'.
@@ -7852,8 +7870,12 @@ function pfb_pfctl_checked_op(string $pfctl, string $table, string $op, string $
 function pfb_live_punch_run(string $pfctl, string $aliasdir, string $dbdir, string $table, string $ip): array {
 	$was_held = isset($GLOBALS['pfb_feed_pass_lock']) && is_resource($GLOBALS['pfb_feed_pass_lock']);
 
-	if (!pfb_feed_pass_acquire()) {
-		return ['status' => 'busy', 'fail' => NULL, 'del_cnt' => 0, 'add_cnt' => 0];
+	$contended = FALSE;
+	if (!pfb_feed_pass_acquire($contended)) {
+		// issue #3012: contention and an acquisition error are different outcomes.
+		// Only the first is worth retrying, and only the caller can word that.
+		return ['status' => $contended ? 'busy' : 'lock_error',
+			'fail' => NULL, 'del_cnt' => 0, 'add_cnt' => 0];
 	}
 
 	try {
@@ -7963,6 +7985,10 @@ function pfb_alerts_ip_action($action, string $ip, string $table, string $descr,
 			case 'busy':
 				$savemsg2 = ' : An update/reload pass is currently in progress, suppression will apply at the next reload';
 				break;
+			case 'lock_error':
+				$savemsg2 = ' : The feed-pass lock could not be acquired, suppression will apply at the next reload'
+					. ' -- see the pfBlockerNG log; retrying will not clear this';
+				break;
 			default:
 				$savemsg2 = " : Live punch failed [ {$apply['fail']} ], suppression will still apply at the next reload";
 				break;
@@ -8019,6 +8045,10 @@ function pfb_alerts_ip_action($action, string $ip, string $table, string $descr,
 			case 'busy':
 				$result['savemsg'] = "Table [ {$table} ] is mid-update -- please retry the Unlock once the current run finishes.";
 				break;
+			case 'lock_error':
+				$result['savemsg'] = "Table [ {$table} ] could not be updated: the feed-pass lock could not be acquired -- "
+					. "see the pfBlockerNG log. Retrying will not clear this.";
+				break;
 			default:
 				$result['savemsg'] = "The live unlock of IP [ {$ip} ] failed [ {$apply['fail']} ] -- table [ {$table} ] still blocks it; see the pfBlockerNG log.";
 				break;
@@ -8028,8 +8058,12 @@ function pfb_alerts_ip_action($action, string $ip, string $table, string $descr,
 
 	if ($action === 'lock') {
 		$was_held = isset($GLOBALS['pfb_feed_pass_lock']) && is_resource($GLOBALS['pfb_feed_pass_lock']);
-		if (!pfb_feed_pass_acquire()) {
-			$result['savemsg'] = "Table [ {$table} ] is mid-update -- please retry the re-lock once the current run finishes.";
+		$contended = FALSE;
+		if (!pfb_feed_pass_acquire($contended)) {
+			$result['savemsg'] = $contended
+				? "Table [ {$table} ] is mid-update -- please retry the re-lock once the current run finishes."
+				: "Table [ {$table} ] could not be updated: the feed-pass lock could not be acquired -- "
+					. "see the pfBlockerNG log. Retrying will not clear this.";
 			return $result;
 		}
 
@@ -8066,8 +8100,12 @@ function pfb_alerts_ip_action($action, string $ip, string $table, string $descr,
 		}
 
 		$was_held = isset($GLOBALS['pfb_feed_pass_lock']) && is_resource($GLOBALS['pfb_feed_pass_lock']);
-		if (!pfb_feed_pass_acquire()) {
-			$result['savemsg'] = "Table [ {$table} ] is mid-update -- please retry adding [ {$ip} ] to the Permit Alias once the current run finishes.";
+		$contended = FALSE;
+		if (!pfb_feed_pass_acquire($contended)) {
+			$result['savemsg'] = $contended
+				? "Table [ {$table} ] is mid-update -- please retry adding [ {$ip} ] to the Permit Alias once the current run finishes."
+				: "The add of [ {$ip} ] to table [ {$table} ] could not start: the feed-pass lock could not be "
+					. "acquired -- see the pfBlockerNG log. Retrying will not clear this.";
 			return $result;
 		}
 

--- a/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
@@ -1314,9 +1314,12 @@ if (isset($_POST) && !empty($_POST)) {
 				$match = pfb_ip_suppressed_match($ip, array_keys($clists[$supp_key]['data']));
 				if ($match !== NULL) {
 					$was_held = isset($GLOBALS['pfb_feed_pass_lock']) && is_resource($GLOBALS['pfb_feed_pass_lock']);
-					if (!pfb_feed_pass_acquire()) {
+					$pfb_contended = FALSE;
+					if (!pfb_feed_pass_acquire($pfb_contended)) {
 						$pfb_found = FALSE;
-						$savemsg = "Table [ {$table} ] is mid-update -- please retry removing [ {$match} ] from the {$type} customlist once the current run finishes.";
+						$savemsg = $pfb_contended
+							? "Table [ {$table} ] is mid-update -- please retry removing [ {$match} ] from the {$type} customlist once the current run finishes."
+							: "Table [ {$table} ] could not be updated: the feed-pass lock could not be acquired -- see the pfBlockerNG log. Retrying will not clear this.";
 						break;
 					}
 
@@ -1369,9 +1372,12 @@ if (isset($_POST) && !empty($_POST)) {
 
 				if (isset($clists['ipwhitelist' . $vtype][$table_2]['data'][$ix[0]])) {
 					$was_held = isset($GLOBALS['pfb_feed_pass_lock']) && is_resource($GLOBALS['pfb_feed_pass_lock']);
-					if (!pfb_feed_pass_acquire()) {
+					$pfb_contended = FALSE;
+					if (!pfb_feed_pass_acquire($pfb_contended)) {
 						$pfb_found = FALSE;
-						$savemsg = "Table [ {$table} ] is mid-update -- please retry deleting [ {$entry} ] from the {$type} customlist once the current run finishes.";
+						$savemsg = $pfb_contended
+							? "Table [ {$table} ] is mid-update -- please retry deleting [ {$entry} ] from the {$type} customlist once the current run finishes."
+							: "Table [ {$table} ] could not be updated: the feed-pass lock could not be acquired -- see the pfBlockerNG log. Retrying will not clear this.";
 						break;
 					}
 

--- a/tests/php/AlertsPfctlCheckedSitesTest.php
+++ b/tests/php/AlertsPfctlCheckedSitesTest.php
@@ -472,6 +472,25 @@ SH
 		);
 	}
 
+	public function testDeleteIpWhitelistLockErrorKeepsEntryAndSkipsPfctlAndWrites(): void
+	{
+		$clists = ['ipwhitelist4' => ['pfB_Permit_v4' => ['base64_idx' => 0, 'data' => ['198.51.100.9' => "198.51.100.9\r\n"]]]];
+
+		$result = $this->withFeedPassLockError(
+			function () use (&$clists): array {
+				return pfb_alerts_oracle_delete_ipwhitelist("'198.51.100.9'", "'pfB_Permit_v4'", $clists);
+			}
+		);
+
+		$this->assertFalse($result['pfb_found']);
+		$this->assertStringContainsString('feed-pass lock could not be acquired', $result['savemsg']);
+		$this->assertStringNotContainsString('mid-update', $result['savemsg']);
+		$this->assertArrayHasKey('198.51.100.9', $clists['ipwhitelist4']['pfB_Permit_v4']['data']);
+		$this->assertFileDoesNotExist($this->logPath, 'an acquisition error must not call pfctl');
+		$this->assertSame([], $GLOBALS['pfb_test_write_config_calls'] ?? [],
+			'an acquisition error must not persist config');
+	}
+
 	public function testDeleteIpWhitelistBusyKeepsEntryAndSkipsPfctlAndWrites(): void
 	{
 		$clists = ['ipwhitelist4' => ['pfB_Permit_v4' => ['base64_idx' => 0, 'data' => ['198.51.100.9' => "198.51.100.9\r\n"]]]];
@@ -557,6 +576,24 @@ SH
 		$this->assertTrue($result['redirect']);
 		$this->assertFileExists($GLOBALS['pfb']['ip_unlock']);
 		$this->assertSame($before, file_get_contents($GLOBALS['pfb']['ip_unlock']));
+	}
+
+	public function testIpRemoveLockErrorKeepsUnlockStoreAndSkipsPfctl(): void
+	{
+		$ip = '198.51.100.20';
+		$before = "{$ip},pfB_Deny_v4\nkeepme.example,pfB_Keep_v4\n";
+		$ip_unlock = [$ip => 'pfB_Deny_v4', 'keepme.example' => 'pfB_Keep_v4'];
+		file_put_contents($GLOBALS['pfb']['ip_unlock'], $before);
+
+		$result = $this->withFeedPassLockError(
+			static fn (): array => pfb_alerts_ip_action('lock', $ip, 'pfB_Deny_v4', '', [], $ip_unlock)
+		);
+
+		$this->assertStringContainsString('feed-pass lock could not be acquired', $result['savemsg']);
+		$this->assertStringNotContainsString('mid-update', $result['savemsg']);
+		$this->assertTrue($result['redirect']);
+		$this->assertSame($before, file_get_contents($GLOBALS['pfb']['ip_unlock']));
+		$this->assertFileDoesNotExist($this->logPath, 'an acquisition error must not call pfctl');
 	}
 
 	public function testIpRemoveLockBusyKeepsUnlockStoreAndSkipsPfctl(): void
@@ -726,6 +763,21 @@ SH
 		$this->assertFileDoesNotExist($GLOBALS['pfb']['ip_unlock']);
 	}
 
+	public function testIpRemoveUnlockLockErrorRecordsNothingAndSkipsPfctl(): void
+	{
+		$result = $this->withFeedPassLockError(
+			static fn (): array => pfb_alerts_ip_action(
+				'unlock', '198.51.100.25', 'pfB_Deny_v4', '', [], []
+			)
+		);
+
+		$this->assertStringContainsString('feed-pass lock could not be acquired', $result['savemsg']);
+		$this->assertStringNotContainsString('mid-update', $result['savemsg']);
+		$this->assertTrue($result['redirect']);
+		$this->assertFileDoesNotExist($GLOBALS['pfb']['ip_unlock']);
+		$this->assertFileDoesNotExist($this->logPath, 'an acquisition error must not call pfctl');
+	}
+
 	public function testIpRemoveUnlockBusyRecordsNothing(): void
 	{
 		$lock = fopen("{$GLOBALS['pfb']['dbdir']}/pfb_feed_pass.lock", 'c');
@@ -774,6 +826,25 @@ SH
 			"{$GLOBALS['pfb']['permitdir']}/Whitelist_custom_v4.update",
 			'a failed add must NOT touch the cron/update flag file'
 		);
+	}
+
+	public function testIpWhiteLockErrorSkipsPfctlAndAllDurableWrites(): void
+	{
+		$table = 'pfB_Whitelist_v4';
+		$clists = ['ipwhitelist4' => [$table => ['base64_idx' => 0, 'data' => []]]];
+
+		$result = $this->withFeedPassLockError(
+			static fn (): array => pfb_alerts_ip_action('ip_white', '198.51.100.30', $table, '', $clists, [])
+		);
+
+		$this->assertStringContainsString('feed-pass lock could not be acquired', $result['savemsg']);
+		$this->assertStringNotContainsString('mid-update', $result['savemsg']);
+		$this->assertTrue($result['redirect']);
+		$this->assertFileDoesNotExist($this->logPath, 'an acquisition error must not call pfctl');
+		$this->assertFileDoesNotExist("{$GLOBALS['pfb']['aliasdir']}/{$table}.txt");
+		$this->assertArrayNotHasKey('installedpackages', $GLOBALS['config'] ?? []);
+		$this->assertSame([], $GLOBALS['pfb_test_write_config_calls'] ?? []);
+		$this->assertFileDoesNotExist("{$GLOBALS['pfb']['permitdir']}/Whitelist_custom_v4.update");
 	}
 
 	public function testIpWhiteBusySkipsPfctlAndAllDurableWrites(): void
@@ -967,6 +1038,33 @@ SH
 		$this->assertTrue($result['redirect']);
 		// issue #1723: pfb_text_area_encode() normalizes the trailing CRLF to LF.
 		$this->assertSame("198.51.100.43/32\n", base64_decode(PfbConfig::read('ip/v4suppression')));
+	}
+
+	public function testAddSuppressLockErrorPersistsDurableSuppressionAndExplainsDeferredLiveWork(): void
+	{
+		$result = $this->withFeedPassLockError(
+			static fn (): array => pfb_alerts_ip_action(
+				'addsuppress',
+				'198.51.100.44',
+				'pfB_Deny_v4',
+				'',
+				['ipsuppression' => ['data' => []]],
+				[]
+			)
+		);
+
+		$this->assertSame(
+			'Host IP address 198.51.100.44 was added to the IPv4 Suppression customlist, '
+			. 'but live suppression was deferred because the feed-pass lock could not be acquired; '
+			. 'see the pfBlockerNG log. It will apply at the next reload.',
+			$result['savemsg']
+		);
+		$this->assertStringNotContainsString('mid-update', $result['savemsg']);
+		$this->assertSame("198.51.100.44/32\n", base64_decode(PfbConfig::read('ip/v4suppression')),
+			'the durable suppression-list add must succeed even though the live punch was refused');
+		$this->assertNotEmpty($GLOBALS['pfb_test_write_config_calls'] ?? []);
+		$this->assertFileExists($GLOBALS['pfb']['supptxt']);
+		$this->assertFileDoesNotExist($this->logPath, 'an acquisition error must not call pfctl');
 	}
 
 	public function testAddSuppressBusyStillPersistsStandingSuppression(): void

--- a/tests/php/AlertsPfctlCheckedSitesTest.php
+++ b/tests/php/AlertsPfctlCheckedSitesTest.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/support/FailingFlockStream.php';
+
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 
@@ -280,6 +282,25 @@ SH
 		}
 	}
 
+	/**
+	 * The non-contended sibling of withFeedPassContention(): the lock cannot be
+	 * ACQUIRED at all rather than being held by someone else. Issue #3012 -- the
+	 * two states must not produce the same operator message, so every row that
+	 * asserts 'mid-update' needs a partner asserting it is absent.
+	 */
+	private function withFeedPassLockError(callable $action): mixed
+	{
+		$this->assertTrue(stream_wrapper_register('pfbalertslockerr', PfbFailingFlockStream::class));
+		$dbdir = $GLOBALS['pfb']['dbdir'];
+		try {
+			$GLOBALS['pfb']['dbdir'] = 'pfbalertslockerr://state';
+			return $action();
+		} finally {
+			$GLOBALS['pfb']['dbdir'] = $dbdir;
+			stream_wrapper_unregister('pfbalertslockerr');
+		}
+	}
+
 	private function feedPassLockIsHeld(): bool
 	{
 		$probe = fopen("{$GLOBALS['pfb']['dbdir']}/pfb_feed_pass.lock", 'c');
@@ -330,6 +351,32 @@ SH
 			$clists['ipsuppression']['data'],
 			'a failed re-add must KEEP the suppression customlist entry'
 		);
+	}
+
+	/**
+	 * Issue #3012: the www/ half. This row is the non-contended partner of the
+	 * 'busy' row below -- same dispatch, same oracle, opposite lock state. It is
+	 * the hermetic half testing.md requires alongside the live tier, and it fails
+	 * if either message is wrong or if the two states collapse to one wording.
+	 */
+	public function testDeleteIpLockErrorSaysSoRatherThanClaimingMidUpdate(): void
+	{
+		$clists = ['ipsuppression' => ['data' => ['198.51.100.5' => "198.51.100.5\r\n"]]];
+
+		$result = $this->withFeedPassLockError(
+			function () use (&$clists): array {
+				return pfb_alerts_oracle_delete_ip("'198.51.100.5'", "'pfB_Deny_v4'", $clists);
+			}
+		);
+
+		$this->assertFalse($result['pfb_found']);
+		$this->assertStringContainsString('could not be acquired', $result['savemsg'],
+			'an acquisition error must say the lock could not be acquired');
+		$this->assertStringNotContainsString('mid-update', $result['savemsg'],
+			'an acquisition error must NOT tell the operator to wait for a run that is not happening');
+		$this->assertArrayHasKey('198.51.100.5', $clists['ipsuppression']['data'],
+			'a refused mutation must keep the customlist entry');
+		$this->assertFileDoesNotExist($this->logPath, 'a refused mutation must not call pfctl');
 	}
 
 	public function testDeleteIpBusyKeepsSuppressionEntryAndSkipsPfctlAndWrites(): void

--- a/tests/php/ExtrasDispatcherDeferralLoggingTest.php
+++ b/tests/php/ExtrasDispatcherDeferralLoggingTest.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/support/FailingFlockStream.php';
+
 use PHPUnit\Framework\TestCase;
 
 /**

--- a/tests/php/ExtrasDispatcherDeferralLoggingTest.php
+++ b/tests/php/ExtrasDispatcherDeferralLoggingTest.php
@@ -182,16 +182,6 @@ final class ExtrasDispatcherDeferralLoggingTest extends TestCase
 	}
 
 	/**
-	 * Scenario: the deferral line must not graft onto a half-written log line.
-	 *   Given the main log ends mid-line (a previous writer's partial write)
-	 *   When  the dispatcher-lock deferral logs
-	 *   Then  the new line starts on a fresh line carrying its own ISO timestamp
-	 *
-	 * pfb_logger() inserts the stamp AFTER any leading newlines and only when the
-	 * target is at BOL (pfb_logger_format_for_target()), so dropping the message's
-	 * leading "\n" would append unstamped text to whatever was written last.
-	 */
-	/**
 	 * Issue #3012: the FEED-pass guard must name itself too.
 	 *
 	 * pfb_feed_pass_begin() logs its own skip line only when the lock is
@@ -220,6 +210,42 @@ final class ExtrasDispatcherDeferralLoggingTest extends TestCase
 		}
 	}
 
+	public function testScheduleCacheAcquisitionErrorNamesTheGuardInTheMainLog(): void
+	{
+		$this->assertTrue(stream_wrapper_register('pfbschedulecachelockerror', PfbFailingFlockStream::class));
+		$dbdir = $GLOBALS['pfb']['dbdir'];
+		try {
+			$GLOBALS['pfb']['dbdir'] = 'pfbschedulecachelockerror://state';
+
+			$this->assertFalse(pfb_schedule_cache_regenerate(),
+				'an unacquirable feed-pass lock must refuse schedule cache regeneration');
+			$this->assertStringContainsString(
+				'Schedule cache regeneration skipped: the feed pass lock could not be acquired.',
+				$this->mainLog(),
+				'the acquisition error must name schedule cache regeneration in the main log'
+			);
+			$this->assertStringNotContainsString('another pfBlockerNG feed pass is running', $this->mainLog(),
+				'an acquisition error must not claim another pass is running');
+			$this->assertFalse(is_resource($GLOBALS['pfb_schedule_dispatch_lock'] ?? NULL),
+				'the refused regeneration must release its dispatcher lock');
+			$this->assertFalse(is_resource($GLOBALS['pfb_feed_pass_lock'] ?? NULL),
+				'the refused regeneration must not leave a feed-pass lock');
+		} finally {
+			$GLOBALS['pfb']['dbdir'] = $dbdir;
+			stream_wrapper_unregister('pfbschedulecachelockerror');
+		}
+	}
+
+	/**
+	 * Scenario: the deferral line must not graft onto a half-written log line.
+	 *   Given the main log ends mid-line (a previous writer's partial write)
+	 *   When  the dispatcher-lock deferral logs
+	 *   Then  the new line starts on a fresh line carrying its own ISO timestamp
+	 *
+	 * pfb_logger() inserts the stamp AFTER any leading newlines and only when the
+	 * target is at BOL (pfb_logger_format_for_target()), so dropping the message's
+	 * leading "\n" would append unstamped text to whatever was written last.
+	 */
 	public function testDeferralLineStartsOnItsOwnStampedLogLine(): void
 	{
 		file_put_contents($GLOBALS['pfb']['log'], 'unterminated line from the lock holder');

--- a/tests/php/ExtrasDispatcherDeferralLoggingTest.php
+++ b/tests/php/ExtrasDispatcherDeferralLoggingTest.php
@@ -189,6 +189,35 @@ final class ExtrasDispatcherDeferralLoggingTest extends TestCase
 	 * target is at BOL (pfb_logger_format_for_target()), so dropping the message's
 	 * leading "\n" would append unstamped text to whatever was written last.
 	 */
+	/**
+	 * Issue #3012: the FEED-pass guard must name itself too.
+	 *
+	 * pfb_feed_pass_begin() logs its own skip line only when the lock is
+	 * CONTENDED. An acquisition error leaves $contended FALSE, so before #3012
+	 * this arm released the dispatcher lock and returned FALSE with nothing in
+	 * the main log naming what was skipped or why -- the operator saw a verb
+	 * silently do nothing.
+	 */
+	public function testFeedPassAcquisitionErrorNamesTheGuardInTheMainLog(): void
+	{
+		$this->assertTrue(stream_wrapper_register('pfbextrasfeedlockerror', PfbFailingFlockStream::class));
+		$dbdir = $GLOBALS['pfb']['dbdir'];
+		try {
+			// Only the feed-pass lock lives under dbdir; the dispatcher lock uses
+			// schedule_state_dir, so it still acquires and this reaches the guard.
+			$GLOBALS['pfb']['dbdir'] = 'pfbextrasfeedlockerror://state';
+
+			$this->assertFalse(pfb_extras_process_begin(),
+				'an unacquirable feed-pass lock must still refuse the extras run');
+			$this->assertStringContainsString('feed pass lock could not be acquired', $this->mainLog(),
+				'an acquisition error must name itself in the main log; contention is the only case '
+				. 'pfb_feed_pass_begin() logs on its own behalf');
+		} finally {
+			$GLOBALS['pfb']['dbdir'] = $dbdir;
+			stream_wrapper_unregister('pfbextrasfeedlockerror');
+		}
+	}
+
 	public function testDeferralLineStartsOnItsOwnStampedLogLine(): void
 	{
 		file_put_contents($GLOBALS['pfb']['log'], 'unterminated line from the lock holder');

--- a/tests/php/LivePunchRunTest.php
+++ b/tests/php/LivePunchRunTest.php
@@ -265,6 +265,31 @@ SH
 	}
 
 	// -------------------------------------------------------------------
+	// issue #3012: an acquisition ERROR is not contention. A caller that
+	// cannot tell them apart reports "mid-update, please retry" for a run
+	// that is not happening, and the retry never succeeds.
+	// -------------------------------------------------------------------
+
+	public function testAcquisitionErrorIsNotReportedAsBusy(): void
+	{
+		$this->assertTrue(stream_wrapper_register('pfblivepunchlockerror', PfbFailingFlockStream::class));
+		$dbdir = $GLOBALS['pfb']['dbdir'];
+		try {
+			$GLOBALS['pfb']['dbdir'] = 'pfblivepunchlockerror://state';
+			$result = pfb_live_punch_run($this->shim, $this->aliasdir, $this->dbdir, $this->table, '203.0.113.5');
+
+			$this->assertSame('lock_error', $result['status'],
+				'a feed-pass lock that could not be acquired is not contention: reporting it as busy '
+				. 'tells the operator to wait for a run that is not happening');
+			$this->assertSame([], $this->readLog(),
+				'a lock error must short-circuit before any pfctl exec, exactly as contention does');
+		} finally {
+			$GLOBALS['pfb']['dbdir'] = $dbdir;
+			stream_wrapper_unregister('pfblivepunchlockerror');
+		}
+	}
+
+	// -------------------------------------------------------------------
 	// $was_held reentrancy guard -- a nested call inside an already-held
 	// lock must NOT release the outer caller's hold.
 	// -------------------------------------------------------------------

--- a/tests/php/LivePunchRunTest.php
+++ b/tests/php/LivePunchRunTest.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/support/FailingFlockStream.php';
+
 use PHPUnit\Framework\Attributes\CoversFunction;
 use PHPUnit\Framework\TestCase;
 

--- a/tests/php/TickScheduleRuntimeTest.php
+++ b/tests/php/TickScheduleRuntimeTest.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/support/FailingFlockStream.php';
+
 use PHPUnit\Framework\TestCase;
 
 /** Runtime schedule source drives the real fixed tick. */
@@ -414,6 +416,41 @@ final class TickScheduleRuntimeTest extends TestCase
 		$this->assertSame(0, $this->feedRuns);
 		flock($lock, LOCK_UN);
 		fclose($lock);
+	}
+
+	public function testFeedPassAcquisitionErrorSkipsScheduledWorkWithoutClaimingContention(): void
+	{
+		$this->assertTrue(stream_wrapper_register('pfbtickfeedlockerror', PfbFailingFlockStream::class));
+		$dbdir = $GLOBALS['pfb']['dbdir'];
+		$before = file_get_contents($this->dir . '/pfb_due_ledger.json');
+		$GLOBALS['pfb_test_logger_calls'] = [];
+		try {
+			$GLOBALS['pfb']['dbdir'] = 'pfbtickfeedlockerror://state';
+
+			$this->tick();
+
+			$messages = array_column($GLOBALS['pfb_test_logger_calls'] ?? [], 'message');
+			$this->assertContains(
+				'Tick: scheduled work skipped -- the feed-pass lock could not be acquired; see the pfBlockerNG log.',
+				$messages,
+				'an acquisition error must name the lock failure'
+			);
+			$this->assertNotContains(
+				'Tick: scheduled work deferred (another feed pass is running).',
+				$messages,
+				'an acquisition error must not claim another pass is running'
+			);
+			$this->assertSame(0, $this->feedRuns, 'an acquisition error must refuse scheduled feed work');
+			$this->assertSame($before, file_get_contents($this->dir . '/pfb_due_ledger.json'),
+				'an acquisition error must leave the schedule cache unchanged');
+			$this->assertFileDoesNotExist($this->stateDir . '/pfb_schedule_state.json',
+				'an acquisition error must not publish schedule state');
+			$this->assertFalse(is_resource($GLOBALS['pfb_schedule_dispatch_lock'] ?? NULL),
+				'the refused tick must release its dispatcher lock');
+		} finally {
+			$GLOBALS['pfb']['dbdir'] = $dbdir;
+			stream_wrapper_unregister('pfbtickfeedlockerror');
+		}
 	}
 
 	public function testLegacyPendingApplyDispatchesWhenMasterOff(): void

--- a/tests/smoke/ui/test_alerts.py
+++ b/tests/smoke/ui/test_alerts.py
@@ -1284,6 +1284,72 @@ for ($i = 0; $i < 1200 && !file_exists('{stop}'); $i++) {{
         helpers.reset(vm)
 
 
+def test_ip_relock_acquisition_error_names_failure_and_keeps_live_and_store_state(
+    webui: WebUI,
+    smoke_vm: helpers.SmokeVM,
+) -> None:
+    """A real feed-pass lock acquisition error refuses a re-lock without claiming contention.
+
+    Given: a v4 feed host was unlocked through the Alerts POST, so it no longer
+        matches its live table and the unlock store records the host.
+    When: the feed-pass lock path is temporarily a directory and re-lock is posted.
+    Then: the rendered response names lock acquisition failure, never ``mid-update``,
+        and both the live table and unlock store remain unchanged.
+    """
+    vm = smoke_vm
+    target = "198.18.7.9"
+    sibling = "198.19.52.7"
+    lock_path = "/var/db/pfblockerng/pfb_feed_pass.lock"
+    feed_url = helpers.write_local_feed(vm, "ui_ip_relock_error.txt", f"{target}\n{sibling}\n")
+    spec = helpers.IpCase(aliasname="uiiprelockerr", feed_url=feed_url, header="uiiprelockerr")
+    table = spec.alias
+
+    helpers.inject(vm, spec)
+    helpers.reload(vm, "updateip")
+    helpers.apply_filter_sync(vm)
+    try:
+        matched, raw = helpers.pfctl_table_test_raw(vm, table, target)
+        assert matched, f"{target} expected to match pf table {table} before unlock; pfctl said: {raw!r}"
+        assert target not in _ip_unlock_hosts(vm), f"{target} already in {IP_UNLOCK_STORE} before the test"
+
+        resp = _post_action(webui, {"ip_remove": "unlock", "ip": target, "table": table})
+        assert not looks_like_login_page(resp.text), "ip_remove=unlock POST returned the login form (session lost)"
+        matched, raw = helpers.pfctl_table_test_raw(vm, table, target)
+        assert not matched, f"{target} still matches pf table {table} after unlock; pfctl said: {raw!r}"
+        assert _ip_unlock_hosts(vm).get(target) == table, (
+            f"expected {IP_UNLOCK_STORE} to record {target!r} -> {table!r}, got {_ip_unlock_hosts(vm)!r}"
+        )
+        table_before = sorted(helpers.pfctl_table_members(vm, table))
+        store_before = _ip_unlock_hosts(vm)
+
+        helpers.wait_no_active_pfb_task(vm)
+        try:
+            replace = vm.ssh(f"rm -f {lock_path} && mkdir {lock_path}")
+            assert replace.returncode == 0, (
+                f"failed to replace feed-pass lock file with a directory: "
+                f"rc={replace.returncode} stderr={replace.stderr!r}"
+            )
+            resp = _post_action(webui, {"ip_remove": "lock", "ip": target, "table": table})
+            assert not looks_like_login_page(resp.text), "lock-error ip_remove=lock POST returned the login form"
+            assert "feed-pass lock could not be acquired" in resp.text, (
+                f"acquisition-error feedback missing from Alerts response: {resp.text[:500]!r}"
+            )
+            assert "mid-update" not in resp.text, (
+                f"acquisition error was misreported as contention: {resp.text[:500]!r}"
+            )
+            assert sorted(helpers.pfctl_table_members(vm, table)) == table_before, (
+                "acquisition-error re-lock changed the live table"
+            )
+            assert _ip_unlock_hosts(vm) == store_before, f"acquisition-error re-lock changed {IP_UNLOCK_STORE}"
+        finally:
+            restore = vm.ssh(f"if [ -d {lock_path} ]; then rmdir {lock_path}; fi && touch {lock_path}")
+            assert restore.returncode == 0, (
+                f"failed to restore feed-pass lock path: rc={restore.returncode} stderr={restore.stderr!r}"
+            )
+    finally:
+        helpers.reset(vm)
+
+
 def test_ip_unlock_v6_carves_containing_range_relock_restores_and_spares_sibling(
     webui: WebUI,
     smoke_vm: helpers.SmokeVM,


### PR DESCRIPTION
Fixes #3012

## The defect

`pfb_feed_pass_acquire()` and `pfb_feed_pass_begin()` report contention through a by-reference `$contended` argument. **Eight call sites omitted it**, so they could not tell a lost race from a lock that could not be acquired at all — an unwritable `dbdir`, a read-only filesystem, `ENOSPC`, `EMFILE`.

Six then told the operator to retry a run that is not happening. Two said nothing at all.

The class is **callers that cannot distinguish an acquisition error from contention**, not callers that print the wrong sentence. Only the first framing finds all eight: a fix driven from the "mid-update" wording finds six and misses the silent pair.

## Group A — said the wrong thing (six)

| site | now |
| --- | --- |
| `pfblockerng_alerts.php` ×2 (customlist remove / delete) | branch on `$contended`; the error arm says the lock could not be acquired and that retrying will not clear it |
| `pfblockerng_extra.inc` live re-lock, Permit Alias add | same branch |
| `pfblockerng_extra.inc` tick scheduled work | logger line branches; the error arm names the lock rather than claiming another pass is running |
| `pfb_live_punch_run()` | returned `'busy'` for both outcomes; now returns **`'lock_error'`** for an acquisition failure |

`pfb_live_punch_run()`'s status is a documented contract, so the docblock and **both** consumers were updated — otherwise `lock_error` fell through to a default rendering `failed [ ]`, since `fail` is NULL on that path.

## Group B — said nothing (two)

`pfb_feed_pass_begin()` logs its own skip line **only when the lock is contended**. The schedule-cache and extras guards therefore released the dispatcher lock and returned FALSE with no record of what was skipped or why — an operator saw a verb silently do nothing. Both now log a line naming themselves when the failure is not contention.

This is the same defect **#2592** fixed for the dispatcher-lock arm of the same function; that fix did not reach the feed-pass arm.

## Tests

- **`LivePunchRunTest`** gains the non-contended sibling of its existing contention row, using the suite's `PfbFailingFlockStream` harness. Executed **RED** on untouched code — `'lock_error'` expected, `'busy'` actual — and the test file is byte-identical across the red and green runs (`git hash-object` = `690a307fc08bdafb8c1e457c694edad34a43cc32` both times).
- **`ExtrasDispatcherDeferralLoggingTest`** gains the feed-pass sibling of its #2592 dispatcher row. **This one carries mutation evidence rather than a red-first run**, because it was written after the production change: removing the logger line reds it, restoring greens it, test file byte-identical. Stated plainly rather than presented as a red-first it is not.

Both sides of the boolean are covered: the contended path keeps its existing assertions (`testConcurrentFeedPassReturnsBusyWithZeroExecs`, and #2592's dispatcher rows).

## Gates

Full suite **61 errors / 13 failures — identical to the pre-change baseline**, so nothing here moves a verdict. Those are this box's known environmental failures (`php-intl` absent, and the archive/tooling family). `php -l`, `phpcs`, coverage-pairing and the policy checkers pass.

## Runtime verification — what a smoke seat measured, and what it does not cover

A smoke seat ran the live tier on a real pfSense guest:

```
pfb-test ui-e2e --ref fbba0bc4 --filter test_ip_unlock_v4_carves_...
tier=ui-e2e  rc=0  157s   collected 673 / 672 deselected / 1 selected
1 passed
```

Box `root@10.20.41.11`, smoke-1 pool. The test drives genuine contention — a PHP process holds the feed-pass flock — POSTs `ip_remove=lock`, asserts `mid-update` in the rendered response, then checks `pfctl` and the unlock store.

**So the CONTENDED path is proven unchanged on a live box, not assumed.** That is the half this PR most needed to leave alone, and it did.

**What that run does NOT cover, stated plainly:** the *acquisition-error* message is new, and no live test renders it. Its coverage is hermetic only — the source-extraction oracle row added here, which evaluates the real `case` body out of `pfblockerng_alerts.php` and asserts the error wording appears and `mid-update` does not. That is the "focused hermetic coverage" `testing.md` requires alongside a live tier, but it is not a rendered-output measurement.

Two incidental findings from that run, both on the harness rather than this diff:

- The `ui-e2e` tier **did not exist** in the local test wrapper and had to be added before the test could be selected at all. `ui-render` and `smoke` were correctly refusing a `ui_e2e` test.
- `tests/smoke/ui/test_alerts.py:49` carries a module-level `pytestmark = pytest.mark.ui_e2e`, so all 24 of its tests are marked. An earlier report that 19 were unmarked and dead was measured against the wrong tier and has been retracted.

## Previously stated here — the UI half

Two of the eight sites are in `www/pfblockerng_alerts.php`, and the operator-facing claim is what the Alerts page **renders**. The existing wording is pinned in `tests/smoke/ui/test_alerts.py`, a live tier a dev seat cannot run, and `testing.md` is explicit that a dev seat never reports runtime behaviour it only reasoned about. A smoke seat has been asked to measure both message states on a live box; **this PR should not merge claiming the rendered output is verified until that comes back.**

## Review resolution — 2026-09-01

- Review-fix commit `7aae1a181f71f5d9e58728486353433bb2e1801a` adds focused non-contended coverage for every previously unpinned branch: schedule-cache, tick, addsuppress, unlock, re-lock, Permit Alias add, and delete-ip-whitelist.
- The required `ui_e2e` acquisition-error row now ships in `tests/smoke/ui/test_alerts.py`; it asserts rendered error wording and unchanged live/store state while cleanup restores the lock path. Exact-head live execution is a pending landing gate, not a claimed local pass.
- The addsuppress acquisition-error sentence was corrected under frozen RED→GREEN proof. `tests/php/AlertsPfctlCheckedSitesTest.php` stayed byte-identical at hash `1953ea62d94dd97a266db8338507097eb324829d`; RED was `64 tests, 313 assertions, 1 failure`, GREEN was `64 tests, 318 assertions`.
- The earlier `LivePunchRunTest.php` hash claim no longer identifies the shipped self-contained file after its required import was added. The owner explicitly waived only that pre-existing test-first chronology; it is not presented as current frozen proof.
- The analogous scheduler-dispatcher caller class is outside #3012 and is tracked in #3042.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved lock-failure handling for alert actions, including suppression, unlocking, relocking, and whitelist changes.
  * Clearly distinguishes temporary update contention from other acquisition failures, with more accurate messages.
  * Prevents failed live firewall updates from being reported as successful or merely “busy.”
  * Preserves saved settings when live updates are deferred or cannot be applied.
  * Scheduled processing now skips safely and records a specific diagnostic message when its lock cannot be acquired.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->