### PR TITLE
CI: migrate GitHub App tokens to client-id

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -3,9 +3,18 @@ paths:
     ignore:
       # GitHub added lossless concurrency queues before actionlint 1.7.12.
       - 'unexpected key "queue" for "concurrency" section'
+      # create-github-app-token v3 gained client-id after actionlint 1.7.12's metadata snapshot.
+      - 'missing input "app-id" which is required by action "actions/create-github-app-token@v3"'
+      - 'input "client-id" is not defined in action "actions/create-github-app-token@v3"'
   .github/workflows/release-published.yml:
     ignore:
       - 'unexpected key "queue" for "concurrency" section'
+      - 'missing input "app-id" which is required by action "actions/create-github-app-token@v3"'
+      - 'input "client-id" is not defined in action "actions/create-github-app-token@v3"'
+  .github/workflows/pkg-tagged-ingest.yml:
+    ignore:
+      - 'missing input "app-id" which is required by action "actions/create-github-app-token@v3"'
+      - 'input "client-id" is not defined in action "actions/create-github-app-token@v3"'
   .github/workflows/pkg-republish.yml:
     ignore:
       - 'unexpected key "queue" for "concurrency" section'

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -482,7 +482,7 @@ jobs:
         id: pkg-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.PKG_GITHUB_APP_ID }}
+          client-id: ${{ secrets.PKG_GITHUB_APP_CLIENT_ID }}
           private-key: ${{ secrets.PKG_GITHUB_APP_PRIVATE_KEY }}
           owner: pfBlockerNG
           repositories: pkg
@@ -528,7 +528,7 @@ jobs:
         id: pkg-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.PKG_GITHUB_APP_ID }}
+          client-id: ${{ secrets.PKG_GITHUB_APP_CLIENT_ID }}
           private-key: ${{ secrets.PKG_GITHUB_APP_PRIVATE_KEY }}
           owner: pfBlockerNG
           repositories: pkg

--- a/.github/workflows/pkg-tagged-ingest.yml
+++ b/.github/workflows/pkg-tagged-ingest.yml
@@ -25,7 +25,7 @@ on:
         required: true
         type: string
     secrets:
-      PKG_GITHUB_APP_ID:
+      PKG_GITHUB_APP_CLIENT_ID:
         required: true
       PKG_GITHUB_APP_PRIVATE_KEY:
         required: true
@@ -52,7 +52,7 @@ jobs:
         id: pkg-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.PKG_GITHUB_APP_ID }}
+          client-id: ${{ secrets.PKG_GITHUB_APP_CLIENT_ID }}
           private-key: ${{ secrets.PKG_GITHUB_APP_PRIVATE_KEY }}
           owner: pfBlockerNG
           repositories: pkg
@@ -176,7 +176,7 @@ jobs:
         id: pkg-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.PKG_GITHUB_APP_ID }}
+          client-id: ${{ secrets.PKG_GITHUB_APP_CLIENT_ID }}
           private-key: ${{ secrets.PKG_GITHUB_APP_PRIVATE_KEY }}
           owner: pfBlockerNG
           repositories: pkg

--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -227,7 +227,7 @@ jobs:
         # to grant it, rather than a confusing empty-token checkout failure.
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.PKG_GITHUB_APP_ID }}
+          client-id: ${{ secrets.PKG_GITHUB_APP_CLIENT_ID }}
           private-key: ${{ secrets.PKG_GITHUB_APP_PRIVATE_KEY }}
           owner: pfBlockerNG
           repositories: FreeBSD-ports

--- a/tests/test_issue2143_callback_destinations.py
+++ b/tests/test_issue2143_callback_destinations.py
@@ -3,6 +3,9 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
+
+import yaml
 
 from tests._workflow_steps import extract_after, extract_between
 
@@ -13,6 +16,53 @@ MANUAL = (ROOT / ".github/workflows/pkg-republish.yml").read_text(encoding="utf-
 TAGGED_INGEST = (ROOT / ".github/workflows/pkg-tagged-ingest.yml").read_text(encoding="utf-8")
 SMOKE_SINGLE = (ROOT / ".github/workflows/smoke-single.yml").read_text(encoding="utf-8")
 NIGHTLY = (ROOT / ".github/workflows/nightly.yml").read_text(encoding="utf-8")
+
+APP_TOKEN_ACTION = "actions/create-github-app-token@v3"
+APP_CLIENT_ID = "${{ secrets.PKG_GITHUB_APP_CLIENT_ID }}"
+APP_PRIVATE_KEY = "${{ secrets.PKG_GITHUB_APP_PRIVATE_KEY }}"
+APP_TOKEN_SCOPES = {
+    "release-published.yml:sync-ports-fork:steps[0]": ("FreeBSD-ports", {"permission-contents": "write"}),
+    "pkg-tagged-ingest.yml:stage-pkg:steps[1]": ("pkg", {"permission-actions": "write"}),
+    "pkg-tagged-ingest.yml:finalize-pkg:steps[1]": ("pkg", {"permission-actions": "write"}),
+    "nightly.yml:ingest-pkg:steps[1]": ("pkg", {"permission-actions": "write"}),
+    "nightly.yml:cleanup-nightly-oci:steps[1]": ("pkg", {"permission-actions": "write"}),
+}
+
+
+def _app_token_steps() -> list[tuple[str, dict[str, Any]]]:
+    found: list[tuple[str, dict[str, Any]]] = []
+    workflows = ROOT / ".github/workflows"
+    for path in sorted([*workflows.glob("*.yml"), *workflows.glob("*.yaml")]):
+        document = yaml.safe_load(path.read_text(encoding="utf-8"))
+        for job_name, job in document["jobs"].items():
+            for step_index, step in enumerate(job.get("steps", [])):
+                if step.get("uses") == APP_TOKEN_ACTION:
+                    found.append((f"{path.name}:{job_name}:steps[{step_index}]", step))
+    return found
+
+
+def test_app_token_steps_use_client_id_and_preserve_private_key() -> None:
+    steps = _app_token_steps()
+    locations = [location for location, _step in steps]
+    assert len(steps) == 5, f"expected exactly five {APP_TOKEN_ACTION} steps, got {locations}"
+    assert set(locations) == set(APP_TOKEN_SCOPES), locations
+
+    for location, step in steps:
+        inputs = step["with"]
+        assert inputs.get("client-id") == APP_CLIENT_ID, f"{location}: client-id must use the App client ID secret"
+        assert "app-id" not in inputs, f"{location}: deprecated app-id input remains"
+        assert inputs.get("private-key") == APP_PRIVATE_KEY, f"{location}: private-key changed"
+        repository, permissions = APP_TOKEN_SCOPES[location]
+        assert inputs.get("owner") == "pfBlockerNG", f"{location}: owner changed"
+        assert inputs.get("repositories") == repository, f"{location}: repository scope changed"
+        assert {name: value for name, value in inputs.items() if name.startswith("permission-")} == permissions, (
+            f"{location}: permission scope changed"
+        )
+
+    tagged = yaml.safe_load(TAGGED_INGEST)
+    secrets = tagged[True]["workflow_call"]["secrets"]
+    assert secrets.get("PKG_GITHUB_APP_CLIENT_ID", {}).get("required") is True
+    assert "PKG_GITHUB_APP_ID" not in secrets
 
 
 def test_published_callback_derives_and_forwards_the_fresh_tuple() -> None:

--- a/tests/test_issue2245_stateless_nightly.py
+++ b/tests/test_issue2245_stateless_nightly.py
@@ -32,12 +32,17 @@ def test_every_nightly_invocation_builds_without_durable_state() -> None:
     assert "needs.prepare.outputs.outcome" not in workflow
 
 
-def test_actionlint_exception_is_narrowly_scoped_to_workflows_using_queue_max() -> None:
+def test_actionlint_exceptions_are_narrowly_scoped_to_exact_workflows() -> None:
     queue_error = 'unexpected key "queue" for "concurrency" section'
+    token_errors = [
+        'missing input "app-id" which is required by action "actions/create-github-app-token@v3"',
+        'input "client-id" is not defined in action "actions/create-github-app-token@v3"',
+    ]
     assert yaml.safe_load(ACTIONLINT_CONFIG.read_text(encoding="utf-8")) == {
         "paths": {
-            ".github/workflows/nightly.yml": {"ignore": [queue_error]},
-            ".github/workflows/release-published.yml": {"ignore": [queue_error]},
+            ".github/workflows/nightly.yml": {"ignore": [queue_error, *token_errors]},
+            ".github/workflows/release-published.yml": {"ignore": [queue_error, *token_errors]},
+            ".github/workflows/pkg-tagged-ingest.yml": {"ignore": token_errors},
             ".github/workflows/pkg-republish.yml": {"ignore": [queue_error]},
             ".github/workflows/release.yml": {"ignore": [queue_error]},
             ".github/workflows/image-refresh.yml": {"ignore": [queue_error]},


### PR DESCRIPTION
## Summary

- migrate all five create-github-app-token v3 calls from deprecated `app-id` to `client-id`
- cleanly replace the tagged reusable secret contract
- preserve private keys, owners, repositories, and exact write permissions
- globally discover token calls across every workflow YAML file
- narrowly suppress actionlint 1.7.12's stale v3 input metadata and pin the complete exception map

## Evidence

| Frozen RED test | git hash-object | RED run tail |
| --- | --- | --- |
| `tests/test_issue2143_callback_destinations.py` | `fdd95711368b5d4d88ae3a5df78d72bd647b9c23` | `deprecated migration, scope, and global sixth-call RED cases` |
| `tests/test_issue2245_stateless_nightly.py` | `fddbb15d5cec131862ea21b05451237258840c7b` | `1 failed: exact actionlint exception map lacked three new path-scoped entries` |

- live `actions/create-github-app-token@v3` schema defines client-id and deprecates app-id
- live repository secret `PKG_GITHUB_APP_CLIENT_ID` exists for dispatcher client `Iv23livHnnzFvA55VhhD`
- GREEN: 9 focused tests; actionlint passes all three workflows
- independent Codex verifier: PASS after global discovery/scope hardening; count/client/private/owner/repository/permission/secret mutants killed

Refs #3004\n\n🤖 Generated by Oh My Pi and posted on behalf of @andrebrait.