### PR TITLE
www: pair a foreground with the Feeds row backgrounds

### DIFF
--- a/src/usr/local/www/pfblockerng/pfblockerng_feeds.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_feeds.php
@@ -632,21 +632,19 @@ include_once('head.inc');
 /*
  * The dark theme sets anchors explicitly, so a painted row's inherited color: #212121 does
  * not reach its links. Scope the link foreground to the rows carrying one of the painted
- * backgrounds -- keyed off the inline background itself, because the live sortable table
- * normalises rows and drops a class attribute while preserving inline style. $tr_style is
- * the only inline background this page sets, so the attribute selector matches exactly the
- * painted rows and nothing else. The theme pins its anchor colour with !important, which no
- * amount of specificity or source order can outrank, so these declarations carry it too.
+ * backgrounds, keyed off the inline background the row already carries: $tr_style is the
+ * only inline background this page sets, so the attribute selector matches exactly those
+ * rows and needs no extra markup on them.
  */
 #pfb_table tr[style*="background-color"] a,
 #pfb_table2 tr[style*="background-color"] a {
-	color: #004D40 !important;
+	color: #004D40;
 }
 #pfb_table tr[style*="background-color"] a:hover,
 #pfb_table tr[style*="background-color"] a:focus,
 #pfb_table2 tr[style*="background-color"] a:hover,
 #pfb_table2 tr[style*="background-color"] a:focus {
-	color: #003D33 !important;
+	color: #003D33;
 }
 </style>
 <?php

--- a/src/usr/local/www/pfblockerng/pfblockerng_feeds.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_feeds.php
@@ -635,17 +635,18 @@ include_once('head.inc');
  * backgrounds -- keyed off the inline background itself, because the live sortable table
  * normalises rows and drops a class attribute while preserving inline style. $tr_style is
  * the only inline background this page sets, so the attribute selector matches exactly the
- * painted rows and nothing else.
+ * painted rows and nothing else. The theme pins its anchor colour with !important, which no
+ * amount of specificity or source order can outrank, so these declarations carry it too.
  */
 #pfb_table tr[style*="background-color"] a,
 #pfb_table2 tr[style*="background-color"] a {
-	color: #004D40;
+	color: #004D40 !important;
 }
 #pfb_table tr[style*="background-color"] a:hover,
 #pfb_table tr[style*="background-color"] a:focus,
 #pfb_table2 tr[style*="background-color"] a:hover,
 #pfb_table2 tr[style*="background-color"] a:focus {
-	color: #003D33;
+	color: #003D33 !important;
 }
 </style>
 <?php

--- a/src/usr/local/www/pfblockerng/pfblockerng_feeds.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_feeds.php
@@ -418,7 +418,7 @@ function pfb_feeds_render_predefined_type($ftype, $info) {
 					}
 				?>
 
-		<tr style="<?=$tr_style;?>">
+		<tr<?=!empty($tr_style) ? ' class="pfb-painted-feed-row"' : '';?> style="<?=$tr_style;?>">
 			<td>
 					<?php
 						// $ftype is always one of ipv4/ipv6/dnsbl here; the default keeps
@@ -626,6 +626,18 @@ $pgtitle = array(gettext('Firewall'), gettext('pfBlockerNG'), gettext('Feeds'), 
 $pglinks = array('', '/pfblockerng/pfblockerng_general.php', "/pfblockerng/pfblockerng_feeds.php?type={$gtype}", '@self');
 $shortcut_section = 'pfblockerng';
 include_once('head.inc');
+
+?>
+<style>
+.pfb-painted-feed-row a {
+	color: #004D40;
+}
+.pfb-painted-feed-row a:hover,
+.pfb-painted-feed-row a:focus {
+	color: #003D33;
+}
+</style>
+<?php
 
 if ($input_errors) {
 	print_input_errors($input_errors);
@@ -853,7 +865,7 @@ print ($section);
 								}
 				?>
 
-			<tr style="<?=$tr_style;?>">
+			<tr<?=!empty($tr_style) ? ' class="pfb-painted-feed-row"' : '';?> style="<?=$tr_style;?>">
 				<td>
 					<?php
 								if ($type != $p_type) {

--- a/src/usr/local/www/pfblockerng/pfblockerng_feeds.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_feeds.php
@@ -418,7 +418,7 @@ function pfb_feeds_render_predefined_type($ftype, $info) {
 					}
 				?>
 
-		<tr<?=!empty($tr_style) ? ' class="pfb-painted-feed-row"' : '';?> style="<?=$tr_style;?>">
+		<tr<?=$tr_style !== '' ? ' class="pfb-painted-feed-row"' : '';?> style="<?=$tr_style;?>">
 			<td>
 					<?php
 						// $ftype is always one of ipv4/ipv6/dnsbl here; the default keeps
@@ -865,7 +865,7 @@ print ($section);
 								}
 				?>
 
-			<tr<?=!empty($tr_style) ? ' class="pfb-painted-feed-row"' : '';?> style="<?=$tr_style;?>">
+			<tr<?=$tr_style !== '' ? ' class="pfb-painted-feed-row"' : '';?> style="<?=$tr_style;?>">
 				<td>
 					<?php
 								if ($type != $p_type) {

--- a/src/usr/local/www/pfblockerng/pfblockerng_feeds.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_feeds.php
@@ -400,20 +400,20 @@ function pfb_feeds_render_predefined_type($ftype, $info) {
 					// Print applicable alternating background color
 					if ($data['action'] == 'permit') {
 						if ($aliasname == $p_aliasname) {
-							$tr_style = 'background-color: #F5FBF6;';		// Light green 1
+							$tr_style = 'background-color: #F5FBF6; color: #212121;';		// Light green 1
 							if ($tr_style == $p_tr_style) {
-								$tr_style = 'background-color: #EEF7EE;';	// Light green 2
+								$tr_style = 'background-color: #EEF7EE; color: #212121;';	// Light green 2
 							}
 						} else {
 							// Dark green (New Alias/Group)
-							$tr_style = 'background-color: #A0B8A0;';	// #C8E6C9;';
+							$tr_style = 'background-color: #A0B8A0; color: #212121;';	// #C8E6C9;';
 						}
 					}
 					else {
 						$tr_style = '';
 						if ($aliasname != $p_aliasname) {
 							// Grey - (New Alias/Group)
-							$tr_style = 'background-color: #B8B8B8;';	//#D8D8D8;';
+							$tr_style = 'background-color: #B8B8B8; color: #212121;';	//#D8D8D8;';
 						}
 					}
 				?>
@@ -849,7 +849,7 @@ print ($section);
 
 								$tr_style = '';
 								if ($row['aliasname'] != $p_aliasname) {
-									$tr_style = 'background-color: #B8B8B8;';   // #D8D8D8;';
+									$tr_style = 'background-color: #B8B8B8; color: #212121;';   // #D8D8D8;';
 								}
 				?>
 

--- a/src/usr/local/www/pfblockerng/pfblockerng_feeds.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_feeds.php
@@ -418,7 +418,7 @@ function pfb_feeds_render_predefined_type($ftype, $info) {
 					}
 				?>
 
-		<tr<?=$tr_style !== '' ? ' class="pfb-painted-feed-row"' : '';?> style="<?=$tr_style;?>">
+		<tr style="<?=$tr_style;?>">
 			<td>
 					<?php
 						// $ftype is always one of ipv4/ipv6/dnsbl here; the default keeps
@@ -629,11 +629,22 @@ include_once('head.inc');
 
 ?>
 <style>
-.pfb-painted-feed-row a {
+/*
+ * The dark theme sets anchors explicitly, so a painted row's inherited color: #212121 does
+ * not reach its links. Scope the link foreground to the rows carrying one of the painted
+ * backgrounds -- keyed off the inline background itself, because the live sortable table
+ * normalises rows and drops a class attribute while preserving inline style. $tr_style is
+ * the only inline background this page sets, so the attribute selector matches exactly the
+ * painted rows and nothing else.
+ */
+#pfb_table tr[style*="background-color"] a,
+#pfb_table2 tr[style*="background-color"] a {
 	color: #004D40;
 }
-.pfb-painted-feed-row a:hover,
-.pfb-painted-feed-row a:focus {
+#pfb_table tr[style*="background-color"] a:hover,
+#pfb_table tr[style*="background-color"] a:focus,
+#pfb_table2 tr[style*="background-color"] a:hover,
+#pfb_table2 tr[style*="background-color"] a:focus {
 	color: #003D33;
 }
 </style>
@@ -865,7 +876,7 @@ print ($section);
 								}
 				?>
 
-			<tr<?=$tr_style !== '' ? ' class="pfb-painted-feed-row"' : '';?> style="<?=$tr_style;?>">
+			<tr style="<?=$tr_style;?>">
 				<td>
 					<?php
 								if ($type != $p_type) {

--- a/tests/php/FeedsPaintedRowLinkContrastTest.php
+++ b/tests/php/FeedsPaintedRowLinkContrastTest.php
@@ -1,0 +1,176 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/** Painted Feeds rows keep visible link affordance on every shipped row background. */
+final class FeedsPaintedRowLinkContrastTest extends TestCase
+{
+	private const PAINTED_ROW_CLASS = 'pfb-painted-feed-row';
+
+	public static function setUpBeforeClass(): void
+	{
+		require_once __DIR__ . '/FeedsPredefinedTypeLoader.php';
+		pfb_test_load_feeds_predefined_type_functions();
+	}
+
+	/** @return array<string, string> */
+	private function feed(string $marker): array
+	{
+		return [
+			'feed'     => $marker,
+			'website'  => "https://{$marker}.example/",
+			'url'      => "https://{$marker}.example/list.txt",
+			'header'   => $marker,
+			'register' => '',
+		];
+	}
+
+	private function renderPredefinedRows(): string
+	{
+		$GLOBALS['ex_feeds']          = [];
+		$GLOBALS['alt_feeds']         = [];
+		$GLOBALS['fconfig']           = [];
+		$GLOBALS['feed_alt_selected'] = [];
+		$GLOBALS['alt_selected']      = '';
+		$GLOBALS['feed_info_row']     = 0;
+		$GLOBALS['aliasname_found']   = [];
+
+		$info = ['ContrastAlias' => [
+			'action' => 'block',
+			'info'   => 'Contrast test alias',
+			'feeds'  => [$this->feed('painted-predefined'), $this->feed('unpainted-predefined')],
+		]];
+
+		ob_start();
+		pfb_feeds_render_predefined_type('ipv4', $info);
+		return (string) ob_get_clean();
+	}
+
+	private function renderCustomRows(): string
+	{
+		$source = file_get_contents(
+			dirname(__DIR__, 2) . '/src/usr/local/www/pfblockerng/pfblockerng_feeds.php'
+		);
+		if ($source === FALSE) {
+			throw new RuntimeException('failed to read pfblockerng_feeds.php');
+		}
+
+		$table = strpos($source, "\n\t\t\t<tbody>\n");
+		$start = strpos($source, "\t\t\t\t\$p_type = '';", $table === FALSE ? 0 : $table);
+		$end   = strpos($source, "\n\t\t\t<tbody>\n\t\t\t</table>", $start === FALSE ? 0 : $start);
+		if ($start === FALSE || $end === FALSE || $end <= $start) {
+			throw new RuntimeException('could not locate the custom-feed row template');
+		}
+
+		$ex_feeds = ['ipv4' => [
+			[
+				'aliasname' => 'ContrastAlias',
+				'url'       => 'https://painted-custom.example/list.txt',
+				'header'    => 'painted-custom',
+				'rowid'     => 1,
+			],
+			[
+				'aliasname' => 'ContrastAlias',
+				'url'       => 'https://unpainted-custom.example/list.txt',
+				'header'    => 'unpainted-custom',
+				'rowid'     => 2,
+			],
+		]];
+		$gtype      = 'ipv4';
+		$type_label = ['ipv4' => 'IPv4'];
+
+		ob_start();
+		eval('?>' . "<?php\n" . substr($source, $start, $end - $start));
+		return (string) ob_get_clean();
+	}
+
+	private function rowContaining(string $html, string $marker): string
+	{
+		preg_match_all('/<tr\b[^>]*>.*?<\/tr>/s', $html, $matches);
+		foreach ($matches[0] as $row) {
+			if (str_contains($row, $marker)) {
+				return $row;
+			}
+		}
+		$this->fail("no rendered row contains {$marker}");
+	}
+
+	private function assertClassTracksBackground(string $html, string $paintedMarker, string $unpaintedMarker): void
+	{
+		$painted = $this->rowContaining($html, $paintedMarker);
+		$this->assertStringContainsString('background-color:', $painted);
+		$this->assertStringContainsString(self::PAINTED_ROW_CLASS, $painted);
+
+		$unpainted = $this->rowContaining($html, $unpaintedMarker);
+		$this->assertStringNotContainsString('background-color:', $unpainted);
+		$this->assertStringNotContainsString(self::PAINTED_ROW_CLASS, $unpainted);
+	}
+
+	private static function relativeLuminance(string $hex): float
+	{
+		$channels = [];
+		foreach ([1, 3, 5] as $offset) {
+			$value = hexdec(substr($hex, $offset, 2)) / 255;
+			$channels[] = $value <= 0.04045 ? $value / 12.92 : (($value + 0.055) / 1.055) ** 2.4;
+		}
+		return 0.2126 * $channels[0] + 0.7152 * $channels[1] + 0.0722 * $channels[2];
+	}
+
+	private static function contrastRatio(string $first, string $second): float
+	{
+		$lighter = max(self::relativeLuminance($first), self::relativeLuminance($second));
+		$darker  = min(self::relativeLuminance($first), self::relativeLuminance($second));
+		return ($lighter + 0.05) / ($darker + 0.05);
+	}
+
+	public function testPredefinedRowClassTracksPaintedBackground(): void
+	{
+		$this->assertClassTracksBackground(
+			$this->renderPredefinedRows(),
+			'painted-predefined.example',
+			'unpainted-predefined.example'
+		);
+	}
+
+	public function testCustomRowClassTracksPaintedBackground(): void
+	{
+		$this->assertClassTracksBackground(
+			$this->renderCustomRows(),
+			'painted-custom.example',
+			'unpainted-custom.example'
+		);
+	}
+
+	public function testScopedLinkColorsMeetNormalTextContrastOnEveryPaintedBackground(): void
+	{
+		$source = (string) file_get_contents(
+			dirname(__DIR__, 2) . '/src/usr/local/www/pfblockerng/pfblockerng_feeds.php'
+		);
+		$this->assertSame(1, preg_match(
+			'/\.pfb-painted-feed-row\s+a\s*\{\s*color:\s*(#[0-9a-f]{6})\s*;\s*\}/i',
+			$source,
+			$normalMatch
+		), 'painted Feeds rows must scope a normal link foreground');
+		$this->assertSame(1, preg_match(
+			'/\.pfb-painted-feed-row\s+a:hover\s*,\s*\.pfb-painted-feed-row\s+a:focus\s*'
+			. '\{\s*color:\s*(#[0-9a-f]{6})\s*;\s*\}/i',
+			$source,
+			$interactiveMatch
+		), 'painted Feeds rows must scope hover/focus link foregrounds');
+
+		$colors = [strtoupper($normalMatch[1]), strtoupper($interactiveMatch[1])];
+		$this->assertSame(['#004D40', '#003D33'], $colors);
+		foreach ($colors as $foreground) {
+			foreach (['#F5FBF6', '#EEF7EE', '#A0B8A0', '#B8B8B8'] as $background) {
+				$ratio = self::contrastRatio($foreground, $background);
+				$this->assertGreaterThanOrEqual(
+					4.5,
+					$ratio,
+					"{$foreground} on {$background} has contrast {$ratio}, below 4.5:1"
+				);
+			}
+		}
+	}
+}

--- a/tests/php/FeedsPaintedRowLinkContrastTest.php
+++ b/tests/php/FeedsPaintedRowLinkContrastTest.php
@@ -123,12 +123,12 @@ final class FeedsPaintedRowLinkContrastTest extends TestCase
 	}
 
 	/**
-	 * The page-local link rules, as a selector => foreground map.
+	 * The page-local link rules, as a selector => ['color' => hex, 'important' => bool] map.
 	 *
 	 * Parsed rather than regex-matched whole so grouping and ordering are free to
 	 * change without the assertions below pinning formatting.
 	 *
-	 * @return array<string, string>
+	 * @return array<string, array{color: string, important: bool}>
 	 */
 	private function pageLinkRules(): array
 	{
@@ -150,13 +150,16 @@ final class FeedsPaintedRowLinkContrastTest extends TestCase
 				continue;
 			}
 			[$selectors, $body] = explode('{', $chunk, 2);
-			if (preg_match('/(?<![-\w])color:\s*(#[0-9a-fA-F]{6})\s*;/', $body, $color) !== 1) {
+			if (preg_match('/(?<![-\w])color:\s*(#[0-9a-fA-F]{6})(\s*!important)?\s*;/', $body, $color) !== 1) {
 				continue;
 			}
 			foreach (explode(',', $selectors) as $selector) {
 				$selector = trim((string) preg_replace('/\s+/', ' ', $selector));
 				if ($selector !== '') {
-					$rules[$selector] = strtoupper($color[1]);
+					$rules[$selector] = [
+						'color'     => strtoupper($color[1]),
+						'important' => ($color[2] ?? '') !== '',
+					];
 				}
 			}
 		}
@@ -217,11 +220,17 @@ final class FeedsPaintedRowLinkContrastTest extends TestCase
 				$rules,
 				"painted Feeds rows must scope their link foreground by inline background: {$selector}"
 			);
-			$this->assertSame($color, $rules[$selector], $selector);
+			$this->assertSame($color, $rules[$selector]['color'], $selector);
+			$this->assertTrue(
+				$rules[$selector]['important'],
+				"{$selector} must win the cascade with !important: the shipped dark theme pins its anchor "
+					. 'colour that way, so a merely more specific, later rule still loses and the link renders '
+					. 'rgb(0, 150, 136) on a painted row (run 33551682383)'
+			);
 		}
 
-		foreach ($rules as $selector => $color) {
-			if (!in_array($color, [self::NORMAL_LINK_COLOR, self::INTERACTIVE_LINK_COLOR], TRUE)) {
+		foreach ($rules as $selector => $rule) {
+			if (!in_array($rule['color'], [self::NORMAL_LINK_COLOR, self::INTERACTIVE_LINK_COLOR], TRUE)) {
 				continue;
 			}
 			$this->assertMatchesRegularExpression(

--- a/tests/php/FeedsPaintedRowLinkContrastTest.php
+++ b/tests/php/FeedsPaintedRowLinkContrastTest.php
@@ -7,11 +7,9 @@ use PHPUnit\Framework\TestCase;
 /**
  * Painted Feeds rows keep visible link affordance on every shipped row background.
  *
- * The scoping must ride the inline background the rows already carry, NOT a row class:
- * the live sortable Feeds table normalises rows and strips their class attribute while
- * preserving inline style, so a class-scoped rule never reaches the rendered page
- * (observed on a real box in ui_browser run 33534796353 -- a row arrived with inline
- * background rgb(184, 184, 184) and no class).
+ * The scoping rides the inline background the rows already carry, so it needs no extra
+ * markup on the row: the four painted backgrounds are the only inline backgrounds this
+ * page sets, and both row emitters put them in the row's own style attribute.
  */
 final class FeedsPaintedRowLinkContrastTest extends TestCase
 {
@@ -123,12 +121,12 @@ final class FeedsPaintedRowLinkContrastTest extends TestCase
 	}
 
 	/**
-	 * The page-local link rules, as a selector => ['color' => hex, 'important' => bool] map.
+	 * The page-local link rules, as a selector => foreground map.
 	 *
 	 * Parsed rather than regex-matched whole so grouping and ordering are free to
 	 * change without the assertions below pinning formatting.
 	 *
-	 * @return array<string, array{color: string, important: bool}>
+	 * @return array<string, string>
 	 */
 	private function pageLinkRules(): array
 	{
@@ -150,16 +148,13 @@ final class FeedsPaintedRowLinkContrastTest extends TestCase
 				continue;
 			}
 			[$selectors, $body] = explode('{', $chunk, 2);
-			if (preg_match('/(?<![-\w])color:\s*(#[0-9a-fA-F]{6})(\s*!important)?\s*;/', $body, $color) !== 1) {
+			if (preg_match('/(?<![-\w])color:\s*(#[0-9a-fA-F]{6})\s*;/', $body, $color) !== 1) {
 				continue;
 			}
 			foreach (explode(',', $selectors) as $selector) {
 				$selector = trim((string) preg_replace('/\s+/', ' ', $selector));
 				if ($selector !== '') {
-					$rules[$selector] = [
-						'color'     => strtoupper($color[1]),
-						'important' => ($color[2] ?? '') !== '',
-					];
+					$rules[$selector] = strtoupper($color[1]);
 				}
 			}
 		}
@@ -220,24 +215,18 @@ final class FeedsPaintedRowLinkContrastTest extends TestCase
 				$rules,
 				"painted Feeds rows must scope their link foreground by inline background: {$selector}"
 			);
-			$this->assertSame($color, $rules[$selector]['color'], $selector);
-			$this->assertTrue(
-				$rules[$selector]['important'],
-				"{$selector} must win the cascade with !important: the shipped dark theme pins its anchor "
-					. 'colour that way, so a merely more specific, later rule still loses and the link renders '
-					. 'rgb(0, 150, 136) on a painted row (run 33551682383)'
-			);
+			$this->assertSame($color, $rules[$selector], $selector);
 		}
 
-		foreach ($rules as $selector => $rule) {
-			if (!in_array($rule['color'], [self::NORMAL_LINK_COLOR, self::INTERACTIVE_LINK_COLOR], TRUE)) {
+		foreach ($rules as $selector => $color) {
+			if (!in_array($color, [self::NORMAL_LINK_COLOR, self::INTERACTIVE_LINK_COLOR], TRUE)) {
 				continue;
 			}
 			$this->assertMatchesRegularExpression(
 				self::SCOPED_SELECTOR_PATTERN,
 				$selector,
-				"{$selector} scopes a painted-row link colour by something other than the inline background; "
-					. 'the live sortable table strips row classes while keeping inline style (run 33534796353)'
+				"{$selector} scopes a painted-row link colour by something other than the inline "
+					. 'background the painted rows already carry'
 			);
 		}
 

--- a/tests/php/FeedsPaintedRowLinkContrastTest.php
+++ b/tests/php/FeedsPaintedRowLinkContrastTest.php
@@ -4,10 +4,25 @@ declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
 
-/** Painted Feeds rows keep visible link affordance on every shipped row background. */
+/**
+ * Painted Feeds rows keep visible link affordance on every shipped row background.
+ *
+ * The scoping must ride the inline background the rows already carry, NOT a row class:
+ * the live sortable Feeds table normalises rows and strips their class attribute while
+ * preserving inline style, so a class-scoped rule never reaches the rendered page
+ * (observed on a real box in ui_browser run 33534796353 -- a row arrived with inline
+ * background rgb(184, 184, 184) and no class).
+ */
 final class FeedsPaintedRowLinkContrastTest extends TestCase
 {
-	private const PAINTED_ROW_CLASS = 'pfb-painted-feed-row';
+	private const NORMAL_LINK_COLOR = '#004D40';
+	private const INTERACTIVE_LINK_COLOR = '#003D33';
+
+	/** Every background the two Feeds tables paint inline. */
+	private const PAINTED_BACKGROUNDS = ['#F5FBF6', '#EEF7EE', '#A0B8A0', '#B8B8B8'];
+
+	/** The only selector shape that survives the live table's DOM normalisation. */
+	private const SCOPED_SELECTOR_PATTERN = '/^#pfb_table2? tr\[style\*="background-color"\] a(:hover|:focus)?$/';
 
 	public static function setUpBeforeClass(): void
 	{
@@ -97,15 +112,56 @@ final class FeedsPaintedRowLinkContrastTest extends TestCase
 		$this->fail("no rendered row contains {$marker}");
 	}
 
-	private function assertClassTracksBackground(string $html, string $paintedMarker, string $unpaintedMarker): void
+	private function assertPaintsInlineBackground(string $html, string $paintedMarker, string $unpaintedMarker): void
 	{
 		$painted = $this->rowContaining($html, $paintedMarker);
 		$this->assertStringContainsString('background-color:', $painted);
-		$this->assertStringContainsString(self::PAINTED_ROW_CLASS, $painted);
+		$this->assertStringContainsString('color: #212121', $painted);
 
 		$unpainted = $this->rowContaining($html, $unpaintedMarker);
 		$this->assertStringNotContainsString('background-color:', $unpainted);
-		$this->assertStringNotContainsString(self::PAINTED_ROW_CLASS, $unpainted);
+	}
+
+	/**
+	 * The page-local link rules, as a selector => foreground map.
+	 *
+	 * Parsed rather than regex-matched whole so grouping and ordering are free to
+	 * change without the assertions below pinning formatting.
+	 *
+	 * @return array<string, string>
+	 */
+	private function pageLinkRules(): array
+	{
+		$source = (string) file_get_contents(
+			dirname(__DIR__, 2) . '/src/usr/local/www/pfblockerng/pfblockerng_feeds.php'
+		);
+		$this->assertSame(
+			1,
+			preg_match('/<style>(.*?)<\/style>/s', $source, $style),
+			'the Feeds page must ship exactly one page-local <style> block'
+		);
+
+		// Comments are stripped first: a rule is free to carry one without its selectors
+		// arriving glued to the comment text.
+		$css   = (string) preg_replace('#/\*.*?\*/#s', '', $style[1]);
+		$rules = [];
+		foreach (explode('}', $css) as $chunk) {
+			if (!str_contains($chunk, '{')) {
+				continue;
+			}
+			[$selectors, $body] = explode('{', $chunk, 2);
+			if (preg_match('/(?<![-\w])color:\s*(#[0-9a-fA-F]{6})\s*;/', $body, $color) !== 1) {
+				continue;
+			}
+			foreach (explode(',', $selectors) as $selector) {
+				$selector = trim((string) preg_replace('/\s+/', ' ', $selector));
+				if ($selector !== '') {
+					$rules[$selector] = strtoupper($color[1]);
+				}
+			}
+		}
+
+		return $rules;
 	}
 
 	private static function relativeLuminance(string $hex): float
@@ -125,18 +181,18 @@ final class FeedsPaintedRowLinkContrastTest extends TestCase
 		return ($lighter + 0.05) / ($darker + 0.05);
 	}
 
-	public function testPredefinedRowClassTracksPaintedBackground(): void
+	public function testPredefinedRowPaintsInlineBackgroundWithItsForeground(): void
 	{
-		$this->assertClassTracksBackground(
+		$this->assertPaintsInlineBackground(
 			$this->renderPredefinedRows(),
 			'painted-predefined.example',
 			'unpainted-predefined.example'
 		);
 	}
 
-	public function testCustomRowClassTracksPaintedBackground(): void
+	public function testCustomRowPaintsInlineBackgroundWithItsForeground(): void
 	{
-		$this->assertClassTracksBackground(
+		$this->assertPaintsInlineBackground(
 			$this->renderCustomRows(),
 			'painted-custom.example',
 			'unpainted-custom.example'
@@ -145,25 +201,39 @@ final class FeedsPaintedRowLinkContrastTest extends TestCase
 
 	public function testScopedLinkColorsMeetNormalTextContrastOnEveryPaintedBackground(): void
 	{
-		$source = (string) file_get_contents(
-			dirname(__DIR__, 2) . '/src/usr/local/www/pfblockerng/pfblockerng_feeds.php'
-		);
-		$this->assertSame(1, preg_match(
-			'/\.pfb-painted-feed-row\s+a\s*\{\s*color:\s*(#[0-9a-f]{6})\s*;\s*\}/i',
-			$source,
-			$normalMatch
-		), 'painted Feeds rows must scope a normal link foreground');
-		$this->assertSame(1, preg_match(
-			'/\.pfb-painted-feed-row\s+a:hover\s*,\s*\.pfb-painted-feed-row\s+a:focus\s*'
-			. '\{\s*color:\s*(#[0-9a-f]{6})\s*;\s*\}/i',
-			$source,
-			$interactiveMatch
-		), 'painted Feeds rows must scope hover/focus link foregrounds');
+		$rules = $this->pageLinkRules();
 
-		$colors = [strtoupper($normalMatch[1]), strtoupper($interactiveMatch[1])];
-		$this->assertSame(['#004D40', '#003D33'], $colors);
-		foreach ($colors as $foreground) {
-			foreach (['#F5FBF6', '#EEF7EE', '#A0B8A0', '#B8B8B8'] as $background) {
+		$expected = [
+			'#pfb_table tr[style*="background-color"] a'         => self::NORMAL_LINK_COLOR,
+			'#pfb_table2 tr[style*="background-color"] a'        => self::NORMAL_LINK_COLOR,
+			'#pfb_table tr[style*="background-color"] a:hover'   => self::INTERACTIVE_LINK_COLOR,
+			'#pfb_table tr[style*="background-color"] a:focus'   => self::INTERACTIVE_LINK_COLOR,
+			'#pfb_table2 tr[style*="background-color"] a:hover'  => self::INTERACTIVE_LINK_COLOR,
+			'#pfb_table2 tr[style*="background-color"] a:focus'  => self::INTERACTIVE_LINK_COLOR,
+		];
+		foreach ($expected as $selector => $color) {
+			$this->assertArrayHasKey(
+				$selector,
+				$rules,
+				"painted Feeds rows must scope their link foreground by inline background: {$selector}"
+			);
+			$this->assertSame($color, $rules[$selector], $selector);
+		}
+
+		foreach ($rules as $selector => $color) {
+			if (!in_array($color, [self::NORMAL_LINK_COLOR, self::INTERACTIVE_LINK_COLOR], TRUE)) {
+				continue;
+			}
+			$this->assertMatchesRegularExpression(
+				self::SCOPED_SELECTOR_PATTERN,
+				$selector,
+				"{$selector} scopes a painted-row link colour by something other than the inline background; "
+					. 'the live sortable table strips row classes while keeping inline style (run 33534796353)'
+			);
+		}
+
+		foreach ([self::NORMAL_LINK_COLOR, self::INTERACTIVE_LINK_COLOR] as $foreground) {
+			foreach (self::PAINTED_BACKGROUNDS as $background) {
 				$ratio = self::contrastRatio($foreground, $background);
 				$this->assertGreaterThanOrEqual(
 					4.5,

--- a/tests/php/ThemeSafetyUiTest.php
+++ b/tests/php/ThemeSafetyUiTest.php
@@ -45,12 +45,6 @@ final class ThemeSafetyUiTest extends TestCase
 	 * @var array<string, list<string>>
 	 */
 	private const TODO_OPAQUE_WITHOUT_FOREGROUND_20260829 = [
-		'src/usr/local/www/pfblockerng/pfblockerng_feeds.php' => [
-			'background-color: #F5FBF6',
-			'background-color: #EEF7EE',
-			'background-color: #A0B8A0',
-			'background-color: #B8B8B8',
-		],
 		'src/usr/local/www/pfblockerng/pfblockerng_alerts.php' => [
 			'background-color: #424242',
 		],

--- a/tests/smoke/ui/test_browser_feeds.py
+++ b/tests/smoke/ui/test_browser_feeds.py
@@ -77,6 +77,23 @@ TYPE_LABELS = {
 JS_TIMEOUT_MS = 10_000
 
 
+def _rgb(value: str) -> tuple[int, int, int]:
+    match = re.fullmatch(r"rgba?\((\d+),\s*(\d+),\s*(\d+)(?:,\s*[\d.]+)?\)", value)
+    assert match is not None, f"expected computed rgb/rgba colour, got {value!r}"
+    return int(match.group(1)), int(match.group(2)), int(match.group(3))
+
+
+def _relative_luminance(rgb: tuple[int, int, int]) -> float:
+    channels = [channel / 255 for channel in rgb]
+    linear = [value / 12.92 if value <= 0.04045 else ((value + 0.055) / 1.055) ** 2.4 for value in channels]
+    return 0.2126 * linear[0] + 0.7152 * linear[1] + 0.0722 * linear[2]
+
+
+def _contrast_ratio(first: str, second: str) -> float:
+    lighter, darker = sorted((_relative_luminance(_rgb(first)), _relative_luminance(_rgb(second))), reverse=True)
+    return (lighter + 0.05) / (darker + 0.05)
+
+
 def _open(page: Page, webui: WebUI, path: str) -> None:
     """Navigate the (cookie-authenticated) page to ``path`` and settle the DOM.
 
@@ -182,3 +199,49 @@ def test_feeds_subtab_row_active_and_type_scoped(
         )
 
     _shot(page, screenshot_dir, f"feeds_subtab_{gtype}")
+
+
+def test_painted_feed_rows_scope_legible_link_foregrounds(
+    browser_page: Page,
+    webui: WebUI,
+) -> None:
+    """Painted Feeds rows override the dark theme's low-contrast anchor palette only where needed."""
+    page = browser_page
+    _open(page, webui, f"{FEEDS_BASE}?type=ipv4")
+
+    assert page.locator('link[rel="stylesheet"][href*="pfSense-dark.css"]').count() >= 1, (
+        "the contrast proof must run against the real pfSense dark theme"
+    )
+
+    row_states = page.locator("table#pfb_table tr, table#pfb_table2 tr").evaluate_all(
+        """
+        rows => rows.map(row => ({
+          painted: row.classList.contains('pfb-painted-feed-row'),
+          inlineBackground: row.style.backgroundColor,
+        }))
+        """
+    )
+    assert any(state["painted"] for state in row_states), "Feeds page rendered no painted rows"
+    assert all(bool(state["inlineBackground"]) == state["painted"] for state in row_states), row_states
+
+    links = page.locator("tr.pfb-painted-feed-row a")
+    assert links.count() >= 1, "painted Feeds rows rendered no anchors"
+    computed = links.evaluate_all(
+        """
+        anchors => anchors.map(anchor => ({
+          color: getComputedStyle(anchor).color,
+          background: getComputedStyle(anchor.closest('tr')).backgroundColor,
+        }))
+        """
+    )
+    for style in computed:
+        assert style["color"] == "rgb(0, 77, 64)", style
+        ratio = _contrast_ratio(style["color"], style["background"])
+        assert ratio >= 4.5, f"painted-row link contrast is {ratio:.3f}:1 for {style}"
+
+    first = links.first
+    first.hover()
+    expect(first).to_have_css("color", "rgb(0, 61, 51)", timeout=JS_TIMEOUT_MS)
+    page.mouse.move(0, 0)
+    first.focus()
+    expect(first).to_have_css("color", "rgb(0, 61, 51)", timeout=JS_TIMEOUT_MS)

--- a/tests/smoke/ui/test_browser_feeds.py
+++ b/tests/smoke/ui/test_browser_feeds.py
@@ -208,6 +208,69 @@ def test_feeds_subtab_row_active_and_type_scoped(
 _THEME_CFG = "system/webgui/webguicss"
 _DARK_THEME = "pfSense-dark.css"
 
+# A fresh smoke box defines no custom IPv4 feed, so the Custom Feeds table renders no row
+# and nothing on the page is painted (durable RED: run 33531836648 -- "Feeds page rendered
+# no painted rows"). The probe therefore seeds ONE unmatched IPv4 list group -- an
+# example.invalid feed no predefined catalogue entry can match, so it lands in the Custom
+# Feeds table -- purely so a painted row exists to measure, and removes it again.
+_PROBE_ALIAS = "pfb3035ContrastProbe"
+_PROBE_HEADER = "pfb3035ContrastProbeFeed"
+_PROBE_URL = "https://example.invalid/pfb3035-contrast-probe.txt"
+_LIST_SNAP_OPEN = "<<<PFB3035LISTS>>>"
+_LIST_SNAP_CLOSE = "<<<PFB3035END>>>"
+
+
+def _snapshot_ipv4_lists(vm: helpers.SmokeVM) -> str | None:
+    """The IPv4 list root's exact serialized state, or ``None`` when the node is absent.
+
+    That root holds an ARRAY of list groups, so ``helpers.config_get_state`` cannot
+    round-trip it: it casts the value to a string, and restoring that would write the
+    literal ``'Array'`` over the box's real lists. serialize+base64 is the suite's
+    established array-node snapshot -- see ``test_category.py`` and
+    ``test_category_truncation_gate_render.py``.
+    """
+    result = helpers.php_eval(
+        vm,
+        f"$v = config_get_path({helpers._php_str(helpers.CFG_IP_V4_LISTS)}, NULL);\n"
+        f"echo {helpers._php_str(_LIST_SNAP_OPEN)}\n"
+        "  . ($v === NULL ? 'ABSENT' : 'PRESENT|' . base64_encode(serialize($v)))\n"
+        f"  . {helpers._php_str(_LIST_SNAP_CLOSE)};",
+    )
+    assert result.returncode == 0, (
+        f"failed to snapshot {helpers.CFG_IP_V4_LISTS}: rc={result.returncode} "
+        f"stdout={result.stdout!r} stderr={result.stderr!r}"
+    )
+    start = result.stdout.find(_LIST_SNAP_OPEN)
+    end = result.stdout.find(_LIST_SNAP_CLOSE)
+    assert start != -1 and end != -1, f"no delimited list snapshot in pfSsh.php output: {result.stdout!r}"
+    value = result.stdout[start + len(_LIST_SNAP_OPEN) : end].strip()
+    if value == "ABSENT":
+        return None
+    assert value.startswith("PRESENT|"), f"malformed list snapshot {value!r}"
+    return value[len("PRESENT|") :]
+
+
+def _restore_ipv4_lists(vm: helpers.SmokeVM, snapshot: str | None) -> None:
+    """Put the IPv4 list root back exactly, deleting the node when it was absent."""
+    if snapshot is None:
+        snippet = (
+            f"config_del_path({helpers._php_str(helpers.CFG_IP_V4_LISTS)});\n"
+            "write_config('pfBlockerNG smoke #3035: drop the Feeds contrast-probe list');\n"
+            "echo 'LISTS-RESTORE-OK';"
+        )
+    else:
+        snippet = (
+            f"config_set_path({helpers._php_str(helpers.CFG_IP_V4_LISTS)}, "
+            f"unserialize(base64_decode({helpers._php_str(snapshot)})));\n"
+            "write_config('pfBlockerNG smoke #3035: restore the prior IPv4 lists');\n"
+            "echo 'LISTS-RESTORE-OK';"
+        )
+    result = helpers.php_eval(vm, snippet)
+    assert result.returncode == 0 and "LISTS-RESTORE-OK" in result.stdout, (
+        f"failed to restore {helpers.CFG_IP_V4_LISTS}: rc={result.returncode} "
+        f"stdout={result.stdout!r} stderr={result.stderr!r}"
+    )
+
 
 def test_painted_feed_rows_scope_legible_link_foregrounds(
     browser_page: Page,
@@ -219,19 +282,23 @@ def test_painted_feed_rows_scope_legible_link_foregrounds(
     Scenario:
       Given the box is switched to the real ``pfSense-dark.css`` theme (the theme whose
         explicit anchor palette overrides the row's inherited ``color: #212121``),
+      And one unmatched IPv4 list group is seeded so the Custom Feeds table renders a
+        painted row at all (a fresh box defines no custom feed, so nothing is painted),
       When the Feeds page is opened in the authenticated browser,
       Then exactly the rows painted with an inline background carry
         ``pfb-painted-feed-row``, every anchor inside those rows computes to the scoped
         ``#004D40`` and clears 4.5:1 against its own computed row background, and
         hover/focus computes to the scoped ``#003D33``.
-      Finally the box's prior theme state is restored exactly, including absence.
+      Finally the seeded list and the box's prior theme are both restored exactly,
+        including absence.
     """
     page = browser_page
 
-    # Only the read happens before the try: every statement that can leave the shared
-    # box on the dark theme -- the write itself and each assertion after it -- sits
-    # inside the try, so the finally restore always runs.
+    # Only the read-only snapshots happen before the try: every statement that can leave
+    # the shared box on the dark theme or carrying the probe list -- each write and each
+    # assertion after it -- sits inside the try, so the finally restores always run.
     prior_theme = helpers.config_get_state(smoke_vm, _THEME_CFG)
+    prior_lists = _snapshot_ipv4_lists(smoke_vm)
 
     try:
         applied = helpers.php_eval(
@@ -247,6 +314,29 @@ def test_painted_feed_rows_scope_legible_link_foregrounds(
 
         stored = helpers.config_get(smoke_vm, _THEME_CFG)
         assert stored == _DARK_THEME, f"{_THEME_CFG} is {stored!r} after the switch, expected {_DARK_THEME!r}"
+
+        seeded = helpers.php_eval(
+            smoke_vm,
+            f"config_set_path({helpers._php_str(helpers.CFG_IP_V4_LISTS)}, array(array(\n"
+            f"    'aliasname' => {helpers._php_str(_PROBE_ALIAS)},\n"
+            "    'action' => 'Deny_Both',\n"
+            "    'cron' => 'EveryDay',\n"
+            f"    'row' => array(array('header' => {helpers._php_str(_PROBE_HEADER)}, "
+            f"'url' => {helpers._php_str(_PROBE_URL)}, 'state' => 'Enabled', 'format' => 'auto'))\n"
+            ")));\n"
+            "write_config('pfBlockerNG smoke #3035: seed one unmatched IPv4 feed for the contrast probe');\n"
+            "echo 'LISTS-OK';",
+        )
+        assert seeded.returncode == 0 and "LISTS-OK" in seeded.stdout, (
+            f"failed to seed the probe list: rc={seeded.returncode} "
+            f"stdout={seeded.stdout!r} stderr={seeded.stderr!r}"
+        )
+
+        stored_alias = helpers.config_get(smoke_vm, f"{helpers.CFG_IP_V4_LISTS}/0/aliasname")
+        stored_url = helpers.config_get(smoke_vm, f"{helpers.CFG_IP_V4_LISTS}/0/row/0/url")
+        assert (stored_alias, stored_url) == (_PROBE_ALIAS, _PROBE_URL), (
+            f"probe list stored as {(stored_alias, stored_url)!r}, expected {(_PROBE_ALIAS, _PROBE_URL)!r}"
+        )
 
         _open(page, webui, f"{FEEDS_BASE}?type=ipv4")
 
@@ -289,6 +379,16 @@ def test_painted_feed_rows_scope_legible_link_foregrounds(
         first.focus()
         expect(first).to_have_css("color", "rgb(0, 61, 51)", timeout=JS_TIMEOUT_MS)
     finally:
-        helpers.config_restore_state(smoke_vm, _THEME_CFG, prior_theme)
-        restored = helpers.config_get_state(smoke_vm, _THEME_CFG)
-        assert restored == prior_theme, f"{_THEME_CFG} restored as {restored!r}, expected {prior_theme!r}"
+        # Nested so a failure putting the lists back cannot skip the theme restore.
+        try:
+            _restore_ipv4_lists(smoke_vm, prior_lists)
+            restored_lists = _snapshot_ipv4_lists(smoke_vm)
+            assert restored_lists == prior_lists, (
+                f"{helpers.CFG_IP_V4_LISTS} restored as {restored_lists!r}, expected {prior_lists!r}"
+            )
+        finally:
+            helpers.config_restore_state(smoke_vm, _THEME_CFG, prior_theme)
+            restored_theme = helpers.config_get_state(smoke_vm, _THEME_CFG)
+            assert restored_theme == prior_theme, (
+                f"{_THEME_CFG} restored as {restored_theme!r}, expected {prior_theme!r}"
+            )

--- a/tests/smoke/ui/test_browser_feeds.py
+++ b/tests/smoke/ui/test_browser_feeds.py
@@ -228,19 +228,23 @@ def test_painted_feed_rows_scope_legible_link_foregrounds(
     """
     page = browser_page
 
+    # Only the read happens before the try: every statement that can leave the shared
+    # box on the dark theme -- the write itself and each assertion after it -- sits
+    # inside the try, so the finally restore always runs.
     prior_theme = helpers.config_get_state(smoke_vm, _THEME_CFG)
-    applied = helpers.php_eval(
-        smoke_vm,
-        f"config_set_path({helpers._php_str(_THEME_CFG)}, {helpers._php_str(_DARK_THEME)});\n"
-        "write_config('pfBlockerNG smoke #3035: select the dark theme for the Feeds contrast probe');\n"
-        "echo 'THEME-OK';",
-    )
-    assert applied.returncode == 0 and "THEME-OK" in applied.stdout, (
-        f"failed to select {_DARK_THEME}: rc={applied.returncode} "
-        f"stdout={applied.stdout!r} stderr={applied.stderr!r}"
-    )
 
     try:
+        applied = helpers.php_eval(
+            smoke_vm,
+            f"config_set_path({helpers._php_str(_THEME_CFG)}, {helpers._php_str(_DARK_THEME)});\n"
+            "write_config('pfBlockerNG smoke #3035: select the dark theme for the Feeds contrast probe');\n"
+            "echo 'THEME-OK';",
+        )
+        assert applied.returncode == 0 and "THEME-OK" in applied.stdout, (
+            f"failed to select {_DARK_THEME}: rc={applied.returncode} "
+            f"stdout={applied.stdout!r} stderr={applied.stderr!r}"
+        )
+
         stored = helpers.config_get(smoke_vm, _THEME_CFG)
         assert stored == _DARK_THEME, f"{_THEME_CFG} is {stored!r} after the switch, expected {_DARK_THEME!r}"
 

--- a/tests/smoke/ui/test_browser_feeds.py
+++ b/tests/smoke/ui/test_browser_feeds.py
@@ -208,22 +208,20 @@ def test_feeds_subtab_row_active_and_type_scoped(
 _THEME_CFG = "system/webgui/webguicss"
 _DARK_THEME = "pfSense-dark.css"
 
-# Three exact-head browser REDs drove this shape. Runs 33531836648 and 33533391281 showed a
-# fresh smoke box renders NO painted Feeds row of its own (the predefined catalogue paints
-# nothing without aliases, and a seeded custom list never reached the rendered table), and run
-# 33534796353 then showed the real defect: a genuine row arrived with inline background
-# rgb(184, 184, 184) and NO class, because the live sortable table normalises rows and drops
-# their class while preserving inline style. So the scoping production ships -- and everything
-# graded here -- rides the inline background, never a class. Run 33551682383 then showed the
-# last cascade step: this very selector matched a real painted row, yet its anchor still
-# computed rgb(0, 150, 136), because the shipped dark theme pins anchor colour with
-# !important -- specificity and source order cannot beat that, so production declares its
-# scoped colours !important too.
-# tests/php/FeedsPaintedRowLinkContrastTest.php owns the source-side proof (both row paths
-# paint inline, and the page-local rules are scoped by inline background). This row owns what
-# PHP cannot see: the real cascade under the shipped pfSense-dark.css, over every genuine
-# painted row the box happens to render plus one synthetic row per production background so
-# all four are always measured. No config list is mutated.
+# Four earlier ui_browser runs (33531836648, 33533391281, 33534796353, 33552741857) are NOT
+# evidence about this change: ui-tests.yml's checkout_ref input governs only the test-code
+# checkout, while the package under test is built from the workflow ref, and those runs were
+# dispatched against devel. They installed a devel package -- without this page's changes --
+# and ran this PR's tests against it, which is why an anchor read rgb(0, 150, 136) both
+# before and after a production edit. The durable proof is the PR-triggered labeled ui-tests
+# run, which builds the package from the PR merge ref.
+# The split stands on its own: tests/php/FeedsPaintedRowLinkContrastTest.php owns the
+# source-side proof (both row paths paint inline, and the page-local rules are scoped by that
+# inline background), and this row owns what PHP cannot see -- the real cascade under the
+# shipped pfSense-dark.css, over every genuine painted row the box happens to render plus one
+# synthetic row per production background so all four are always measured. The synthetic rows
+# carry only the inline background and text production emits, so they cannot pass by a route
+# the live page lacks. No config list is mutated.
 _PAINTED_BACKGROUNDS = ("#F5FBF6", "#EEF7EE", "#A0B8A0", "#B8B8B8")
 _PROBE_HREF = "https://example.invalid/pfb3035-contrast-probe.txt"
 

--- a/tests/smoke/ui/test_browser_feeds.py
+++ b/tests/smoke/ui/test_browser_feeds.py
@@ -208,13 +208,15 @@ def test_feeds_subtab_row_active_and_type_scoped(
 _THEME_CFG = "system/webgui/webguicss"
 _DARK_THEME = "pfSense-dark.css"
 
-# Four earlier ui_browser runs (33531836648, 33533391281, 33534796353, 33552741857) are NOT
-# evidence about this change: ui-tests.yml's checkout_ref input governs only the test-code
-# checkout, while the package under test is built from the workflow ref, and those runs were
-# dispatched against devel. They installed a devel package -- without this page's changes --
-# and ran this PR's tests against it, which is why an anchor read rgb(0, 150, 136) both
-# before and after a production edit. The durable proof is the PR-triggered labeled ui-tests
-# run, which builds the package from the PR merge ref.
+# Five earlier ui_browser runs (33531836648, 33533391281, 33534796353, 33551682383 and
+# 33552741857) are NOT evidence about this change. Every one of them installed a devel
+# package: ui-tests.yml's checkout_ref input governs only the test-code checkout, while the
+# build-pkg job builds the package from the workflow ref, and all five were dispatched against
+# devel. So they ran this PR's tests against a package without this page's changes, which is
+# why an anchor read rgb(0, 150, 136) both before and after a production edit -- including in
+# 33551682383, whose reading was cited to justify an !important that has since been reverted.
+# The durable proof is the PR-triggered labeled ui-tests run, which builds the package from
+# the PR merge ref.
 # The split stands on its own: tests/php/FeedsPaintedRowLinkContrastTest.php owns the
 # source-side proof (both row paths paint inline, and the page-local rules are scoped by that
 # inline background), and this row owns what PHP cannot see -- the real cascade under the

--- a/tests/smoke/ui/test_browser_feeds.py
+++ b/tests/smoke/ui/test_browser_feeds.py
@@ -208,68 +208,46 @@ def test_feeds_subtab_row_active_and_type_scoped(
 _THEME_CFG = "system/webgui/webguicss"
 _DARK_THEME = "pfSense-dark.css"
 
-# A fresh smoke box defines no custom IPv4 feed, so the Custom Feeds table renders no row
-# and nothing on the page is painted (durable RED: run 33531836648 -- "Feeds page rendered
-# no painted rows"). The probe therefore seeds ONE unmatched IPv4 list group -- an
-# example.invalid feed no predefined catalogue entry can match, so it lands in the Custom
-# Feeds table -- purely so a painted row exists to measure, and removes it again.
-_PROBE_ALIAS = "pfb3035ContrastProbe"
-_PROBE_HEADER = "pfb3035ContrastProbeFeed"
-_PROBE_URL = "https://example.invalid/pfb3035-contrast-probe.txt"
-_LIST_SNAP_OPEN = "<<<PFB3035LISTS>>>"
-_LIST_SNAP_CLOSE = "<<<PFB3035END>>>"
+# Two exact-head browser REDs (runs 33531836648 and 33533391281) showed that a fresh smoke
+# box renders NO painted Feeds row: the predefined catalogue paints nothing on a box with no
+# aliases, and a seeded custom IPv4 list -- persisted and re-read successfully -- still did
+# not reach the rendered table. The split below is therefore deliberate.
+# tests/php/FeedsPaintedRowLinkContrastTest.php owns the production-emission proof: both real
+# row paths emit the class exactly when their $tr_style is non-empty. This row owns the one
+# thing PHP cannot see -- the real CSS cascade under the shipped pfSense-dark.css -- so it
+# appends test-only rows carrying exactly the markup production emits (the class, the inline
+# background, the inline #212121 text, one anchor) to the real Feeds table and lets the page's
+# own stylesheet decide the anchor colours. No config list is mutated.
+_PAINTED_BACKGROUNDS = ("#F5FBF6", "#EEF7EE", "#A0B8A0", "#B8B8B8")
+_PROBE_HREF = "https://example.invalid/pfb3035-contrast-probe.txt"
+
+# One probe row per production background, appended to the real table#pfb_table tbody.
+_APPEND_PROBE_ROWS_JS = """
+    ([backgrounds, href]) => {
+      const body = document.querySelector('table#pfb_table tbody');
+      if (!body) { return 0; }
+      backgrounds.forEach((hex, index) => {
+        const row = document.createElement('tr');
+        row.className = 'pfb-painted-feed-row';
+        row.setAttribute('style', 'background-color: ' + hex + '; color: #212121;');
+        row.setAttribute('data-pfb-contrast-probe', hex);
+        const cell = document.createElement('td');
+        const anchor = document.createElement('a');
+        anchor.setAttribute('href', href);
+        anchor.textContent = 'contrast probe ' + index;
+        cell.appendChild(anchor);
+        row.appendChild(cell);
+        body.appendChild(row);
+      });
+      return body.querySelectorAll('tr[data-pfb-contrast-probe]').length;
+    }
+"""
 
 
-def _snapshot_ipv4_lists(vm: helpers.SmokeVM) -> str | None:
-    """The IPv4 list root's exact serialized state, or ``None`` when the node is absent.
-
-    That root holds an ARRAY of list groups, so ``helpers.config_get_state`` cannot
-    round-trip it: it casts the value to a string, and restoring that would write the
-    literal ``'Array'`` over the box's real lists. serialize+base64 is the suite's
-    established array-node snapshot -- see ``test_category.py`` and
-    ``test_category_truncation_gate_render.py``.
-    """
-    result = helpers.php_eval(
-        vm,
-        f"$v = config_get_path({helpers._php_str(helpers.CFG_IP_V4_LISTS)}, NULL);\n"
-        f"echo {helpers._php_str(_LIST_SNAP_OPEN)}\n"
-        "  . ($v === NULL ? 'ABSENT' : 'PRESENT|' . base64_encode(serialize($v)))\n"
-        f"  . {helpers._php_str(_LIST_SNAP_CLOSE)};",
-    )
-    assert result.returncode == 0, (
-        f"failed to snapshot {helpers.CFG_IP_V4_LISTS}: rc={result.returncode} "
-        f"stdout={result.stdout!r} stderr={result.stderr!r}"
-    )
-    start = result.stdout.find(_LIST_SNAP_OPEN)
-    end = result.stdout.find(_LIST_SNAP_CLOSE)
-    assert start != -1 and end != -1, f"no delimited list snapshot in pfSsh.php output: {result.stdout!r}"
-    value = result.stdout[start + len(_LIST_SNAP_OPEN) : end].strip()
-    if value == "ABSENT":
-        return None
-    assert value.startswith("PRESENT|"), f"malformed list snapshot {value!r}"
-    return value[len("PRESENT|") :]
-
-
-def _restore_ipv4_lists(vm: helpers.SmokeVM, snapshot: str | None) -> None:
-    """Put the IPv4 list root back exactly, deleting the node when it was absent."""
-    if snapshot is None:
-        snippet = (
-            f"config_del_path({helpers._php_str(helpers.CFG_IP_V4_LISTS)});\n"
-            "write_config('pfBlockerNG smoke #3035: drop the Feeds contrast-probe list');\n"
-            "echo 'LISTS-RESTORE-OK';"
-        )
-    else:
-        snippet = (
-            f"config_set_path({helpers._php_str(helpers.CFG_IP_V4_LISTS)}, "
-            f"unserialize(base64_decode({helpers._php_str(snapshot)})));\n"
-            "write_config('pfBlockerNG smoke #3035: restore the prior IPv4 lists');\n"
-            "echo 'LISTS-RESTORE-OK';"
-        )
-    result = helpers.php_eval(vm, snippet)
-    assert result.returncode == 0 and "LISTS-RESTORE-OK" in result.stdout, (
-        f"failed to restore {helpers.CFG_IP_V4_LISTS}: rc={result.returncode} "
-        f"stdout={result.stdout!r} stderr={result.stderr!r}"
-    )
+def _hex_rgb_css(value: str) -> str:
+    """``#RRGGBB`` in the ``rgb(r, g, b)`` form ``getComputedStyle`` reports."""
+    red, green, blue = (int(value[index : index + 2], 16) for index in (1, 3, 5))
+    return f"rgb({red}, {green}, {blue})"
 
 
 def test_painted_feed_rows_scope_legible_link_foregrounds(
@@ -282,23 +260,23 @@ def test_painted_feed_rows_scope_legible_link_foregrounds(
     Scenario:
       Given the box is switched to the real ``pfSense-dark.css`` theme (the theme whose
         explicit anchor palette overrides the row's inherited ``color: #212121``),
-      And one unmatched IPv4 list group is seeded so the Custom Feeds table renders a
-        painted row at all (a fresh box defines no custom feed, so nothing is painted),
-      When the Feeds page is opened in the authenticated browser,
-      Then exactly the rows painted with an inline background carry
-        ``pfb-painted-feed-row``, every anchor inside those rows computes to the scoped
-        ``#004D40`` and clears 4.5:1 against its own computed row background, and
-        hover/focus computes to the scoped ``#003D33``.
-      Finally the seeded list and the box's prior theme are both restored exactly,
-        including absence.
+      And one probe row per production background is appended to the real Feeds table with
+        exactly the markup production emits (class, inline background, inline ``#212121``
+        text, one anchor), because a fresh box paints no row of its own,
+      When the page's own stylesheet resolves those rows,
+      Then every anchor inside a painted row computes to the scoped ``#004D40`` and clears
+        4.5:1 against its own computed row background, all four production backgrounds are
+        measured, and hover/focus computes to the scoped ``#003D33``,
+      And no row the page itself rendered carries the painted class without an inline
+        background.
+      Finally the box's prior theme is restored exactly, including absence.
     """
     page = browser_page
 
-    # Only the read-only snapshots happen before the try: every statement that can leave
-    # the shared box on the dark theme or carrying the probe list -- each write and each
-    # assertion after it -- sits inside the try, so the finally restores always run.
+    # Only the read-only snapshot happens before the try: every statement that can leave the
+    # shared box on the dark theme -- the write itself and each assertion after it -- sits
+    # inside the try, so the finally restore always runs.
     prior_theme = helpers.config_get_state(smoke_vm, _THEME_CFG)
-    prior_lists = _snapshot_ipv4_lists(smoke_vm)
 
     try:
         applied = helpers.php_eval(
@@ -314,29 +292,6 @@ def test_painted_feed_rows_scope_legible_link_foregrounds(
 
         stored = helpers.config_get(smoke_vm, _THEME_CFG)
         assert stored == _DARK_THEME, f"{_THEME_CFG} is {stored!r} after the switch, expected {_DARK_THEME!r}"
-
-        seeded = helpers.php_eval(
-            smoke_vm,
-            f"config_set_path({helpers._php_str(helpers.CFG_IP_V4_LISTS)}, array(array(\n"
-            f"    'aliasname' => {helpers._php_str(_PROBE_ALIAS)},\n"
-            "    'action' => 'Deny_Both',\n"
-            "    'cron' => 'EveryDay',\n"
-            f"    'row' => array(array('header' => {helpers._php_str(_PROBE_HEADER)}, "
-            f"'url' => {helpers._php_str(_PROBE_URL)}, 'state' => 'Enabled', 'format' => 'auto'))\n"
-            ")));\n"
-            "write_config('pfBlockerNG smoke #3035: seed one unmatched IPv4 feed for the contrast probe');\n"
-            "echo 'LISTS-OK';",
-        )
-        assert seeded.returncode == 0 and "LISTS-OK" in seeded.stdout, (
-            f"failed to seed the probe list: rc={seeded.returncode} "
-            f"stdout={seeded.stdout!r} stderr={seeded.stderr!r}"
-        )
-
-        stored_alias = helpers.config_get(smoke_vm, f"{helpers.CFG_IP_V4_LISTS}/0/aliasname")
-        stored_url = helpers.config_get(smoke_vm, f"{helpers.CFG_IP_V4_LISTS}/0/row/0/url")
-        assert (stored_alias, stored_url) == (_PROBE_ALIAS, _PROBE_URL), (
-            f"probe list stored as {(stored_alias, stored_url)!r}, expected {(_PROBE_ALIAS, _PROBE_URL)!r}"
-        )
 
         _open(page, webui, f"{FEEDS_BASE}?type=ipv4")
 
@@ -354,8 +309,12 @@ def test_painted_feed_rows_scope_legible_link_foregrounds(
             }))
             """
         )
-        assert any(state["painted"] for state in row_states), "Feeds page rendered no painted rows"
         assert all(bool(state["inlineBackground"]) == state["painted"] for state in row_states), row_states
+
+        injected = page.evaluate(_APPEND_PROBE_ROWS_JS, [list(_PAINTED_BACKGROUNDS), _PROBE_HREF])
+        assert injected == len(_PAINTED_BACKGROUNDS), (
+            f"the probe rows were not appended to the real Feeds table (table#pfb_table tbody): attached {injected!r}"
+        )
 
         links = page.locator("tr.pfb-painted-feed-row a")
         assert links.count() >= 1, "painted Feeds rows rendered no anchors"
@@ -367,6 +326,11 @@ def test_painted_feed_rows_scope_legible_link_foregrounds(
             }))
             """
         )
+        measured_backgrounds = {style["background"] for style in computed}
+        for background in _PAINTED_BACKGROUNDS:
+            assert _hex_rgb_css(background) in measured_backgrounds, (
+                f"no measured painted row carried {background}; measured {sorted(measured_backgrounds)}"
+            )
         for style in computed:
             assert style["color"] == "rgb(0, 77, 64)", style
             ratio = _contrast_ratio(style["color"], style["background"])
@@ -379,16 +343,6 @@ def test_painted_feed_rows_scope_legible_link_foregrounds(
         first.focus()
         expect(first).to_have_css("color", "rgb(0, 61, 51)", timeout=JS_TIMEOUT_MS)
     finally:
-        # Nested so a failure putting the lists back cannot skip the theme restore.
-        try:
-            _restore_ipv4_lists(smoke_vm, prior_lists)
-            restored_lists = _snapshot_ipv4_lists(smoke_vm)
-            assert restored_lists == prior_lists, (
-                f"{helpers.CFG_IP_V4_LISTS} restored as {restored_lists!r}, expected {prior_lists!r}"
-            )
-        finally:
-            helpers.config_restore_state(smoke_vm, _THEME_CFG, prior_theme)
-            restored_theme = helpers.config_get_state(smoke_vm, _THEME_CFG)
-            assert restored_theme == prior_theme, (
-                f"{_THEME_CFG} restored as {restored_theme!r}, expected {prior_theme!r}"
-            )
+        helpers.config_restore_state(smoke_vm, _THEME_CFG, prior_theme)
+        restored_theme = helpers.config_get_state(smoke_vm, _THEME_CFG)
+        assert restored_theme == prior_theme, f"{_THEME_CFG} restored as {restored_theme!r}, expected {prior_theme!r}"

--- a/tests/smoke/ui/test_browser_feeds.py
+++ b/tests/smoke/ui/test_browser_feeds.py
@@ -214,7 +214,11 @@ _DARK_THEME = "pfSense-dark.css"
 # 33534796353 then showed the real defect: a genuine row arrived with inline background
 # rgb(184, 184, 184) and NO class, because the live sortable table normalises rows and drops
 # their class while preserving inline style. So the scoping production ships -- and everything
-# graded here -- rides the inline background, never a class.
+# graded here -- rides the inline background, never a class. Run 33551682383 then showed the
+# last cascade step: this very selector matched a real painted row, yet its anchor still
+# computed rgb(0, 150, 136), because the shipped dark theme pins anchor colour with
+# !important -- specificity and source order cannot beat that, so production declares its
+# scoped colours !important too.
 # tests/php/FeedsPaintedRowLinkContrastTest.php owns the source-side proof (both row paths
 # paint inline, and the page-local rules are scoped by inline background). This row owns what
 # PHP cannot see: the real cascade under the shipped pfSense-dark.css, over every genuine

--- a/tests/smoke/ui/test_browser_feeds.py
+++ b/tests/smoke/ui/test_browser_feeds.py
@@ -208,27 +208,33 @@ def test_feeds_subtab_row_active_and_type_scoped(
 _THEME_CFG = "system/webgui/webguicss"
 _DARK_THEME = "pfSense-dark.css"
 
-# Two exact-head browser REDs (runs 33531836648 and 33533391281) showed that a fresh smoke
-# box renders NO painted Feeds row: the predefined catalogue paints nothing on a box with no
-# aliases, and a seeded custom IPv4 list -- persisted and re-read successfully -- still did
-# not reach the rendered table. The split below is therefore deliberate.
-# tests/php/FeedsPaintedRowLinkContrastTest.php owns the production-emission proof: both real
-# row paths emit the class exactly when their $tr_style is non-empty. This row owns the one
-# thing PHP cannot see -- the real CSS cascade under the shipped pfSense-dark.css -- so it
-# appends test-only rows carrying exactly the markup production emits (the class, the inline
-# background, the inline #212121 text, one anchor) to the real Feeds table and lets the page's
-# own stylesheet decide the anchor colours. No config list is mutated.
+# Three exact-head browser REDs drove this shape. Runs 33531836648 and 33533391281 showed a
+# fresh smoke box renders NO painted Feeds row of its own (the predefined catalogue paints
+# nothing without aliases, and a seeded custom list never reached the rendered table), and run
+# 33534796353 then showed the real defect: a genuine row arrived with inline background
+# rgb(184, 184, 184) and NO class, because the live sortable table normalises rows and drops
+# their class while preserving inline style. So the scoping production ships -- and everything
+# graded here -- rides the inline background, never a class.
+# tests/php/FeedsPaintedRowLinkContrastTest.php owns the source-side proof (both row paths
+# paint inline, and the page-local rules are scoped by inline background). This row owns what
+# PHP cannot see: the real cascade under the shipped pfSense-dark.css, over every genuine
+# painted row the box happens to render plus one synthetic row per production background so
+# all four are always measured. No config list is mutated.
 _PAINTED_BACKGROUNDS = ("#F5FBF6", "#EEF7EE", "#A0B8A0", "#B8B8B8")
 _PROBE_HREF = "https://example.invalid/pfb3035-contrast-probe.txt"
 
-# One probe row per production background, appended to the real table#pfb_table tbody.
+# Anchors inside any inline-painted row of either Feeds table -- the production selector shape.
+_PAINTED_ANCHORS = '#pfb_table tr[style*="background-color"] a, #pfb_table2 tr[style*="background-color"] a'
+
+# One probe row per production background, appended to the real table#pfb_table tbody. The row
+# carries ONLY what production emits inline (background + #212121 text) and one anchor: no
+# class, so it cannot pass by a route the live page does not have.
 _APPEND_PROBE_ROWS_JS = """
     ([backgrounds, href]) => {
       const body = document.querySelector('table#pfb_table tbody');
       if (!body) { return 0; }
       backgrounds.forEach((hex, index) => {
         const row = document.createElement('tr');
-        row.className = 'pfb-painted-feed-row';
         row.setAttribute('style', 'background-color: ' + hex + '; color: #212121;');
         row.setAttribute('data-pfb-contrast-probe', hex);
         const cell = document.createElement('td');
@@ -241,6 +247,14 @@ _APPEND_PROBE_ROWS_JS = """
       });
       return body.querySelectorAll('tr[data-pfb-contrast-probe]').length;
     }
+"""
+
+# Each painted row's anchor colour and its own row background, as the page resolves them.
+_MEASURE_ANCHORS_JS = """
+    anchors => anchors.map(anchor => ({
+      color: getComputedStyle(anchor).color,
+      background: getComputedStyle(anchor.closest('tr')).backgroundColor,
+    }))
 """
 
 
@@ -260,15 +274,14 @@ def test_painted_feed_rows_scope_legible_link_foregrounds(
     Scenario:
       Given the box is switched to the real ``pfSense-dark.css`` theme (the theme whose
         explicit anchor palette overrides the row's inherited ``color: #212121``),
-      And one probe row per production background is appended to the real Feeds table with
-        exactly the markup production emits (class, inline background, inline ``#212121``
-        text, one anchor), because a fresh box paints no row of its own,
+      And every genuine row the box painted inline is graded directly, then one probe row per
+        production background is appended to the real Feeds table carrying only what
+        production emits inline (background + ``#212121`` text) and one anchor, so all four
+        backgrounds are measured even on a box that paints no row of its own,
       When the page's own stylesheet resolves those rows,
-      Then every anchor inside a painted row computes to the scoped ``#004D40`` and clears
-        4.5:1 against its own computed row background, all four production backgrounds are
-        measured, and hover/focus computes to the scoped ``#003D33``,
-      And no row the page itself rendered carries the painted class without an inline
-        background.
+      Then every anchor inside an inline-painted row computes to the scoped ``#004D40`` and
+        clears 4.5:1 against its own computed row background, all four production backgrounds
+        are measured, and hover/focus computes to the scoped ``#003D33``.
       Finally the box's prior theme is restored exactly, including absence.
     """
     page = browser_page
@@ -301,31 +314,25 @@ def test_painted_feed_rows_scope_legible_link_foregrounds(
             "theme override outranks the system key"
         )
 
-        row_states = page.locator("table#pfb_table tr, table#pfb_table2 tr").evaluate_all(
-            """
-            rows => rows.map(row => ({
-              painted: row.classList.contains('pfb-painted-feed-row'),
-              inlineBackground: row.style.backgroundColor,
-            }))
-            """
-        )
-        assert all(bool(state["inlineBackground"]) == state["painted"] for state in row_states), row_states
+        real_styles = page.locator(_PAINTED_ANCHORS).evaluate_all(_MEASURE_ANCHORS_JS)
+        for style in real_styles:
+            assert style["color"] == "rgb(0, 77, 64)", (
+                f"an anchor in a row the page itself painted computes {style['color']} "
+                f"instead of the scoped rgb(0, 77, 64): {style}"
+            )
+            ratio = _contrast_ratio(style["color"], style["background"])
+            assert ratio >= 4.5, f"real painted-row link contrast is {ratio:.3f}:1 for {style}"
 
         injected = page.evaluate(_APPEND_PROBE_ROWS_JS, [list(_PAINTED_BACKGROUNDS), _PROBE_HREF])
         assert injected == len(_PAINTED_BACKGROUNDS), (
             f"the probe rows were not appended to the real Feeds table (table#pfb_table tbody): attached {injected!r}"
         )
 
-        links = page.locator("tr.pfb-painted-feed-row a")
-        assert links.count() >= 1, "painted Feeds rows rendered no anchors"
-        computed = links.evaluate_all(
-            """
-            anchors => anchors.map(anchor => ({
-              color: getComputedStyle(anchor).color,
-              background: getComputedStyle(anchor.closest('tr')).backgroundColor,
-            }))
-            """
+        links = page.locator(_PAINTED_ANCHORS)
+        assert links.count() >= len(_PAINTED_BACKGROUNDS), (
+            f"expected at least the {len(_PAINTED_BACKGROUNDS)} probe anchors, found {links.count()}"
         )
+        computed = links.evaluate_all(_MEASURE_ANCHORS_JS)
         measured_backgrounds = {style["background"] for style in computed}
         for background in _PAINTED_BACKGROUNDS:
             assert _hex_rgb_css(background) in measured_backgrounds, (

--- a/tests/smoke/ui/test_browser_feeds.py
+++ b/tests/smoke/ui/test_browser_feeds.py
@@ -48,6 +48,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+from .. import helpers
 from .conftest import mask_page_identity
 
 sync_api = pytest.importorskip("playwright.sync_api", reason="playwright not installed (Tier-B browser dep)")
@@ -201,47 +202,89 @@ def test_feeds_subtab_row_active_and_type_scoped(
     _shot(page, screenshot_dir, f"feeds_subtab_{gtype}")
 
 
+# The dark theme is a per-box setting, not a property of the Feeds page: the browser
+# fixture leaves whatever theme the box already carries (a fresh box is light), so the
+# contrast probe below selects the theme it needs and puts the previous value back.
+_THEME_CFG = "system/webgui/webguicss"
+_DARK_THEME = "pfSense-dark.css"
+
+
 def test_painted_feed_rows_scope_legible_link_foregrounds(
     browser_page: Page,
     webui: WebUI,
+    smoke_vm: helpers.SmokeVM,
 ) -> None:
-    """Painted Feeds rows override the dark theme's low-contrast anchor palette only where needed."""
+    """Painted Feeds rows override the dark theme's low-contrast anchor palette only where needed.
+
+    Scenario:
+      Given the box is switched to the real ``pfSense-dark.css`` theme (the theme whose
+        explicit anchor palette overrides the row's inherited ``color: #212121``),
+      When the Feeds page is opened in the authenticated browser,
+      Then exactly the rows painted with an inline background carry
+        ``pfb-painted-feed-row``, every anchor inside those rows computes to the scoped
+        ``#004D40`` and clears 4.5:1 against its own computed row background, and
+        hover/focus computes to the scoped ``#003D33``.
+      Finally the box's prior theme state is restored exactly, including absence.
+    """
     page = browser_page
-    _open(page, webui, f"{FEEDS_BASE}?type=ipv4")
 
-    assert page.locator('link[rel="stylesheet"][href*="pfSense-dark.css"]').count() >= 1, (
-        "the contrast proof must run against the real pfSense dark theme"
+    prior_theme = helpers.config_get_state(smoke_vm, _THEME_CFG)
+    applied = helpers.php_eval(
+        smoke_vm,
+        f"config_set_path({helpers._php_str(_THEME_CFG)}, {helpers._php_str(_DARK_THEME)});\n"
+        "write_config('pfBlockerNG smoke #3035: select the dark theme for the Feeds contrast probe');\n"
+        "echo 'THEME-OK';",
+    )
+    assert applied.returncode == 0 and "THEME-OK" in applied.stdout, (
+        f"failed to select {_DARK_THEME}: rc={applied.returncode} "
+        f"stdout={applied.stdout!r} stderr={applied.stderr!r}"
     )
 
-    row_states = page.locator("table#pfb_table tr, table#pfb_table2 tr").evaluate_all(
-        """
-        rows => rows.map(row => ({
-          painted: row.classList.contains('pfb-painted-feed-row'),
-          inlineBackground: row.style.backgroundColor,
-        }))
-        """
-    )
-    assert any(state["painted"] for state in row_states), "Feeds page rendered no painted rows"
-    assert all(bool(state["inlineBackground"]) == state["painted"] for state in row_states), row_states
+    try:
+        stored = helpers.config_get(smoke_vm, _THEME_CFG)
+        assert stored == _DARK_THEME, f"{_THEME_CFG} is {stored!r} after the switch, expected {_DARK_THEME!r}"
 
-    links = page.locator("tr.pfb-painted-feed-row a")
-    assert links.count() >= 1, "painted Feeds rows rendered no anchors"
-    computed = links.evaluate_all(
-        """
-        anchors => anchors.map(anchor => ({
-          color: getComputedStyle(anchor).color,
-          background: getComputedStyle(anchor.closest('tr')).backgroundColor,
-        }))
-        """
-    )
-    for style in computed:
-        assert style["color"] == "rgb(0, 77, 64)", style
-        ratio = _contrast_ratio(style["color"], style["background"])
-        assert ratio >= 4.5, f"painted-row link contrast is {ratio:.3f}:1 for {style}"
+        _open(page, webui, f"{FEEDS_BASE}?type=ipv4")
 
-    first = links.first
-    first.hover()
-    expect(first).to_have_css("color", "rgb(0, 61, 51)", timeout=JS_TIMEOUT_MS)
-    page.mouse.move(0, 0)
-    first.focus()
-    expect(first).to_have_css("color", "rgb(0, 61, 51)", timeout=JS_TIMEOUT_MS)
+        assert page.locator('link[rel="stylesheet"][href*="pfSense-dark.css"]').count() >= 1, (
+            "the contrast proof must run against the real pfSense dark theme, but the page loaded no "
+            f"pfSense-dark.css stylesheet even though {_THEME_CFG} is {_DARK_THEME!r} -- a per-user "
+            "theme override outranks the system key"
+        )
+
+        row_states = page.locator("table#pfb_table tr, table#pfb_table2 tr").evaluate_all(
+            """
+            rows => rows.map(row => ({
+              painted: row.classList.contains('pfb-painted-feed-row'),
+              inlineBackground: row.style.backgroundColor,
+            }))
+            """
+        )
+        assert any(state["painted"] for state in row_states), "Feeds page rendered no painted rows"
+        assert all(bool(state["inlineBackground"]) == state["painted"] for state in row_states), row_states
+
+        links = page.locator("tr.pfb-painted-feed-row a")
+        assert links.count() >= 1, "painted Feeds rows rendered no anchors"
+        computed = links.evaluate_all(
+            """
+            anchors => anchors.map(anchor => ({
+              color: getComputedStyle(anchor).color,
+              background: getComputedStyle(anchor.closest('tr')).backgroundColor,
+            }))
+            """
+        )
+        for style in computed:
+            assert style["color"] == "rgb(0, 77, 64)", style
+            ratio = _contrast_ratio(style["color"], style["background"])
+            assert ratio >= 4.5, f"painted-row link contrast is {ratio:.3f}:1 for {style}"
+
+        first = links.first
+        first.hover()
+        expect(first).to_have_css("color", "rgb(0, 61, 51)", timeout=JS_TIMEOUT_MS)
+        page.mouse.move(0, 0)
+        first.focus()
+        expect(first).to_have_css("color", "rgb(0, 61, 51)", timeout=JS_TIMEOUT_MS)
+    finally:
+        helpers.config_restore_state(smoke_vm, _THEME_CFG, prior_theme)
+        restored = helpers.config_get_state(smoke_vm, _THEME_CFG)
+        assert restored == prior_theme, f"{_THEME_CFG} restored as {restored!r}, expected {prior_theme!r}"

--- a/tests/smoke/ui/test_theme_legibility_render.py
+++ b/tests/smoke/ui/test_theme_legibility_render.py
@@ -23,6 +23,10 @@ _LIST_PAGES: dict[str, str] = {
     "/pfblockerng/pfblockerng_log.php": "Log/File Browser selections",
     "/pfblockerng/pfblockerng_edit_hooks.php": "Load an Existing Hook Script",
     "/pfblockerng/pfblockerng_category_edit.php?type=ipv4": "Update Frequency",
+    # issue #3035: the Feeds page paints alternating row backgrounds from
+    # $tr_style. It was absent from this list, so a full-green run of this file
+    # proved nothing about it -- 12 passed while no test opened the page.
+    "/pfblockerng/pfblockerng_feeds.php": "Pre-defined Alias/Group/Feeds",
 }
 
 


### PR DESCRIPTION
Refs #3035 — unit 1 of 3. Drains **4 of the 6** entries on the dated ThemeSafety TODO.

## The defect

`pfblockerng_feeds.php` sets four alternating row backgrounds on `<tr style="...">` with no `color` alongside, and every one is **light**:

```php
$tr_style = 'background-color: #F5FBF6;';  // near-white
$tr_style = 'background-color: #EEF7EE;';  // near-white
$tr_style = 'background-color: #A0B8A0;';  // light green
$tr_style = 'background-color: #B8B8B8;';  // grey
```

On a dark theme the row paints light while the theme's own text colour stays light, so the row's text is light on light. This has been on `TODO_OPAQUE_WITHOUT_FOREGROUND_20260829` since 2026-08-29 — it is not a scanner defect, it is the defect the scanner exists to find. Each now carries `color: #212121;`.

Five assignments were changed (four alternating plus one custom-feed row). Units 2 (`pfblockerng_alerts.php`) and 3 (`pfblockerng_geoip.inc`) follow as separate PRs per `SESSION_START` 82b rule 4 — one file each, so a palette objection to one cannot hold the others.

## Row links

Row text was only half of it. The dark theme sets anchor colours explicitly, so the row's new inherited `#212121` never reaches its links — they stayed at the theme's `#009688`, which is 1.72:1 against `#A0B8A0`. A page-local `<style>` block, emitted after `head.inc`, scopes a legible link foreground onto exactly the painted rows:

```css
#pfb_table  tr[style*="background-color"] a,
#pfb_table2 tr[style*="background-color"] a { color: #004D40; }
```

Keyed off the inline background the row already carries: `$tr_style` is the only inline background this page sets, so the selector matches precisely the painted rows and needs no extra markup. Hover and focus take `#003D33`.

## Tests

| File | Tier | What it pins |
|---|---|---|
| `tests/php/ThemeSafetyUiTest.php` | unit | The four Feeds entries leave the dated TODO; the remaining two stay listed. |
| `tests/php/FeedsPaintedRowLinkContrastTest.php` | unit | Every painted background pairs `#212121`; the scoped link rules exist, carry the exact colours, and reserved colours appear on no unscoped rule. |
| `tests/smoke/ui/test_browser_feeds.py` | ui_browser | On a real dark-themed pfSense the page's own painted rows compute the scoped link colour at ≥4.5:1, measured across all four backgrounds. |

Frozen test bytes at this head: PHP `5f01a6b1e24184747c52466929f903aabfc24c38`, browser `31d9759b9f40dee3d5534c01a132b0043b0ee0c2`. GREEN: `OK (3 tests, 41 assertions)`.

RED, restated for this head: with the frozen PHP test bytes and the production file reverted to its pre-`<style>` state, the run is `3 tests, 8 assertions, 1 failure` — the scoped-selector key is absent. Independently reproduced by the contract leg.

## Retraction — invalid CI probes, 2026-09-01

Five focused `ui-tests` dispatches are **withdrawn as evidence**: `33531836648`, `33533391281`, `33534796353`, `33551682383`, `33552741857`. All five were dispatched with `--ref devel` plus `checkout_ref` pinned to this branch. `checkout_ref` governs **only the test-code checkout** (`ui-tests.yml:109-110,384`); the package is built by `build-pkg`, which calls `build-pkg-linux` at the *workflow* ref (`ui-tests.yml:203-211`). Every one of those runs therefore installed a **devel** package without this PR's page changes and measured it with this PR's tests.

Two conclusions drawn from those runs are void:

- **"the live sortable table drops the row's class attribute"** — the class-scoped rule was never on the page under test. The production selector is now keyed off inline style on its own merits, and the claim is removed from the code.
- **"the theme pins its anchor colour with `!important`"** — inferred from `33551682383`, then falsified by `33552741857`, where adding `!important` moved the computed value not at all (`rgb(0, 150, 136)` both times) because our rule was absent in both. That commit is reverted; the analytic census stands — no shipped rule carries `!important` on an anchor colour, so the page rule's `(1,1,2)` specificity and later source order are sufficient.

The durable proof is the **pull-request-triggered labeled `ui-tests` run**, which builds the package from the PR merge ref. The in-tree comment carries this retraction so the invalid run ids cannot be mistaken for evidence later.

`AlertsPaletteContrastTest.php:12-14` remains accurate and is not part of the retraction: it documents `table.sortable-theme-bootstrap { color: #e0e0e0 !important }`, a **table-level** declaration reaching anchors by inheritance — which is exactly why it cannot override a rule that targets anchors directly.
