### PR TITLE
tests: stop ThemeSafety reporting three shapes of correct code

### DIFF
--- a/tests/php/ThemeSafetyUiTest.php
+++ b/tests/php/ThemeSafetyUiTest.php
@@ -76,6 +76,11 @@ final class ThemeSafetyUiTest extends TestCase
 			// hyphen matters: \b treats it as a boundary, which let foo-var( through.
 			'.pfb-subhdr { background-color: lavar(--pfb-bg); }',
 			'.pfb-subhdr { background-color: foo-var(--pfb-bg); }',
+			// issue #3015: the slash form is only translucent when its alpha says so.
+			'.pfb-subhdr { background-color: rgb(0 0 0 / 100%); }',
+			'.pfb-subhdr { background-color: rgb(0 0 0); }',
+			// issue #3037: the boundary narrows detection, so pin that it still detects.
+			'<svg style="enable-background:new 0 0 1 1; background: #424242;">',
 		];
 		foreach ($bad as $src) {
 			$this->assertNotSame([], self::scan($src), 'expected a violation in: ' . $src);
@@ -104,6 +109,20 @@ final class ThemeSafetyUiTest extends TestCase
 			// so it arrives as a bare '+'. Still an operator, still not a colour.
 			"el.style = 'background-color: ' +\n\ttheme.bg;",
 			'colors: { background: null, segmentStroke: "#ffffff" }',
+			// issue #3015: the theme decides these, which is the condition the
+			// transparent/none/null allow set already exists for.
+			'.pfb-subhdr { background-color: currentColor; }',
+			'.pfb-subhdr { background-color: inherit; }',
+			// issue #3015: the space/slash functional forms carry alpha after a solidus
+			// rather than a fourth comma operand.
+			'.pfb-subhdr { background-color: rgb(0 0 0 / 50%); }',
+			'.pfb-subhdr { background-color: hsl(0 0% 0% / 0.2); }',
+			'.pfb-subhdr { background-color: color-mix(in srgb, red 20%, transparent); }',
+			// issue #3037: enable-background is an inert SVG presentation attribute that
+			// ends in the token scan() looks for. It shipped in this tree at
+			// pfblockerng_general.php:579 and returns with any pasted vector-editor SVG.
+			'<svg viewBox="30 225 560 470" style="enable-background:new 30 225 560 470;">',
+			'const s = { myBackgroundColor: "#123456" };',
 		];
 		foreach ($good as $src) {
 			$this->assertSame([], self::scan($src), 'false positive in: ' . $src);
@@ -211,6 +230,11 @@ final class ThemeSafetyUiTest extends TestCase
 			'empty heredoc body'        => ["\$e = <<<EOT\nEOT;\ncolor: red;\n\$s = <<<EOT\nbackground-color: #123456;\nEOT;", FALSE],
 			// A body is one literal, so it is the scope -- the quote scans must not answer
 			// first and hand back a quoted run inside it as if it were its own literal.
+			// issue #2965: newlineAt()/newlineBefore() exist ONLY for CRLF, and markerLine()
+			// ltrims an indented PHP 7.3+ closer. Both were correct and unpinned, so a
+			// regression in either would ship green. These rows pin them from both sides.
+			'indented closer, unpaired' => ["\$s = <<<EOT\n\tbackground-color: #123456;\n\tEOT;\ncolor: red;", FALSE],
+			'indented closer, paired'   => ["\$s = <<<EOT\n\tcolor: black;" . str_repeat(' ', 200) . "\n\tbackground-color: #123456;\n\tEOT;", TRUE],
 			'heredoc outranks quotes'   => ["\$s = <<<EOT\n'background-color: #123456;' color: red;\nEOT;", TRUE],
 			'template literal, unpaired'=> ["function f() {\n\tconst a = `background-color: #123456;`;\n\tconst b = \"color: red;\";\n}", FALSE],
 			'template literal, paired'  => ["const a = `color: black;" . str_repeat(' ', 200) . "\nbackground-color: #123456;`;", TRUE],
@@ -506,6 +530,29 @@ final class ThemeSafetyUiTest extends TestCase
 		}
 	}
 
+	/**
+	 * The CRLF helpers, pinned directly (issue #2965).
+	 *
+	 * newlineAt() and newlineBefore() exist solely so a heredoc body in a CRLF file
+	 * keeps its exact bounds. Pinning them through scan() does not work: dropping the
+	 * "\r\n" branch shifts a body boundary by ONE byte, and every pairing row carries
+	 * enough slack to absorb that, so the mutant survives a green suite. Asserting the
+	 * helpers directly is what actually fails when the CRLF branch goes.
+	 */
+	public function testTheCrlfHelpersReturnTheWholeLineBreak(): void
+	{
+		$at = new ReflectionMethod(self::class, 'newlineAt');
+		$before = new ReflectionMethod(self::class, 'newlineBefore');
+
+		$crlf = "a\r\nb";
+		$this->assertSame("\r\n", $at->invoke(NULL, $crlf, 1), 'newlineAt must return both bytes of a CRLF');
+		$this->assertSame("\r\n", $before->invoke(NULL, $crlf, 3), 'newlineBefore must return both bytes of a CRLF');
+
+		$lf = "a\nb";
+		$this->assertSame("\n", $at->invoke(NULL, $lf, 1), 'a bare LF is still one byte');
+		$this->assertSame("\n", $before->invoke(NULL, $lf, 2), 'a bare LF is still one byte');
+	}
+
 	#[DataProvider('valuesContainingABackslash')]
 	public function testABackslashInsideAValueDoesNotHideTheBackground(string $source): void
 	{
@@ -580,8 +627,12 @@ final class ThemeSafetyUiTest extends TestCase
 		// backslash-excluding: a backslash inside url() or a CSS escape is part of the value.
 		$bs = '\\\\*';
 		$matched = preg_match_all(
-			'/background(?:-color)?\s*:\s*(?<css>[^;}\n]+)'
-			. '|backgroundColor\s*:\s*' . $bs . '(?<jsq>["\'])(?<js>[^"\']*?)' . $bs . '\k<jsq>'
+			// (?<![-\w]) so the token is the whole property: enable-background: is an inert
+			// SVG attribute ending in `background`, and myBackgroundColor: is an ordinary
+			// object key (issue #3037). The obj/set/dom branches are already bounded by a
+			// quote or a dot.
+			'/(?<![-\w])background(?:-color)?\s*:\s*(?<css>[^;}\n]+)'
+			. '|(?<![-\w])backgroundColor\s*:\s*' . $bs . '(?<jsq>["\'])(?<js>[^"\']*?)' . $bs . '\k<jsq>'
 			. '|' . $bs . '(?<objq>["\'])background(?:-color|Color)?' . $bs . '\k<objq>\s*:\s*'
 			. $bs . '(?<objvq>["\'])(?<obj>[^"\']*?)' . $bs . '\k<objvq>'
 			. '|(?:\.css\(|(?<![A-Za-z0-9_])setProperty\()\s*' . $bs . '(?<setq>["\'])background(?:-color|Color)?' . $bs . '\k<setq>\s*,\s*'
@@ -1390,7 +1441,9 @@ final class ThemeSafetyUiTest extends TestCase
 		if ($raw === '') {
 			return '';
 		}
-		if (preg_match('/^((?:rgba?|hsla?)\s*\([^)]*\))/i', $raw, $m)) {
+		// A functional value must survive whole: its operands are comma-separated and the
+		// generic rule below would cut it at the first one (issue #3015, color-mix).
+		if (preg_match('/^((?:rgba?|hsla?|color-mix)\s*\([^)]*\))/i', $raw, $m)) {
 			return $m[1];
 		}
 		if (preg_match('/^([^,;}\n]+)/', $raw, $m)) {
@@ -1417,11 +1470,24 @@ final class ThemeSafetyUiTest extends TestCase
 	private static function isTranslucent(string $value): bool
 	{
 		$v = strtolower(trim($value, " \t\"',"));
-		if ($v === 'transparent' || $v === 'none' || $v === 'null' || $v === '') {
+		// currentcolor and inherit defer the colour to the theme, which is the same
+		// condition transparent/none/null are here for (issue #3015).
+		if ($v === 'transparent' || $v === 'none' || $v === 'null' || $v === ''
+			|| $v === 'currentcolor' || $v === 'inherit') {
 			return TRUE;
 		}
 		if (preg_match('/^(?:rgba|hsla)\s*\(\s*[^,]+,[^,]+,[^,]+,\s*([0-9.]+)\s*\)/', $v, $m)) {
 			return (float)$m[1] < 1.0;
+		}
+		// The space/slash form carries alpha after a solidus instead of a fourth comma
+		// operand: rgb(0 0 0 / 50%). A percentage is over 100, a number over 1.
+		if (preg_match('/^(?:rgba?|hsla?)\s*\([^,\/]*\/\s*([0-9.]+)(%?)\s*\)/', $v, $m)) {
+			return (float)$m[1] < ($m[2] === '%' ? 100.0 : 1.0);
+		}
+		// color-mix() resolves through its operands; one of them being transparent is
+		// the documented way to write a translucent mix.
+		if (str_starts_with($v, 'color-mix(') && str_contains($v, 'transparent')) {
+			return TRUE;
 		}
 		if (preg_match('/^#([0-9a-f]{8})$/', $v, $m)) {
 			return hexdec(substr($m[1], 6, 2)) < 255;

--- a/tests/php/ThemeSafetyUiTest.php
+++ b/tests/php/ThemeSafetyUiTest.php
@@ -79,12 +79,25 @@ final class ThemeSafetyUiTest extends TestCase
 			// issue #3015: the slash form is only translucent when its alpha says so.
 			'.pfb-subhdr { background-color: rgb(0 0 0 / 100%); }',
 			'.pfb-subhdr { background-color: rgb(0 0 0); }',
-			// issue #3037: the boundary narrows detection, so pin that it still detects.
-			'<svg style="enable-background:new 0 0 1 1; background: #424242;">',
 		];
 		foreach ($bad as $src) {
 			$this->assertNotSame([], self::scan($src), 'expected a violation in: ' . $src);
 		}
+	}
+
+	/**
+	 * The #3037 boundary narrows detection, so pin that it still detects.
+	 *
+	 * This cannot live in the $bad array: that is a foreach over one assertion, so any
+	 * mutation strong enough to reach this row breaks an identically-shaped earlier row
+	 * first and this one is never the failure observed. It needs its own assertion.
+	 */
+	public function testTheBackgroundBoundaryStillDetectsARealBackground(): void
+	{
+		$this->assertNotSame([], self::scan('<svg style="enable-background:new 0 0 1 1; background: #424242;">'),
+			'a real background beside enable-background must still be reported');
+		$this->assertSame([], self::scan('<svg style="enable-background:new 0 0 1 1;">'),
+			'enable-background alone must not be reported');
 	}
 
 	public function testTranslucentOrPairedForegroundIsNotAViolation(): void
@@ -1486,7 +1499,7 @@ final class ThemeSafetyUiTest extends TestCase
 		}
 		// color-mix() resolves through its operands; one of them being transparent is
 		// the documented way to write a translucent mix.
-		if (str_starts_with($v, 'color-mix(') && str_contains($v, 'transparent')) {
+		if (str_starts_with($v, 'color-mix(') && preg_match('/(?<![\w-])transparent(?![\w-])/', $v)) {
 			return TRUE;
 		}
 		if (preg_match('/^#([0-9a-f]{8})$/', $v, $m)) {


### PR DESCRIPTION
Closes #3015. Closes #2965. Closes #3037.

Three false positives and one coverage gap in `ThemeSafetyUiTest`, batched because they share one file — per SESSION_START 2b rule 4, issues that share a file are one unit of work, and three branches against this file would produce two rebases and two chances to lose a fix.

**None of these grows the scanner's parser.** Each either widens an allow-set or narrows a detection pattern. One clause needed tightening for that to hold: `isTranslucent()`'s `color-mix` test was substring containment, so `color-mix(in srgb, red 50%, nottransparent)` was graded translucent. It now requires a whole token — `nottransparent` and `transparent-ish` are opaque, the real form is not. That boundary is deliberate: the scanner's scope was reviewed this session and the parser is frozen, with three lexer-growth issues (#2953, #2961, #2966) recorded as limitations instead.

## What was reported on correct code

| Shape | Was | Issue |
| --- | --- | --- |
| `background-color: currentColor` | violation | #3015 |
| `background-color: inherit` | violation | #3015 |
| `background-color: rgb(0 0 0 / 50%)` | violation | #3015 |
| `background-color: color-mix(in srgb, red 20%, transparent)` | violation | #3015 |
| `<svg style="enable-background:new 30 225 560 470;">` | violation | #3037 |
| `const s = { myBackgroundColor: "#123456" };` | violation | #3037 |

`currentColor` and `inherit` defer the colour to the theme, which is the exact condition `transparent` / `none` / `null` are already allowed for. Both are ordinary values in an inline `style` attribute in a scanned `.php` or `.js` file, so a contributor writing correct CSS was told to fix it.

`enable-background` is an inert SVG presentation attribute emitted as a matter of course by Illustrator and Inkscape. It **shipped in this tree** at `pfblockerng_general.php:579` in PR #2857 and is absent today only because a layout fix happened to delete that attribute — not because the scanner was corrected.

## Three fixes

- **`isTranslucent()`** gains `currentcolor` and `inherit` in the keyword allow-set, the space/slash functional form (`rgb(0 0 0 / 50%)`, where a percentage is over 100 and a bare number over 1), and `color-mix(… transparent)`.
- **`firstColorToken()`** now keeps a functional value whole. It truncated at the first comma, so `color-mix(in srgb, red 20%, transparent)` reached the predicate as `color-mix(in srgb` and could never have been recognised however the predicate was written.
- **`scan()`** gains `(?<![-\w])` on its two unquoted branches, so the matched token is the whole property name. The `obj`, `set` and `dom` branches are already bounded by a quote or a dot.

## #2965: two helpers pinned, one of them not the way it looks

`newlineAt()` and `newlineBefore()` exist solely so a heredoc body in a CRLF file keeps its exact bounds, and nothing exercised them.

They **cannot** be pinned through `scan()`. Dropping the `\r\n` branch shifts a body boundary by one byte, and every pairing row carries enough slack to absorb that — the mutant survives a green suite. My first attempt at this test was exactly that, and it passed while the mutant lived. They are asserted directly instead, where the mutant dies:

```
newlineAt must return both bytes of a CRLF
Tests: 1, Failures: 1
```

The indented PHP 7.3+ heredoc closer **can** be pinned through `scan()` and is, from both sides.

## Evidence

Red before, green after, per issue. Every added row proved by an executed mutation:

| Mutation | Killed by |
| --- | --- |
| drop the `currentcolor`/`inherit` keywords | `false positive in: … background-color: currentColor;` |
| drop the css-branch `(?<![-\w])` | `false positive in: <svg … enable-background:new 30 225 560 470;>` |
| drop the js-branch `(?<![-\w])` | `false positive in: const s = { myBackgroundColor: "#123456" };` |
| over-narrow the css boundary to `(?<![-\w;\s])` | `expected a violation in: … background-color: #f0f0f0` — **43 failures** |
| drop the `\r\n` branch from `newlineAt()` | `newlineAt must return both bytes of a CRLF` |
| drop `ltrim` from `markerLine()` | `indented closer, unpaired` + `indented closer, paired` |

The over-narrowing mutant matters for #3037, but review showed it is **not** observed on the `$bad` row that names it: `$bad` is a `foreach` over one assertion, so the mutant breaks an identically-shaped earlier row first and never reaches it. That row now has its own test, `testTheBackgroundBoundaryStillDetectsARealBackground`, with one assertion per direction — over-narrowing fails *"a real background beside enable-background must still be reported"*, dropping the boundary fails *"enable-background alone must not be reported"*.

Anti-laundering rows pin the other direction — `rgb(0 0 0 / 100%)` and `rgb(0 0 0)` stay violations, and an SVG carrying both `enable-background` and a real `background:` is still reported.

`OK (119 tests, 181 assertions)`. Full suite unchanged from base: `Errors: 61, Failures: 13`, with zero `ThemeSafetyUiTest` entries in either.

## Not in this diff

#2953, #2961 and #2966 are recorded as limitations on their issues with reproductions. #3023's remainder is not started. #2970 remains open and unimplemented as before.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved theme safety scanning to avoid false positives for SVG attributes and similarly named object keys.
  * Enhanced color handling for `color-mix()`, transparency values, inherited colors, and modern RGB alpha syntax.
  * Improved recognition of indented heredoc endings and Windows-style line breaks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->