### PR TITLE
policy: accept descendant base advances

### DIFF
--- a/.agents/policy/landing.md
+++ b/.agents/policy/landing.md
@@ -19,19 +19,15 @@ See [`workflow.md`](workflow.md), [`waits.md`](waits.md), and [`coderabbit.md`](
 - **Local fast-forward is not a bypass.** It requires the same PR, findings, exact-head
   CI, and catch-all gates; every landed commit is locally signed and verified, the base
   is rechecked immediately before push, and the update must be fast-forward.
-- **Advisory bots never gate.** `wait-checks.sh` excludes advisory contexts; bot state
-  never blocks CI or landing. Triage real findings, including security, as unsolicited
-  review, but never gate-count the bot.
+- **Advisory bots never gate.** Exclude their contexts; triage real findings on merit.
 - **Never request Copilot code review** (owner, 2026-08-01) or enable its rule/auto-request;
   strip only that rule when bundled. Triage one that arrives, but never gate-count it or
   publicly restate the ban.
 - **Review effort:** use the fixed matrix in [`delegation.md`](delegation.md) "Effort per
   role" for every leg, round, and verifier; never inherit or override it.
-- **Four leg reviewers, whole-PR diff, incremental focus.** Run four parallel read-only
-  lenses (contract · correctness/hostile input · test honesty · over-engineering).
-  Round 1 covers the full PR; each leg posts its reviewed SHA. Later rounds use that
-  leg's delta in full-PR context, preserve clean ground, recheck every defect, and rerun
-  only affected legs on small tier.
+- **Four independent read-only legs review the whole PR:** contract, correctness/hostile
+  input, test honesty, and over-engineering. Round 1 covers all. Later small-tier rounds
+  focus on that leg's recorded-head delta in full context and run only affected legs.
 - **Convergence rule.** Fix→re-review loop continue only while latest round returned `blocking` finding; all-nitpick or clean round close it (hard cap and CI-retry limits per workflow.md "Retry and fix-loop limits").
 - **Bounded waits.** Every background wait self-terminating (hard iteration cap + wall-clock deadline inside loop), swept instant task reach terminal state.
 - **Worktree isolation.** All rebase/push work happen in dedicated worktree the session created, never primary checkout, never foreign worktree.
@@ -184,8 +180,8 @@ Poll until every **required** check complete, excluding only the advisory contex
   Run `git fetch origin` after that verification and require the exact landed squash commit OID to be GitHub-signed.
 - **Maintainer-local path:** Immediately before push, run the PR head fence, verify every commit, then
   `git push origin HEAD:devel` without force. After push, fetch `origin`, run the PR head fence again,
-  and require `origin/devel == reviewed_sha`.
-- **Post-push PR head fence mismatch:** After `origin/devel == reviewed_sha` but the fetched PR head differs from `reviewed_sha`,
+  then run `git merge-base --is-ancestor "$reviewed_sha" origin/devel`. A non-descendant `origin/devel` stops for investigation; a descendant proves `reviewed_sha` landed.
+- **Post-push PR head fence mismatch:** After `reviewed_sha` is confirmed landed but the fetched PR head differs,
   read the PR state; retain the remote head branch and worktree; stop.
   - `MERGED` keeps terminal state and routes newer head commits to a new PR.
   - `OPEN` stays open and restarts affected review plus exact-head CI for the current head.

--- a/tests/test_cross_agent_tooling.py
+++ b/tests/test_cross_agent_tooling.py
@@ -89,7 +89,8 @@ def test_landing_policy_pins_both_signed_linear_paths() -> None:
     assert base_fetch < fence_call < base_guard < hosted
 
     local = extract_between(merge, "**Maintainer-local path:**", "From OUTSIDE")
-    assert "require `origin/devel == reviewed_sha`" in local
+    assert 'git merge-base --is-ancestor "$reviewed_sha" origin/devel' in local
+    assert "A non-descendant `origin/devel` stops" in local
     pre_push_fence = local.index("Immediately before push, run the PR head fence")
     push = local.index("git push origin HEAD:devel")
     post_push_fence = local.index("After push, fetch `origin`, run the PR head fence again")
@@ -99,7 +100,7 @@ def test_landing_policy_pins_both_signed_linear_paths() -> None:
     assert match_marker in local, "evidence and terminal synchronization need a fresh-fence success gate"
 
     mismatch = extract_between(local, mismatch_marker, match_marker)
-    assert "After `origin/devel == reviewed_sha` but the fetched PR head differs from `reviewed_sha`" in mismatch
+    assert "After `reviewed_sha` is confirmed landed but the fetched PR head differs" in mismatch
     assert "retain the remote head branch and worktree; stop" in mismatch
     mismatch_state = mismatch.index("read the PR state")
     assert mismatch_state < mismatch.index("`MERGED` keeps terminal state")
@@ -120,6 +121,9 @@ def test_landing_policy_pins_both_signed_linear_paths() -> None:
     open_state = matched.index("If it is `OPEN`")
     close = matched.index("close the PR and issue")
     terminal = matched.index("verify both terminal states")
+    assert "If it is `MERGED`, verify the linked issue completed" in matched
+    assert "Any other state stops" in matched
+    assert "verify both terminal states and retain the worktree" in matched
     delete = matched.index("--force-with-lease=refs/heads/<head>:<reviewed_sha>")
     assert pre_push_fence < push < post_push_fence < local.index(mismatch_marker) < local.index(match_marker)
     assert evidence < state_read < merged_state < open_state < close < terminal < delete


### PR DESCRIPTION
## Summary

- treat a post-push descendant `devel` advance as proof that the reviewed SHA landed
- stop only when the reviewed SHA is not an ancestor of the fetched base
- pin descendant/non-descendant handling in the focused landing-policy contract

## Verification

- `uv run pytest tests/test_cross_agent_tooling.py::test_landing_policy_pins_both_signed_linear_paths tests/test_worktrunk_config.py::test_landing_fetches_before_json_cleanup_and_reports_branch_deletion` — 2 passed
- `npx markdownlint-cli2 .agents/policy/landing.md` — 0 issues
- commit `609063337d48cfa8bdac489955291a07bf69846b` — valid legacy ED25519 signature

| Frozen RED test | `git hash-object` | RED run tail |
| --- | --- | --- |
| `tests/test_cross_agent_tooling.py` | `ff81a8110798dc87599fc38d0508759dd421c007` | `1 failed` |

Follow-up to #2996 and PR #3038.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved validation of merge workflows to ensure reviewed commits are correctly landed before merging.
  * Added checks for linked issue completion and terminal state handling after pushes.
  * Updated scenarios covering non-descendant development branches while preserving the worktree.
* **Chores**
  * Refreshed generated graph metadata to reflect the latest test structure and revision.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->