### PR TITLE
ci: sign workflow Git objects as project bot

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -61,7 +61,7 @@ while IFS=' ' read -r local_ref local_sha remote_ref _remote_sha; do
         exit 1
     fi
 
-    trailers=$(git for-each-ref --format='%(contents)' "$tag_ref" | git interpret-trailers --parse)
+    trailers=$(git for-each-ref --format='%(trailers:unfold)' "$tag_ref")
     channel_count=$(printf '%s\n' "$trailers" | grep -Eic '^pfBlockerNG-Release-Channel:' || true)
     if [ "$channel_count" -ne 1 ]; then
         echo "error: tag '$tag' must carry exactly one release-channel trailer" >&2

--- a/.github/workflows/hsts-refresh.yml
+++ b/.github/workflows/hsts-refresh.yml
@@ -97,12 +97,28 @@ jobs:
             git diff --stat -- src/usr/local/pkg/pfblockerng/pfb_py_hsts.txt
           fi
 
+      - name: Configure pfblockerng-bot signing
+        if: steps.refresh.outputs.changed == 'true' && env.DRY_RUN != 'true'
+        env:
+          PFB_BOT_SIGNING_KEY: ${{ secrets.PFB_BOT_SIGNING_KEY }}
+        run: |
+          set -eu
+          [ -n "${PFB_BOT_SIGNING_KEY:-}" ] || {
+            echo "::error::PFB_BOT_SIGNING_KEY secret is not set"
+            exit 1
+          }
+          install -m 600 /dev/null "$RUNNER_TEMP/pfb-bot-signing-key"
+          printf '%s\n' "$PFB_BOT_SIGNING_KEY" > "$RUNNER_TEMP/pfb-bot-signing-key"
+          git config user.name "pfblockerng-bot"
+          git config user.email "293667935+pfblockerng-bot@users.noreply.github.com"
+          git config gpg.format ssh
+          git config user.signingkey "$RUNNER_TEMP/pfb-bot-signing-key"
+          git config commit.gpgsign true
+
       - name: Open or update the refresh PR
         if: steps.refresh.outputs.changed == 'true' && env.DRY_RUN != 'true'
         run: |
           set -eu
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
           # No pipeline: a missing header must fail loudly under set -e, not
           # yield an empty date in the commit message.

--- a/.github/workflows/image-refresh.yml
+++ b/.github/workflows/image-refresh.yml
@@ -400,6 +400,24 @@ jobs:
       # continue-on-error is deliberate: the image already published, so a failure here
       # (including the refusal above) surfaces as an ::error:: annotation with no PR,
       # never a red run.
+      - name: Configure pfblockerng-bot signing
+        continue-on-error: true
+        env:
+          PFB_BOT_SIGNING_KEY: ${{ secrets.PFB_BOT_SIGNING_KEY }}
+        run: |
+          set -eu
+          [ -n "${PFB_BOT_SIGNING_KEY:-}" ] || {
+            echo "::error::PFB_BOT_SIGNING_KEY secret is not set"
+            exit 1
+          }
+          install -m 600 /dev/null "$RUNNER_TEMP/pfb-bot-signing-key"
+          printf '%s\n' "$PFB_BOT_SIGNING_KEY" > "$RUNNER_TEMP/pfb-bot-signing-key"
+          git config user.name "pfblockerng-bot"
+          git config user.email "293667935+pfblockerng-bot@users.noreply.github.com"
+          git config gpg.format ssh
+          git config user.signingkey "$RUNNER_TEMP/pfb-bot-signing-key"
+          git config commit.gpgsign true
+
       - name: Open activation PR (box-verified matrix update)
         continue-on-error: true
         env:
@@ -476,8 +494,6 @@ jobs:
             exit 0
           fi
 
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           BR="tracker/matrix-activate-${VARIANT}-${FAMILY}"
           # Build the PR branch in a SEPARATE worktree: `git checkout -B` here
           # would swap the JOB's tree to the ci-metadata ref and break the

--- a/.github/workflows/module-durations.yml
+++ b/.github/workflows/module-durations.yml
@@ -119,6 +119,23 @@ jobs:
           echo "=== refreshed table ==="
           cat tests/smoke/module-durations.txt
 
+      - name: Configure pfblockerng-bot signing
+        env:
+          PFB_BOT_SIGNING_KEY: ${{ secrets.PFB_BOT_SIGNING_KEY }}
+        run: |
+          set -eu
+          [ -n "${PFB_BOT_SIGNING_KEY:-}" ] || {
+            echo "::error::PFB_BOT_SIGNING_KEY secret is not set"
+            exit 1
+          }
+          install -m 600 /dev/null "$RUNNER_TEMP/pfb-bot-signing-key"
+          printf '%s\n' "$PFB_BOT_SIGNING_KEY" > "$RUNNER_TEMP/pfb-bot-signing-key"
+          git config user.name "pfblockerng-bot"
+          git config user.email "293667935+pfblockerng-bot@users.noreply.github.com"
+          git config gpg.format ssh
+          git config user.signingkey "$RUNNER_TEMP/pfb-bot-signing-key"
+          git config commit.gpgsign true
+
       - name: Commit the refreshed table (only if it changed)
         env:
           GH_TOKEN: ${{ github.token }}
@@ -128,8 +145,6 @@ jobs:
             echo "module-durations.txt unchanged — nothing to commit."
             exit 0
           fi
-          git config user.name  "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
           git add tests/smoke/module-durations.txt
           git commit -m "tests/smoke: refresh module-durations table from nightly smoke run"
           # devel can advance between the nightly smoke start and now — rebase onto the

--- a/.github/workflows/psl-refresh.yml
+++ b/.github/workflows/psl-refresh.yml
@@ -97,12 +97,28 @@ jobs:
             git diff --stat -- src/usr/local/pkg/pfblockerng/dnsbl_psl
           fi
 
+      - name: Configure pfblockerng-bot signing
+        if: steps.refresh.outputs.changed == 'true' && env.DRY_RUN != 'true'
+        env:
+          PFB_BOT_SIGNING_KEY: ${{ secrets.PFB_BOT_SIGNING_KEY }}
+        run: |
+          set -eu
+          [ -n "${PFB_BOT_SIGNING_KEY:-}" ] || {
+            echo "::error::PFB_BOT_SIGNING_KEY secret is not set"
+            exit 1
+          }
+          install -m 600 /dev/null "$RUNNER_TEMP/pfb-bot-signing-key"
+          printf '%s\n' "$PFB_BOT_SIGNING_KEY" > "$RUNNER_TEMP/pfb-bot-signing-key"
+          git config user.name "pfblockerng-bot"
+          git config user.email "293667935+pfblockerng-bot@users.noreply.github.com"
+          git config gpg.format ssh
+          git config user.signingkey "$RUNNER_TEMP/pfb-bot-signing-key"
+          git config commit.gpgsign true
+
       - name: Open or update the refresh PR
         if: steps.refresh.outputs.changed == 'true' && env.DRY_RUN != 'true'
         run: |
           set -eu
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
           # No pipeline: a missing header must fail loudly under set -e, not
           # yield an empty sha in the commit message.

--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -149,7 +149,7 @@ jobs:
           git fetch --tags --force origin
           TYPE=$(git cat-file -t "refs/tags/${TAG}" 2>/dev/null || true)
           [ "$TYPE" = tag ] || { echo "::error::published tag ${TAG} is not an annotated tag"; exit 1; }
-          TRAILERS=$(git for-each-ref --format='%(contents)' "refs/tags/${TAG}" | git interpret-trailers --parse)
+          TRAILERS=$(git for-each-ref --format='%(trailers:unfold)' "refs/tags/${TAG}")
           CHANNEL_COUNT=$(printf '%s\n' "$TRAILERS" | grep -Eic '^pfBlockerNG-Release-Channel:' || true)
           [ "$CHANNEL_COUNT" -eq 1 ] || { echo "::error::published tag ${TAG} must carry exactly one release-channel trailer"; exit 1; }
           CHANNEL_LINE=$(printf '%s\n' "$TRAILERS" | grep -F 'pfBlockerNG-Release-Channel:' || true)

--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -279,10 +279,22 @@ jobs:
       - name: Install the Graphify merge driver
         run: sh "${GITHUB_WORKSPACE}/pfblockerng-src/scripts/agent/ensure-graphify-merge-driver.sh" .
 
-      - name: Configure git
+      - name: Configure pfblockerng-bot signing
+        env:
+          PFB_BOT_SIGNING_KEY: ${{ secrets.PFB_BOT_SIGNING_KEY }}
         run: |
-          git config user.name  "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          set -eu
+          [ -n "${PFB_BOT_SIGNING_KEY:-}" ] || {
+            echo "::error::PFB_BOT_SIGNING_KEY secret is not set"
+            exit 1
+          }
+          install -m 600 /dev/null "$RUNNER_TEMP/pfb-bot-signing-key"
+          printf '%s\n' "$PFB_BOT_SIGNING_KEY" > "$RUNNER_TEMP/pfb-bot-signing-key"
+          git config user.name "pfblockerng-bot"
+          git config user.email "293667935+pfblockerng-bot@users.noreply.github.com"
+          git config gpg.format ssh
+          git config user.signingkey "$RUNNER_TEMP/pfb-bot-signing-key"
+          git config commit.gpgsign true
 
       - name: Bump PORTVERSION and push to use-github
         # source/channel/version ride in via env (NOT inline ${{ }}) so a crafted tag can't

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -382,7 +382,7 @@ jobs:
               echo "::error::tag ${TAG} already exists at ${EXISTING}, but this release pins ${SHA} — delete the stale (unpublished) tag or bump the version"
               exit 1
             fi
-            TRAILERS=$(git for-each-ref --format='%(contents)' "refs/tags/${TAG}" | git interpret-trailers --parse)
+            TRAILERS=$(git for-each-ref --format='%(trailers)' "refs/tags/${TAG}")
             MATCHES=$(printf '%s\n' "$TRAILERS" | grep -Fxc "pfBlockerNG-Release-Channel: ${CHANNEL}" || true)
             CHANNEL_TRAILERS=$(printf '%s\n' "$TRAILERS" | grep -Eic '^pfBlockerNG-Release-Channel:' || true)
             if [ "$MATCHES" -ne 1 ] || [ "$CHANNEL_TRAILERS" -ne 1 ]; then
@@ -844,7 +844,7 @@ jobs:
               echo "::error::tag ${TAG} already exists at ${EXISTING}, but this run built and verified ${SHA} — delete the stale (unpublished) tag or bump the version"
               exit 1
             fi
-            TRAILERS=$(git for-each-ref --format='%(contents)' "refs/tags/${TAG}" | git interpret-trailers --parse)
+            TRAILERS=$(git for-each-ref --format='%(trailers)' "refs/tags/${TAG}")
             MATCHES=$(printf '%s\n' "$TRAILERS" | grep -Fxc "pfBlockerNG-Release-Channel: ${CHANNEL}" || true)
             CHANNEL_TRAILERS=$(printf '%s\n' "$TRAILERS" | grep -Eic '^pfBlockerNG-Release-Channel:' || true)
             if [ "$MATCHES" -ne 1 ] || [ "$CHANNEL_TRAILERS" -ne 1 ]; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1020,10 +1020,11 @@ jobs:
           def exact_primary_trailer(candidate: str, primary: str) -> bool:
               if git("cat-file", "-t", f"refs/tags/{candidate}") != "tag":
                   return False
-              contents = git("for-each-ref", "--format=%(contents)", f"refs/tags/{candidate}")
               trailers = [
                   line
-                  for line in git("interpret-trailers", "--parse", input_text=contents).splitlines()
+                  for line in git(
+                      "for-each-ref", "--format=%(trailers:unfold)", f"refs/tags/{candidate}"
+                  ).splitlines()
                   if line.startswith("pfBlockerNG-Release-Channel: ")
               ]
               return trailers == [f"pfBlockerNG-Release-Channel: {primary}"]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -330,6 +330,24 @@ jobs:
           REPO:     ${{ github.repository }}
         run: sh "${GITHUB_WORKSPACE}/pfblockerng-src/scripts/release-ci-gate.sh"
 
+      - name: Configure pfblockerng-bot signing
+        env:
+          PFB_BOT_SIGNING_KEY: ${{ secrets.PFB_BOT_SIGNING_KEY }}
+        run: |
+          set -eu
+          [ -n "${PFB_BOT_SIGNING_KEY:-}" ] || {
+            echo "::error::PFB_BOT_SIGNING_KEY secret is not set"
+            exit 1
+          }
+          install -m 600 /dev/null "$RUNNER_TEMP/pfb-bot-signing-key"
+          printf '%s\n' "$PFB_BOT_SIGNING_KEY" > "$RUNNER_TEMP/pfb-bot-signing-key"
+          git config user.name "pfblockerng-bot"
+          git config user.email "293667935+pfblockerng-bot@users.noreply.github.com"
+          git config gpg.format ssh
+          git config user.signingkey "$RUNNER_TEMP/pfb-bot-signing-key"
+          git config commit.gpgsign true
+          git config tag.gpgSign true
+
       - name: Pin the release SHA + mint the tag locally
         id: pin
         # PIN the channel-branch tip as THE release commit, then create the annotated
@@ -352,8 +370,6 @@ jobs:
           CHANNEL: ${{ steps.resolve.outputs.channel }}
         run: |
           set -eu
-          git config user.name  "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
           SHA=$(git rev-parse HEAD)
           if git rev-parse -q --verify "refs/tags/${TAG}" > /dev/null 2>&1; then
             TYPE=$(git cat-file -t "refs/tags/${TAG}" 2>/dev/null || true)
@@ -784,6 +800,24 @@ jobs:
           fetch-depth: 0             # full history + tags: the resume check below
           persist-credentials: true  # need to push the tag via GITHUB_TOKEN
 
+      - name: Configure pfblockerng-bot signing
+        env:
+          PFB_BOT_SIGNING_KEY: ${{ secrets.PFB_BOT_SIGNING_KEY }}
+        run: |
+          set -eu
+          [ -n "${PFB_BOT_SIGNING_KEY:-}" ] || {
+            echo "::error::PFB_BOT_SIGNING_KEY secret is not set"
+            exit 1
+          }
+          install -m 600 /dev/null "$RUNNER_TEMP/pfb-bot-signing-key"
+          printf '%s\n' "$PFB_BOT_SIGNING_KEY" > "$RUNNER_TEMP/pfb-bot-signing-key"
+          git config user.name "pfblockerng-bot"
+          git config user.email "293667935+pfblockerng-bot@users.noreply.github.com"
+          git config gpg.format ssh
+          git config user.signingkey "$RUNNER_TEMP/pfb-bot-signing-key"
+          git config commit.gpgsign true
+          git config tag.gpgSign true
+
       - name: Create + push the tag on the verified commit
         id: tag
         # RESUME semantics, narrowed to the crash-after-tag window: the only
@@ -798,8 +832,6 @@ jobs:
           CHANNEL: ${{ github.event.inputs.channel }}
         run: |
           set -eu
-          git config user.name  "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
           git fetch --tags --force origin
           if git rev-parse -q --verify "refs/tags/${TAG}" > /dev/null 2>&1; then
             TYPE=$(git cat-file -t "refs/tags/${TAG}" 2>/dev/null || true)

--- a/.github/workflows/tld-refresh.yml
+++ b/.github/workflows/tld-refresh.yml
@@ -125,12 +125,28 @@ jobs:
             git diff --stat -- src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
           fi
 
+      - name: Configure pfblockerng-bot signing
+        if: steps.refresh.outputs.changed == 'true' && env.DRY_RUN != 'true'
+        env:
+          PFB_BOT_SIGNING_KEY: ${{ secrets.PFB_BOT_SIGNING_KEY }}
+        run: |
+          set -eu
+          [ -n "${PFB_BOT_SIGNING_KEY:-}" ] || {
+            echo "::error::PFB_BOT_SIGNING_KEY secret is not set"
+            exit 1
+          }
+          install -m 600 /dev/null "$RUNNER_TEMP/pfb-bot-signing-key"
+          printf '%s\n' "$PFB_BOT_SIGNING_KEY" > "$RUNNER_TEMP/pfb-bot-signing-key"
+          git config user.name "pfblockerng-bot"
+          git config user.email "293667935+pfblockerng-bot@users.noreply.github.com"
+          git config gpg.format ssh
+          git config user.signingkey "$RUNNER_TEMP/pfb-bot-signing-key"
+          git config commit.gpgsign true
+
       - name: Open or update the refresh PR
         if: steps.refresh.outputs.changed == 'true' && env.DRY_RUN != 'true'
         run: |
           set -eu
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
           # Rebuild the bot-owned automation branch from the current change and
           # force-push it (no human works on it, so a reset+force is safe).

--- a/.github/workflows/version-tracker.yml
+++ b/.github/workflows/version-tracker.yml
@@ -536,6 +536,25 @@ jobs:
       # PR body — a new family often tracks a NEWER FreeBSD than its sibling.
       # matrix_pr_ga_flip: beta entry whose final build was seen → status flip.
       # Contract pinned by tests/test_version_tracker_reconcile_contract.py.
+      - name: Configure pfblockerng-bot signing
+        if: steps.probe_gate.outputs.probe_disabled != 'true' && steps.plan.outcome == 'success'
+        continue-on-error: true
+        env:
+          PFB_BOT_SIGNING_KEY: ${{ secrets.PFB_BOT_SIGNING_KEY }}
+        run: |
+          set -eu
+          [ -n "${PFB_BOT_SIGNING_KEY:-}" ] || {
+            echo "::error::PFB_BOT_SIGNING_KEY secret is not set"
+            exit 1
+          }
+          install -m 600 /dev/null "$RUNNER_TEMP/pfb-bot-signing-key"
+          printf '%s\n' "$PFB_BOT_SIGNING_KEY" > "$RUNNER_TEMP/pfb-bot-signing-key"
+          git config user.name "pfblockerng-bot"
+          git config user.email "293667935+pfblockerng-bot@users.noreply.github.com"
+          git config gpg.format ssh
+          git config user.signingkey "$RUNNER_TEMP/pfb-bot-signing-key"
+          git config commit.gpgsign true
+
       - name: Open matrix PRs for planned actions
         if: steps.probe_gate.outputs.probe_disabled != 'true' && steps.plan.outcome == 'success'
         continue-on-error: true
@@ -553,8 +572,6 @@ jobs:
 
           git fetch origin ci-metadata -q || true
           git show origin/ci-metadata:supported-versions.json > matrix_current.json
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
           # open_matrix_pr BRANCH TITLE BODY_FILE NEW_MATRIX_FILE — (re)build the
           # bot-owned tracker/* branch from ci-metadata + the new matrix file,

--- a/scripts/release_version.py
+++ b/scripts/release_version.py
@@ -129,18 +129,10 @@ def derive_destinations_from_git(
     def has_exact_channel_trailer(candidate: str, expected: Channel) -> bool:
         if git_optional("cat-file", "-t", f"refs/tags/{candidate}") != "tag":
             return False
-        contents = git("for-each-ref", "--format=%(contents)", f"refs/tags/{candidate}")
-        trailer_result = subprocess.run(
-            ["git", "-C", repo_path, "interpret-trailers", "--parse"],
-            input=contents,
-            capture_output=True,
-            text=True,
-            check=False,
-        )
-        if trailer_result.returncode != 0:
-            raise RuntimeError(f"git interpret-trailers failed for {candidate}")
         trailers = [
-            line for line in trailer_result.stdout.splitlines() if line.startswith("pfBlockerNG-Release-Channel:")
+            line
+            for line in git("for-each-ref", "--format=%(trailers:unfold)", f"refs/tags/{candidate}").splitlines()
+            if line.startswith("pfBlockerNG-Release-Channel:")
         ]
         return trailers == [f"pfBlockerNG-Release-Channel: {expected}"]
 

--- a/tests/test_issue2143_git_classifier.py
+++ b/tests/test_issue2143_git_classifier.py
@@ -55,6 +55,50 @@ def test_classifier_validates_selected_sha_before_tag_classification(tmp_path: P
     )
 
 
+def test_classifier_accepts_a_signed_tag_with_the_exact_channel_trailer(tmp_path: Path) -> None:
+    repo, _anchor, current = _repo_with_release_line(tmp_path)
+    signing_key = tmp_path / "signing-key"
+    subprocess.run(
+        ["ssh-keygen", "-q", "-t", "ed25519", "-N", "", "-f", str(signing_key)],
+        check=True,
+        env=scrubbed_git_env(),
+    )
+    _git(repo, "config", "gpg.format", "ssh")
+    _git(repo, "config", "user.signingkey", str(signing_key))
+    _git(repo, "config", "tag.gpgSign", "true")
+    _git(
+        repo,
+        "tag",
+        "-a",
+        "-m",
+        "v4.0.1.a1",
+        "-m",
+        "pfBlockerNG-Release-Channel: testing",
+        "v4.0.1.a1",
+        current,
+    )
+    assert "BEGIN SSH SIGNATURE" in _git(repo, "cat-file", "tag", "v4.0.1.a1")
+    assert derive_destinations_from_git("v4.0.1.a1", "release/4.0", repo, current_commit=current) == (
+        "testing",
+        "edge",
+    )
+
+
+@pytest.mark.parametrize(
+    ("relative_path", "expected_readers"),
+    [
+        (".githooks/pre-push", 1),
+        (".github/workflows/release-published.yml", 1),
+        (".github/workflows/release.yml", 3),
+        ("scripts/release_version.py", 1),
+    ],
+)
+def test_all_release_channel_trailer_readers_ignore_signature_blocks(relative_path: str, expected_readers: int) -> None:
+    source = (Path(__file__).resolve().parents[1] / relative_path).read_text(encoding="utf-8")
+    assert "%(contents)" not in source
+    assert source.count("%(trailers:unfold)") + source.count("%(trailers)") == expected_readers
+
+
 def test_classifier_rejects_tag_commit_off_release_branch(tmp_path: Path) -> None:
     repo, _anchor, _current = _repo_with_release_line(tmp_path)
     _git(repo, "checkout", "-q", "main")

--- a/tests/test_release_tag_after_verify.py
+++ b/tests/test_release_tag_after_verify.py
@@ -1281,14 +1281,25 @@ def test_tag_step_creates_and_pushes_an_annotated_tag_on_the_pinned_sha(tmp_path
     assert f"sha={older}" in (repo / "gh_output").read_text()
 
 
-def test_tag_step_resumes_a_tag_that_already_points_at_the_verified_sha(tmp_path: Path) -> None:
-    """Reuse an existing annotated tag only when it points to the pinned SHA."""
+def test_tag_step_resumes_a_signed_tag_that_already_points_at_the_verified_sha(tmp_path: Path) -> None:
+    """Reuse an existing signed annotated tag only when it points to the pinned SHA."""
     repo, head, _older = _tag_repo(tmp_path)
+    signing_key = tmp_path / "signing-key"
+    subprocess.run(
+        ["ssh-keygen", "-q", "-t", "ed25519", "-N", "", "-f", str(signing_key)],
+        check=True,
+        env=scrubbed_git_env(drop_git_vars=True),
+    )
+    _git(repo, "config", "gpg.format", "ssh")
+    _git(repo, "config", "user.signingkey", str(signing_key))
+    _git(repo, "config", "tag.gpgSign", "true")
     _git(repo, "tag", "-a", "v9.9.9.r1", "-m", "v9.9.9.r1", "-m", "pfBlockerNG-Release-Channel: testing", head)
+    assert "BEGIN SSH SIGNATURE" in _git(repo, "cat-file", "tag", "v9.9.9.r1")
     _git(repo, "push", "-q", "origin", "refs/tags/v9.9.9.r1")
     result = _run_tag_step(repo, "v9.9.9.r1", head)
     assert result.returncode == 0, result.stdout + result.stderr
     assert _git(repo, "rev-list", "-n", "1", "refs/tags/v9.9.9.r1") == head
+    assert RELEASE_WORKFLOW.read_text(encoding="utf-8").count("--format='%(trailers)'") == 2
 
 
 def test_tag_step_refuses_a_stale_tag_pointing_at_other_code(tmp_path: Path) -> None:

--- a/tests/test_workflow_git_signing.py
+++ b/tests/test_workflow_git_signing.py
@@ -1,0 +1,79 @@
+"""GitHub Actions jobs that write Git objects use the project bot's SSH key."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOWS = ROOT / ".github" / "workflows"
+_SIGNING_STEP = "Configure pfblockerng-bot signing"
+_SIGNING_SECRET = "${{ secrets.PFB_BOT_SIGNING_KEY }}"
+_COMMIT = re.compile(r"\bgit(?:\s+-C\s+\S+)?\s+commit\b")
+_ANNOTATED_TAG = re.compile(r"\bgit\s+tag\s+-a\b")
+_REQUIRED_CONFIG = (
+    'git config user.name "pfblockerng-bot"',
+    'git config user.email "293667935+pfblockerng-bot@users.noreply.github.com"',
+    "git config gpg.format ssh",
+    'git config user.signingkey "$RUNNER_TEMP/pfb-bot-signing-key"',
+    "git config commit.gpgsign true",
+)
+
+
+def _writer_jobs() -> list[tuple[str, str, list[dict[str, Any]], bool]]:
+    writers: list[tuple[str, str, list[dict[str, Any]], bool]] = []
+    for path in sorted(WORKFLOWS.glob("*.yml")):
+        workflow = yaml.safe_load(path.read_text(encoding="utf-8"))
+        for job_name, job in workflow.get("jobs", {}).items():
+            steps = job.get("steps", [])
+            scripts = [step.get("run", "") for step in steps]
+            writes_commit = any(_COMMIT.search(script) for script in scripts)
+            writes_annotated_tag = any(_ANNOTATED_TAG.search(script) for script in scripts)
+            if writes_commit or writes_annotated_tag:
+                writers.append((path.name, job_name, steps, writes_annotated_tag))
+    return writers
+
+
+def test_git_object_writer_jobs_configure_pfblockerng_bot_ssh_signing() -> None:
+    writers = _writer_jobs()
+    assert writers, "no Git-object writer jobs discovered"
+
+    for workflow, job, steps, writes_annotated_tag in writers:
+        setup_index = next(
+            (index for index, step in enumerate(steps) if step.get("name") == _SIGNING_STEP),
+            None,
+        )
+        assert setup_index is not None, f"{workflow}:{job} lacks {_SIGNING_STEP!r}"
+
+        writer_indexes = [
+            index
+            for index, step in enumerate(steps)
+            if _COMMIT.search(step.get("run", "")) or _ANNOTATED_TAG.search(step.get("run", ""))
+        ]
+        assert setup_index < min(writer_indexes), f"{workflow}:{job} configures signing after writing a Git object"
+
+        setup = steps[setup_index]
+        assert setup.get("env", {}).get("PFB_BOT_SIGNING_KEY") == _SIGNING_SECRET, (
+            f"{workflow}:{job} does not consume the org signing-key secret"
+        )
+        script = setup.get("run", "")
+        assert '[ -n "${PFB_BOT_SIGNING_KEY:-}" ]' in script, f"{workflow}:{job} accepts an empty signing key"
+        assert 'install -m 600 /dev/null "$RUNNER_TEMP/pfb-bot-signing-key"' in script
+        assert 'printf \'%s\\n\' "$PFB_BOT_SIGNING_KEY" > "$RUNNER_TEMP/pfb-bot-signing-key"' in script
+        for command in _REQUIRED_CONFIG:
+            assert command in script, f"{workflow}:{job} lacks {command!r}"
+        if writes_annotated_tag:
+            assert "git config tag.gpgSign true" in script, f"{workflow}:{job} does not sign annotated tags"
+
+
+def test_workflows_never_configure_the_generic_actions_commit_identity() -> None:
+    generic_identity = re.compile(r"git config user\.(?:name|email).*github-actions(?:\[bot\])?", re.IGNORECASE)
+    offenders = [
+        path.name
+        for path in sorted(WORKFLOWS.glob("*.yml"))
+        if generic_identity.search(path.read_text(encoding="utf-8"))
+    ]
+    assert not offenders, f"generic Actions commit identity remains in: {', '.join(offenders)}"

--- a/tests/test_workflow_git_signing_guards.py
+++ b/tests/test_workflow_git_signing_guards.py
@@ -1,0 +1,36 @@
+"""Runtime guards cannot let a Git writer outlive its signing setup."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+WORKFLOWS = Path(__file__).resolve().parents[1] / ".github" / "workflows"
+_SIGNING_STEP = "Configure pfblockerng-bot signing"
+_COMMIT = re.compile(r"\bgit(?:\s+-C\s+\S+)?\s+commit\b")
+_ANNOTATED_TAG = re.compile(r"\bgit\s+tag\s+-a\b")
+
+
+def test_writer_steps_match_their_signing_step_runtime_guards() -> None:
+    for path in sorted(WORKFLOWS.glob("*.yml")):
+        workflow: dict[str, Any] = yaml.safe_load(path.read_text(encoding="utf-8"))
+        for job_name, job in workflow.get("jobs", {}).items():
+            steps: list[dict[str, Any]] = job.get("steps", [])
+            writers = [
+                step
+                for step in steps
+                if _COMMIT.search(step.get("run", "")) or _ANNOTATED_TAG.search(step.get("run", ""))
+            ]
+            if not writers:
+                continue
+            setup = next(step for step in steps if step.get("name") == _SIGNING_STEP)
+            for writer in writers:
+                assert writer.get("if") == setup.get("if"), (
+                    f"{path.name}:{job_name} signing and writer if guards differ"
+                )
+                assert writer.get("continue-on-error") == setup.get("continue-on-error"), (
+                    f"{path.name}:{job_name} signing and writer failure semantics differ"
+                )

--- a/tests/test_workflow_git_signing_key_order.py
+++ b/tests/test_workflow_git_signing_key_order.py
@@ -1,0 +1,29 @@
+"""Bot signing keys are written only after the mode-600 file exists."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+WORKFLOWS = Path(__file__).resolve().parents[1] / ".github" / "workflows"
+_SIGNING_STEP = "Configure pfblockerng-bot signing"
+_INSTALL = 'install -m 600 /dev/null "$RUNNER_TEMP/pfb-bot-signing-key"'
+_WRITE = 'printf \'%s\\n\' "$PFB_BOT_SIGNING_KEY" > "$RUNNER_TEMP/pfb-bot-signing-key"'
+
+
+def test_signing_steps_create_the_protected_key_file_before_writing_it() -> None:
+    setups: list[tuple[str, str, str]] = []
+    for path in sorted(WORKFLOWS.glob("*.yml")):
+        document: dict[str, Any] = yaml.safe_load(path.read_text(encoding="utf-8"))
+        for job_name, job in document.get("jobs", {}).items():
+            for step in job.get("steps", []):
+                if step.get("name") == _SIGNING_STEP:
+                    setups.append((path.name, job_name, step.get("run", "")))
+
+    assert setups, "no bot-signing steps discovered"
+    for workflow_name, job, script in setups:
+        assert script.index(_INSTALL) < script.index(_WRITE), (
+            f"{workflow_name}:{job} must create the mode-600 key file before writing the secret"
+        )


### PR DESCRIPTION
## Summary

- configure every workflow commit writer as `pfblockerng-bot <293667935+pfblockerng-bot@users.noreply.github.com>` with the org-level `PFB_BOT_SIGNING_KEY` SSH key
- sign both release annotated-tag creation paths while preserving existing `GITHUB_TOKEN` push and PR authentication
- make every release-channel trailer reader signature-aware, including release resume, publication, previous-tag selection, and the pre-push hook
- add source-derived contracts for writer signing, runtime-guard parity, protected key-write ordering, and signed-tag parsing

This replaces the GitHub-API commit workaround proposed during #3003 triage now that the project bot has a registered signing key.

## Verification

| Frozen RED test | git hash-object | RED run tail |
| --- | --- | --- |
| `tests/test_workflow_git_signing.py` | `c2227a98c4df3630ea23a227b74da421cec27b7c` | `2 failed: writer jobs lacked pfblockerng-bot signing and generic Actions identities remained` |
| `tests/test_release_tag_after_verify.py` | `43893fe9dd32a8e2fc682e27d774092a368c2ae2` | `FAILED: signed existing tag was rejected with invalid release-channel trailer metadata` |
| `tests/test_workflow_git_signing_guards.py` | `c5a56f68e41fe09b665f330912870be1dfef25aa` | `FAILED: planted hsts-refresh signing/writer if-guard mismatch was detected` |
| `tests/test_issue2143_git_classifier.py` | `c226f291bd16c60e0ce666e348d44120b0d04b22` | `5 failed: signed tag classifier rejected the exact trailer and four raw-content reader contracts remained` |
| `tests/test_workflow_git_signing_key_order.py` | `1131966f24c7baefe87aabbd3706b1c67bba70da` | `FAILED: planted hsts-refresh key write before mode-600 install was detected` |

- GREEN: focused signing/parser contracts -> 20 passed
- full relevant release/signing regression set -> 160 passed
- workflow hygiene contracts -> 32 passed
- pre-push tag shellspec -> 8 passed
- actionlint 1.7.12 with the CI-pinned ShellCheck 0.11.0 over all changed workflows -> exit 0
- targeted Ruff format/lint and mypy -> pass
- exact private-key-path smoke created both an SSH-signed commit and SSH-signed annotated tag
- independent writer/signing verifier -> PASS; four-lens review found and fixed signing-key order coverage, signed-tag resume and downstream trailer-reader defects, plus writer/signing guard-parity coverage
- `scripts/agent/run-gates.sh --diff origin/devel`: ruff, format, and mypy passed; full pytest reached 5,833 passed / 6 skipped with four host-environment failures unrelated to this diff (`/usr/bin/time` absent, root can read mode-000 files, and Node v26.8.1 emits a newer nested-suite JUnit name)

The first real writer run after landing remains the GitHub-side proof that the org secret matches the signing key registered on `pfblockerng-bot`.

Fixes #3003
Refs #2999
