### PR TITLE
pfb_unbound: build the PSL index once per instance, not per lookup (#3046)

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -40,7 +40,6 @@ from contextlib import nullcontext
 from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
-from functools import lru_cache
 from typing import TYPE_CHECKING, Any
 
 # CPython 3.11+ internal regex AST parser used by the literal-prefilter to extract
@@ -123,6 +122,28 @@ class PslRules:
     private_exact: tuple[str, ...] = ()
     private_wildcard: tuple[str, ...] = ()
     private_exception: tuple[str, ...] = ()
+    # Membership sets, built on first use and held on the instance. compare=False
+    # so value equality still reflects the rules alone, whether or not an
+    # instance has been indexed.
+    _index: tuple[_PslSets, _PslSets] | None = field(default=None, compare=False, repr=False)
+
+    def index(self) -> tuple[_PslSets, _PslSets]:
+        """(ICANN-only, ICANN+PRIVATE) membership sets for this rule set.
+
+        Built once per instance. Do NOT reintroduce an lru_cache keyed on this
+        dataclass: computing that key hashes all six rule tuples on every call,
+        and CPython does not cache tuple hashes, so the key costs more than the
+        scan the cache exists to avoid (issue #3046).
+
+        Unlocked on purpose. init_standard runs per unbound worker thread, so two
+        threads may race here; both build equal values and the worst case is one
+        wasted build.
+        """
+        idx = self._index
+        if idx is None:
+            idx = _psl_build_index(self)
+            object.__setattr__(self, "_index", idx)
+        return idx
 
 
 @dataclass(frozen=True)
@@ -238,13 +259,13 @@ def parse_psl_rules(text: str) -> PslRules:
 _PslSets = tuple[frozenset[str], frozenset[str], frozenset[str]]
 
 
-@lru_cache(maxsize=4)
-def _psl_index(rules: PslRules) -> tuple[_PslSets, _PslSets]:
-    """(ICANN-only, ICANN+PRIVATE) (exact, wildcard, exception) membership sets.
+def _psl_build_index(rules: PslRules) -> tuple[_PslSets, _PslSets]:
+    """Build the (ICANN-only, ICANN+PRIVATE) (exact, wildcard, exception) sets.
 
-    Built once per PslRules (frozen, hashable) so each resolution costs O(name
-    labels), never a scan over the ~10k shipped rules -- the classifier runs per
-    feed entry at build time and TLD-Allow runs on the live DNS query path.
+    Called once per PslRules via PslRules.index(), which holds the result on the
+    instance, so each resolution costs O(name labels) rather than a scan over the
+    ~10k shipped rules -- the classifier runs per feed entry at build time and
+    TLD-Allow runs on the live DNS query path.
     """
     icann: _PslSets = (
         frozenset(rules.icann_exact),
@@ -288,7 +309,7 @@ def resolve_public_suffix(name: str, rules: PslRules) -> PslResolution:
     """Apply PSL prevailing-rule semantics for ICANN and combined sections."""
     normalized = _psl_normalize_name(name)
     labels = normalized.split(".")
-    icann_sets, combined_sets = _psl_index(rules)
+    icann_sets, combined_sets = rules.index()
     icann_suffix = _psl_prevailing(labels, *icann_sets)
     public_suffix = _psl_prevailing(labels, *combined_sets)
     suffix_labels = public_suffix.split(".")
@@ -6549,7 +6570,7 @@ def _tld_allow_blocks(
     except (AttributeError, TypeError, ValueError):
         # Structurally invalid names cannot be matched safely; fail closed.
         return True
-    icann_sets, combined_sets = _psl_index(rules)
+    icann_sets, combined_sets = rules.index()
     icann_suffix = _psl_prevailing(labels, *icann_sets)
     public_suffix = _psl_prevailing(labels, *combined_sets)
     suffix_roots = {

--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -123,9 +123,10 @@ class PslRules:
     private_wildcard: tuple[str, ...] = ()
     private_exception: tuple[str, ...] = ()
     # Membership sets, built on first use and held on the instance. compare=False
-    # so value equality still reflects the rules alone, whether or not an
-    # instance has been indexed.
-    _index: tuple[_PslSets, _PslSets] | None = field(default=None, compare=False, repr=False)
+    # keeps value equality (and the hash) a function of the rules alone; init=False
+    # keeps a foreign index out of the constructor and makes dataclasses.replace
+    # rebuild rather than carry the previous rules' sets.
+    _index: tuple[_PslSets, _PslSets] | None = field(default=None, compare=False, repr=False, init=False)
 
     def index(self) -> tuple[_PslSets, _PslSets]:
         """(ICANN-only, ICANN+PRIVATE) membership sets for this rule set.
@@ -135,9 +136,11 @@ class PslRules:
         and CPython does not cache tuple hashes, so the key costs more than the
         scan the cache exists to avoid (issue #3046).
 
-        Unlocked on purpose. init_standard runs per unbound worker thread, so two
-        threads may race here; both build equal values and the worst case is one
-        wasted build.
+        Hand-rolled rather than functools.cached_property because on 3.11 that
+        descriptor takes a lock shared across all instances, serialising the first
+        build across worker threads; this check-then-set is unlocked on purpose, so
+        racing threads each build an equal value and the cost is one wasted build
+        per racing thread.
         """
         idx = self._index
         if idx is None:

--- a/tests/test_psl_resolver.py
+++ b/tests/test_psl_resolver.py
@@ -137,15 +137,9 @@ def test_resolver_throughput_is_indexed_not_linear_scan() -> None:
     The DNSBL build classifies every feed entry and TLD-Allow resolves on the live
     DNS query path, so per-lookup work proportional to the rule set is a defect.
 
-    issue #3051: this asserted only that 2000 resolves finished inside 2.0 s. That
-    ceiling is ~26x looser than the regression it exists to catch, so it stayed
-    green throughout issue #3046, where every lookup hashed all six rule tuples to
-    build an lru_cache key -- touching the whole rule set per resolve, the exact
-    failure named above. A duration also makes the verdict depend on the runner
-    rather than on the code. The property is now asserted structurally: a resolve
-    must neither hash the rule set nor rebuild the index. The elapsed time is kept
-    only as a coarse cap against an outright linear matcher and proves nothing on
-    its own.
+    Asserted structurally, never on a clock (issue #3051): a resolve must neither
+    hash the rule set nor rebuild the index. A duration cannot see a constant-factor
+    scan and makes the verdict depend on the runner.
     """
     import pathlib
     import time

--- a/tests/test_psl_resolver.py
+++ b/tests/test_psl_resolver.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+from typing import Any
+from unittest import mock
+
 import pytest
 
 import pfb_unbound
@@ -132,10 +135,17 @@ def test_resolver_throughput_is_indexed_not_linear_scan() -> None:
     """Resolution must be O(name labels), never a scan over all ~10k shipped rules.
 
     The DNSBL build classifies every feed entry and TLD-Allow resolves on the live
-    DNS query path, so a per-lookup scan over the full rule set (measured ~3.6 ms
-    per resolve, ~30 minutes for a 500k-entry build) is a defect. 2000 resolves
-    against the SHIPPED authority must finish comfortably inside 2 seconds; the
-    indexed matcher needs ~0.1 s, the linear scan needs ~7 s.
+    DNS query path, so per-lookup work proportional to the rule set is a defect.
+
+    issue #3051: this asserted only that 2000 resolves finished inside 2.0 s. That
+    ceiling is ~26x looser than the regression it exists to catch, so it stayed
+    green throughout issue #3046, where every lookup hashed all six rule tuples to
+    build an lru_cache key -- touching the whole rule set per resolve, the exact
+    failure named above. A duration also makes the verdict depend on the runner
+    rather than on the code. The property is now asserted structurally: a resolve
+    must neither hash the rule set nor rebuild the index. The elapsed time is kept
+    only as a coarse cap against an outright linear matcher and proves nothing on
+    its own.
     """
     import pathlib
     import time
@@ -152,8 +162,35 @@ def test_resolver_throughput_is_indexed_not_linear_scan() -> None:
         "no-rule.zz-unknown",
         "x.act.edu.au",
     ] * 250
+    rules.index()  # prime: every build counted below is one too many
+
+    hashed: list[str] = []
+    builds: list[str] = []
+    original_hash = pfb_unbound.PslRules.__hash__
+    original_build = pfb_unbound._psl_build_index
+
+    def counting_hash(self: pfb_unbound.PslRules) -> int:
+        hashed.append("hash")
+        return original_hash(self)
+
+    def counting_build(rule_set: pfb_unbound.PslRules) -> tuple[Any, Any]:
+        builds.append("build")
+        return original_build(rule_set)
+
     started = time.perf_counter()
-    for name in names:
-        pfb_unbound.resolve_public_suffix(name, rules)
+    with (
+        mock.patch.object(pfb_unbound.PslRules, "__hash__", counting_hash),
+        mock.patch.object(pfb_unbound, "_psl_build_index", counting_build),
+    ):
+        for name in names:
+            pfb_unbound.resolve_public_suffix(name, rules)
     elapsed = time.perf_counter() - started
+
+    assert hashed == [], (
+        f"{len(hashed)} rule-set hashes across {len(names)} resolves: the index is behind a cache "
+        "keyed on the rules, so every lookup walks all six rule tuples (issue #3046)"
+    )
+    assert builds == [], f"the index was rebuilt {len(builds)} time(s) across {len(names)} resolves"
+    # Coarse salvage cap only (issue #3051): catches an outright linear matcher,
+    # ~7 s here. The two assertions above are what prove the property.
     assert elapsed < 2.0, f"2000 resolves took {elapsed:.2f}s; matcher is scanning rules per lookup"

--- a/tests/test_psl_runtime_integration.py
+++ b/tests/test_psl_runtime_integration.py
@@ -467,3 +467,33 @@ def test_the_instance_index_matches_a_direct_build() -> None:
     rules = P.parse_psl_rules(PSL)
 
     assert rules.index() == P._psl_build_index(rules)
+
+
+def test_the_live_query_path_does_not_rebuild_the_index_per_query() -> None:
+    """issue #3046: TLD-Allow resolves through the memoised index too.
+
+    ``_tld_allow_blocks`` calls ``rules.index()`` on the live DNS query path,
+    the same method ``resolve_public_suffix`` uses on the build path. Counting
+    hashes alone does not cover it: swapping that one call site back to a direct
+    ``_psl_build_index(rules)`` rebuilds the sets on EVERY query while hashing
+    nothing, so a hash-count assertion stays green while the query path silently
+    pays the whole build. Count builds instead, after priming, so re-introducing
+    a per-query rebuild at this call site fails here.
+    """
+    rules = P.parse_psl_rules(PSL)
+    containers = _allow_containers(rules)
+    cfg = _allow_cfg(tld_allow_list=["com"])
+    rules.index()  # prime: every build counted below is one too many
+
+    builds: list[str] = []
+    original_build = P._psl_build_index
+
+    def counting_build(r: P.PslRules) -> Any:
+        builds.append("build")
+        return original_build(r)
+
+    with mock.patch.object(P, "_psl_build_index", counting_build):
+        for name in ("x.example.com", "y.example.com", "x.github.io"):
+            P.evaluate_domain(name, name, "com", False, cfg, containers)
+
+    assert builds == [], f"the live query path rebuilt the index {len(builds)} time(s); issue #3046 has regressed"

--- a/tests/test_psl_runtime_integration.py
+++ b/tests/test_psl_runtime_integration.py
@@ -403,9 +403,9 @@ def test_resolving_a_name_never_hashes_the_rule_set() -> None:
 
     ``_psl_index`` was ``@lru_cache``d on the frozen dataclass, so every lookup
     computed a key by hashing all six rule tuples. CPython does not cache tuple
-    hashes, so the key cost more than the scan the cache existed to avoid --
-    13.89us per call, against 0.034us for an ordinary small-tuple hash. Hashing
-    the rule set during a resolution is the mechanical signature of that defect,
+    hashes, so the key cost more than the scan the cache existed to avoid.
+    Hashing the rule set during a resolution is the mechanical signature of that
+    defect,
     and it is what this asserts against: not a timing, which would be flaky, but
     the operation whose cost was the defect.
 

--- a/tests/test_psl_runtime_integration.py
+++ b/tests/test_psl_runtime_integration.py
@@ -401,16 +401,9 @@ def test_resolving_a_name_never_hashes_the_rule_set() -> None:
     """issue #3046: the membership index must not sit behind a cache keyed on
     ``PslRules``.
 
-    ``_psl_index`` was ``@lru_cache``d on the frozen dataclass, so every lookup
-    computed a key by hashing all six rule tuples. CPython does not cache tuple
-    hashes, so the key cost more than the scan the cache existed to avoid.
-    Hashing the rule set during a resolution is the mechanical signature of that
-    defect,
-    and it is what this asserts against: not a timing, which would be flaky, but
-    the operation whose cost was the defect.
-
-    Both call sites pay it: the per-entry classifier on the DNSBL build path and
-    TLD-Allow on the live DNS query path.
+    Computing such a key hashes all six rule tuples, and CPython does not cache
+    tuple hashes, so the key costs more than the scan the cache exists to avoid.
+    Asserted on the hashing itself rather than on a timing, which would be flaky.
     """
     rules = P.parse_psl_rules(PSL)
     hashed: list[str] = []
@@ -472,13 +465,9 @@ def test_the_instance_index_matches_a_direct_build() -> None:
 def test_the_live_query_path_does_not_rebuild_the_index_per_query() -> None:
     """issue #3046: TLD-Allow resolves through the memoised index too.
 
-    ``_tld_allow_blocks`` calls ``rules.index()`` on the live DNS query path,
-    the same method ``resolve_public_suffix`` uses on the build path. Counting
-    hashes alone does not cover it: swapping that one call site back to a direct
-    ``_psl_build_index(rules)`` rebuilds the sets on EVERY query while hashing
-    nothing, so a hash-count assertion stays green while the query path silently
-    pays the whole build. Count builds instead, after priming, so re-introducing
-    a per-query rebuild at this call site fails here.
+    ``_tld_allow_blocks`` reaches the index on the live DNS query path. Builds are
+    counted rather than hashes because un-memoising that call site rebuilds the
+    sets per query while hashing nothing, which a hash count cannot see.
     """
     rules = P.parse_psl_rules(PSL)
     containers = _allow_containers(rules)

--- a/tests/test_psl_runtime_integration.py
+++ b/tests/test_psl_runtime_integration.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 from typing import Any
+from unittest import mock
 
 import pytest
 
@@ -394,3 +395,75 @@ def test_allow_private_off_blocks_private_boundary_and_parent_alike() -> None:
         decision = P.evaluate_domain(name, name, "io", False, _allow_cfg(), containers)
         assert decision.is_found is True, name
         assert decision.feed == "TLD_Allow"
+
+
+def test_resolving_a_name_never_hashes_the_rule_set() -> None:
+    """issue #3046: the membership index must not sit behind a cache keyed on
+    ``PslRules``.
+
+    ``_psl_index`` was ``@lru_cache``d on the frozen dataclass, so every lookup
+    computed a key by hashing all six rule tuples. CPython does not cache tuple
+    hashes, so the key cost more than the scan the cache existed to avoid --
+    13.89us per call, against 0.034us for an ordinary small-tuple hash. Hashing
+    the rule set during a resolution is the mechanical signature of that defect,
+    and it is what this asserts against: not a timing, which would be flaky, but
+    the operation whose cost was the defect.
+
+    Both call sites pay it: the per-entry classifier on the DNSBL build path and
+    TLD-Allow on the live DNS query path.
+    """
+    rules = P.parse_psl_rules(PSL)
+    hashed: list[str] = []
+    original_hash = P.PslRules.__hash__
+
+    def counting_hash(self: P.PslRules) -> int:
+        hashed.append("hashed")
+        return original_hash(self)
+
+    with mock.patch.object(P.PslRules, "__hash__", counting_hash):
+        for name in ("example.com", "a.b.example.com", "example.github.io", "www.ck"):
+            P.resolve_public_suffix(name, rules)
+
+    assert hashed == [], f"resolution hashed the rule set {len(hashed)} time(s); issue #3046 has regressed"
+
+
+def test_the_index_is_built_once_per_instance() -> None:
+    """The sets are held on the instance, so repeated resolution reuses them.
+
+    Identity, not equality: two equal-but-distinct builds would mean the index
+    is being recomputed, which is the cost this change exists to remove.
+    """
+    rules = P.parse_psl_rules(PSL)
+
+    first = rules.index()
+
+    assert rules.index() is first
+    assert rules.index() is first
+
+
+def test_indexing_an_instance_leaves_value_equality_and_hash_untouched() -> None:
+    """``_index`` carries ``compare=False``, so an indexed instance stays equal
+    to an un-indexed one built from the same rules -- and keeps the same hash.
+
+    Both halves matter. Equality is the dataclass contract other tests rely on
+    (``_load_psl_authority(...) == PslRules()``); the hash must also hold,
+    because PslRules remains hashable and any caller putting one in a set or
+    dict key would otherwise see two distinct entries for the same rules
+    depending on whether a lookup had happened to run first.
+    """
+    indexed = P.parse_psl_rules(PSL)
+    fresh = P.parse_psl_rules(PSL)
+
+    indexed.index()
+
+    assert indexed == fresh
+    assert hash(indexed) == hash(fresh)
+
+
+def test_the_instance_index_matches_a_direct_build() -> None:
+    """Moving the sets onto the instance changed where they live, not what they
+    are: the memoised value equals what the builder returns for the same rules.
+    """
+    rules = P.parse_psl_rules(PSL)
+
+    assert rules.index() == P._psl_build_index(rules)


### PR DESCRIPTION
Closes #3046.

`_psl_index()` was decorated `@lru_cache(maxsize=4)` and took the frozen
`PslRules` dataclass as its only argument. Computing that cache key hashes a
tuple of six tuples holding every PSL rule, and **CPython does not cache tuple
hashes** — so every call walked all ~10k shipped rules before reaching the O(1)
dict lookup. The docstring's promise, "never a scan over the ~10k shipped
rules", was defeated by the cache mechanism itself.

Two call sites paid it: `resolve_public_suffix()` on the per-entry DNSBL build
path, and the TLD-Allow check on the live DNS query path.

The sets are now built once per `PslRules` instance and held on it.

## Measured, on hardware

Micro-benchmark (Debian, this repo's interpreter):

| | |
|---|---|
| `lru_cache` hit — hash + lookup | 13.89 µs |
| `rules.index()` after the change | 0.72 µs (19×) |
| `hash()` of an ordinary 3-tuple, control | 0.034 µs |

The key cost 394× an ordinary small-tuple hash. That is the defect: the cache
key was the expensive part.

**Live appliance, same box, back to back** — pfSense Plus 26.07-RELEASE,
2 cores / 4029 MB, DNSBL 187,379 entries across 3 feeds (StevenBlack_ADs
78,617 · UT1_redirector 108,713 · UT1_remote_control 49). `cd /var/unbound &&
time unbound-checkconf`, three complete runs each side:

| | real | user | sys |
|---|---|---|---|
| before, run 1 | 5.23 | 5.14 | 0.03 |
| before, run 2 | 7.32 | 5.20 | 0.03 |
| before, run 3 | 7.17 | 5.07 | 0.03 |
| **before mean** | | **5.14** (spread 0.13) | |
| after, run 1 | 1.73 | 1.72 | 0.00 |
| after, run 2 | 1.76 | 1.74 | 0.00 |
| after, run 3 | 3.82 | 1.76 | 0.02 |
| **after mean** | | **1.74** (spread 0.04) | |

**3.40 s of user CPU removed — a 66% reduction**, implying 18.15 µs per entry,
between the 13.89 µs measured on Debian and the 27.4 µs ceiling the before-number
itself imposes. `user` is the figure to read: `real` is noisy on a 2-core guest
with the daemon live.

The magnitude was **predicted before the patched run was executed** (2.2–3.0 s
from 187,379 × 13.89 µs) and pre-registered on the lab bus. The mechanism held;
the band was conservative, because a slower guest pays more per call and so
saves more. Recording the miss as well as the hit.

Composition verified at both ends rather than assumed — before `md5
0a31b83…82738` with zero `eq=False` occurrences, after `md5 29cf010f…66156`
verified byte-exact in **both** the package and chroot copies.

`psl_feed_policy_active` is false on that box (`/var/db/pfblockerng/dnsbl_tld/`
absent), so 1.74 s is the single-index cost. A box carrying suffix-feed policy
pays a second `index()` per entry and should improve further — untested, not
claimed.

## A note on the 49 s figure in the issue

It is **not** a baseline. The originating handoff records it as taken *after* a
one-line `eq=False` edit, which gives `PslRules` identity hashing and so removes
this very cost by a different, unshippable mechanism. It is that box's *after*.
The 5.14 s above is the first clean unpatched measurement this defect has ever
had. Its 44.68 s of remaining user time is a separate per-entry parse cost, not
this issue.

## Tests

Executed red against `b78bec5cc`, green here.

`test_resolving_a_name_never_hashes_the_rule_set` is the regression guard. It
counts `PslRules.__hash__` calls during resolution rather than timing anything,
because the defect is mechanical and a timing assertion would be flaky. Red it
reports **"resolution hashed the rule set 4 time(s)"** for four resolutions —
one key hash per lookup, independently corroborating the per-entry model that
predicted the appliance result.

Three more pin the replacement: built once per instance (identity, not
equality — two equal builds would mean recomputation); indexing leaves value
equality *and* hash untouched, so the `compare=False` field cannot silently
regress; and the memoised value still equals a direct `_psl_build_index` call.

Red on `b78bec5cc`: 4 failed. Green: 105 passed across the three PSL suites,
test file byte-identical between runs (`md5 5e47fe17…6b45c`).

## Method notes, credited to claude-smoke

Two traps that each manufacture a *flatteringly small* number:

1. `unbound.conf`'s `python-script: pfb_unbound.py` is **relative**, and
   `checkconf` does not chroot — so it resolves against the working directory.
   Run from anywhere but `/var/unbound` it fails fatally in 0.02 s, which reads
   as a spectacular result.
2. Piping a deploy script and a 341 KB payload down one stdin to `sh -s` lets
   `sh` read ahead and swallow the head of the payload. The module lands
   headless and fails fast — again, small and flattering. Caught by md5-ing the
   deployed file before trusting it.

`checkconf` from `/var/unbound` reads the **chroot** copy, while the package
copy is what survives; both must be updated and both verified.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance Improvements**
  - Improved public suffix and TLD-Allow resolution efficiency by reusing prepared lookup data.
  - Reduced repeated processing during domain lookups, especially for repeated queries.

- **Reliability**
  - Preserved existing public suffix matching behavior while improving runtime performance.
  - Added safeguards to ensure lookup data remains consistent across repeated resolutions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->