### PR TITLE
unbound: normalize the TLD blacklist once per build

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -5285,7 +5285,7 @@ def build(
     # Whole-TLD block: a blacklisted TLD becomes a synthetic DNSBL_TLD zone entry
     # (feed/group ``DNSBL_TLD``, log ``1``) -- the sole writer of this row shape
     # since ADR-65 retired PHP's own equivalent write.
-    for tld in blacklist_roots:
+    for tld in sorted(blacklist_roots):  # sorted: a set would insert in hash-seed order
         if not tld:
             continue
         idx = index_for("DNSBL_TLD", "DNSBL_TLD")

--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -36,6 +36,7 @@ import stat
 import sys
 import time
 from collections.abc import Callable, Iterable, Iterator
+from collections.abc import Set as AbstractSet
 from contextlib import nullcontext
 from dataclasses import dataclass, field
 from datetime import datetime
@@ -4589,16 +4590,12 @@ def tld_wildcard_classify(
     exclusion: set[str],
     *,
     include_private: bool = True,
-    blacklist: frozenset[str] | set[str] | None = None,
+    blacklist: AbstractSet[str] = frozenset(),
 ) -> tuple[str, str]:
     """Return ``(DNSBL_CLASS_ZONE, registrable-domain)`` or exact DATA.
 
-    issue #3050: ``blacklist`` is already dot-stripped TLD roots -- the same
-    contract ``exclusion`` carries -- because this runs once per feed entry at
-    build time and once per TLD-Allow query, so nothing here may cost
-    O(len(blacklist)). ``build()`` normalizes the user's textarea ONCE into that
-    frozenset before its per-entry loop; the config boundary is where a dotted
-    ``.uk`` becomes ``uk``.
+    ``blacklist`` is already dot-stripped TLD roots -- the contract ``exclusion``
+    also carries -- normalized ONCE by ``build()`` at the config boundary (#3050).
     """
     if not any(
         (
@@ -4611,20 +4608,13 @@ def tld_wildcard_classify(
         )
     ):
         return DNSBL_CLASS_DATA, domain
-    root_blacklist = blacklist or frozenset()
     try:
         resolution = resolve_public_suffix(domain, rules)
     except ValueError:
         return DNSBL_CLASS_DATA, domain
     suffix = resolution.public_suffix if include_private else resolution.icann_suffix
     root = suffix.rsplit(".", 1)[-1]
-    if (
-        suffix in root_blacklist
-        or root in root_blacklist
-        or suffix in exclusion
-        or root in exclusion
-        or domain in exclusion
-    ):
+    if suffix in blacklist or root in blacklist or suffix in exclusion or root in exclusion or domain in exclusion:
         return DNSBL_CLASS_DATA, domain
     labels = domain.split(".")
     suffix_labels = suffix.split(".")
@@ -5256,13 +5246,9 @@ def build(
     tallied 'suffix_drop') or a wildcard ZONE anchor demoted to exact DATA ('apex',
     tallied 'suffix_demote'); USER provenance is exempt in every state.
     """
-    tld_wildcard_blacklist = list(config.get("tld_wildcard_blacklist", []))
-    tld_wildcard_exclusion = list(config.get("tld_wildcard_exclusion", []))
-    # issue #3050: both user textareas become dot-stripped roots ONCE, here at the
-    # config boundary, and the SAME objects are handed to tld_wildcard_classify()
-    # for every feed entry -- the per-entry path never rebuilds or re-strips them.
-    blacklist_roots = frozenset(t.strip(".") for t in tld_wildcard_blacklist)
-    exclusion = {e.strip(".") for e in tld_wildcard_exclusion}
+    # issue #3050: dot-stripped ONCE here; every consumer below reads these as-is.
+    blacklist_roots = frozenset(t.strip(".") for t in config.get("tld_wildcard_blacklist", []))
+    exclusion = {e.strip(".") for e in config.get("tld_wildcard_exclusion", [])}
 
     static_cap = bool(config.get("regex_cap", False))
 
@@ -5299,8 +5285,7 @@ def build(
     # Whole-TLD block: a blacklisted TLD becomes a synthetic DNSBL_TLD zone entry
     # (feed/group ``DNSBL_TLD``, log ``1``) -- the sole writer of this row shape
     # since ADR-65 retired PHP's own equivalent write.
-    for raw_tld in tld_wildcard_blacklist:
-        tld = raw_tld.strip(".")
+    for tld in blacklist_roots:
         if not tld:
             continue
         idx = index_for("DNSBL_TLD", "DNSBL_TLD")

--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -4589,9 +4589,17 @@ def tld_wildcard_classify(
     exclusion: set[str],
     *,
     include_private: bool = True,
-    blacklist: set[str] | None = None,
+    blacklist: frozenset[str] | set[str] | None = None,
 ) -> tuple[str, str]:
-    """Return ``(DNSBL_CLASS_ZONE, registrable-domain)`` or exact DATA."""
+    """Return ``(DNSBL_CLASS_ZONE, registrable-domain)`` or exact DATA.
+
+    issue #3050: ``blacklist`` is already dot-stripped TLD roots -- the same
+    contract ``exclusion`` carries -- because this runs once per feed entry at
+    build time and once per TLD-Allow query, so nothing here may cost
+    O(len(blacklist)). ``build()`` normalizes the user's textarea ONCE into that
+    frozenset before its per-entry loop; the config boundary is where a dotted
+    ``.uk`` becomes ``uk``.
+    """
     if not any(
         (
             rules.icann_exact,
@@ -4603,7 +4611,7 @@ def tld_wildcard_classify(
         )
     ):
         return DNSBL_CLASS_DATA, domain
-    root_blacklist = {entry.strip(".") for entry in blacklist or set()}
+    root_blacklist = blacklist or frozenset()
     try:
         resolution = resolve_public_suffix(domain, rules)
     except ValueError:
@@ -5250,6 +5258,10 @@ def build(
     """
     tld_wildcard_blacklist = list(config.get("tld_wildcard_blacklist", []))
     tld_wildcard_exclusion = list(config.get("tld_wildcard_exclusion", []))
+    # issue #3050: both user textareas become dot-stripped roots ONCE, here at the
+    # config boundary, and the SAME objects are handed to tld_wildcard_classify()
+    # for every feed entry -- the per-entry path never rebuilds or re-strips them.
+    blacklist_roots = frozenset(t.strip(".") for t in tld_wildcard_blacklist)
     exclusion = {e.strip(".") for e in tld_wildcard_exclusion}
 
     static_cap = bool(config.get("regex_cap", False))
@@ -5444,7 +5456,7 @@ def build(
                 psl_classification_rules,
                 exclusion,
                 include_private=bool(config.get("psl_include_private", True)),
-                blacklist=set(tld_wildcard_blacklist),
+                blacklist=blacklist_roots,
             )
             # Non-ABP block: band 1 (downloaded feed) or 5 (USER Custom_List); never
             # $important (the plain path has no $options grammar).

--- a/tests/test_issue3050_blacklist_normalization.py
+++ b/tests/test_issue3050_blacklist_normalization.py
@@ -1,8 +1,7 @@
 """Issue #3050 -- the TLD-wildcard blacklist is normalized ONCE, by the caller.
 
-``tld_wildcard_classify()`` runs once per DNSBL feed entry (and once per
-TLD-Allow query), so nothing inside it may cost O(len(blacklist)). The intent
-pinned here is a contract, not a duration:
+``tld_wildcard_classify()`` runs once per DNSBL feed entry, so nothing inside it
+may cost O(len(blacklist)). The intent pinned here is a contract, not a duration:
 
 * the classifier CONSUMES already dot-stripped TLD roots -- it never iterates or
   re-strips the blacklist it is handed, and
@@ -129,19 +128,12 @@ class TestBuildNormalizesTheBlacklistOnce:
         Then every call receives the SAME pre-derived roots object -- not a fresh
         set built per entry.
         """
-        seen: list[frozenset[str] | set[str] | None] = []
+        seen: list[Any] = []
         real = P.tld_wildcard_classify
 
-        def recording(
-            domain: str,
-            rules: P.PslRules,
-            exclusion: set[str],
-            *,
-            include_private: bool = True,
-            blacklist: Any = None,
-        ) -> tuple[str, str]:
-            seen.append(blacklist)
-            return real(domain, rules, exclusion, include_private=include_private, blacklist=blacklist)
+        def recording(*a: Any, **k: Any) -> tuple[str, str]:
+            seen.append(k.get("blacklist"))
+            return real(*a, **k)
 
         monkeypatch.setattr(P, "tld_wildcard_classify", recording)
         _run_build(["a.example.com", "b.example.com", "c.example.com"], blacklist=[".uk", "test"])
@@ -152,28 +144,6 @@ class TestBuildNormalizesTheBlacklistOnce:
             f"expected 1 shared blacklist object across {len(seen)} entries, got {len(distinct)} distinct objects "
             "-- the loop-invariant blacklist is being rebuilt per feed entry"
         )
-
-    def test_classifier_receives_dot_stripped_roots(self, monkeypatch: Any) -> None:
-        """A dotted user entry ('.uk') reaches the classifier already stripped."""
-        seen: list[Any] = []
-        real = P.tld_wildcard_classify
-
-        def recording(
-            domain: str,
-            rules: P.PslRules,
-            exclusion: set[str],
-            *,
-            include_private: bool = True,
-            blacklist: Any = None,
-        ) -> tuple[str, str]:
-            seen.append(blacklist)
-            return real(domain, rules, exclusion, include_private=include_private, blacklist=blacklist)
-
-        monkeypatch.setattr(P, "tld_wildcard_classify", recording)
-        _run_build(["a.example.com"], blacklist=[".uk"])
-
-        assert seen, "expected the plain block path to reach tld_wildcard_classify()"
-        assert set(seen[0]) == {"uk"}, f"expected the classifier to receive {{'uk'}}, got {set(seen[0])!r}"
 
     def test_dotted_user_blacklist_still_blocks_at_the_root(self) -> None:
         """End-to-end behaviour is unchanged by moving the strip to the caller."""

--- a/tests/test_issue3050_blacklist_normalization.py
+++ b/tests/test_issue3050_blacklist_normalization.py
@@ -1,0 +1,192 @@
+"""Issue #3050 -- the TLD-wildcard blacklist is normalized ONCE, by the caller.
+
+``tld_wildcard_classify()`` runs once per DNSBL feed entry (and once per
+TLD-Allow query), so nothing inside it may cost O(len(blacklist)). The intent
+pinned here is a contract, not a duration:
+
+* the classifier CONSUMES already dot-stripped TLD roots -- it never iterates or
+  re-strips the blacklist it is handed, and
+* ``build()`` derives those roots ONCE before its per-entry loop and passes the
+  SAME object for every entry -- exactly the treatment ``tld_wildcard_exclusion``
+  has always had (``exclusion`` at ``build()``'s prologue).
+
+Both are asserted structurally (iteration counting, object identity), never by
+timing, and each pairs with a behaviour row proving the blacklist still decides
+the classification it is supposed to decide -- a classifier that simply ignored
+the blacklist would satisfy the cost contract alone.
+
+Pure pytest, stdlib only, no Unbound symbols (CI-runnable).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Any
+
+import pfb_unbound as P
+
+# Minimal self-contained PSL: an ICANN two-label suffix (co.uk) whose root (uk)
+# is what a user blacklists, plus a single-label ICANN suffix to contrast with.
+PSL = """// ===BEGIN ICANN DOMAINS===
+com
+co.uk
+// ===END ICANN DOMAINS===
+// ===BEGIN PRIVATE DOMAINS===
+// ===END PRIVATE DOMAINS===
+"""
+
+
+def _rules() -> P.PslRules:
+    return P.parse_psl_rules(PSL)
+
+
+class _CountingRoots(frozenset):  # type: ignore[type-arg]
+    """A blacklist of TLD roots that records every iteration over itself.
+
+    Membership tests (``in``) are free; ``__iter__`` is what a per-call
+    normalization pass needs, so counting it isolates exactly the work this
+    issue removes from the per-entry path.
+    """
+
+    iterations = 0
+
+    def __iter__(self) -> Iterator[str]:
+        self.iterations += 1
+        return super().__iter__()
+
+
+class TestClassifierConsumesPreStrippedRoots:
+    """``tld_wildcard_classify()``'s ``blacklist`` is pre-stripped TLD roots."""
+
+    def test_blacklisted_root_forces_exact_data(self) -> None:
+        """Before-state for the rows below: the root DOES decide the class."""
+        no_blacklist = P.tld_wildcard_classify("example.co.uk", _rules(), set())
+        assert no_blacklist == (P.DNSBL_CLASS_ZONE, "example.co.uk"), (
+            f"expected {(P.DNSBL_CLASS_ZONE, 'example.co.uk')!r} without a blacklist, got {no_blacklist!r}"
+        )
+        blacklisted = P.tld_wildcard_classify("example.co.uk", _rules(), set(), blacklist={"uk"})
+        assert blacklisted == (P.DNSBL_CLASS_DATA, "example.co.uk"), (
+            f"expected {(P.DNSBL_CLASS_DATA, 'example.co.uk')!r} with root 'uk' blacklisted, got {blacklisted!r}"
+        )
+
+    def test_classifier_never_iterates_the_blacklist(self) -> None:
+        """Per-call cost is O(name labels), never O(len(blacklist))."""
+        roots = _CountingRoots({"uk"})
+        domains = ("example.co.uk", "sub.example.co.uk", "example.com", "other.co.uk", "deep.sub.example.com")
+        for domain in domains:
+            P.tld_wildcard_classify(domain, _rules(), set(), blacklist=roots)
+        # Snapshot first: rendering the set (repr) iterates it, so reading the
+        # counter inside the failure message would report one iteration too many.
+        observed = roots.iterations
+        assert observed == 0, (
+            f"expected 0 iterations over the blacklist across {len(domains)} classifications, "
+            f"got {observed} -- the blacklist is being re-normalized per call"
+        )
+
+    def test_blacklist_still_decides_while_never_iterated(self) -> None:
+        """The cost contract must not be satisfied by ignoring the blacklist."""
+        roots = _CountingRoots({"uk"})
+        verdict = P.tld_wildcard_classify("example.co.uk", _rules(), set(), blacklist=roots)
+        observed = roots.iterations
+        assert verdict == (P.DNSBL_CLASS_DATA, "example.co.uk"), (
+            f"expected {(P.DNSBL_CLASS_DATA, 'example.co.uk')!r} with root 'uk' blacklisted, got {verdict!r}"
+        )
+        assert observed == 0, f"expected 0 iterations, got {observed}"
+
+
+def _run_build(
+    lines: list[str],
+    *,
+    blacklist: list[str],
+) -> P.BuildResult:
+    """Drive ``build()`` over a synthetic single-feed manifest (issue #2371 idiom)."""
+    raw_key = "feed.raw"
+    manifest = {"feeds": [{"feed": "FEED", "group": "GRP", "log_flag": "1", "provenance": "feed", "raw": raw_key}]}
+    config: dict[str, Any] = {
+        "psl_rules": _rules(),
+        "psl_wildcard_enabled": True,
+        "psl_include_private": True,
+        "tld_wildcard_blacklist": blacklist,
+        "tld_wildcard_exclusion": [],
+        "user_whitelist": [],
+    }
+
+    def reader(raw: str) -> list[str]:
+        assert raw == raw_key
+        return list(lines)
+
+    return P.build(manifest, config, line_reader=reader)
+
+
+class TestBuildNormalizesTheBlacklistOnce:
+    """``build()`` hoists the blacklist out of its per-entry loop."""
+
+    def test_one_shared_blacklist_object_for_every_entry(self, monkeypatch: Any) -> None:
+        """Scenario: three feed entries, one blacklist.
+
+        Given a build over three block entries
+        When each reaches ``tld_wildcard_classify()``
+        Then every call receives the SAME pre-derived roots object -- not a fresh
+        set built per entry.
+        """
+        seen: list[frozenset[str] | set[str] | None] = []
+        real = P.tld_wildcard_classify
+
+        def recording(
+            domain: str,
+            rules: P.PslRules,
+            exclusion: set[str],
+            *,
+            include_private: bool = True,
+            blacklist: Any = None,
+        ) -> tuple[str, str]:
+            seen.append(blacklist)
+            return real(domain, rules, exclusion, include_private=include_private, blacklist=blacklist)
+
+        monkeypatch.setattr(P, "tld_wildcard_classify", recording)
+        _run_build(["a.example.com", "b.example.com", "c.example.com"], blacklist=[".uk", "test"])
+
+        assert len(seen) == 3, f"expected 3 classifications, got {len(seen)}"
+        distinct = {id(entry) for entry in seen}
+        assert len(distinct) == 1, (
+            f"expected 1 shared blacklist object across {len(seen)} entries, got {len(distinct)} distinct objects "
+            "-- the loop-invariant blacklist is being rebuilt per feed entry"
+        )
+
+    def test_classifier_receives_dot_stripped_roots(self, monkeypatch: Any) -> None:
+        """A dotted user entry ('.uk') reaches the classifier already stripped."""
+        seen: list[Any] = []
+        real = P.tld_wildcard_classify
+
+        def recording(
+            domain: str,
+            rules: P.PslRules,
+            exclusion: set[str],
+            *,
+            include_private: bool = True,
+            blacklist: Any = None,
+        ) -> tuple[str, str]:
+            seen.append(blacklist)
+            return real(domain, rules, exclusion, include_private=include_private, blacklist=blacklist)
+
+        monkeypatch.setattr(P, "tld_wildcard_classify", recording)
+        _run_build(["a.example.com"], blacklist=[".uk"])
+
+        assert seen, "expected the plain block path to reach tld_wildcard_classify()"
+        assert set(seen[0]) == {"uk"}, f"expected the classifier to receive {{'uk'}}, got {set(seen[0])!r}"
+
+    def test_dotted_user_blacklist_still_blocks_at_the_root(self) -> None:
+        """End-to-end behaviour is unchanged by moving the strip to the caller."""
+        without = _run_build(["example.co.uk"], blacklist=[])
+        assert "example.co.uk" in without.zone_db, (
+            f"expected a wildcard ZONE without a blacklist, zone_db={sorted(without.zone_db)!r} "
+            f"data_db={sorted(without.data_db)!r}"
+        )
+        with_root = _run_build(["example.co.uk"], blacklist=[".uk"])
+        assert "example.co.uk" in with_root.data_db, (
+            f"expected an exact DATA block with '.uk' blacklisted, data_db={sorted(with_root.data_db)!r} "
+            f"zone_db={sorted(with_root.zone_db)!r}"
+        )
+        assert "uk" in with_root.zone_db, (
+            f"expected the synthetic whole-TLD zone for 'uk', zone_db={sorted(with_root.zone_db)!r}"
+        )

--- a/tests/test_issue3050_blacklist_normalization.py
+++ b/tests/test_issue3050_blacklist_normalization.py
@@ -9,10 +9,8 @@ may cost O(len(blacklist)). The intent pinned here is a contract, not a duration
   SAME object for every entry -- exactly the treatment ``tld_wildcard_exclusion``
   has always had (``exclusion`` at ``build()``'s prologue).
 
-Both are asserted structurally (iteration counting, object identity), never by
-timing, and each pairs with a behaviour row proving the blacklist still decides
-the classification it is supposed to decide -- a classifier that simply ignored
-the blacklist would satisfy the cost contract alone.
+Each cost row pairs with a behaviour row: the blacklist must still decide the
+classification, so ignoring it cannot satisfy the cost contract alone.
 
 Pure pytest, stdlib only, no Unbound symbols (CI-runnable).
 """
@@ -74,8 +72,7 @@ class TestClassifierConsumesPreStrippedRoots:
         domains = ("example.co.uk", "sub.example.co.uk", "example.com", "other.co.uk", "deep.sub.example.com")
         for domain in domains:
             P.tld_wildcard_classify(domain, _rules(), set(), blacklist=roots)
-        # Snapshot first: rendering the set (repr) iterates it, so reading the
-        # counter inside the failure message would report one iteration too many.
+        # Read the counter BEFORE asserting: rendering the set iterates it.
         observed = roots.iterations
         assert observed == 0, (
             f"expected 0 iterations over the blacklist across {len(domains)} classifications, "

--- a/tests/test_psl_runtime_integration.py
+++ b/tests/test_psl_runtime_integration.py
@@ -64,11 +64,8 @@ def test_psl_classifier_uses_arbitrary_depth_and_private_policy() -> None:
     [("example.com", ".com"), ("example.com", "com."), ("example.github.io", ".github.io")],
 )
 def test_psl_build_normalizes_dotted_blacklist_entries(domain: str, blacklist: str) -> None:
-    """issue #3050: the dotted-entry strip moved OUT of the per-entry classifier and
-    into ``build()``'s config boundary, so the three user-textarea shapes are pinned
-    where they are now normalized. The classifier's own contract (it consumes
-    dot-stripped roots and never re-derives them) lives in
-    tests/test_issue3050_blacklist_normalization.py.
+    """A dotted or trailing-dot user blacklist entry still blocks at its root: ``build()``
+    normalizes the textarea shape, so the entry lands as an exact DATA block (#3050).
     """
     result = P.build(
         {"feeds": [{"feed": "FEED", "group": "GRP", "log_flag": "1", "raw": "feed.raw"}]},

--- a/tests/test_psl_runtime_integration.py
+++ b/tests/test_psl_runtime_integration.py
@@ -63,10 +63,26 @@ def test_psl_classifier_uses_arbitrary_depth_and_private_policy() -> None:
     ("domain", "blacklist"),
     [("example.com", ".com"), ("example.com", "com."), ("example.github.io", ".github.io")],
 )
-def test_psl_classifier_normalizes_dotted_blacklist_entries(domain: str, blacklist: str) -> None:
-    assert P.tld_wildcard_classify(domain, P.parse_psl_rules(PSL), set(), blacklist={blacklist}) == (
-        P.DNSBL_CLASS_DATA,
-        domain,
+def test_psl_build_normalizes_dotted_blacklist_entries(domain: str, blacklist: str) -> None:
+    """issue #3050: the dotted-entry strip moved OUT of the per-entry classifier and
+    into ``build()``'s config boundary, so the three user-textarea shapes are pinned
+    where they are now normalized. The classifier's own contract (it consumes
+    dot-stripped roots and never re-derives them) lives in
+    tests/test_issue3050_blacklist_normalization.py.
+    """
+    result = P.build(
+        {"feeds": [{"feed": "FEED", "group": "GRP", "log_flag": "1", "raw": "feed.raw"}]},
+        {
+            "psl_rules": P.parse_psl_rules(PSL),
+            "tld_wildcard_blacklist": [blacklist],
+            "tld_wildcard_exclusion": [],
+            "user_whitelist": [],
+        },
+        line_reader=lambda _raw: [domain],
+    )
+    assert domain in result.data_db, (
+        f"expected an exact DATA block for {domain!r} with {blacklist!r} blacklisted, "
+        f"data_db={sorted(result.data_db)!r} zone_db={sorted(result.zone_db)!r}"
     )
 
 


### PR DESCRIPTION
Fixes #3050

## What changed

`tld_wildcard_classify()` runs once per DNSBL feed entry at build time (`build()` is its only production caller; the TLD-Allow query path reaches the PSL index and `_psl_prevailing` directly and never touches the blacklist), so nothing in it may cost O(len(blacklist)). Two places made it exactly that:

- `build()` passed `blacklist=set(tld_wildcard_blacklist)` from inside its per-entry loop, constructing one set per feed entry from a loop-invariant list.
- `tld_wildcard_classify()` then re-derived `root_blacklist = {entry.strip(".") for entry in blacklist or set()}` on every call.

`build()` now derives the dot-stripped roots once at its config boundary — the line directly above where `tld_wildcard_exclusion` has always been normalized the same way — and hands the same `frozenset` to every entry. The classifier documents and consumes that contract directly: the parameter is `AbstractSet[str] = frozenset()` (it was `set[str] | None`), read straight by the four membership tests, so the per-call rebinding is gone too. The production diff is a net removal: 13 insertions, 16 deletions.

`build()`'s whole-TLD synthetic-zone loop also consumes `blacklist_roots` instead of stripping the same textarea a second time, so exactly one normalization site remains per config value. That loop runs once per blacklist entry, never per feed entry, so it is not a hot path — the point is the single source of truth: a mutant that forgets the strip now corrupts the classifier verdict and the synthetic zone key in one run instead of half of each. It iterates `sorted(blacklist_roots)`, because a bare set would give the synthetic `DNSBL_TLD` rows a hash-seed-dependent insertion order; `zone_db` is only ever read by key (`find_zone_match`, `_scan_block_band`) so no consumer can observe either order, and a repository running byte-identity oracles should not carry avoidable non-determinism.

## Measured

#3046's fix has since landed (`79233b5c`), so this branch is rebased onto it and the numbers below are **measured end to end against that base**, not modelled. Full `build()` over 200k synthetic plain feed entries (2–4 labels over 10 suffixes) with the shipped `dnsbl_psl` (10,239 rules), `unboundmodule` stubbed, `uv run python` (Python 3.11.15, x86_64). Same command on both sides, production file swapped in place:

```
                              origin/devel      this PR
build(),  10-TLD blacklist    20.58 us/entry    18.55 us/entry     -10%
build(), 100-TLD blacklist    32.82 us/entry    18.57 us/entry     -43%
```

Blacklist length no longer appears in the per-entry cost at all: 18.55 vs 18.57 us across a 10x change in list length, against 20.58 vs 32.82 before. At a 100-TLD blacklist that is **~14 s of build time removed per million feed entries**; at 10 TLDs, ~2 s per million.

Isolating the classifier alone (pre-stripped roots passed straight in, so `build()`'s per-entry `set()` construction is excluded and only the internal re-strip is visible) gives 11.72 → 11.09 us/entry at 10 TLDs and 17.09 → 10.98 at 100 — the two halves of the fix, per-entry set construction and per-call re-derivation, are roughly equal contributors at that list length.

For the record, the pre-#3046 baseline this work started from was 41.51 us/entry (10-TLD) and 52.23 us/entry (100-TLD) through the classifier, of which ~29 us was the PSL index cache key hash #3046 removed.

## Test-first proof

New reproduction file `tests/test_issue3050_blacklist_normalization.py`. The contract is asserted structurally — iteration counting and object identity — never by a clock.

Original red→green run, file byte-identical across both (`git hash-object` = `4cb2776e1bae8b3d4048584fe04e5ef606de3c29`): 4 failed / 2 passed against untouched production code, then 6 passed with the same file unedited after the production edit.

Review round 1 then trimmed the test file (one redundant structural row deleted, the surviving spy wrapper switched to the suite's `*a/**k` idiom), so the proof was re-executed for the file as it now stands (`git hash-object` = `6a27d331fd6e5ef21e1dbe359214a7810d1299b0`) by swapping `origin/devel`'s production file into place and back:

```
$ git show origin/devel:src/usr/local/pkg/pfblockerng/pfb_unbound.py > src/usr/local/pkg/pfblockerng/pfb_unbound.py
$ uv run pytest tests/test_issue3050_blacklist_normalization.py -p no:randomly -q
FAILED ...::test_one_shared_blacklist_object_for_every_entry - expected 1 shared blacklist object across 3 entries, got 3 distinct objects -- the loop-invariant blacklist is being rebuilt per feed entry
FAILED ...::test_blacklist_still_decides_while_never_iterated - expected 0 iterations, got 1
FAILED ...::test_classifier_never_iterates_the_blacklist - expected 0 iterations over the blacklist across 5 classifications, got 5 -- the blacklist is being re-normalized per call
3 failed, 2 passed in 0.67s

$ # production file restored
$ uv run pytest tests/test_issue3050_blacklist_normalization.py -p no:randomly -q
5 passed
```

The two green rows are the paired before-states (a blacklisted root does decide the class; an unblacklisted name is still a wildcard ZONE), so the red rows cannot be satisfied by a classifier that simply ignores the blacklist.

## Migrated coverage

`test_psl_classifier_normalizes_dotted_blacklist_entries` pinned the old contract (the classifier strips dots itself). The strip moved to the caller, so the test moved with it: it is now `test_psl_build_normalizes_dotted_blacklist_entries` and drives the same three user-textarea shapes — `.com`, `com.`, `.github.io` — through `build()`, asserting the exact DATA block still lands. No input shape was dropped.

## Gates

```
$ sh scripts/agent/run-gates.sh --diff origin/devel
GATE FAIL: uv run --locked pytest        # 2 pre-existing environment reds, see below
GATE PASS: uv run --locked ruff check .
GATE PASS: uv run --locked ruff format --check .
GATE PASS: uv run --locked mypy tests/
```

`2 failed, 5848 passed, 6 skipped`. Both failures reproduce on `origin/devel` with this branch's changes stashed, and neither touches this code path:

- `test_issue1542_top1m_fixed_file.py::...[unreadable]` — root bypasses the permission bits the row needs; filed as #3052.
- `test_issue2369_skip_gate_coverage_hostile.py::test_native_node_canary_report_is_rejected_with_exact_skip_semantics` — Node 26 JUnit suite prefix, already tracked as #2983.

Targeted PSL/DNSBL suites are clean: `tests/test_psl_runtime_integration.py tests/test_issue3050_blacklist_normalization.py tests/test_adr66_tld_naming_oracle.py tests/test_psl_resolver.py tests/test_issue2371_feed_suffix_policy.py` → `141 passed`.

## Not in this PR

- #3046 — the PSL index `lru_cache` key hashing ~29 us/entry, claimed by its author. Independent lines; the measurements above model it rather than change it.
- #3051 — `test_resolver_throughput_is_indexed_not_linear_scan` is a duration assertion 26x too loose to have caught either defect.
- `include_private=bool(config.get("psl_include_private", True))` is a second loop-invariant expression in the same call. It is ~0.15 us/entry and outside this issue's scope; left for whoever wants to file it.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved wildcard domain classification when blacklist entries include leading or trailing dots.
  * Ensured blacklist rules are applied consistently across all feed entries.
  * Preserved accurate blocking behavior at the appropriate top-level domain.

* **Tests**
  * Added coverage for normalized blacklist handling and end-to-end classification behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
