### PR TITLE
agent-tools: provision uv per seat instead of adopting a system uv

### DIFF
--- a/scripts/agent/setup-agent-tools.sh
+++ b/scripts/agent/setup-agent-tools.sh
@@ -250,16 +250,25 @@ main() {
 
 	case "$platform" in
 		Linux)
-			if command -v uv >/dev/null 2>&1; then
-				# Maintenance, not a prerequisite: every later use is
-				# `uv tool install --upgrade`, which any uv performs. A uv
-				# that did not come from the standalone installer refuses to
-				# self-update and exits non-zero; under `set -eu` that ends
-				# the run before a single tool is installed.
-				uv self update || true
-			else
-				install_from_url 'https://astral.sh/uv/install.sh'
-			fi
+			uv_path=$(command -v uv 2>/dev/null) || uv_path=
+			case "$uv_path" in
+				"$HOME"/*)
+					# A uv this seat owns: keep it current. Maintenance, not a
+					# prerequisite -- every later use is `uv tool install --upgrade`,
+					# which any uv performs, and a self-update can still fail on a
+					# transient error; under `set -eu` that would end the run before
+					# a single tool is installed.
+					uv self update || true
+					;;
+				*)
+					# No uv, or one outside this seat's HOME -- a shared, root-owned
+					# /usr/local/bin/uv satisfies `command -v` and shadows provisioning,
+					# so every seat inherits one uv that no seat can self-update and the
+					# boxes drift apart. Provision this seat's own; PATH above already
+					# prefers it for every later call.
+					install_from_url 'https://astral.sh/uv/install.sh'
+					;;
+			esac
 			;;
 		Darwin)
 			if brew list --versions uv >/dev/null 2>&1; then

--- a/scripts/agent/setup-agent-tools.sh
+++ b/scripts/agent/setup-agent-tools.sh
@@ -251,21 +251,19 @@ main() {
 	case "$platform" in
 		Linux)
 			uv_path=$(command -v uv 2>/dev/null) || uv_path=
+			# $xdg_bin_home is where this script installs uv, and XDG_BIN_HOME can put
+			# it outside HOME; matching the PATH entry verbatim keeps a seat that sets
+			# it converging on self-update instead of reinstalling every run.
 			case "$uv_path" in
-				"$HOME"/*)
-					# A uv this seat owns: keep it current. Maintenance, not a
-					# prerequisite -- every later use is `uv tool install --upgrade`,
-					# which any uv performs, and a self-update can still fail on a
-					# transient error; under `set -eu` that would end the run before
-					# a single tool is installed.
+				"$xdg_bin_home"/uv|"$HOME"/*)
+					# `|| true`: self-update is maintenance, not a prerequisite -- every
+					# later use is `uv tool install --upgrade`, which any uv performs -- so
+					# a transient failure must not end the run before a tool is installed.
 					uv self update || true
 					;;
 				*)
-					# No uv, or one outside this seat's HOME -- a shared, root-owned
-					# /usr/local/bin/uv satisfies `command -v` and shadows provisioning,
-					# so every seat inherits one uv that no seat can self-update and the
-					# boxes drift apart. Provision this seat's own; PATH above already
-					# prefers it for every later call.
+					# issue #3010: a shared root-owned uv outside this seat satisfies
+					# `command -v` but no seat can self-update it -- provision our own.
 					install_from_url 'https://astral.sh/uv/install.sh'
 					;;
 			esac

--- a/tests/shell/agent_tools_setup_spec.sh
+++ b/tests/shell/agent_tools_setup_spec.sh
@@ -354,6 +354,14 @@ GROK
     cp "$installables/$1" "$activebin/$1"
   }
 
+  # A uv the seat already owns, at the path the standalone installer uses. The
+  # default fixture uv lives in "$activebin" -- outside HOME -- which models the
+  # shared root-owned /usr/local/bin/uv (#3010), not a seat's own.
+  seat_uv() {
+    mkdir -p "$home/.local/bin"
+    cp "$installables/uv" "$home/.local/bin/uv"
+  }
+
   cleanup() {
     rm -rf "$fixture"
   }
@@ -458,6 +466,7 @@ GROK
   End
 
   It 'updates existing Linux uv and CodeGraph while rerunning global auto configuration'
+    seat_uv
     When run sh "$script_abs" "$repository"
     The status should equal 0
     The contents of file "$curl_log" should equal \
@@ -473,6 +482,17 @@ GROK
       'wt:config shell install --yes' \
       'serena:init')"
     The file "$apt_log" should not be exist
+  End
+
+  It 'installs a per-seat uv when the only uv on PATH lives outside HOME'
+    # A root-owned /usr/local/bin/uv satisfies `command -v uv`, so the standalone
+    # installer never runs: every seat shares one uv that no seat can update, and
+    # the two boxes drift to different versions (#3010). The seat's own uv must be
+    # provisioned regardless of what is already on PATH outside its HOME.
+    When run sh "$script_abs" "$repository"
+    The status should equal 0
+    The contents of file "$curl_log" should include 'https://astral.sh/uv/install.sh'
+    The path "$home/.local/bin/uv" should be executable
   End
 
   It 'installs a managed Homebrew uv when an unmanaged Darwin uv command exists'
@@ -833,8 +853,9 @@ UNMANAGED_UV
     The contents of file "$tool_log" should not include 'grok:mcp'
     The contents of file "$tool_log" should include 'codegraph:install -l global -y -t auto'
     The file "$apt_log" should not be exist
-    The contents of file "$curl_log" should equal \
-      'https://github.com/max-sixty/worktrunk/releases/latest/download/worktrunk-installer.sh'
+    The contents of file "$curl_log" should equal "$(printf '%s\n%s' \
+      'https://astral.sh/uv/install.sh' \
+      'https://github.com/max-sixty/worktrunk/releases/latest/download/worktrunk-installer.sh')"
   End
 
   It 'creates the canonical global Worktrunk key when the user config is missing'
@@ -986,7 +1007,10 @@ CONFIG
     The status should equal 0
     The contents of file "$worktrunk_config" should equal "$canonical_worktree_path"
     Assert [ "$(grep -Fxc "$canonical_worktree_path" "$worktrunk_config")" -eq 1 ]
-    Assert [ "$(grep -c '^uv:self update$' "$tool_log")" -eq 2 ]
+    # Run 1 has no seat uv and provisions one; run 2 finds it under HOME and
+    # self-updates. Converging on one self-update is the guard working (#3010).
+    Assert [ "$(grep -c '^uv:self update$' "$tool_log")" -eq 1 ]
+    Assert [ "$(grep -c '^https://astral.sh/uv/install.sh$' "$curl_log")" -eq 1 ]
     Assert [ "$(grep -c '^uv:tool install --upgrade serena-agent$' "$tool_log")" -eq 2 ]
     Assert [ "$(grep -c '^uv:tool install --upgrade graphifyy$' "$tool_log")" -eq 2 ]
     Assert [ "$(grep -c '^uv:tool install --upgrade ast-grep-cli$' "$tool_log")" -eq 2 ]
@@ -1007,6 +1031,7 @@ CONFIG
     # exits non-zero here, and under `set -eu` that aborted the whole run before
     # a single tool was installed.
     export DEBIAN_UV_SELF_UPDATE_FAILS=1
+    seat_uv
     When run sh "$script_abs" "$repository"
     The status should equal 0
     Assert [ "$(grep -c '^uv:self update$' "$tool_log")" -eq 1 ]

--- a/tests/shell/agent_tools_setup_spec.sh
+++ b/tests/shell/agent_tools_setup_spec.sh
@@ -157,9 +157,9 @@ CURL
 printf 'uv:%s\n' "$*" >> "$DEBIAN_TOOL_LOG"
 case "$*" in
   'self update')
-    # A uv that did not come from the standalone installer refuses to
-    # self-update and exits non-zero (issue: package-managed uv). The
-    # installer must treat that as maintenance, not a prerequisite.
+    # A self-update can fail -- transient network error, or a uv that did not
+    # come from the standalone installer. The provisioner must treat that as
+    # maintenance, not a prerequisite.
     if [ -n "${DEBIAN_UV_SELF_UPDATE_FAILS:-}" ]; then
       printf 'error: Self-update is only available for uv binaries installed via the standalone installation scripts.\n' >&2
       exit 1
@@ -485,14 +485,27 @@ GROK
   End
 
   It 'installs a per-seat uv when the only uv on PATH lives outside HOME'
-    # A root-owned /usr/local/bin/uv satisfies `command -v uv`, so the standalone
-    # installer never runs: every seat shares one uv that no seat can update, and
-    # the two boxes drift to different versions (#3010). The seat's own uv must be
-    # provisioned regardless of what is already on PATH outside its HOME.
+    # issue #3010: a uv outside this seat must not satisfy provisioning of its own.
     When run sh "$script_abs" "$repository"
     The status should equal 0
     The contents of file "$curl_log" should include 'https://astral.sh/uv/install.sh'
     The path "$home/.local/bin/uv" should be executable
+    # Without this the example also passes an "always install" implementation:
+    # the foreign uv must be left alone, not adopted and self-updated.
+    The contents of file "$tool_log" should not include 'uv:self update'
+  End
+
+  It 'converges on the seat uv when XDG_BIN_HOME lives outside HOME'
+    # The seat's own uv is installed into $xdg_bin_home, which XDG_BIN_HOME can put
+    # outside HOME. Testing ownership against HOME alone re-classifies that uv as
+    # foreign on every later run, so it is reinstalled instead of self-updated.
+    custom_xdg_bin="$fixture/custom xdg bin"
+    When run env XDG_BIN_HOME="$custom_xdg_bin" \
+      sh -c 'sh "$1" "$2" && sh "$1" "$2"' _ "$script_abs" "$repository"
+    The status should equal 0
+    Assert [ "$(grep -c '^https://astral.sh/uv/install.sh$' "$curl_log")" -eq 1 ]
+    Assert [ "$(grep -c '^uv:self update$' "$tool_log")" -eq 1 ]
+    The path "$custom_xdg_bin/uv" should be executable
   End
 
   It 'installs a managed Homebrew uv when an unmanaged Darwin uv command exists'
@@ -1024,12 +1037,13 @@ CONFIG
     Assert [ "$(grep -c "^init-worktree-tools:$repository$" "$helper_log")" -eq 2 ]
   End
 
-  It 'continues when a package-managed uv refuses to self-update'
+  It "continues when the seat's own uv refuses to self-update"
     # `uv self update` is maintenance, not a prerequisite: every later use is
-    # `uv tool install --upgrade`, which a package-managed uv performs happily.
-    # A uv installed by apt/curl-to-/usr/local rather than the standalone script
-    # exits non-zero here, and under `set -eu` that aborted the whole run before
-    # a single tool was installed.
+    # `uv tool install --upgrade`, which any uv performs happily. A self-update
+    # can still fail -- a transient network error, or a uv the seat did not get
+    # from the standalone installer -- and under `set -eu` that aborted the whole
+    # run before a single tool was installed. Only a seat-owned uv reaches this
+    # call now, so the fixture seeds one.
     export DEBIAN_UV_SELF_UPDATE_FAILS=1
     seat_uv
     When run sh "$script_abs" "$repository"

--- a/tests/shell/agent_tools_setup_spec.sh
+++ b/tests/shell/agent_tools_setup_spec.sh
@@ -508,6 +508,20 @@ GROK
     The path "$custom_xdg_bin/uv" should be executable
   End
 
+  It 'keeps a seat uv that lives under HOME but not in the XDG bin dir'
+    # PATH also carries $HOME/.cargo/bin, so a seat can legitimately own a uv that
+    # is not at $xdg_bin_home. That is what the HOME alternative of the guard
+    # covers, and without this example dropping it ships green.
+    rm -f "$activebin/uv"
+    custom_xdg_bin="$fixture/custom xdg bin"
+    mkdir -p "$home/.cargo/bin"
+    cp "$installables/uv" "$home/.cargo/bin/uv"
+    When run env XDG_BIN_HOME="$custom_xdg_bin" sh "$script_abs" "$repository"
+    The status should equal 0
+    Assert [ "$(grep -c '^uv:self update$' "$tool_log")" -eq 1 ]
+    Assert [ "$(grep -c '^https://astral.sh/uv/install.sh$' "$curl_log")" -eq 0 ]
+  End
+
   It 'installs a managed Homebrew uv when an unmanaged Darwin uv command exists'
     cat > "$activebin/uv" <<'UNMANAGED_UV'
 #!/bin/sh


### PR DESCRIPTION
Refs #3010.

`setup-agent-tools.sh` treats any `uv` on `PATH` as the seat's own. A shared,
root-owned `/usr/local/bin/uv` satisfies `command -v uv`, so the
standalone-installer branch never executes and no seat ever gets its own uv —
every seat inherits one binary that no seat can `uv self update`, and the boxes
drift to different versions.

## What changed

The Linux branch resolved uv by existence alone:

```sh
if command -v uv >/dev/null 2>&1; then
        uv self update || true
else
        install_from_url 'https://astral.sh/uv/install.sh'
fi
```

It now resolves uv by ownership — **the directory this script installs into**:

- a uv at `$xdg_bin_home/uv`, or anywhere under `$HOME`, is the seat's own and is
  kept current, exactly as before;
- anything else is treated as absent, and the seat's own uv is provisioned.

Matching `$xdg_bin_home` and not merely `$HOME` is load-bearing: `XDG_BIN_HOME`
can place the seat's own uv outside `$HOME`, and the first version of this branch
then re-classified that uv as foreign on every later run. See the review round.

`PATH` is built with the per-seat directories first (`$uv_tool_bin`,
`$codegraph_bin`, `$xdg_bin_home`, `$cargo_bin`), so once the seat copy exists
every later `uv tool install --upgrade` resolves to it. The shadowing was only
ever in the install decision, not in lookup.

#3008's `|| true` is unchanged. A self-update failure must still never abort
provisioning, and a standalone uv's self-update can still fail on a transient
network error.

## Why this is a code change at all

#3010 states no code change is needed, on the basis that removing the binary
lets the existing `else` branch run. That is true, and this PR does not replace
that step — the root-owned binary still needs removing, and that still needs
root. What this fixes is separate: the script's contract adopts whatever uv is
on `PATH`, so the shadowing returns the moment any system uv exists again.

## Test-first proof

Executed, not reasoned through, and re-executed after the review round below.
The reproduction runs against the spec file as it now stands, by swapping
`origin/devel`'s production script into place and back — the spec is
byte-identical across both runs
(`git hash-object` = `926fc81958b7056a7a793d599f0ba86055afe053`).

```
$ git show origin/devel:scripts/agent/setup-agent-tools.sh > scripts/agent/setup-agent-tools.sh
$ shellspec tests/shell/agent_tools_setup_spec.sh
47 examples, 4 failures
shellspec tests/shell/agent_tools_setup_spec.sh:487  # 1) installs a per-seat uv when the only uv on PATH lives outside HOME FAILED
shellspec tests/shell/agent_tools_setup_spec.sh:498  # 2) converges on the seat uv when XDG_BIN_HOME lives outside HOME FAILED
shellspec tests/shell/agent_tools_setup_spec.sh:873  # 3) ignores agent environment markers when no client executable is present FAILED
shellspec tests/shell/agent_tools_setup_spec.sh:1032 # 4) updates tools and keeps one canonical Worktrunk key across repeated installer runs FAILED

$ # production file restored
$ shellspec tests/shell/agent_tools_setup_spec.sh
47 examples, 0 failures
```

The new example failed for the intended reasons, not incidentally: `curl.log`
contained no `https://astral.sh/uv/install.sh`, and `$HOME/.local/bin/uv` was
absent. The fixture already models the defect without any new scaffolding —
`setup()` seeds `$activebin/uv`, and `$activebin` is a sibling of `$home`, not
under it.

| Frozen RED test | git hash-object | RED run tail |
| --- | --- | --- |
| `tests/shell/agent_tools_setup_spec.sh` | `926fc81958b7056a7a793d599f0ba86055afe053` | `47 examples, 4 failures` — `:487` installs a per-seat uv when the only uv on PATH lives outside HOME FAILED; `:498` converges on the seat uv when XDG_BIN_HOME lives outside HOME FAILED; `:873` ignores agent environment markers FAILED; `:1032` updates tools and keeps one canonical Worktrunk key across repeated installer runs FAILED |

## Migrated coverage

Four existing examples encoded the old contract. Each was updated to preserve
its intent, not to accommodate the diff. A `seat_uv` helper seeds a uv at the
path the standalone installer uses, so "an existing uv" can still be expressed.

- `updates existing Linux uv and CodeGraph …` — seeds a seat-owned uv. Its
  intent is that an existing uv is *updated* rather than reinstalled; that is
  now a property of a uv the seat owns.
- `continues when a package-managed uv refuses to self-update` (#3008) — seeds a
  seat-owned uv, the only branch where that failure can now arise. The assertion
  and the intent are otherwise untouched.
- `updates tools and keeps one canonical Worktrunk key across repeated installer
  runs` — self-update count is now 1, not 2: run 1 provisions the seat uv, run 2
  maintains it. A new assertion pins the installer to exactly one fetch, so
  convergence is proven rather than assumed.
- `ignores agent environment markers …` — incidental exact-`curl.log`
  expectation, now including the uv installer fetch.

No input shape was dropped and no assertion was loosened.

## Gates

Six gates are selected for this diff. On the authoring box (pfb-dev) five pass
and one fails:

```
$ sh scripts/agent/run-gates.sh --diff origin/devel
GATE PASS: python3 scripts/check_coverage_pairing.py --name-status-z
GATE PASS: uv run --locked python scripts/check_reentry_bounds.py --self-test && …
GATE PASS: sh -n scripts/agent/setup-agent-tools.sh
GATE PASS: shellcheck scripts/agent/setup-agent-tools.sh
GATE PASS: sh -n tests/shell/agent_tools_setup_spec.sh
GATE FAIL: shellspec --shell $(command -v dash || command -v sh)
GATES: FAIL
```

That failure is `7 skip(s) not on tests/skip-allowlist.txt`, all from
`pfblockerng_suppress_spec.sh`, `module_durations_spec.sh` and
`shard_modules_spec.sh` — they skip because pfb-dev has no `iprange` binary and
no comma-decimal locale, so the skips are unlisted and the allowlist gate errors.
Nothing in that set is touched by this diff.

**Independently confirmed on a second box**, because "it's my box, not the diff"
is not a claim the author should be trusted on:

> Independent gate run on smoke-1 (Debian 13) at `8c9071bf`, origin/devel
> `84255c3b`: `sh scripts/agent/run-gates.sh --diff origin/devel` → **GATES: PASS
> (6/6)**; `shellspec tests/shell` → **1830 examples, 0 failures, 0 skips**. Box
> has `iprange`, `de_DE.utf8` and php `ext-intl`, which pfb-dev lacks.

The seven skips vanish exactly where the two missing inputs exist, which is the
discriminating result rather than a second reproduction of the same gap. The
`+2` examples versus the review leg's earlier `1828` count are this branch's new
HOME-arm coverage.

`shellcheck -s sh` and `dash -n` are clean on the changed script.

## Not in this PR

- The retirement itself. Removing the root-owned `/usr/local/bin/uv` — and
  `/usr/local/bin/uvx`, which #3010 does not currently mention — needs root and
  is unchanged by this branch.
- The provisioning path that installs those binaries. Left to the issue, since
  it is outside this repository.
- **`codegraph` carries the identical defect** at `setup-agent-tools.sh:295`, and
  is worse in one respect: it has no `|| true`, so a foreign copy it cannot write
  turns `codegraph upgrade` into the #3008 abort shape. Found by the contract leg,
  filed as **#3070** rather than folded in here. Other axes were checked and are
  clean: `wt` is an unconditional install, and `serena`/`ast-grep`/`semgrep` go
  through `uv tool install --upgrade` with no adoption path.

## Reviewer notes

- **Correction to an earlier revision of this body.** It claimed
  `githooks_prepare_commit_msg_guard_maintenance_spec.sh:24` was a pre-existing
  failure. The contract leg checked it in a clean clone and it **passes** at both
  `cca715aa` and `f75cb6e9`, with the full `tests/shell` suite green
  (`1828 examples, 0 failures, 7 skips`). The red was local to my checkout, not
  a property of the repository. The claim is withdrawn.
- Authored by a dev seat with **no independent review**; `landing.md` requires
  one before merge.
- No live-appliance behaviour is claimed. The evidence above is the repository
  shell suite only.

## Review round 1

Four adversarial legs per `landing.md`, each in an isolated sandbox, audits posted above.

| Leg | Model | Outcome |
| --- | --- | --- |
| Correctness + hostile inputs | `claude-fable-5` | 1 blocking (F1), 4 nitpick, 1 outside-diff |
| Contract conformance | `claude-opus-5` | 2 blocking (F1, codegraph), 3 nitpick |
| Test honesty | `claude-sonnet-5` | 0 blocking, 1 nitpick; 5/5 mandated mutations caught |
| Over-engineering | `claude-fable-5` | 0 blocking, 3 nitpick, 9 net lines removable |

**Two legs independently found F1**, by different routes, each with a probe that
*passes* against the old head — the defective behaviour was demonstrated, not
inferred. Fixed in `f50113b5`, with a new example pinning two runs under
`XDG_BIN_HOME` outside `$HOME` to exactly one install and one self-update.

Also addressed: the migrated #3008 example and the uv stub no longer document a
scenario the guard makes unreachable, and the comment budget was trimmed per
`coding.md`. The new example gained an assertion that the foreign uv is left
alone — see round 2 for what that assertion does and does not achieve.

Declined, with reason: folding `uv_path` into the `case` word (−1 line). Both
other legs reason about `uv_path` as a named value, and the over-engineering leg
itself noted the named binding is a legitimate keep.

## Review round 2

All four legs re-run on small tier per `landing.md`, at `f50113b5`, each given its
round-1 audit to re-check. Audits posted above.

| Leg | Outcome |
| --- | --- |
| Correctness + hostile inputs | **Clean.** F1 re-attacked with 13 probes; F2/F3/F6 correctly unaddressed |
| Contract conformance | **Clean.** Every body claim re-executed; #3070 deferral judged legitimate |
| Test honesty | **2 findings** — see below |
| Over-engineering | **Clean.** 0 findings, 0 lines removable |

Two results are worth stating plainly because they correct me.

**A round-1 fix of mine did not do what I said it did.** I claimed the added
`should not include 'uv:self update'` assertion made the `:487` example prove
ownership branching on its own. The test-honesty leg ran that example *in
isolation* against an always-install mutant: `1 example, 0 failures`. For that
fixture the correct behaviour and the mutant produce byte-identical output, so
the vacuity is structural and no assertion inside that example can close it. The
assertion stays — it independently catches the branch-swap mutation in isolation
— but my justification for it was wrong, and the suite-level coverage is what
actually rules out that mutant.

**A real coverage hole, now closed (`8e2d671d`).** Mutation (g) — deleting the
`"$HOME"/*` alternative from the guard — left the suite **fully green**, because
every seat-owned uv in the fixtures sits at `$home/.local/bin`, which is also
where `$xdg_bin_home` resolves by default. That arm had no test that could fail.
I reproduced it independently before fixing.

`PATH` also carries `$HOME/.cargo/bin`, so a seat can legitimately own a uv that
is not at `$xdg_bin_home`. The new example seeds one there with `XDG_BIN_HOME`
pointed elsewhere. Both arms are now individually pinned:

| Mutation | Result |
| --- | --- |
| drop `"$xdg_bin_home"/uv` | `47 examples, 1 failure` — only `:498` |
| drop `"$HOME"/*` | `47 examples, 1 failure` — only `:511` |

Each alternative is caught by exactly one example and no other.

Also corrected here: the round-1 recap undercounted the correctness leg's
nitpicks as 3; its own per-file table lists 4 (F2–F5).
