### PR TITLE
tests: seed valid sources in sort-mode browser test

### DIFF
--- a/tests/smoke/ui/test_browser_category_edit.py
+++ b/tests/smoke/ui/test_browser_category_edit.py
@@ -1085,6 +1085,8 @@ def test_sort_mode_renders_no_manual_reorder_ui_and_preserves_auto_sort(
     auto-sort transform is unchanged (Semantics #2 -- ZERO delta). Seeds two
     ENABLED rows out of alphabetical header order -- the exact
     ``CategoryEditAutoSortTest`` fixture pair -- with ``sort`` left at 'sort'.
+    Each Enabled row carries an RFC 5737 Source so save validation accepts the
+    seed (issue #3044).
     """
     vm = smoke_vm
     cfg_root = CFG_DNSBL
@@ -1093,11 +1095,12 @@ def test_sort_mode_renders_no_manual_reorder_ui_and_preserves_auto_sort(
         payload = _dnsbl_payload(rowid, "pfbresortd", sort="sort")
         payload["format-0"] = "auto"
         payload["state-0"] = "Enabled"
-        payload["url-0"] = ""
+        # issue #3044: Enabled rows require Source; RFC 5737 host skips DNS.
+        payload["url-0"] = "http://192.0.2.1/bravo"
         payload["header-0"] = "Bravo"
         payload["format-1"] = "auto"
         payload["state-1"] = "Enabled"
-        payload["url-1"] = ""
+        payload["url-1"] = "http://192.0.2.1/alpha"
         payload["header-1"] = "Alpha"
         _post_form(webui, payload)
         page = browser_page


### PR DESCRIPTION
Fixes #3044

## Summary

`test_sort_mode_renders_no_manual_reorder_ui_and_preserves_auto_sort` seeded two Enabled DNSBL source rows with empty Source fields. Category-edit save validation rejects that (`Source field must be defined` and `Invalid URL or Hostname not resolvable!`), so `_post_form` failed before the reorder-UI assertions. That blocked unrelated `ui-tests`-labeled PRs after their own rows passed.

Seed RFC 5737 URLs (`http://192.0.2.1/bravo` and `http://192.0.2.1/alpha`) so the save is accepted and the test can check that sort mode still injects no manual-reorder controls.

## Evidence

**Red** (pre-existing, executed in CI):

- PR #3033 run https://github.com/pfBlockerNG/pfBlockerNG/actions/runs/33526125922
- PR #3036 run https://github.com/pfBlockerNG/pfBlockerNG/actions/runs/33526878624

```text
FAILED tests/smoke/ui/test_browser_category_edit.py::test_sort_mode_renders_no_manual_reorder_ui_and_preserves_auto_sort
AssertionError: the page rejected this save:
DNSBL Source Definitions, Line 1: Source field must be defined.
DNSBL Source Definitions, Line 1: Invalid URL or Hostname not resolvable!
DNSBL Source Definitions, Line 2: Source field must be defined.
DNSBL Source Definitions, Line 2: Invalid URL or Hostname not resolvable!
```

**Green** (this branch, executed):

```text
scripts/local-smoke.sh --marker ui_browser --filter test_sort_mode_renders_no_manual_reorder_ui_and_preserves_auto_sort
PFB_BOX=root@10.0.0.35  (CE 2.8)
PASSED [100%]
1 passed, 674 deselected in 78.69s
```

Label-gated UI matrix: run https://github.com/pfBlockerNG/pfBlockerNG/actions/runs/33567668160

## Test plan

- [x] Enabled sort-mode seed carries non-empty RFC 5737 Sources
- [x] `scripts/local-smoke.sh --marker ui_browser --filter test_sort_mode_renders_no_manual_reorder_ui_and_preserves_auto_sort`
- [ ] `ui-tests` label: browser legs no longer fail this test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated browser coverage for category editing and automatic sorting.
  * Test data now uses valid source URLs for enabled entries, ensuring save validation and sorting behavior are accurately verified.
  * Added documentation within the test scenario clarifying the source requirement for enabled entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->