### PR TITLE
tests: add root-uid guard to issue1542 unreadable-sidecar row

### DIFF
--- a/tests/skip-allowlist.txt
+++ b/tests/skip-allowlist.txt
@@ -57,6 +57,9 @@ pytest:tests.test_build_pkg_portable::test_output_macos_os_alias_is_allowed[/tmp
 pytest:tests.test_build_pkg_portable::test_output_macos_os_alias_is_allowed[/var-/private/var]  # macOS-only alias case; the runner is Linux
 pytest:tests.test_cross_agent_tooling::test_ast_grep_parses_a_php_inc_file_as_php  # ast-grep is an agent-host uv tool, not in CI's locked dev group
 pytest:tests.test_cross_agent_tooling::test_semgrep_scans_a_php_inc_file_only_with_the_documented_flag  # semgrep is an agent-host uv tool, not in CI's locked dev group
+pytest:tests.test_context_budget::test_ledger_unreadable_fires  # root bypasses file permissions — denial cannot be simulated
+pytest:tests.test_context_budget::test_indirect_unreadable_helper_fails_closed  # root bypasses file permissions — denial cannot be simulated
+pytest:tests.test_issue1542_top1m_fixed_file::test_enabled_missing_directory_or_unreadable_fixed_file_fails_closed[unreadable]  # root bypasses file permissions — denial cannot be simulated
 
 # ui -- the live-VM Tier-B browser legs. Whether any pre-defined feed exposes an
 # Alternate-URL radio is feed-data dependent, so the case has always skipped cleanly when

--- a/tests/test_issue1542_top1m_fixed_file.py
+++ b/tests/test_issue1542_top1m_fixed_file.py
@@ -301,7 +301,20 @@ def test_enabled_top1m_is_exact_allow_with_www_fallback_not_deeper_wildcard(tmp_
     assert _decision_label(deep_decision) == "block-null"
 
 
-@pytest.mark.parametrize("kind", ["missing", "directory", "unreadable"])
+@pytest.mark.parametrize(
+    "kind",
+    [
+        "missing",
+        "directory",
+        pytest.param(
+            "unreadable",
+            marks=pytest.mark.skipif(
+                os.geteuid() == 0,
+                reason="root bypasses file permissions — denial cannot be simulated",
+            ),
+        ),
+    ],
+)
 def test_enabled_missing_directory_or_unreadable_fixed_file_fails_closed(tmp_path: Path, kind: str) -> None:
     manifest = _manifest(tmp_path)
     path = tmp_path / "pfb_py_top1m.txt"


### PR DESCRIPTION
Fixes #3052

## Summary
Guard the `unreadable` parametrization of `test_enabled_missing_directory_or_unreadable_fixed_file_fails_closed` with `os.geteuid() == 0` in `tests/test_issue1542_top1m_fixed_file.py` so that it skips cleanly under root (uid 0) where permission denial cannot be simulated, and record the skip in `tests/skip-allowlist.txt`.

## Verification
- Reproduced red before fix under uid 0:
```
FAILED tests/test_issue1542_top1m_fixed_file.py::test_enabled_missing_directory_or_unreadable_fixed_file_fails_closed[unreadable] - AssertionError: assert BuildResult(...) is None
```
- Verified green/skipped after fix:
```
pytest tests/test_issue1542_top1m_fixed_file.py: 19 passed, 1 skipped in 1.68s
python3 scripts/check_skip_allowlist.py: PASS
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test handling for environments running with elevated permissions.
  * Added conditional skips for permission-denial scenarios that cannot be reliably simulated by the test runner.
  * Preserved coverage for missing files, directories, and other failure cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->