### PR TITLE
_git_paths: decode path listings byte-exactly, diffs lossily

### DIFF
--- a/scripts/_git_paths.py
+++ b/scripts/_git_paths.py
@@ -91,7 +91,13 @@ def nul_paths(listing: str) -> list[str]:
 
 def _run(args: list[str]) -> bytes:
     """git's stdout, undecoded: the two routes out of this module disagree on how."""
-    return subprocess.run(args, capture_output=True, check=True).stdout
+    out = subprocess.run(args, capture_output=True, check=False)
+    if out.returncode != 0:
+        # stderr is a MESSAGE, not a path, and callers print it straight into
+        # their own error line -- decode it here (lossily, like diff text) so
+        # they get git's complaint rather than a bytes repr of it.
+        raise subprocess.CalledProcessError(out.returncode, args, out.stdout, out.stderr.decode("utf-8", "replace"))
+    return out.stdout
 
 
 def unified_diff(args: list[str]) -> str:

--- a/scripts/_git_paths.py
+++ b/scripts/_git_paths.py
@@ -12,13 +12,16 @@ reports a clean pass (issue #2212).
 ``-z`` form, so those parsers decode the header here instead.
 
 This module is the single place the diff-scoped gates talk to git about paths:
-one invocation, one decode. Three gates previously carried byte-identical copies
-of the diff command and its header parse, which is why one quoting defect
-reproduced across every one of them.
+one invocation, and one decode per route -- byte-exact for a listing whose paths
+the caller will OPEN, deliberately lossy for diff text it will only match and
+print (issue #3073). Three gates previously carried byte-identical copies of the
+diff command and its header parse, which is why one quoting defect reproduced
+across every one of them.
 """
 
 from __future__ import annotations
 
+import os
 import subprocess
 from pathlib import Path
 
@@ -86,17 +89,9 @@ def nul_paths(listing: str) -> list[str]:
     return [path for path in listing.split("\0") if path]
 
 
-def _run(args: list[str]) -> str:
-    out = subprocess.run(
-        args,
-        capture_output=True,
-        # A non-UTF-8 byte anywhere in the output must not crash the whole run
-        # with a UnicodeDecodeError -- decode lossily instead of raising.
-        encoding="utf-8",
-        errors="replace",
-        check=True,
-    )
-    return out.stdout
+def _run(args: list[str]) -> bytes:
+    """git's stdout, undecoded: the two routes out of this module disagree on how."""
+    return subprocess.run(args, capture_output=True, check=True).stdout
 
 
 def unified_diff(args: list[str]) -> str:
@@ -108,6 +103,9 @@ def unified_diff(args: list[str]) -> str:
     outright — each silently defeats a gate built on ``+++ b/<path>``, so user
     config and environment cannot bypass one through this.
     """
+    # Lossy on purpose: diff text is somebody's file CONTENT, it is only matched
+    # and printed, and a stray non-UTF-8 byte in it must neither raise here nor
+    # reach a strict stdout as a lone surrogate and kill the report instead.
     return _run(
         [
             "git",
@@ -121,7 +119,7 @@ def unified_diff(args: list[str]) -> str:
             "--dst-prefix=b/",
             *args,
         ]
-    )
+    ).decode("utf-8", "replace")
 
 
 def nul_listing(root: Path, *args: str) -> list[str]:
@@ -129,5 +127,14 @@ def nul_listing(root: Path, *args: str) -> list[str]:
 
     The caller supplies ``-z`` with the rest of the subcommand, so the flag sits
     where git wants it (``ls-files -z``, ``diff --name-only -z <rev>``).
+
+    ``os.fsdecode`` because these paths get OPENED: it is the decode ``open`` and
+    ``os.listdir`` themselves use, so every name round-trips byte-exactly, raw
+    non-UTF-8 bytes included. A lossy decode instead hands back a U+FFFD name
+    that opens nothing, and a gate classifying that name against no rule reports
+    a clean pass over a file it never read (issue #3073). Hard-coding UTF-8
+    would fix only the hosts where the filesystem encoding already is UTF-8 --
+    under an ASCII one it turns a valid ``café.php`` into a ``str`` ``open``
+    cannot encode back.
     """
-    return nul_paths(_run(["git", "-C", str(root), *args]))
+    return nul_paths(os.fsdecode(_run(["git", "-C", str(root), *args])))

--- a/scripts/check_context_budget.py
+++ b/scripts/check_context_budget.py
@@ -618,10 +618,11 @@ def main(argv: list[str] | None = None) -> int:
         return 2
     for violation in violations:
         # A tracked name that is not valid UTF-8 reaches here byte-exactly, as
-        # os.fsdecode renders it -- lone surrogates a strict stdout cannot
-        # encode. Escape them so the gate REPORTS the file it measured instead
-        # of dying on the report (issue #3073).
-        print(violation.encode(sys.stdout.encoding or "utf-8", "backslashreplace").decode())
+        # os.fsdecode renders it -- lone surrogates no stdout codec can encode.
+        # Escaping them through UTF-8 in BOTH directions keeps every other name
+        # intact whatever stdout's codec is, so the gate reports the file it
+        # measured instead of dying on the report (issue #3073).
+        print(violation.encode("utf-8", "backslashreplace").decode())
     return 1 if violations else 0
 
 

--- a/scripts/check_context_budget.py
+++ b/scripts/check_context_budget.py
@@ -617,7 +617,11 @@ def main(argv: list[str] | None = None) -> int:
         print(f"context-budget: git failed: {exc}", file=sys.stderr)
         return 2
     for violation in violations:
-        print(violation)
+        # A tracked name that is not valid UTF-8 reaches here byte-exactly, as
+        # os.fsdecode renders it -- lone surrogates a strict stdout cannot
+        # encode. Escape them so the gate REPORTS the file it measured instead
+        # of dying on the report (issue #3073).
+        print(violation.encode(sys.stdout.encoding or "utf-8", "backslashreplace").decode())
     return 1 if violations else 0
 
 

--- a/tests/test_issue3073_git_paths_byte_exact.py
+++ b/tests/test_issue3073_git_paths_byte_exact.py
@@ -213,3 +213,52 @@ def test_budget_gate_reports_a_violation_whose_path_is_not_valid_utf8(tmp_path: 
         f"the over-budget file must be named in the report; stdout={stdout!r} stderr={stderr!r}"
     )
     assert proc.returncode == 1, f"an over-budget file must fail the gate; exit={proc.returncode} stdout={stdout!r}"
+
+
+def test_budget_gate_reports_a_valid_non_ascii_name_on_a_latin1_stdout(tmp_path: Path) -> None:
+    """The escape must not narrow which names the gate can report.
+
+    Making a lone surrogate printable is worthless if it costs the ordinary
+    case: `pölicy.md` is valid UTF-8 and the unpatched gate printed it fine on
+    any stdout codec, so the escape has to round-trip in ONE codec rather than
+    encoding in stdout's and decoding as UTF-8.
+    """
+    _seed_repo(tmp_path, (b"seed.php",))
+    (tmp_path / ".agents" / "policy").mkdir(parents=True)
+    (tmp_path / ".agents" / "policy" / "pölicy.md").write_bytes(b"x" * 40_000)
+    _git(tmp_path, "add", "-A")
+    _git(tmp_path, "commit", "-qm", "oversized")
+
+    proc = subprocess.run(
+        [sys.executable, str(_BUDGET_TOOL), "--all", "--root", str(tmp_path)],
+        capture_output=True,
+        check=False,
+        env={**scrubbed_git_env(drop_git_vars=True), "PYTHONIOENCODING": "latin-1"},
+    )
+    stdout = proc.stdout.decode("latin-1")
+    stderr = proc.stderr.decode("latin-1")
+
+    assert "UnicodeDecodeError" not in stderr, f"the gate died reporting a perfectly valid name: {stderr}"
+    # NFC/NFD filename normalization differs per OS -- match the ASCII tail only,
+    # as tests/test_context_budget.py does for the same reason.
+    assert "licy.md" in stdout and "40000 bytes > budget" in stdout, (
+        f"the over-budget file must be named in the report; stdout={stdout!r} stderr={stderr!r}"
+    )
+
+
+def test_a_failed_git_run_reports_a_readable_message(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """git's stderr is a MESSAGE, not a path, so it decodes rather than staying bytes.
+
+    Both `unified_diff` consumers print `exc.stderr` straight into their own
+    error line; bytes there collapse git's multi-line complaint into one line of
+    escaped `\\n`.
+    """
+    _seed_repo(tmp_path, (b"seed.php",))
+    monkeypatch.chdir(tmp_path)
+
+    with pytest.raises(subprocess.CalledProcessError) as caught:
+        unified_diff(["no-such-ref-xyz...HEAD"])
+
+    stderr = caught.value.stderr
+    assert isinstance(stderr, str), f"a caller printing this gets a bytes repr, not a message: {stderr!r}"
+    assert "fatal:" in stderr, f"expected git's complaint, got {stderr!r}"

--- a/tests/test_issue3073_git_paths_byte_exact.py
+++ b/tests/test_issue3073_git_paths_byte_exact.py
@@ -1,0 +1,215 @@
+"""Issue #3073: a path `nul_listing` hands back must name the file it came from.
+
+`scripts/_git_paths.py` serves two routes out of one `git` invocation, and only
+one of them is text. Diff TEXT is matched and printed, so it decodes lossily --
+a stray non-UTF-8 byte in someone's file content must never abort a gate. Path
+LISTINGS are opened by their consumers, so the same lossy decode is a defect:
+U+FFFD names no file, and a scanner handed one either raises or -- the worse
+outcome -- classifies the mangled name against no rule and reports a clean pass
+over a file it never read (`check_agent_roles.py`, `check_context_budget.py`,
+`tests/test_issue3066_php_grammar_parse.py`).
+
+Byte-exactness here means `os.fsdecode`, not a hard-coded UTF-8 surrogateescape:
+the two agree only while the filesystem encoding IS UTF-8, and under an ASCII one
+(`LC_ALL=C` with UTF-8 mode off, which is what a hook or a locale-less CI shell
+gets) a hard-coded UTF-8 decode turns a perfectly valid `café.php` into a `str`
+that `open` cannot encode back.
+
+Byte-exact paths carry lone surrogates, which a strict stdout cannot encode, so
+the one consumer that PRINTS a listed path is pinned here too: a gate must report
+the violation it found, not die reporting it.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+from _git_paths import nul_listing, unified_diff
+
+from tests.gitenv import scrubbed_git_env
+
+# A raw 0xFF is not valid UTF-8 in any position, so it is the shortest name that
+# distinguishes a byte-exact decode from a lossy one.
+_NON_UTF8_NAME = b"bad_\xff_name.php"
+# Valid UTF-8, but not ASCII: the name that only `os.fsdecode` keeps openable
+# when the filesystem encoding is not UTF-8.
+_UTF8_NAME = "café.php".encode()
+_SPACED_NAME = b"has space.php"
+_BODY = b"<?php\n"
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_BUDGET_TOOL = _REPO_ROOT / "scripts" / "check_context_budget.py"
+
+
+def _git(root: Path, *args: str) -> None:
+    # scrubbed_git_env: a scratch repo must not inherit commit.gpgsign or a real
+    # core.hooksPath from the developer's config (issue #1967), and must not be
+    # redirected at the REAL repo by an inherited GIT_DIR when the suite runs
+    # under a hook.
+    subprocess.run(["git", "-C", str(root), *args], check=True, env=scrubbed_git_env(drop_git_vars=True))
+
+
+def _seed_repo(root: Path, names: tuple[bytes, ...]) -> None:
+    """A committed scratch repo holding one file per name in `names`."""
+    subprocess.run(["git", "init", "-q", "-b", "main", str(root)], check=True, env=scrubbed_git_env(drop_git_vars=True))
+    _git(root, "config", "user.email", "test@example.invalid")
+    _git(root, "config", "user.name", "test")
+    for name in names:
+        (root / os.fsdecode(name)).write_bytes(_BODY)
+    _git(root, "add", "-A")
+    _git(root, "commit", "-qm", "seed")
+
+
+@pytest.mark.parametrize(
+    ("label", "name"),
+    [("non-UTF-8", _NON_UTF8_NAME), ("spaced", _SPACED_NAME), ("valid UTF-8", _UTF8_NAME)],
+)
+def test_listed_path_opens_the_file_it_names(tmp_path: Path, label: str, name: bytes) -> None:
+    """Every listed path is openable -- the whole contract, one row per byte class."""
+    _seed_repo(tmp_path, (_NON_UTF8_NAME, _SPACED_NAME, _UTF8_NAME))
+    listed = nul_listing(tmp_path, "ls-files", "-z")
+
+    wanted = os.fsdecode(name)
+    assert wanted in listed, f"the {label} name must survive the listing: expected {wanted!r} among {listed!r}"
+    assert (tmp_path / wanted).read_bytes() == _BODY, (
+        f"the {label} path came back unopenable, so every consumer that reads what it lists is "
+        f"scanning nothing: {wanted!r}"
+    )
+
+
+def test_listing_is_byte_identical_to_what_git_emitted(tmp_path: Path) -> None:
+    """No path is silently re-encoded: fsencode of each listed path is git's own bytes."""
+    _seed_repo(tmp_path, (_NON_UTF8_NAME, _SPACED_NAME, _UTF8_NAME))
+    raw = subprocess.run(
+        ["git", "-C", str(tmp_path), "ls-files", "-z"],
+        capture_output=True,
+        check=True,
+        env=scrubbed_git_env(drop_git_vars=True),
+    ).stdout
+    expected = sorted(field for field in raw.split(b"\0") if field)
+
+    listed = sorted(os.fsencode(path) for path in nul_listing(tmp_path, "ls-files", "-z"))
+    assert listed == expected, f"listing is not byte-exact: expected {expected!r}, got {listed!r}"
+
+
+def test_valid_utf8_name_opens_under_an_ascii_filesystem_encoding(tmp_path: Path) -> None:
+    """Scenario: the decode follows the FILESYSTEM's encoding, not a hard-coded UTF-8.
+
+    Given a tracked `café.php` and an interpreter whose filesystem encoding is
+    ASCII (`LC_ALL=C`, UTF-8 mode off -- a git hook's environment), when the
+    listing is decoded as UTF-8 the returned `str` holds U+00E9, which `open`
+    cannot encode back onto an ASCII filesystem; decoded with `os.fsdecode` it
+    holds the two escaped bytes git actually emitted and opens.
+    """
+    _seed_repo(tmp_path, (_UTF8_NAME,))
+    probe = (
+        "import sys;"
+        "sys.path.insert(0, sys.argv[1]);"
+        "from _git_paths import nul_listing;"
+        "from pathlib import Path;"
+        "root = Path(sys.argv[2]);"
+        "listed = nul_listing(root, 'ls-files', '-z');"
+        "sys.stdout.buffer.write(b'|'.join((root / p).read_bytes() for p in listed))"
+    )
+    env = {
+        **scrubbed_git_env(drop_git_vars=True),
+        # PEP 540 would otherwise force UTF-8 mode for the C locale and hide the
+        # difference this case exists to catch.
+        "PYTHONUTF8": "0",
+        "PYTHONCOERCECLOCALE": "0",
+        "LC_ALL": "C",
+        "LANG": "C",
+    }
+    proc = subprocess.run(
+        [sys.executable, "-c", probe, str(_REPO_ROOT / "scripts"), str(tmp_path)],
+        capture_output=True,
+        check=False,
+        env=env,
+    )
+    assert proc.returncode == 0, (
+        "a valid UTF-8 tracked name must stay openable under an ASCII filesystem encoding; "
+        f"the probe exited {proc.returncode}: {proc.stderr.decode('utf-8', 'replace')}"
+    )
+    assert proc.stdout == _BODY, f"expected the file's body back, got {proc.stdout!r}"
+
+
+def test_staged_but_deleted_file_stays_in_the_listing(tmp_path: Path) -> None:
+    """`ls-files` reports the INDEX, and so does this helper -- no worktree filter.
+
+    Dropping a path whose file is missing from the worktree would be the same
+    silent skip this issue is about, and it would be wrong on top: the staged
+    mode of `check_context_budget.py` materialises the index into a temp root
+    (`checkout-index --all`) and joins these paths against THAT, where the file
+    is present. Callers own the missing-file case -- `check_sizes` already turns
+    the `OSError` into a fail-closed violation rather than a skip.
+    """
+    _seed_repo(tmp_path, (_SPACED_NAME,))
+    staged = tmp_path / "staged_then_removed.php"
+    staged.write_bytes(_BODY)
+    _git(tmp_path, "add", staged.name)
+    staged.unlink()
+
+    listed = nul_listing(tmp_path, "ls-files", "-z")
+    assert staged.name in listed, (
+        f"a staged file removed from the worktree must still be listed so the caller can decide; got {listed!r}"
+    )
+
+
+def test_diff_text_with_a_non_utf8_byte_decodes_lossily_instead_of_raising(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Diff TEXT keeps the lossy decode: it is matched and PRINTED, never opened.
+
+    A byte-exact decode would put lone surrogates in the returned text, and the
+    first gate that prints a violation line would die on `UnicodeEncodeError`
+    instead of reporting -- the crash the lossy decode exists to prevent.
+    """
+    content = tmp_path / "content.txt"
+    _seed_repo(tmp_path, (b"seed.php",))
+    content.write_bytes(b"first\n")
+    _git(tmp_path, "add", "-A")
+    _git(tmp_path, "commit", "-qm", "content")
+    content.write_bytes(b"first\nlatin \xff byte\n")
+    _git(tmp_path, "add", "-A")
+
+    monkeypatch.chdir(tmp_path)
+    diff = unified_diff(["--cached"])
+
+    assert "latin \ufffd byte" in diff, f"the undecodable byte must be replaced, not dropped or raised on: {diff!r}"
+    # The property the replacement buys: the text can reach a strict UTF-8 stream.
+    assert diff.encode("utf-8"), "diff text must stay encodable so a gate can print the line it flagged"
+
+
+def test_budget_gate_reports_a_violation_whose_path_is_not_valid_utf8(tmp_path: Path) -> None:
+    """Scenario: the gate must REPORT the file it just became able to measure.
+
+    Given an over-budget policy file whose tracked name holds a raw 0xFF, when
+    `check_context_budget.py` runs on a strict-UTF-8 stdout (`PYTHONIOENCODING`,
+    i.e. any real `*.UTF-8` locale), then it prints the size violation and exits
+    1 -- it does not die with `UnicodeEncodeError` while printing the lone
+    surrogate `os.fsdecode` correctly put in the path.
+    """
+    _seed_repo(tmp_path, (b"seed.php",))
+    (tmp_path / ".agents" / "policy").mkdir(parents=True)
+    (tmp_path / os.fsdecode(b".agents/policy/bad_\xff_rule.md")).write_bytes(b"x" * 40_000)
+    _git(tmp_path, "add", "-A")
+    _git(tmp_path, "commit", "-qm", "oversized")
+
+    proc = subprocess.run(
+        [sys.executable, str(_BUDGET_TOOL), "--all", "--root", str(tmp_path)],
+        capture_output=True,
+        check=False,
+        env={**scrubbed_git_env(drop_git_vars=True), "PYTHONIOENCODING": "utf-8:strict"},
+    )
+    stdout = proc.stdout.decode("utf-8", "backslashreplace")
+    stderr = proc.stderr.decode("utf-8", "backslashreplace")
+
+    assert "UnicodeEncodeError" not in stderr, f"the gate died reporting instead of reporting: {stderr}"
+    assert "40000 bytes > budget" in stdout, (
+        f"the over-budget file must be named in the report; stdout={stdout!r} stderr={stderr!r}"
+    )
+    assert proc.returncode == 1, f"an over-budget file must fail the gate; exit={proc.returncode} stdout={stdout!r}"


### PR DESCRIPTION
Fixes #3073

`nul_listing`'s paths get **opened** by their consumers, so decoding git's stdout with
`errors="replace"` hands back a U+FFFD name that opens nothing. Split the one decode by route:
`_run` returns bytes, diff text keeps the lossy decode it needs, and listings go through
`os.fsdecode`.

## Consumers, enumerated from source

```
$ git grep -n 'nul_listing\|nul_paths\|_git_paths\|unified_diff\|diff_header_name\|unquote_git_path' -- scripts tests
scripts/check_agent_roles.py:44:      from _git_paths import nul_listing
scripts/check_agent_roles.py:467:     return nul_listing(root, "diff", "--name-only", "-z", "--no-color", *git_args)
scripts/check_comment_narration.py:34: from _git_paths import diff_header_name, unified_diff
scripts/check_context_budget.py:63:   from _git_paths import nul_listing
scripts/check_context_budget.py:602:  if not touches_context_surface(nul_listing(root, *diff_args)):
scripts/check_context_budget.py:607:  tracked = nul_listing(root, "ls-files", "-z")
scripts/check_version_literals.py:80: from _git_paths import diff_header_name, unified_diff
tests/test_issue3066_php_grammar_parse.py:20: from _git_paths import nul_listing
```

What each does with a path it cannot open. **The silent-skip rows are the dangerous class.**

| Consumer | Route | With a mangled path |
| --- | --- | --- |
| `check_agent_roles.py:467` | `nul_listing` (diff `--name-only -z`) | **silently skips.** Result feeds only `touches_role_surface()`, a prefix/exact match; a mangled name matches no trigger, so the whole role validation is skipped and the gate reports a clean pass. |
| `check_context_budget.py:602` | `nul_listing` (diff `--name-only -z`) | **silently skips**, same shape — `touches_context_surface()` gate. |
| `check_context_budget.py:607` | `nul_listing` (`ls-files -z`) | **reports the wrong thing.** `check_sizes` catches the `OSError` and emits `<path>: unreadable (No such file or directory)` — loud, but the budget was never measured, and the reported name does not exist. |
| `tests/test_issue3066_php_grammar_parse.py:56` | `nul_listing` (`ls-files -z`) | **raises.** `(_REPO_ROOT / path).read_bytes()` → `FileNotFoundError`. |
| `check_version_literals.py:488` | `diff_header_name` (lossy diff text) | **silently skips** — out of scope here, filed as #3076 with an executed reproduction. |
| `check_comment_narration.py:92` | `diff_header_name` (lossy diff text) | **reports, mis-named** — it scans the diff's added lines and never opens the path, so the violation is still flagged; only the printed location is wrong. Probed, not assumed. |

## Hypotheses and the probes that decided between them

**H1 — the lossy decode is the whole cause; `surrogateescape` fixes it.** Partly true, and the
part that is false is the part the issue prescribed.

**H2 — a `str`-typed path can never round-trip some real name, so listings must return `bytes`
or `os.PathLike`.** **Refuted.** `os.fsencode(os.fsdecode(b)) == b` for every byte string, and the
resulting `str` opens the file:

```
$ python3 p7.py            # filesystem encoding utf-8
  os.fsdecode 'bad_\udcff.php'  -> OK
  os.fsdecode 'caf\xe9.php'     -> OK
  os.listdir -> ['.git', 'bad_\udcff.php', 'caf\xe9.php']
```

The listing stays `list[str]`; no API change, no consumer change for the type.

**H3 (the one that mattered) — "surrogateescape" is under-specified: in WHICH encoding?**
Discriminating probe, same script under a non-UTF-8 filesystem encoding:

```
$ PYTHONUTF8=0 PYTHONCOERCECLOCALE=0 LC_ALL=C python3 p7.py     # filesystem encoding ascii
  utf8-surrogate 'bad_\udcff.php'      -> OK
  utf8-surrogate 'caf\xe9.php'         -> UnicodeEncodeError: 'ascii' codec can't encode
                                          character '\xe9' in position 20: ordinal not in range(128)
  os.fsdecode    'bad_\udcff.php'      -> OK
  os.fsdecode    'caf\udcc3\udca9.php' -> OK
  os.listdir -> ['.git', 'bad_\udcff.php', 'caf\udcc3\udca9.php']
```

A hard-coded UTF-8 surrogateescape trades one unopenable name for another under `LC_ALL=C` with
UTF-8 mode off — a git hook's environment. `os.fsdecode` matches `os.listdir` byte-for-byte under
both encodings because it *is* the pairing `open` uses. Issue body corrected in place and a
correction comment posted on #3073.

**H4 — byte-exactness is free.** **Refuted, and it changed the diff.** Byte-exact paths carry lone
surrogates, and a strict-UTF-8 stdout cannot encode one. With the helper fixed and nothing else
changed, `check_context_budget.py` stops mis-measuring the file and starts dying while *reporting*
it (`C`/`C.UTF-8` coerce stdio to `surrogateescape` and hide this; a real `*.UTF-8` locale does not):

```
$ LC_ALL=de_DE.utf8 python scripts/check_context_budget.py --all --root "$S"
Traceback (most recent call last):
  File ".../scripts/check_context_budget.py", line 620, in main
    print(violation)
UnicodeEncodeError: 'utf-8' codec can't encode character '\udcff' in position 19: surrogates not allowed
```

So the one consumer that prints a listed path escapes it on the way out. That is the whole of the
second file in this diff: one line and its comment, at the single choke point every violation
already routes through.

## The staged-but-deleted decision: caller responsibility, pinned

`ls-files` reports the INDEX, and so does the helper. Filtering worktree-missing paths inside
`nul_listing` would be the same silent skip this issue is about, and it would be wrong on top: the
`--staged` mode of `check_context_budget.py` materialises the index into a temp root
(`checkout-index --all --prefix=`) and joins these paths against **that**, where the file is
present — a worktree filter would drop a file the commit ships. `check_sizes` already owns the
missing-file case explicitly, turning the `OSError` into a fail-closed violation rather than a skip.
`test_staged_but_deleted_file_stays_in_the_listing` pins the current loud behaviour so nobody
"fixes" it into a filter.

## Red → green, executed

| Frozen RED test | git hash-object | RED run tail |
| --- | --- | --- |
| `tests/test_issue3073_git_paths_byte_exact.py` | `5c3c3669ae9e7bc757bdfe03e729bd7ee76c86aa` | `FAILED test_budget_gate_reports_a_valid_non_ascii_name_on_a_latin1_stdout / FAILED test_a_failed_git_run_reports_a_readable_message — 2 failed, 8 passed` (cycle 2, the review-fix rows; cycle 1's frozen hash `d4812163f9ae0907686f17f5c463c48dfcd90f3d` and its 4-failed run are below) |


Test file frozen byte-identical across both runs:

```
$ git hash-object tests/test_issue3073_git_paths_byte_exact.py
d4812163f9ae0907686f17f5c463c48dfcd90f3d
```

**RED**, production identical to `origin/devel`
(`test "$(git hash-object scripts/_git_paths.py)" = "$(git rev-parse origin/devel:scripts/_git_paths.py)"` → YES):

```
FAILED test_listed_path_opens_the_file_it_names[non-UTF-8-bad_\xff_name.php]
  - AssertionError: the non-UTF-8 name must survive the listing: expected 'bad_\udcff_name.php'
    among ['bad_\ufffd_name.php', 'café.php', 'has space.php']
FAILED test_listing_is_byte_identical_to_what_git_emitted
  - expected [b'bad_\xff_name.php', ...], got [b'bad_\xef\xbf\xbd_name.php', ...]
FAILED test_valid_utf8_name_opens_under_an_ascii_filesystem_encoding
  - UnicodeEncodeError: 'ascii' codec can't encode character '\xe9' in position 66
FAILED test_budget_gate_reports_a_violation_whose_path_is_not_valid_utf8
  - AssertionError: the over-budget file must be named in the report; stdout=
    '.agents/policy/bad_\ufffd_rule.md: unreadable (No such file or directory)\n...'
========================= 4 failed, 4 passed in 0.75s ==========================
```

**Intermediate** — helper fixed, consumer print not yet, isolating the second half:

```
FAILED test_budget_gate_reports_a_violation_whose_path_is_not_valid_utf8
  - UnicodeEncodeError: 'utf-8' codec can't encode character '\udcff' in position 19
========================= 1 failed, 7 passed in 0.64s ==========================
```

**GREEN**, zero test edits (`git hash-object` still `d4812163…`):

```
========================= 8 passed in 0.62s ==========================
```

### Cycle 2 — the review-fix rows (legs 2 and 4)

Two rows added for findings the legs raised, frozen at
`5c3c3669ae9e7bc757bdfe03e729bd7ee76c86aa` and unchanged from red to green.

**RED**, production at `3a44651c` (the reviewed head):

```
FAILED test_budget_gate_reports_a_valid_non_ascii_name_on_a_latin1_stdout
  - AssertionError: the gate died reporting a perfectly valid name: Traceback ...
    UnicodeDecodeError: 'utf-8' codec can't decode byte 0xf6 in position 16
FAILED test_a_failed_git_run_reports_a_readable_message
  - AssertionError: a caller printing this gets a bytes repr, not a message:
    b"fatal: ambiguous argument 'no-such-ref-xyz...HEAD': unknown revision ...\nUse '--' ..."
========================= 2 failed, 8 passed in 0.47s ==========================
```

**GREEN** at `dcb97983`, zero test edits (`git hash-object` still `5c3c3669…`):

```
========================= 10 passed in 0.82s ==========================
```

## Assertions are failable — four mutations, each killed

```
M1: hard-coded utf-8 surrogateescape (the issue's original prescription)
    FAILED test_valid_utf8_name_opens_under_an_ascii_filesystem_encoding      1 failed, 7 passed
M2: back to the lossy decode (the defect)
    FAILED test_listing_is_byte_identical_to_what_git_emitted
    FAILED test_valid_utf8_name_opens_under_an_ascii_filesystem_encoding
    FAILED test_budget_gate_reports_a_violation_whose_path_is_not_valid_utf8  4 failed, 4 passed
M3: helper filters worktree-missing paths
    FAILED test_staged_but_deleted_file_stays_in_the_listing                  1 failed, 7 passed
M4: diff text made byte-exact
    FAILED test_diff_text_with_a_non_utf8_byte_decodes_lossily_instead_of_raising  1 failed, 7 passed
```

```
M6: revert the escape to the stdout-codec form (leg 2 F1 / leg 4 F4)
    FAILED test_budget_gate_reports_a_valid_non_ascii_name_on_a_latin1_stdout  1 failed, 9 passed
M7: revert _run to a plain check=True (leg 2 F2)
    FAILED test_a_failed_git_run_reports_a_readable_message                    1 failed, 9 passed
```

M5 (drop the consumer's `backslashreplace`) is the intermediate run above. Production was restored
by hash after every mutation — `2d348c18…` for cycle 1, `bc05324c…`/`26592641…` for cycle 2 — so no
mutant leaked into a commit.

## End-to-end proof on a real consumer

Scratch repo tracking a 40 000-byte `.agents/policy/bad_\xff_rule.md` (`cat -v`):

```
--- BEFORE (origin/devel _git_paths) ---
.agents/policy/bad_M-oM-?M-=_rule.md: unreadable (No such file or directory)
exit=1
--- AFTER (this branch) ---
.agents/policy/bad_M-^?_rule.md: 40000 bytes > budget 12288
exit=1
```

The gate now measures the file, and the name it prints is git's exact bytes.

## Verification

```
$ uv run pytest tests/test_issue3066_php_grammar_parse.py tests/test_context_budget.py \
      tests/test_agent_roles_check.py tests/test_coverage_pairing_check.py \
      tests/test_issue3073_git_paths_byte_exact.py -q
283 passed, 2 skipped in 2.26s

$ COMPOSER_ALLOW_SUPERUSER=1 scripts/agent/run-gates.sh --diff origin/devel
GATE PASS: uv run --locked ruff check .
GATE PASS: uv run --locked ruff format --check .
GATE PASS: uv run --locked mypy tests/
GATE FAIL: uv run --locked pytest    # 1 failed, 5863 passed, 7 skipped
```

The single pytest failure is
`tests/test_issue2369_skip_gate_coverage_hostile.py::test_native_node_canary_report_is_rejected_with_exact_skip_semantics`,
pre-existing and unrelated (Node skip-allowlist parsing). Confirmed identical on unmodified `devel`
at `a8164885` with no working-tree changes:

```
$ cd /root/git/pfBlockerNG && git log --oneline -1
a8164885 agent: record the #3071 CodeRabbit miss
$ uv run pytest tests/test_issue2369_skip_gate_coverage_hostile.py::test_native_node_canary_report_is_rejected_with_exact_skip_semantics -q
1 failed in 0.27s
```

CI is the authoritative toolchain.

## Sibling coverage

`tests/test_context_budget.py::test_cli_all_flags_non_ascii_named_policy_file` already covers the
**valid** non-ASCII name (`pölicy.md`, C-quoted under default `core.quotePath`). The new file covers
the row it does not: a name that is not valid UTF-8 at all. Both byte classes now have a case.

## Out of scope

`unified_diff` → `diff_header_name` has the same defect class and wants the opposite decode out of
the same command — making header names byte-exact would put lone surrogates in every violation line.
Left alone deliberately and filed as **#3076** with an executed reproduction (a staged
`src/bad_\xff.php` carrying `$v = "php83";` makes `check_version_literals.py --staged` exit 0).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of filenames containing non-UTF-8 bytes, spaces, or valid non-ASCII characters.
  - Ensured staged-but-deleted files remain correctly listed.
  - Prevented context-budget reports from failing when filenames contain unusual characters.
  - Improved readability of Git command error messages.
  - Diff output now handles invalid bytes without crashing.

- **Tests**
  - Added regression coverage for byte-exact path handling, file access, diff decoding, reporting, and Git errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->