### PR TITLE
archive: probe and list ZIP with unzip, not the host's tar flavour

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -841,6 +841,26 @@ jobs:
           /usr/bin/tar --version | grep -q '^bsdtar'
           tar --version | grep -q 'GNU tar'
 
+      - name: Put bsdunzip at /usr/bin/unzip
+        # Same reasoning as the tar step above, for the binary issue #3068 moved the ZIP
+        # probe and lister onto. The appliance's /usr/bin/unzip is bsdunzip (libarchive);
+        # Ubuntu's is Info-ZIP, and the two disagree on inputs the code meets in
+        # production — Info-ZIP rejects an SFX/junk-prefixed zip that bsdunzip reads, and
+        # rejects a truncated zip that bsdunzip lists. Grading the zip arm on Info-ZIP
+        # would therefore test a toolchain the appliance does not run, and would turn the
+        # octet-stream recovery case into a silent skip.
+        #
+        # Same --no-rename + explicit mv + /usr/sbin diversion as tar, and for the same
+        # reason: everything resolving `unzip` by NAME (composer's --prefer-dist zip
+        # extraction, setup-* actions) keeps Info-ZIP, while the absolute path the code
+        # under test hardcodes becomes bsdunzip. Hence the two checks, one per lookup.
+        run: |
+          sudo dpkg-divert --no-rename --divert /usr/sbin/unzip --add /usr/bin/unzip
+          sudo mv /usr/bin/unzip /usr/sbin/unzip
+          sudo ln -s bsdunzip /usr/bin/unzip
+          /usr/bin/unzip --version | grep -q '^bsdunzip'
+          unzip -v | grep -q 'Info-ZIP'
+
       - name: Put rsync at /usr/local/bin/rsync
         # The code under test execs the absolute path /usr/local/bin/rsync (where the
         # appliance ships it); Debian's package installs /usr/bin/rsync, so without the

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -1132,10 +1132,22 @@ function pfb_mime_normalise(string $raw): string {
 // Returns the binary + flags array (file NOT included; pfb_validate_archive() appends
 // it at call time so this helper stays pure and trivially oracle-testable).
 // Returns NULL for non-archive types — nothing to probe.
+//
+// issue #3068: application/zip probes with `unzip -t`, not `tar -tf`. Both binaries
+// live at the same absolute path on both platforms (FreeBSD's /usr/bin/unzip is
+// bsdunzip, Debian's is Info-ZIP), so this depends on no new package -- while
+// `tar -tf` only read a ZIP at all because the appliance's /usr/bin/tar happens to be
+// bsdtar. Two things came with that accident: the probe could not run on a GNU-tar
+// dev host, and -- worse -- libarchive reads gzip and tar too, so "is this a valid
+// application/zip?" answered TRUE for a plain .tar.gz. pfb_octet_recover_type() asks
+// exactly that, zip FIRST, so an octet-stream-typed tarball was recovered as
+// application/zip. `unzip -t` is also the real analogue of the gunzip/bzip2 arms: it
+// inflates and CRC-checks the members instead of walking the central directory, so a
+// body-corrupt ZIP is now refused at the structural gate rather than at extraction.
 function pfb_archive_probe(string $canonical_type): ?array {
 	switch ($canonical_type) {
 		case 'application/zip':
-			return array('/usr/bin/tar', '-tf');
+			return array('/usr/bin/unzip', '-t');
 		case 'application/gzip':
 		case 'application/x-gzip':
 			return array('/usr/bin/gunzip', '-t');
@@ -1217,19 +1229,33 @@ function pfb_reject_detail_summary(array $reject_detail): string {
 	return "{$reject_detail['mime_raw']} rc={$reject_detail['retval']}";
 }
 
-// ADR-46: list an archive's member names via bsdtar. stderr goes to /dev/null so a
-// bsdtar diagnostic (e.g. "tar: Failed to set default locale") can NEVER be mistaken
-// for a member name -- merging streams and prefix-filtering would let a member
-// literally named "tar: ../x" be silently dropped, bypassing the guard. Returns NULL
-// on a listing failure (rc != 0) so every DISK-writing caller fails CLOSED: the
-// gzip/UT1 sites' ADR-45 probe is only `gunzip -t` (gzip-stream integrity, not the
-// inner tar), so a valid-gzip / corrupt-inner-tar archive lists rc != 0 here and must
-// be rejected, not fail-open extracted. A genuinely intact archive always lists rc 0,
-// so this rejects nothing legitimate.
-function pfb_archive_member_names(string $file): ?array {
+// ADR-46: list an archive's member names. The lister is chosen by the archive's own
+// canonical MIME type (issue #3068): `unzip -Z1` for application/zip, `tar -tf` for
+// every other container. Listing a ZIP with tar only worked because the appliance's
+// /usr/bin/tar is bsdtar; /usr/bin/unzip is present on both platforms (bsdunzip on
+// FreeBSD, Info-ZIP on Debian) and reads exactly one format, so the guard no longer
+// depends on which tar the host installed. Callers pass the type they already
+// dispatched on; a gzip-wrapped tar lists through the tar arm, which reads it.
+//
+// stderr goes to /dev/null so a tool diagnostic (e.g. "tar: Failed to set default
+// locale") can NEVER be mistaken for a member name -- merging streams and
+// prefix-filtering would let a member literally named "tar: ../x" be silently
+// dropped, bypassing the guard. Info-ZIP additionally writes some complaints to
+// STDOUT, which is why the rc check comes FIRST and $output is never read on a
+// failure: rc, not the absence of output, is what decides.
+//
+// Returns NULL on a listing failure (rc != 0) so every DISK-writing caller fails
+// CLOSED: the gzip/UT1 sites' ADR-45 probe is only `gunzip -t` (gzip-stream
+// integrity, not the inner tar), so a valid-gzip / corrupt-inner-tar archive lists
+// rc != 0 here and must be rejected, not fail-open extracted. A genuinely intact
+// archive always lists rc 0, so this rejects nothing legitimate.
+function pfb_archive_member_names(string $file, string $canonical_type): ?array {
+	$lister = $canonical_type === 'application/zip'
+		? '/usr/bin/unzip -Z1 '
+		: '/usr/bin/tar -tf ';
 	$output = array();
 	$retval = 1;
-	exec('/usr/bin/tar -tf ' . escapeshellarg($file) . ' 2>/dev/null', $output, $retval);
+	exec($lister . escapeshellarg($file) . ' 2>/dev/null', $output, $retval);
 	if ($retval != 0) {
 		return NULL;
 	}
@@ -4378,7 +4404,9 @@ function pfb_geoip_extract_tar_to_share(
 ): PfbDownloadResult {
 	global $pfb;
 
-	$unsafe_member = pfb_archive_unsafe_member(pfb_archive_member_names($file_download));
+	// The gzip and uncompressed x-tar GeoIP arms share this helper; both are tar
+	// containers, and tar reads the gzip wrapper itself.
+	$unsafe_member = pfb_archive_unsafe_member(pfb_archive_member_names($file_download, 'application/x-tar'));
 	if ($unsafe_member !== NULL) {
 		pfb_validate_log($header, 'member', 'unsafe_member_name', $unsafe_member);
 		unlink_if_exists($file_download);
@@ -15200,7 +15228,7 @@ function pfb_download_fetch(PfbDownloadRequest $request): PfbDownloadResult {
 					// ADR-46: disk-writing extraction of a THIRD-PARTY archive (member
 					// names feed on-disk filenames) -- reject hostile member names first
 					// (a NULL member list = unlistable archive rejects too, fail-closed).
-					$unsafe_member = pfb_archive_unsafe_member(pfb_archive_member_names($file_dwn));
+					$unsafe_member = pfb_archive_unsafe_member(pfb_archive_member_names($file_dwn, $file_type));
 					if ($unsafe_member !== NULL) {
 						pfb_validate_log($header, 'member', 'unsafe_member_name', $unsafe_member);
 						unlink_if_exists($file_dwn);
@@ -15320,7 +15348,7 @@ function pfb_download_fetch(PfbDownloadRequest $request): PfbDownloadResult {
 			if ($type == 'geoip') {
 				// Determine if the Zip contains multiple files. A NULL list
 				// (unlistable) falls through to stdout extraction exactly as before.
-				$archive_members = pfb_archive_member_names($file_download);
+				$archive_members = pfb_archive_member_names($file_download, $file_type);
 				if ($archive_members !== NULL && count($archive_members) > 1) {
 					// ADR-46: disk-writing extraction -- reject hostile member names first.
 					$unsafe_member = pfb_archive_unsafe_member($archive_members);
@@ -15367,7 +15395,7 @@ function pfb_download_fetch(PfbDownloadRequest $request): PfbDownloadResult {
 			}
 
 			if ($type == 'top1m') {
-				$archive_members = pfb_archive_member_names($file_download);
+				$archive_members = pfb_archive_member_names($file_download, $file_type);
 				$unsafe_member = pfb_archive_unsafe_member($archive_members);
 				if ($unsafe_member !== NULL || $archive_members === NULL || count($archive_members) === 0) {
 					if ($unsafe_member !== NULL) {
@@ -15640,7 +15668,7 @@ function pfb_download_fetch(PfbDownloadRequest $request): PfbDownloadResult {
 						unlink_if_exists($file_download);
 						return PfbDownloadResult::failure();
 					}
-					$archive_members = pfb_archive_member_names($file_download);
+					$archive_members = pfb_archive_member_names($file_download, $file_type);
 					$unsafe_member = pfb_archive_unsafe_member($archive_members);
 					if ($unsafe_member !== NULL || $archive_members === NULL || count($archive_members) !== 1) {
 						if ($unsafe_member !== NULL) {
@@ -15760,7 +15788,7 @@ function pfb_download_fetch(PfbDownloadRequest $request): PfbDownloadResult {
 						pfb_logger("\n Invalid filename [{$filename}]", 1);
 						return PfbDownloadResult::failure();
 					}
-					$unsafe_member = pfb_archive_unsafe_member(pfb_archive_member_names($file_dwn));
+					$unsafe_member = pfb_archive_unsafe_member(pfb_archive_member_names($file_dwn, $file_type));
 					if ($unsafe_member !== NULL) {
 						pfb_validate_log($header, 'member', 'unsafe_member_name', $unsafe_member);
 						unlink_if_exists($file_dwn);

--- a/tests/php/ArchiveMemberSafetyTest.php
+++ b/tests/php/ArchiveMemberSafetyTest.php
@@ -13,8 +13,9 @@ use PHPUnit\Framework\TestCase;
  * component, a component over 255 bytes = FreeBSD NAME_MAX, or a total name over
  * 1024 bytes = PATH_MAX), a fail-closed sentinel for a NULL (unlistable) list, or
  * NULL when all are safe. Pure -- the full hostile/benign matrix is pinned
- * off-appliance. pfb_archive_member_names() is the thin bsdtar lister the call
- * sites feed it from; it returns NULL on a listing failure (rc != 0) so a caller
+ * off-appliance. pfb_archive_member_names() is the thin lister the call sites feed
+ * it from -- `unzip -Z1` for application/zip, `tar -tf` for every other container
+ * (issue #3068) -- and it returns NULL on a listing failure (rc != 0) so a caller
  * fails closed, and it must NOT drop a member merely because its name begins with
  * "tar: " (stderr is discarded, never merged into the member list).
  */
@@ -81,16 +82,13 @@ final class ArchiveMemberSafetyTest extends TestCase
 		$this->assertSame('unlistable-archive', pfb_archive_unsafe_member(NULL));
 	}
 
-	// --- bsdtar lister (real-tool wiring, skip-guarded) ----------------------
+	// --- the listers (real-tool wiring) --------------------------------------
 
 	public function testMemberNamesListsRealArchiveAndKeepsTarPrefixedMember(): void
 	{
-		// A plain .tar, NOT a zip: a dev host whose /usr/bin/tar is GNU tar cannot read
-		// zip at all (the CI image now supplies bsdtar there, as the appliance does, but a
-		// bare Linux host still does not). A .tar pins the same lister behaviour on every
-		// host; the zip leg is live-proven by the ADR-46 smoke cases.
-		// A member literally named "tar: keep.txt" must survive -- stderr is discarded,
-		// so a member name can never be confused with a bsdtar diagnostic.
+		// The tar lister, pinned with a plain .tar so it runs on every host's tar
+		// flavour. A member literally named "tar: keep.txt" must survive -- stderr is
+		// discarded, so a member name can never be confused with a bsdtar diagnostic.
 		$dir  = sys_get_temp_dir() . '/pfb_members_' . uniqid('', TRUE);
 		$path = "{$dir}/members.tar";
 		mkdir($dir);
@@ -100,7 +98,7 @@ final class ArchiveMemberSafetyTest extends TestCase
 		$tar->addFromString('tar: keep.txt', "inert\n");
 		unset($tar);
 
-		$members = pfb_archive_member_names($path);
+		$members = pfb_archive_member_names($path, 'application/x-tar');
 		@unlink($path);
 		@rmdir($dir);
 
@@ -114,12 +112,82 @@ final class ArchiveMemberSafetyTest extends TestCase
 		);
 	}
 
+	/**
+	 * Scenario: issue #3068 -- the ZIP leg of the ADR-46 guard, on any host.
+	 *   Given  a ZIP whose members include an absolute path and a '..' escape
+	 *   When   the lister is asked for its members as application/zip
+	 *   Then   it returns every name VERBATIM, so pfb_archive_unsafe_member() sees
+	 *          the hostile ones and the guard can refuse them.
+	 *
+	 * This used to be unrunnable off the appliance: the lister execed `tar -tf` for
+	 * every type, and only a libarchive tar reads ZIP, so a GNU-tar host got NULL and
+	 * the whole ZIP leg of ADR-46 was proven live-only. Routing ZIP through
+	 * /usr/bin/unzip -- present on both platforms -- makes it hermetic everywhere.
+	 */
+	public function testMemberNamesListsAZipVerbatimIncludingHostileNames(): void
+	{
+		if (!class_exists('ZipArchive')) {
+			$this->markTestSkipped('ZipArchive not available (php-zip extension missing)');
+		}
+		$dir  = sys_get_temp_dir() . '/pfb_zipmembers_' . uniqid('', TRUE);
+		$path = "{$dir}/members.zip";
+		mkdir($dir);
+		$zip = new ZipArchive();
+		$this->assertTrue($zip->open($path, ZipArchive::CREATE) === TRUE);
+		$this->assertTrue($zip->addFromString('GeoLite2-Country.mmdb', "inert\n"));
+		$this->assertTrue($zip->addFromString('dir/two.txt', "inert\n"));
+		$this->assertTrue($zip->addFromString('../pfb3068_escape.txt', "inert\n"));
+		$this->assertTrue($zip->addFromString('/pfb3068_absolute.txt', "inert\n"));
+		$this->assertTrue($zip->close());
+
+		$members = pfb_archive_member_names($path, 'application/zip');
+		@unlink($path);
+		@rmdir($dir);
+
+		$this->assertNotNull($members, 'a readable zip must list, not fail closed');
+		$real = array_values(array_filter($members, static fn (string $m): bool => !str_ends_with($m, '/')));
+		sort($real);
+		$this->assertSame(
+			['../pfb3068_escape.txt', '/pfb3068_absolute.txt', 'GeoLite2-Country.mmdb', 'dir/two.txt'],
+			$real,
+			'the zip lister must report hostile member names verbatim, never normalised away'
+		);
+		// The point of listing them: the ADR-46 guard rejects on the first one.
+		$this->assertNotNull(pfb_archive_unsafe_member($members),
+			'a zip carrying an escape must be refused by the member guard');
+	}
+
 	public function testMemberNamesOnUnreadableArchiveIsNullFailClosed(): void
 	{
 		// Listing failure returns NULL so the caller fails CLOSED -- for the gzip/UT1
 		// sites the ADR-45 probe is only `gunzip -t` (stream integrity, not the inner
 		// tar), so a corrupt-inner archive that passed the probe must be rejected here,
 		// never fail-open extracted.
-		$this->assertNull(pfb_archive_member_names(sys_get_temp_dir() . '/pfb_members_does_not_exist.tar'));
+		$this->assertNull(pfb_archive_member_names(
+			sys_get_temp_dir() . '/pfb_members_does_not_exist.tar', 'application/x-tar'));
+	}
+
+	/**
+	 * The same fail-closed contract on the ZIP lister: a missing file, and a file that
+	 * is not a zip at all, both list as NULL so the caller refuses the archive rather
+	 * than extracting something it could not read.
+	 *
+	 * Deliberately NOT a truncated zip: Info-ZIP rejects one (rc 9) while bsdunzip
+	 * still lists it (rc 0), so pinning that fixture would pass on the appliance and
+	 * fail on a plain Debian host -- the exact trap issue #3068 is about.
+	 */
+	public function testZipMemberNamesFailClosedOnSomethingThatIsNotAZip(): void
+	{
+		$dir = sys_get_temp_dir() . '/pfb_zipmembers_neg_' . uniqid('', TRUE);
+		mkdir($dir);
+		$notAZip = "{$dir}/feed.tar.gz";
+		$this->assertNotFalse(file_put_contents($notAZip, gzencode(str_repeat("\0", 1024))));
+
+		$this->assertNull(pfb_archive_member_names($notAZip, 'application/zip'),
+			'a gzip stream is not a zip: the zip lister must fail closed, never fall back to tar');
+		$this->assertNull(pfb_archive_member_names("{$dir}/absent.zip", 'application/zip'));
+
+		@unlink($notAZip);
+		@rmdir($dir);
 	}
 }

--- a/tests/php/ArchiveProbeTest.php
+++ b/tests/php/ArchiveProbeTest.php
@@ -16,12 +16,21 @@ use PHPUnit\Framework\TestCase;
 #[CoversFunction('pfb_archive_probe')]
 final class ArchiveProbeTest extends TestCase
 {
-	public function test_probe_zip_returns_tar_tf(): void
+	public function test_probe_zip_returns_unzip_t(): void
 	{
-		// application/zip → bsdtar (/usr/bin/tar on FreeBSD) -tf: the same tool
-		// pfb_download() already uses for ZIP listing (L8350/L8376). File is NOT
-		// part of the output — pfb_validate_archive() appends it at call time.
-		$this->assertSame(['/usr/bin/tar', '-tf'], pfb_archive_probe('application/zip'));
+		// issue #3068: application/zip → /usr/bin/unzip -t. The previous mapping was
+		// `tar -tf`, which only worked because the appliance's /usr/bin/tar IS bsdtar
+		// (libarchive), so it happened to read ZIP. That made the probe depend on the
+		// host's tar FLAVOUR rather than on the archive format, and it was also the
+		// weakest probe of the four: `tar -tf` walks a ZIP's central directory and
+		// never inflates a member, so it accepted a body-corrupt ZIP -- and it accepted
+		// a gzip TAR as "a valid zip", which the octet-stream recovery loop turns into a
+		// MIME misidentification. `unzip -t` is the direct analogue of the gzip and
+		// bzip2 arms below: a real integrity test of the container's own format.
+		// /usr/bin/unzip exists on both platforms (bsdunzip on FreeBSD, Info-ZIP on
+		// Debian), so nothing new is depended on. File is NOT part of the output --
+		// pfb_validate_archive() appends it at call time.
+		$this->assertSame(['/usr/bin/unzip', '-t'], pfb_archive_probe('application/zip'));
 	}
 
 	public function test_probe_gzip_returns_gunzip_t(): void

--- a/tests/php/ArchiveValidateTest.php
+++ b/tests/php/ArchiveValidateTest.php
@@ -98,8 +98,8 @@ final class ArchiveValidateTest extends TestCase
 		pfb_validate_archive($file, 'application/zip', $runner);
 
 		$this->assertNotNull($capturedArgv, 'Runner must have been called');
-		$this->assertSame('/usr/bin/tar', $capturedArgv[0], 'argv[0] must be the probe binary');
-		$this->assertSame('-tf',          $capturedArgv[1], 'argv[1] must be the probe flags');
+		$this->assertSame('/usr/bin/unzip', $capturedArgv[0], 'argv[0] must be the probe binary');
+		$this->assertSame('-t',             $capturedArgv[1], 'argv[1] must be the probe flags');
 		$this->assertSame($file,          $capturedArgv[2], 'argv[2] must be the $file path (last element)');
 		$this->assertCount(3, $capturedArgv, 'argv must have exactly 3 elements: binary, flags, file');
 	}

--- a/tests/php/ArchiveValidateWiringTest.php
+++ b/tests/php/ArchiveValidateWiringTest.php
@@ -157,18 +157,30 @@ final class ArchiveValidateWiringTest extends TestCase
 	// -----------------------------------------------------------------------
 
 	/**
-	 * Scenario: zip — valid archive accepted, truncated rejected
+	 * Scenario: zip — valid archive accepted, unreadable one rejected
 	 *
 	 * Given  a real zip file built via ZipArchive and a copy truncated to
-	 *        20 bytes (local file header start; omits end-of-central-directory)
+	 *        20 bytes (a partial local file header — no member, no central
+	 *        directory, unreadable to every unzip implementation)
 	 * When   pfb_validate_archive() is called on each with 'application/zip'
 	 * Then   the valid file returns TRUE and the truncated file returns FALSE,
-	 *        proving the tar -tf probe is wired and distinguishes them.
+	 *        proving the `unzip -t` probe is wired and distinguishes them.
+	 *
+	 * Issue #3068 removed the skip that used to sit here. The probe was `tar -tf`,
+	 * which only reads ZIP when /usr/bin/tar is bsdtar, so this case never ran on a
+	 * GNU-tar dev host and the whole zip arm of ADR-45 was CI-only. /usr/bin/unzip
+	 * exists on both platforms, so it runs everywhere now.
+	 *
+	 * The 20-byte truncation is chosen because all three implementations agree on it
+	 * (bsdtar -tf rc 1, bsdunzip -t rc 1, Info-ZIP -t rc 9). A LARGER truncation that
+	 * still carries a local header does NOT agree — bsdunzip accepts it, Info-ZIP
+	 * rejects it — so pinning one of those would pass on the appliance and fail on a
+	 * plain Debian host, which is the trap this issue exists to remove.
 	 */
 	public function test_zip_valid_accepted_and_corrupt_rejected(): void
 	{
-		if (!is_executable('/usr/bin/tar')) {
-			$this->markTestSkipped('/usr/bin/tar not available on this host');
+		if (!is_executable('/usr/bin/unzip')) {
+			$this->markTestSkipped('/usr/bin/unzip not available on this host');
 		}
 		if (!class_exists('ZipArchive')) {
 			$this->markTestSkipped('ZipArchive not available (php-zip extension missing)');
@@ -182,19 +194,6 @@ final class ArchiveValidateWiringTest extends TestCase
 		$this->assertSame(TRUE, $opened, 'ZipArchive::open() failed to create test.zip');
 		$zip->addFromString('data.txt', 'pfblockerng zip wiring test ' . uniqid('', TRUE));
 		$zip->close();
-
-		// pfBlockerNG targets FreeBSD, where /usr/bin/tar IS bsdtar (libarchive) and reads
-		// ZIP — the production probe (application/zip -> tar -tf). On a host whose /usr/bin/tar
-		// is GNU tar (typical Linux CI), tar cannot read ZIP at all, so the probe is untestable
-		// here. Skip rather than fail: it is a host-tool limitation, not a production defect.
-		$tarout = [];
-		exec('/usr/bin/tar -tf ' . escapeshellarg($validPath) . ' >/dev/null 2>&1', $tarout, $tarrv);
-		if ($tarrv !== 0) {
-			$this->markTestSkipped(
-				'/usr/bin/tar on this host cannot read ZIP (GNU tar, not bsdtar/libarchive); '
-				. 'pfBlockerNG targets FreeBSD where /usr/bin/tar is bsdtar — skipping the zip probe wiring here'
-			);
-		}
 
 		$raw = file_get_contents($validPath);
 		$this->assertNotFalse($raw, 'Could not read created zip file');
@@ -212,5 +211,44 @@ final class ArchiveValidateWiringTest extends TestCase
 			"Expected pfb_validate_archive(corrupt.zip) === FALSE; got TRUE.\n"
 			. 'File size: ' . filesize($corruptPath) . ' bytes (truncated)'
 		);
+	}
+
+	/**
+	 * Scenario: issue #3068 — the zip probe must not accept a tar.
+	 *
+	 * Given  a perfectly valid gzip TAR
+	 * When   pfb_validate_archive() is called on it with 'application/zip'
+	 * Then   it returns FALSE.
+	 *
+	 * This is the reason the mapping had to change rather than merely be made
+	 * portable. The old probe was `tar -tf`, and libarchive's tar reads gzip, tar AND
+	 * zip — so "is this a valid application/zip?" answered TRUE for a gzip tarball on
+	 * the appliance. pfb_filter()'s octet-stream recovery loop asks exactly that
+	 * question, application/zip FIRST, and adopts the first type that answers TRUE:
+	 * an octet-stream-typed .tar.gz feed was therefore recovered as application/zip
+	 * and routed down the zip arm. `unzip -t` cannot make that mistake.
+	 */
+	public function test_zip_probe_refuses_a_gzip_tar(): void
+	{
+		if (!is_executable('/usr/bin/unzip')) {
+			$this->markTestSkipped('/usr/bin/unzip not available on this host');
+		}
+		$member = $this->dir . '/member.txt';
+		$tgz    = $this->dir . '/feed.tar.gz';
+		$this->assertNotFalse(file_put_contents($member, "203.0.113.7\n"));
+		$output = [];
+		$retval = 1;
+		exec('/usr/bin/tar -czf ' . escapeshellarg($tgz) . ' -C ' . escapeshellarg($this->dir)
+			. ' member.txt 2>/dev/null', $output, $retval);
+		$this->assertSame(0, $retval, 'the fixture tarball must be built');
+
+		// Control: it really is a valid archive of its own type, so a FALSE below is
+		// the probe discriminating, not the fixture being broken.
+		$this->assertTrue(pfb_validate_archive($tgz, 'application/gzip'),
+			'the fixture must be a valid gzip stream, or the assertion below proves nothing');
+
+		$this->assertFalse(pfb_validate_archive($tgz, 'application/zip'),
+			'a gzip tarball must never pass the application/zip probe — that misidentification '
+			. 'is what the octet-stream recovery loop turns into a wrong MIME type');
 	}
 }

--- a/tests/php/DownloadGeoipStagePublishTest.php
+++ b/tests/php/DownloadGeoipStagePublishTest.php
@@ -136,6 +136,64 @@ final class DownloadGeoipStagePublishTest extends TestCase
 	}
 
 	/**
+	 * The same ceiling wiring for a ZIP fixture. ZIP is not a tar container, and no
+	 * unzip implementation has a --strip equivalent (-j junks EVERY component, not
+	 * one), so the staged tree keeps the archive's own top-level directory. That is
+	 * irrelevant to the cases that use this: what they assert is that a failing
+	 * extraction publishes nothing and leaves the served share byte-identical, and
+	 * the shape of the staged tree never reaches the share.
+	 */
+	private function extractZipCmd(string $archive, string $into, int $blocks): string
+	{
+		return pfb_extract_cmd('/usr/bin/unzip -o -q ' . escapeshellarg($archive) . ' -d '
+			. escapeshellarg($into) . ' >/dev/null 2>&1', $blocks);
+	}
+
+	/**
+	 * Issue #3068: skip unless this host's /usr/bin/tar can actually run the shipped
+	 * extraction, which every case reaching pfb_geoip_extract_tar_to_share() does.
+	 *
+	 * The helper execs PFB_TAR_EXTRACT_FLAGS (issue #2659), and GNU tar rejects
+	 * --no-fflags outright with exit 64 -- a usage error, before it reads one byte of
+	 * the archive. A case that runs anyway is not testing the branch: it reports
+	 * "extraction failed" for a reason the appliance can never produce, which is a
+	 * manufactured red at best and a vacuous green at worst. The appliance ships
+	 * bsdtar and CI installs it (test.yml diverts GNU tar and symlinks
+	 * /usr/bin/tar -> bsdtar), so this gate closes only on a dev host that has not
+	 * done the same -- and its message says how.
+	 *
+	 * Probed by running the real flag set, never by parsing a version string: it is
+	 * the tar's acceptance of the argv that decides, not its name.
+	 */
+	private function skipUnlessTarRunsTheShippedExtractionFlags(): void
+	{
+		$probe = "{$this->dir}/tarcap";
+		$this->assertTrue(mkdir("{$probe}/src", 0755, TRUE));
+		$this->assertTrue(mkdir("{$probe}/out", 0755, TRUE));
+		$this->assertNotFalse(file_put_contents("{$probe}/src/probe.txt", "probe\n"));
+		$output = array();
+		$retval = 1;
+		exec('/usr/bin/tar -cf ' . escapeshellarg("{$probe}/probe.tar") . ' -C '
+			. escapeshellarg("{$probe}/src") . ' probe.txt 2>/dev/null', $output, $retval);
+		$this->assertSame(0, $retval, 'the capability probe must be able to build a one-member tar');
+		exec('/usr/bin/tar -xf ' . escapeshellarg("{$probe}/probe.tar") . ' ' . PFB_TAR_EXTRACT_FLAGS
+			. ' -C ' . escapeshellarg("{$probe}/out") . ' 2>/dev/null', $output, $retval);
+		if ($retval !== 0) {
+			$version = array();
+			exec('/usr/bin/tar --version 2>&1', $version);
+			$this->markTestSkipped(
+				'/usr/bin/tar on this host (' . ($version[0] ?? 'unknown tar') . ') rejects the shipped '
+				. 'PFB_TAR_EXTRACT_FLAGS with exit ' . $retval . ' -- it is not libarchive. The appliance '
+				. 'ships bsdtar and CI installs it; to run this case here: apt-get install libarchive-tools '
+				. '&& dpkg-divert --no-rename --divert /usr/sbin/tar --add /usr/bin/tar '
+				. '&& mv /usr/bin/tar /usr/sbin/tar && ln -s bsdtar /usr/bin/tar'
+			);
+		}
+		$this->assertFileExists("{$probe}/out/probe.txt",
+			'a tar that accepted the flag set must also have extracted the member');
+	}
+
+	/**
 	 * Scenario: the failure issue #2658 introduced a new way to reach.
 	 *   Given  a GeoIP share already in service
 	 *   And    an archive whose member is larger than the extraction ceiling
@@ -204,19 +262,27 @@ final class DownloadGeoipStagePublishTest extends TestCase
 	 *          extraction, with one member already written
 	 *   When   it extracts through the staged publish
 	 *   Then   nothing is published and every served byte is exactly what it was.
+	 *
+	 * Both the listing and the extraction go through ZIP tools rather than tar
+	 * (issue #3068). Listing a ZIP with `tar -tf` only ever worked because the
+	 * appliance's /usr/bin/tar is bsdtar; on a GNU-tar host the lister returned NULL,
+	 * the case died on the assertion below, and even had it survived, GNU tar would
+	 * have "failed" the extraction because it cannot read a ZIP at all -- not because
+	 * the member's CRC is wrong. The whole point of the fixture is WHICH failure it
+	 * produces, so the extractor has to be one that can read the container.
 	 */
 	public function testCorruptArchiveThatListsCleanlyLeavesTheServedShareByteIdentical(): void
 	{
 		$before = $this->seedServedShare();
 		$archive = $this->buildCorruptArchive();
-		$this->assertNotNull(pfb_archive_member_names($archive),
+		$this->assertNotNull(pfb_archive_member_names($archive, 'application/zip'),
 			'the archive must list cleanly, or the branch refuses it before extracting');
 		$retval = pfb_download_initial_retval();
 		$output = array();
 
 		$published = pfb_stage_publish_dir_merge($this->share,
 			function (string $staged) use ($archive, &$output, &$retval): int {
-				exec($this->extractCmd($archive, $staged, PFB_EXTRACT_MAX_BLOCKS), $output, $retval);
+				exec($this->extractZipCmd($archive, $staged, PFB_EXTRACT_MAX_BLOCKS), $output, $retval);
 				return $retval;
 			});
 
@@ -246,6 +312,7 @@ final class DownloadGeoipStagePublishTest extends TestCase
 	 */
 	public function testExtractionThatFailsPartWayLeavesTheServedShareByteIdentical(): void
 	{
+		$this->skipUnlessTarRunsTheShippedExtractionFlags();
 		$this->assertTrue(symlink('/nonexistent/pfb2668', "{$this->share}/sub"));
 		$before = $this->seedServedShare();
 		// Only the leaf is archived, so no directory member replaces the symlink
@@ -261,7 +328,7 @@ final class DownloadGeoipStagePublishTest extends TestCase
 			. ' GeoLite2-Country_20260801/GeoLite2-Country.mmdb GeoLite2-Country_20260801/sub/two.csv',
 			$output, $retval);
 		$this->assertSame(0, $retval);
-		$this->assertNotNull(pfb_archive_member_names($archive),
+		$this->assertNotNull(pfb_archive_member_names($archive, 'application/x-tar'),
 			'the archive must list cleanly, or the branch refuses it before extracting');
 
 		$result = pfb_geoip_extract_tar_to_share('GeoIP', $archive, escapeshellarg($archive), $retval);
@@ -278,6 +345,7 @@ final class DownloadGeoipStagePublishTest extends TestCase
 	 */
 	public function testSuccessfulExtractionPublishesEveryMemberIntoTheLiveShare(): void
 	{
+		$this->skipUnlessTarRunsTheShippedExtractionFlags();
 		$this->seedServedShare();
 		$archive = $this->buildArchive(array(
 			'GeoLite2-Country.mmdb' => "fresh-mmdb\n",
@@ -321,6 +389,7 @@ final class DownloadGeoipStagePublishTest extends TestCase
 	 */
 	public function testPublicationLeavesTheGenerationLockFileAndItsDirectoryUntouched(): void
 	{
+		$this->skipUnlessTarRunsTheShippedExtractionFlags();
 		$this->seedServedShare();
 		$lockFile = "{$this->share}/cc/.pfb_generation.lock";
 		$inodeBefore = stat($lockFile)['ino'];
@@ -498,6 +567,7 @@ final class DownloadGeoipStagePublishTest extends TestCase
 	 */
 	public function testAPublicationRefusalIsNotLoggedAsATarFailure(): void
 	{
+		$this->skipUnlessTarRunsTheShippedExtractionFlags();
 		$this->seedServedShare();
 		$this->assertTrue(mkdir("{$this->build}/GeoLite2-Country_20260801", 0755));
 		// A member named like the live generation directory: tar extracts it
@@ -539,6 +609,7 @@ final class DownloadGeoipStagePublishTest extends TestCase
 	/** The converse: a real extractor failure keeps naming its exit status. */
 	public function testAnExtractorFailureStillNamesItsExitStatus(): void
 	{
+		$this->skipUnlessTarRunsTheShippedExtractionFlags();
 		$this->seedServedShare();
 		$archive = $this->buildCorruptArchive();
 		$retval = pfb_download_initial_retval();

--- a/tests/php/DownloadGeoipStagePublishTest.php
+++ b/tests/php/DownloadGeoipStagePublishTest.php
@@ -150,24 +150,16 @@ final class DownloadGeoipStagePublishTest extends TestCase
 	}
 
 	/**
-	 * Issue #3068: skip unless this host's /usr/bin/tar can actually run the shipped
-	 * extraction, which every case reaching pfb_geoip_extract_tar_to_share() does.
+	 * Exit status of the SHIPPED extraction argv (issue #2659's PFB_TAR_EXTRACT_FLAGS)
+	 * run by this host's /usr/bin/tar against a real one-member tar.
 	 *
-	 * The helper execs PFB_TAR_EXTRACT_FLAGS (issue #2659), and GNU tar rejects
-	 * --no-fflags outright with exit 64 -- a usage error, before it reads one byte of
-	 * the archive. A case that runs anyway is not testing the branch: it reports
-	 * "extraction failed" for a reason the appliance can never produce, which is a
-	 * manufactured red at best and a vacuous green at worst. The appliance ships
-	 * bsdtar and CI installs it (test.yml diverts GNU tar and symlinks
-	 * /usr/bin/tar -> bsdtar), so this gate closes only on a dev host that has not
-	 * done the same -- and its message says how.
-	 *
-	 * Probed by running the real flag set, never by parsing a version string: it is
-	 * the tar's acceptance of the argv that decides, not its name.
+	 * Deliberately the real argv against a real archive, never a version-string parse:
+	 * what matters is whether this tar ACCEPTS the flags the branch execs, and only
+	 * running them answers that.
 	 */
-	private function skipUnlessTarRunsTheShippedExtractionFlags(): void
+	private function shippedExtractionFlagsExitCode(): int
 	{
-		$probe = "{$this->dir}/tarcap";
+		$probe = "{$this->dir}/tarcap_" . bin2hex(random_bytes(4));
 		$this->assertTrue(mkdir("{$probe}/src", 0755, TRUE));
 		$this->assertTrue(mkdir("{$probe}/out", 0755, TRUE));
 		$this->assertNotFalse(file_put_contents("{$probe}/src/probe.txt", "probe\n"));
@@ -178,19 +170,82 @@ final class DownloadGeoipStagePublishTest extends TestCase
 		$this->assertSame(0, $retval, 'the capability probe must be able to build a one-member tar');
 		exec('/usr/bin/tar -xf ' . escapeshellarg("{$probe}/probe.tar") . ' ' . PFB_TAR_EXTRACT_FLAGS
 			. ' -C ' . escapeshellarg("{$probe}/out") . ' 2>/dev/null', $output, $retval);
+		if ($retval === 0) {
+			$this->assertFileExists("{$probe}/out/probe.txt",
+				'a tar that accepted the flag set must also have extracted the member');
+		}
+		return $retval;
+	}
+
+	/** First line of /usr/bin/tar --version, for skip and failure messages. */
+	private function tarVersion(): string
+	{
+		$version = array();
+		exec('/usr/bin/tar --version 2>&1', $version);
+		return trim((string) ($version[0] ?? 'unknown tar'));
+	}
+
+	/**
+	 * Issue #3068: skip unless this host's /usr/bin/tar can actually run the shipped
+	 * extraction, which every case reaching pfb_geoip_extract_tar_to_share() does.
+	 *
+	 * GNU tar rejects --no-fflags outright with exit 64 -- a usage error, raised before
+	 * it reads one byte of the archive. A case that runs anyway is not testing the
+	 * branch: it reports "extraction failed" for a reason the appliance can never
+	 * produce, which is a manufactured red at best and a vacuous green at worst. The
+	 * appliance ships bsdtar and CI installs it (test.yml diverts GNU tar and symlinks
+	 * /usr/bin/tar -> bsdtar), so this gate closes only on a dev host that has not done
+	 * the same -- and its message says how.
+	 */
+	private function skipUnlessTarRunsTheShippedExtractionFlags(): void
+	{
+		$retval = $this->shippedExtractionFlagsExitCode();
 		if ($retval !== 0) {
-			$version = array();
-			exec('/usr/bin/tar --version 2>&1', $version);
 			$this->markTestSkipped(
-				'/usr/bin/tar on this host (' . ($version[0] ?? 'unknown tar') . ') rejects the shipped '
+				'/usr/bin/tar on this host (' . $this->tarVersion() . ') rejects the shipped '
 				. 'PFB_TAR_EXTRACT_FLAGS with exit ' . $retval . ' -- it is not libarchive. The appliance '
 				. 'ships bsdtar and CI installs it; to run this case here: apt-get install libarchive-tools '
 				. '&& dpkg-divert --no-rename --divert /usr/sbin/tar --add /usr/bin/tar '
 				. '&& mv /usr/bin/tar /usr/sbin/tar && ln -s bsdtar /usr/bin/tar'
 			);
 		}
-		$this->assertFileExists("{$probe}/out/probe.txt",
-			'a tar that accepted the flag set must also have extracted the member');
+	}
+
+	/**
+	 * Scenario: the gate above must not be able to swallow the cases it guards.
+	 *   Given  this host's /usr/bin/tar, whatever it is
+	 *   When   the shipped flag set is run against a real archive
+	 *   Then   a libarchive tar accepts it -- so the gate stays OPEN and all five
+	 *          guarded cases really run on the appliance's toolchain and in CI
+	 *   And    a tar that is not libarchive rejects it -- so when the gate closes, it
+	 *          closes for the stated reason and not by accident.
+	 *
+	 * Without this, a gate that closed unconditionally -- a typo in the flag constant, a
+	 * probe that can never succeed -- would delete five cases from the CI run while the
+	 * suite still read green. That is exactly the issue #2356 class the skip allowlist
+	 * exists for, and an allowlisted id cannot distinguish "skipped for its reason" from
+	 * "skipped because the probe broke".
+	 *
+	 * The version string picks WHICH outcome to demand; the assertion is always on the
+	 * executed exit status. This case itself never skips, on any host.
+	 */
+	public function testTheExtractionFlagGateTracksWhetherTheHostTarIsLibarchive(): void
+	{
+		$version    = $this->tarVersion();
+		$libarchive = stripos($version, 'bsdtar') !== FALSE || stripos($version, 'libarchive') !== FALSE;
+		$retval     = $this->shippedExtractionFlagsExitCode();
+
+		if ($libarchive) {
+			$this->assertSame(0, $retval,
+				"this host's tar ({$version}) is libarchive, so it must accept the shipped "
+				. 'PFB_TAR_EXTRACT_FLAGS and leave the gate open; exit ' . $retval . ' means the five '
+				. 'guarded cases are silently skipping on the appliance toolchain and in CI');
+			return;
+		}
+		$this->assertNotSame(0, $retval,
+			"this host's tar ({$version}) is not libarchive, so it cannot accept --no-fflags; "
+			. 'a clean exit here means the probe is not running the shipped flag set at all, and the '
+			. 'gate would let the guarded cases run against an extractor that cannot express them');
 	}
 
 	/**

--- a/tests/php/OctetStreamRecoveryWiringTest.php
+++ b/tests/php/OctetStreamRecoveryWiringTest.php
@@ -112,7 +112,7 @@ final class OctetStreamRecoveryWiringTest extends TestCase
 	 *        and an allow-list containing application/zip but not application/octet-stream
 	 * When   pfb_filter() runs the FILE_MIME gate
 	 * Then   pfb_octet_recover_type() probes each supported type in order (zip first);
-	 *        pfb_validate_archive() confirms it is a ZIP via `tar -tf`;
+	 *        pfb_validate_archive() confirms it is a ZIP via `unzip -t`;
 	 *        pfb_filter() returns 'application/zip'.
 	 *        Before Phase 3 the same input returned FALSE.
 	 */
@@ -130,14 +130,20 @@ final class OctetStreamRecoveryWiringTest extends TestCase
 			);
 		}
 
-		// Recovery adopts application/zip only if the structural probe (tar -tf) can list the
-		// junk-prefixed ZIP — which needs bsdtar (the FreeBSD target). On a host whose /usr/bin/tar
-		// is GNU tar (cannot read ZIP), the recovery is untestable — skip rather than fail.
-		$tarout = [];
-		exec('/usr/bin/tar -tf ' . escapeshellarg($this->junkPrefixedZip) . ' >/dev/null 2>&1', $tarout, $tarrv);
-		if ($tarrv !== 0) {
+		// Recovery adopts application/zip only if the structural probe can read the
+		// junk-prefixed ZIP. Issue #3068 moved that probe from `tar -tf` to `unzip -t`, so
+		// the guard follows it: the appliance's /usr/bin/unzip is bsdunzip, which applies
+		// libarchive's SFX-offset correction and reads the fixture, while Info-ZIP warns
+		// about the 8 leading bytes and exits 1. CI installs bsdunzip at that path for the
+		// same reason it installs bsdtar; a plain Debian host cannot exercise the recovery
+		// and skips rather than failing on its own unzip.
+		$unzipout = [];
+		exec('/usr/bin/unzip -t ' . escapeshellarg($this->junkPrefixedZip) . ' >/dev/null 2>&1',
+			$unzipout, $unziprv);
+		if ($unziprv !== 0) {
 			$this->markTestSkipped(
-				'/usr/bin/tar on this host cannot read the junk-prefixed ZIP (GNU tar, not bsdtar); '
+				'/usr/bin/unzip on this host refuses the junk-prefixed ZIP (Info-ZIP exits 1 on the '
+				. 'leading bytes; the appliance ships bsdunzip, which reads it); '
 				. 'octet-stream->zip recovery is untestable here — skipping'
 			);
 		}
@@ -152,7 +158,7 @@ final class OctetStreamRecoveryWiringTest extends TestCase
 			'Expected "application/zip" after octet-stream recovery via structural probe; '
 			. 'got: ' . var_export($result, TRUE) . '. '
 			. 'If FALSE: pfb_octet_recover_type() is not wired into pfb_filter(), '
-			. 'or tar -tf could not list the junk-prefixed ZIP on this host.'
+			. 'or unzip -t could not read the junk-prefixed ZIP on this host.'
 		);
 	}
 

--- a/tests/php/README.md
+++ b/tests/php/README.md
@@ -72,6 +72,27 @@ Deep pfSense-runtime integration (config apply, service reloads, pf/Unbound
 wiring, URL/MIME validation that shells out to `/usr/bin/file` or resolves
 hosts) stays the live-VM smoke's job — see `legacy/ADRs/ADR_04_VM_Smoke_Tests/`.
 
+## Host archive toolchain (why some cases skip locally)
+
+The package execs absolute paths, and on FreeBSD `/usr/bin/tar` is **bsdtar** and
+`/usr/bin/unzip` is **bsdunzip** — both libarchive. Debian puts GNU tar and Info-ZIP
+there instead, and they are not interchangeable: GNU tar rejects the shipped
+`PFB_TAR_EXTRACT_FLAGS` (`--no-fflags`) with exit 64 before reading the archive. Cases
+that drive a real extraction therefore skip on such a host, naming that reason.
+
+CI installs the appliance's binaries rather than living with the gap, and a dev host
+can do the same (`test.yml`, jobs "Put bsdtar at /usr/bin/tar" and "Put bsdunzip at
+/usr/bin/unzip"):
+
+```sh
+sudo apt-get install -y --no-install-recommends libarchive-tools
+sudo dpkg-divert --no-rename --divert /usr/sbin/tar --add /usr/bin/tar
+sudo mv /usr/bin/tar /usr/sbin/tar && sudo ln -s bsdtar /usr/bin/tar
+```
+
+`/usr/sbin` precedes `/usr/bin` on PATH, so a bare `tar` still resolves to GNU tar for
+everything else. Reverse it with `dpkg-divert --remove` after moving the binary back.
+
 ## Adding a test
 
 - Put `*Test.php` here; it is picked up automatically (`phpunit.xml` testsuite

--- a/tests/php/fixtures/function_inventory.json
+++ b/tests/php/fixtures/function_inventory.json
@@ -626,6 +626,13 @@
                 "variadic": false,
                 "type": "string",
                 "default": null
+            },
+            {
+                "name": "canonical_type",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
             }
         ]
     },

--- a/tests/skip-allowlist.txt
+++ b/tests/skip-allowlist.txt
@@ -27,7 +27,7 @@
 # name an unlisted PHPUnit skip but never its reason -- read the suite output for that.
 
 # PHPUnit -- union of PHP 8.3 and PHP 8.5 (issue #2356's four remaining skips).
-phpunit:OctetStreamRecoveryWiringTest::test_octet_stream_archive_recovered_to_zip  # host file(1) classification (PHP 8.3 and 8.5)
+phpunit:OctetStreamRecoveryWiringTest::test_octet_stream_archive_recovered_to_zip  # host file(1) classification (PHP 8.3 and 8.5); also skips wherever /usr/bin/unzip is Info-ZIP, which exits 1 on the fixture's leading junk bytes that the appliance's bsdunzip reads (issue #3068)
 phpunit:PfbFeedNormalizeTest::testBomAndZwjAreStrippedAsNonPrintable  # platform locale data (PHP 8.3 and 8.5)
 phpunit:PfbFeedNormalizeTest::testInteriorNbspIsDataWhileTrailingNbspIsTrimmed  # platform locale data (PHP 8.3 and 8.5)
 phpunit:PfbFlockBoundedTest::testBoundedAcquireRealErrorReturnsFalsePromptlyWithTimedOutFalse  # PHP 8.3's php://memory can fail flock(); absent from the PHP 8.5 report (informational there)
@@ -46,6 +46,11 @@ phpunit:DownloadExtractRestrictiveFlagsTest::test_the_flag_set_strips_what_the_a
 phpunit:DownloadRejectValidatorClearTest::test_every_reject_stage_clears_the_promoted_validators with data set "zip payload is an HTML error page"  # Linux CI's /bin/sh is dash, which aborts on the ZIP arm's `set -o pipefail`, and GNU tar cannot read a ZIP at all; FreeBSD sh + bsdtar have both, so the arm is covered live by ADR-04 smoke (issue #2820)
 phpunit:DownloadRejectValidatorClearTest::test_every_reject_stage_clears_the_promoted_validators with data set "zip payload MIME is not allowed"  # Linux CI's /bin/sh is dash, which aborts on the ZIP arm's `set -o pipefail`, and GNU tar cannot read a ZIP at all; FreeBSD sh + bsdtar have both, so the arm is covered live by ADR-04 smoke (issue #2820)
 phpunit:DownloadRejectValidatorClearTest::test_every_reject_stage_clears_the_promoted_validators with data set "zip archive fails its probe"  # Linux CI's /bin/sh is dash, which aborts on the ZIP arm's `set -o pipefail`, and GNU tar cannot read a ZIP at all; FreeBSD sh + bsdtar have both, so the arm is covered live by ADR-04 smoke (issue #2820)
+phpunit:DownloadGeoipStagePublishTest::testSuccessfulExtractionPublishesEveryMemberIntoTheLiveShare  # drives the shipped PFB_TAR_EXTRACT_FLAGS through pfb_geoip_extract_tar_to_share(); GNU tar rejects --no-fflags with exit 64, so a host whose /usr/bin/tar is not libarchive cannot run the branch at all (issue #3068)
+phpunit:DownloadGeoipStagePublishTest::testPublicationLeavesTheGenerationLockFileAndItsDirectoryUntouched  # same PFB_TAR_EXTRACT_FLAGS gate: GNU tar exits 64 before reading the archive, so the generation-lock assertions would grade a usage error (issue #3068)
+phpunit:DownloadGeoipStagePublishTest::testAPublicationRefusalIsNotLoggedAsATarFailure  # same PFB_TAR_EXTRACT_FLAGS gate: the case requires a CLEAN extractor exit to mean anything, and GNU tar cannot give one here (exit 64) (issue #3068)
+phpunit:DownloadGeoipStagePublishTest::testAnExtractorFailureStillNamesItsExitStatus  # same PFB_TAR_EXTRACT_FLAGS gate; the exit status it names must come from the archive, not from GNU tar refusing --no-fflags (issue #3068)
+phpunit:DownloadGeoipStagePublishTest::testExtractionThatFailsPartWayLeavesTheServedShareByteIdentical  # same PFB_TAR_EXTRACT_FLAGS gate; without it GNU tar's exit 64 satisfied the assertions before the part-way extraction under test ever ran (issue #3068)
 
 # ShellSpec -- macOS/BSD host lacks the GNU stat/date/touch branch exercised in Linux CI.
 shellspec:tests/shell/pfblockerng_adr26_locale_spec.sh::ADR-26 — pfb_list_orig_by_mtime() diagnostic listing (Phase 3) lists *.orig oldest-first as "<YYYY-MM-DD> <HH:MM><TAB><name>" (ISO date, path + .orig stripped)  # GNU-only off-box branch; BSD branch is covered live by ADR-04 smoke


### PR DESCRIPTION
Fixes #3068.

## The filed diagnosis was wrong; the corrected one is in the issue body

#3068 blamed one cause ("GNU tar cannot list the ZIP fixture") and left CI's green run
unexplained. Both halves were wrong, and the
[correction comment](https://github.com/pfBlockerNG/pfBlockerNG/issues/3068#issuecomment-5502615247)
carries the executed evidence. Summary:

**CI is not a GNU-tar host.** `test.yml` installs `libarchive-tools`, `dpkg-divert`s GNU tar
to `/usr/sbin/tar`, symlinks `/usr/bin/tar -> bsdtar` and asserts `^bsdtar` before the
PHPUnit step (run `33573506573`, job `100072386300`, log lines 243-248). CI grades on the
appliance's archive toolchain, which is why it reports zero failures with no allowlist entry.

**Only one of the five is a ZIP-listing failure.** Three build a gzip tarball and die on
`PFB_TAR_EXTRACT_FLAGS`, which ends in `--no-fflags`:

```
$ /usr/bin/tar --no-fflags -xf t.tgz
/usr/bin/tar: unrecognized option '--no-fflags'
exit 64
```

GNU tar rejects that as a usage error before reading a byte. A **sixth** case,
`testExtractionThatFailsPartWayLeavesTheServedShareByteIdentical`, was *passing* here for
that same reason: exit 64 satisfied "a part-way extraction must fail the download" before the
extraction under test ever started — a vacuous green invisible in the failure count.

**Single root cause, proven by discriminating probe.** Unmodified tree, bsdtar bind-mounted
over `/usr/bin/tar`: `Tests: 19, Assertions: 209, Skipped: 1`, no failures, versus
`Failures: 5` on GNU tar at the same commit. Nothing else lurks behind the five.

## What changed, split by cause

### (a) Production: ZIP no longer rides the host's tar flavour

`pfb_archive_probe('application/zip')` → `/usr/bin/unzip -t`;
`pfb_archive_member_names($file, $canonical_type)` uses `unzip -Z1` for
`application/zip` and `tar -tf` for every other container. All six call sites pass the type
they already dispatched on.

This is not only a portability fix. libarchive's tar reads gzip and tar as well as zip, so
"is this a valid `application/zip`?" answered **TRUE for a plain `.tar.gz` on the appliance**
— and `pfb_octet_recover_type()` asks exactly that with `application/zip` FIRST and adopts
the first type that answers TRUE. An octet-stream-typed gzip feed was recovered as
`application/zip`. `test_zip_probe_refuses_a_gzip_tar` pins the repair.

`/usr/bin/unzip` is that exact path on both platforms (bsdunzip — libarchive, FreeBSD base —
and Info-ZIP on Debian), so **no port `RUN_DEPENDS` changes**
(`scripts/misc/install_deps_CE_2.8.sh` is unchanged). Executed parity, all fixtures
stored-only:

| fixture | `bsdtar -tf` | `bsdunzip -Z1` | Info-ZIP `-Z1` | `bsdunzip -t` | Info-ZIP `-t` |
| --- | --- | --- | --- | --- | --- |
| valid zip | 0 | 0 | 0 | 0 | 0 |
| body-corrupt zip (CRC) | 0 | 0 | 0 | 1 | 2 |
| truncated zip (mid-body) | 0 | 0 | 9 | 0 | 9 |
| 20-byte zip | 1 | 1 | 9 | 1 | 9 |
| gzip tar | 0 | 1 | 9 | 1 | 9 |
| SFX/junk-prefixed zip | 0 | 0 | 1 | 0 | 1 |

`bsdunzip -Z1` matches today's `bsdtar -tf` on every row, so **appliance listing behaviour is
unchanged and ADR-46 fail-closed is preserved as-is** — `retval != 0 -> NULL ->
unsafe_member_name reason=unlistable-archive`, and the rc check still precedes any read of
stdout (Info-ZIP writes some complaints there). `pfb_extract_cmd`'s #2658 ceiling still wraps
every extraction; none of them moved.

Rows 3 and 6 are where Info-ZIP is stricter than libarchive. Tests are written to avoid both:
no case pins listing on a partially truncated zip, and the SFX case guards on the host's
unzip. The 20-byte truncation in `ArchiveValidateWiringTest` is used precisely because all
three implementations agree on it.

**Scope held deliberately: ZIP extraction stays on tar.** No unzip implementation has a
`--strip=1` equivalent (`-j` junks every component, not one), and no failing case's
assertions need it. Widening to extraction would rewrite the GeoIP multi-member arm, the
stdout arm and the TOP1M single-member move for no assertion in this issue.

### (b) Tests: capability gate for the `--no-fflags` cases

The six flags are #2659 appliance hardening and have no unzip answer, so the five cases that
exec them (the four failures plus the vacuous pass) gate on the host tar **actually running
the shipped flag set** — probed by extracting a one-member tar with it, never by parsing a
version string — and skip with the one-line remedy in the message. Every id is in
`tests/skip-allowlist.txt` with its reason, and `tests/php/README.md` documents the opt-in.

### (c) CI: the same swap for unzip that already exists for tar

Ubuntu's `/usr/bin/unzip` is Info-ZIP; the appliance's is bsdunzip. Without this, CI would
grade the zip arm on a toolchain the appliance does not run and
`OctetStreamRecoveryWiringTest::test_octet_stream_archive_recovered_to_zip` would become a
silent skip. Uses the identical `--no-rename` + explicit `mv` + `/usr/sbin` diversion, so a
bare `unzip` (composer `--prefer-dist`, setup actions) still resolves to Info-ZIP while the
absolute path the code hardcodes becomes bsdunzip. Sequence executed end to end on a Debian
host, including the PATH claim:

```
$ dpkg-divert --no-rename --divert /usr/sbin/unzip --add /usr/bin/unzip
$ mv /usr/bin/unzip /usr/sbin/unzip && ln -s bsdunzip /usr/bin/unzip
$ /usr/bin/unzip --version | grep -q '^bsdunzip' && echo OK
OK
$ command -v unzip
/usr/sbin/unzip          # bare name still Info-ZIP
```

`actionlint .github/workflows/test.yml` → clean.

## Test-first proof (executed, not reasoned)

Reproduction tests written first and run against untouched production code. The four
reproduction files are frozen byte-identical from red to green — the hashes below are the
ones recorded at RED time and are still what ships.

| Frozen RED test | git hash-object | RED run tail |
| --- | --- | --- |
| `tests/php/ArchiveProbeTest.php` | `db547e668e02ec043825410d88221520f1540386` | `test_probe_zip_returns_unzip_t` — `-    0 => '/usr/bin/unzip'` / `+    0 => '/usr/bin/tar'` |
| `tests/php/ArchiveMemberSafetyTest.php` | `8cc023212a4acb8e1b1efee1eb25af84a3022856` | `testMemberNamesListsAZipVerbatimIncludingHostileNames` — `a readable zip must list, not fail closed / Failed asserting that null is not null.` |
| `tests/php/ArchiveValidateWiringTest.php` | `ca6375b9cdd32f9bccfa9b67ae2f9dfb2b1a9fcd` | `test_zip_probe_refuses_a_gzip_tar` — `Failed asserting that true is false.` |
| `tests/php/DownloadGeoipStagePublishTest.php` | `e11c85698ca93eb40c39558bfc1b3988771ba9db` | `testCorruptArchiveThatListsCleanlyLeavesTheServedShareByteIdentical` — `the archive must list cleanly / Failed asserting that null is not null.` (RED blob was `a790d132…`; the review's leg-3 fix added `testTheExtractionFlagGateTracksWhetherTheHostTarIsLibarchive` afterwards, itself mutation-proven red in both directions) |
| `tests/php/ArchiveValidateTest.php` | `ca16a8bfb370ccef55d9b17d3634a8aad555fed3` | `test_file_is_appended_as_last_argv_element` — `Failed asserting that two strings are identical` after the probe moved; the argv pin was then updated to follow it |
| `tests/php/OctetStreamRecoveryWiringTest.php` | `2971f0c76374a95c8a639188650945bea252496e` | its guard probed `tar -tf`, which no longer runs the probe under test; on a GNU-tar host that read as `SKIPPED test_octet_stream_archive_recovered_to_zip` for a stale reason, so the guard was repointed at `unzip -t` |
| `tests/php/fixtures/function_inventory.json` | `5036a46ef0b6cad18897e599cf97cf12077dfe5f` | `FunctionInventoryParityTest::testPackageFunctionInventoryMatchesGolden` — `pass -> failure` on the new `pfb_archive_member_names` signature; regenerated with `PFB_UPDATE_FUNCTION_INVENTORY=1` |
| `tests/skip-allowlist.txt` | `1222c0acec4deebc0f05314dc6794c36bb1d62af` | `check_skip_allowlist.py` — `error: 32 skip(s) not on tests/skip-allowlist.txt` listing the five newly gated `DownloadGeoipStagePublishTest` ids |

The first four rows are the test-first reproduction set. The last four are files this change
forced to move afterwards; each carries the failing output that made it move, not a
retrofitted claim of test-first authorship.

**RED** (untouched `pfblockerng.inc`):

```
$ vendor/bin/phpunit --filter 'ArchiveProbeTest|ArchiveMemberSafetyTest|ArchiveValidateWiringTest|DownloadGeoipStagePublishTest'
1) ArchiveMemberSafetyTest::testMemberNamesListsAZipVerbatimIncludingHostileNames
   a readable zip must list, not fail closed / Failed asserting that null is not null.
2) ArchiveMemberSafetyTest::testZipMemberNamesFailClosedOnSomethingThatIsNotAZip
   a gzip stream is not a zip / Failed asserting that Array &0 [] is null.
3) ArchiveProbeTest::test_probe_zip_returns_unzip_t
   -    0 => '/usr/bin/unzip'   +    0 => '/usr/bin/tar'
4) ArchiveValidateWiringTest::test_zip_valid_accepted_and_corrupt_rejected
   Expected pfb_validate_archive(valid.zip) === TRUE; got FALSE.
5) ArchiveValidateWiringTest::test_zip_probe_refuses_a_gzip_tar
   a gzip tarball must never pass the application/zip probe / Failed asserting that true is false.
6) DownloadGeoipStagePublishTest::testCorruptArchiveThatListsCleanlyLeavesTheServedShareByteIdentical
   the archive must list cleanly / Failed asserting that null is not null.

Tests: 56, Assertions: 204, Failures: 6, Skipped: 6.
```

**GREEN**, same four files, zero test edits (hashes above re-verified):

```
Tests: 56, Assertions: 211, Skipped: 6.
```

### The named cases

```
before:  Tests: 19, Assertions: 193, Failures: 5, Skipped: 1.
after:   Tests: 19, Assertions: 152, Skipped: 6.
```

### The gate is not hiding a defect

Same changed tree, bsdtar **and** bsdunzip bind-mounted onto the paths the code hardcodes —
i.e. the appliance's toolchain — every gated case runs and passes, and the octet-stream
recovery case runs too:

```
$ vendor/bin/phpunit --filter 'ArchiveProbeTest|ArchiveMemberSafetyTest|ArchiveValidateTest|ArchiveValidateWiringTest|DownloadGeoipStagePublishTest|OctetStreamRecoveryWiringTest|GeoipZipPublicationTest'
Tests: 68, Assertions: 331, Skipped: 2.
```

(the 2 remaining are the pre-existing root-uid permission guards.)

### Full suite, against unmodified `devel` at the same base

```
devel  95145e1f : Tests: 6421, Errors: 54, Failures: 30, Warnings: 66, Skipped: 40
this branch     : Tests: 6424, Errors: 54, Failures: 25, Warnings: 66, Skipped: 44
```

Per-case JUnit diff — the complete list of everything that moved:

```
ABSENT  -> pass     ArchiveMemberSafetyTest::testMemberNamesListsAZipVerbatimIncludingHostileNames
ABSENT  -> pass     ArchiveMemberSafetyTest::testZipMemberNamesFailClosedOnSomethingThatIsNotAZip
pass    -> ABSENT   ArchiveProbeTest::test_probe_zip_returns_tar_tf
ABSENT  -> pass     ArchiveProbeTest::test_probe_zip_returns_unzip_t
ABSENT  -> pass     ArchiveValidateWiringTest::test_zip_probe_refuses_a_gzip_tar
skipped -> pass     ArchiveValidateWiringTest::test_zip_valid_accepted_and_corrupt_rejected
failure -> pass     DownloadGeoipStagePublishTest::testCorruptArchiveThatListsCleanlyLeavesTheServedShareByteIdentical
failure -> skipped  DownloadGeoipStagePublishTest::testSuccessfulExtractionPublishesEveryMemberIntoTheLiveShare
failure -> skipped  DownloadGeoipStagePublishTest::testPublicationLeavesTheGenerationLockFileAndItsDirectoryUntouched
failure -> skipped  DownloadGeoipStagePublishTest::testAPublicationRefusalIsNotLoggedAsATarFailure
failure -> skipped  DownloadGeoipStagePublishTest::testAnExtractorFailureStillNamesItsExitStatus
pass    -> skipped  DownloadGeoipStagePublishTest::testExtractionThatFailsPartWayLeavesTheServedShareByteIdentical
```

Nothing else moved. `ArchiveValidateTest::test_file_is_appended_as_last_argv_element` and
`FunctionInventoryParityTest` also moved mid-work and are repaired in this commit (the argv
pin follows the probe; the golden was regenerated with
`PFB_UPDATE_FUNCTION_INVENTORY=1`). The 54 errors / 25 failures / 66 warnings that remain are
the documented local Linux+root baseline, identical on unmodified `devel`; CI is the
authoritative toolchain.

The unlisted-skip set **shrank** by one and gained nothing — every new skip is allowlisted:

```
$ diff <baseline unlisted> <branch unlisted>
< ArchiveValidateWiringTest::test_zip_valid_accepted_and_corrupt_rejected
```

## No assertion weakened

Every one of the five still asserts exactly what it was written to assert — corrupt archive
refuses publication, successful extraction publishes every member, refusal is not logged as a
tar failure, a real extractor failure names its exit status, the lock file survives
publication down to the inode. The only change to the corrupt-archive case is *which
extractor* drives the ZIP fixture, because reaching that assertion through GNU tar would have
graded "GNU tar cannot read a ZIP" rather than the flipped CRC byte the fixture exists to
produce.

## Gates

```
GATE PASS: composer phpstan          ([OK] No errors)
GATE PASS: composer phpcs -- --standard=phpcs.xml.dist src/
GATE PASS: npx markdownlint-cli2
php -l src/usr/local/pkg/pfblockerng/pfblockerng.inc  ->  No syntax errors detected
actionlint .github/workflows/test.yml                 ->  clean
```

`scripts/agent/run-gates.sh --diff origin/devel` reports the PHPUnit gate FAIL on the
documented local baseline above (identical on unmodified `devel`); PHPStan and PHPCS were
re-run directly with `COMPOSER_ALLOW_SUPERUSER=1`.

## Live tier

Hermetically proven here: the probe/lister mapping, the ADR-46 fail-closed contract for ZIP,
the gzip-tar rejection, and the corrupt-ZIP publication refusal — the last three now runnable
on any host for the first time. The bsdunzip column of the parity table was executed against
libarchive 3.7.4, the same source FreeBSD builds, but on Linux. What still wants the live
tier is the appliance's own `/usr/bin/unzip` on a real GeoIP/TOP1M feed: the ADR-46 smoke
cases in `tests/smoke/test_smoke_feeds.py` already drive those paths and are the right seat
for it. That leg is being routed rather than reasoned about; nothing in this PR claims an
on-box run it did not perform.
