### PR TITLE
registry: align scalar page defaults and widen RULE 2 (#2994)

### DIFF
--- a/docs/misc/config-gateway.md
+++ b/docs/misc/config-gateway.md
@@ -255,12 +255,13 @@ pages. Wired into `.github/workflows/test.yml`, `.githooks/pre-commit` and
 - **RULE 1** — a `$pfb['<mirror>']['<key>'] = … PFB_FILTER_ON_OFF …` save into a section
   that `PFB_SECTIONS` knows MUST name a registered key. So a new settings checkbox
   cannot land without a registry entry.
-- **RULE 2** — a registered **toggle**'s default MUST NOT be restated by the page: no
+- **RULE 2** — a registered field's default MUST NOT be restated by the page: no
   `$pconfig[…] = $pfb['<mirror>']['<key>'] ?: '<literal>'` and no
   `isset($pfb['<mirror>']['<key>']) ? … : '<literal>'`. Read it with `PfbConfig::read()`.
-  Scoped to toggles on purpose — several registered plain scalars carry a page default
-  their registry entry does not, so widening the rule would push a behaviour change
-  through a lint (issue #2812).
+  issue #2994 widened this from toggles to every registered key after aligning the
+  six page/registry scalar divergences (`pfb_dnsport`/`pfb_dnsport_ssl`/`aliaslog`
+  follow the page; `pfb_dnsbl_rule` keeps registry `Disabled`; `pfb_dnsvip4/6`
+  store `''` and map the Form_Select sentinel `none` after the gateway read).
 - The mirror → alias mapping is DERIVED from each page's own
   `$pfb['<mirror>'] = PfbConfig::readSection('<path>')`, so a new page needs no edit here.
 - Fails CLOSED: an unreadable registry, an unparseable `PFB_SECTIONS`, or fewer than 100

--- a/docs/misc/config-gateway.md
+++ b/docs/misc/config-gateway.md
@@ -260,8 +260,11 @@ pages. Wired into `.github/workflows/test.yml`, `.githooks/pre-commit` and
   `isset($pfb['<mirror>']['<key>']) ? … : '<literal>'`. Read it with `PfbConfig::read()`.
   issue #2994 widened this from toggles to every registered key after aligning the
   six page/registry scalar divergences (`pfb_dnsport`/`pfb_dnsport_ssl`/`aliaslog`
-  follow the page; `pfb_dnsbl_rule` keeps registry `Disabled`; `pfb_dnsvip4/6`
-  store `''` and map the Form_Select sentinel `none` after the gateway read).
+  follow the page, and a fresh install now seeds those values; `pfb_dnsbl_rule` keeps
+  registry `Disabled`; `pfb_dnsvip4/6` store `''` and map the Form_Select sentinel
+  `none` after the gateway read). The matchers require a literal key; a dynamic
+  `$pfb['gconfig']['log_max_' . $suffix]` restatement is a documented ceiling, not a
+  clean scan of those sites.
 - The mirror → alias mapping is DERIVED from each page's own
   `$pfb['<mirror>'] = PfbConfig::readSection('<path>')`, so a new page needs no edit here.
 - Fails CLOSED: an unreadable registry, an unparseable `PFB_SECTIONS`, or fewer than 100

--- a/scripts/check_toggle_registry.py
+++ b/scripts/check_toggle_registry.py
@@ -13,13 +13,15 @@ which is the shape a registered scalar takes:
   RULE 1 -- REGISTERED. A `PFB_FILTER_ON_OFF` save into a section mirror must name a key
   that `pfb_cfg_registry()` knows, under the alias the mirror's own section resolves to.
 
-  RULE 2 -- NO PAGE DEFAULT. Once a key IS registered, the page must not restate its
-  default: a READ of `$pfb['<mirror>']['<key>']` may not carry a `?:` fallback or sit
-  inside an `isset(...) ? ... : <literal>`. The default belongs to the registry entry.
-  Reads are distinguished from saves by side: a save has the mirror expression on the
-  LEFT of `=`, a read has it on the right. The save site's own `?: ''` is left alone on
-  purpose -- it is transport normalisation of an absent checkbox, not a default, and
-  `PfbConfig::writeSection()` re-normalises it through the registered adapter anyway.
+  RULE 2 -- NO PAGE DEFAULT. Once a key IS registered (toggle or plain scalar), the page
+  must not restate its default: a READ of `$pfb['<mirror>']['<key>']` may not carry a
+  `?:` fallback or sit inside an `isset(...) ? ... : <literal>`. The default belongs
+  to the registry entry. issue #2994 widened this off toggles after aligning the six
+  page/registry divergences. Reads are distinguished from saves by side: a save has
+  the mirror expression on the LEFT of `=`, a read has it on the right. The save
+  site's own `?: ''` is left alone on purpose -- it is transport normalisation of an
+  absent checkbox, not a default, and `PfbConfig::writeSection()` re-normalises it
+  through the registered adapter anyway.
 
 The mirror -> section mapping is DERIVED, never listed: each page declares it itself
 with `$pfb['<mirror>'] = PfbConfig::readSection('<section path>')`, and the section path
@@ -172,16 +174,16 @@ def find_violations(
             )
         )
 
-    # RULE 2 -- scoped to TOGGLE entries. A registered plain scalar whose page still
-    # carries a `?:` fallback is a separate backlog (issue #2812), not this rule: several
-    # of those page defaults genuinely disagree with their registry entry, so deleting
-    # them would change behaviour and needs its own evidence.
+    # RULE 2 -- every registered key. issue #2994 aligned the six page/registry
+    # scalar divergences, so the toggle-only scope #2123 kept (and #2812 left as
+    # work item 2) can widen: a registered plain scalar may not restate its
+    # default on a section-mirror read either.
     seen: set[int] = set()
     for matcher in (_READ_COALESCE_RE, _READ_ISSET_RE):
         for match in matcher.finditer(text):
             mirror, key = match.group(1), match.group(2)
             alias = alias_by_mirror.get(mirror)
-            if alias is None or not registry_keys.get((alias, key), False):
+            if alias is None or (alias, key) not in registry_keys:
                 continue
             if (basename, key) in EXEMPT:
                 continue
@@ -194,7 +196,7 @@ def find_violations(
                     source,
                     lineno,
                     "page-level-default",
-                    f"'{alias}/{key}' is a registered toggle, so its default belongs to "
+                    f"'{alias}/{key}' is a registered field, so its default belongs to "
                     "the registry entry -- read it with PfbConfig::read()",
                     snippet,
                 )

--- a/scripts/check_toggle_registry.py
+++ b/scripts/check_toggle_registry.py
@@ -126,7 +126,7 @@ def find_violations(
     text: str,
     source: str,
     sections_by_path: dict[str, str],
-    registry_keys: set[tuple[str, str]] | dict[tuple[str, str], object],
+    registry_keys: set[tuple[str, str]],
 ) -> list[Violation]:
     """Apply both rules to one page's source."""
     basename = Path(source).name
@@ -226,7 +226,7 @@ if ($_POST) {
 """
 
 
-def _self_test(sections_by_path: dict[str, str], registry_keys: dict[tuple[str, str], bool]) -> int:
+def _self_test(sections_by_path: dict[str, str], registry_keys: set[tuple[str, str]]) -> int:
     """Red canary: prove both rules fire on a known-violating synthetic page."""
     found = find_violations(_SELF_TEST_PAGE, "self-test/pfblockerng_ip.php", sections_by_path, registry_keys)
     rules = {v.rule for v in found}

--- a/scripts/check_toggle_registry.py
+++ b/scripts/check_toggle_registry.py
@@ -56,13 +56,12 @@ from typing import NamedTuple
 REGISTRY_FILE = "src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc"
 WWW_DIR = "src/usr/local/www/pfblockerng"
 
-# A registry entry: its path key plus enough of the entry body to see which read
-# adapter it declares. Non-greedy to the entry's own closing `],`.
+# A registry entry: its path key plus enough of the entry body to bound the match
+# to the entry's own closing `],`.
 _REGISTRY_ENTRY_RE = re.compile(
     r"^\s*'([a-z]+)/([A-Za-z0-9_]+)'\s*=>\s*\[(.*?)^\t\t\],",
     re.DOTALL | re.MULTILINE,
 )
-_TOGGLE_ADAPTER = "pfb_cfg_toggle_read"
 
 # One `PFB_SECTIONS` row: `'ip' => 'installedpackages/pfblockerngipsettings/config/0',`.
 _SECTIONS_BLOCK_RE = re.compile(r"const PFB_SECTIONS\s*=\s*\[(.*?)^\];", re.DOTALL | re.MULTILINE)
@@ -118,19 +117,16 @@ def parse_sections(registry_text: str) -> dict[str, str]:
     return {path: alias for alias, path in _SECTIONS_ROW_RE.findall(block.group(1))}
 
 
-def parse_registry_keys(registry_text: str) -> dict[tuple[str, str], bool]:
-    """Every `(alias, bare key)` pair `pfb_cfg_registry()` declares literally, mapped
-    to whether the entry carries the on/off toggle read adapter."""
-    return {
-        (alias, key): (f"'{_TOGGLE_ADAPTER}'" in body) for alias, key, body in _REGISTRY_ENTRY_RE.findall(registry_text)
-    }
+def parse_registry_keys(registry_text: str) -> set[tuple[str, str]]:
+    """Every `(alias, bare key)` pair `pfb_cfg_registry()` declares literally."""
+    return {(alias, key) for alias, key, _body in _REGISTRY_ENTRY_RE.findall(registry_text)}
 
 
 def find_violations(
     text: str,
     source: str,
     sections_by_path: dict[str, str],
-    registry_keys: dict[tuple[str, str], bool],
+    registry_keys: set[tuple[str, str]] | dict[tuple[str, str], object],
 ) -> list[Violation]:
     """Apply both rules to one page's source."""
     basename = Path(source).name

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -1234,11 +1234,13 @@ function pfb_cfg_registry(): array
 		],
 
 		// DNSBL lighttpd HTTP port. Default '8081' (the page/save contract since 3.2).
+		// pfb_registry_pass seeds this on a fresh install, so apply no longer hits
+		// "DNSBL Ports are not defined" on a never-saved config.
 		'dnsbl/pfb_dnsport' => [
 			'default'       => '8081',
 			'read_adapter'  => NULL,
 			'write_adapter' => NULL,
-			'no_grandfather' => '#2994 page/save default 8081 is the operator-visible contract; absent already rendered 8081',
+			'no_grandfather' => '#2994 page/save default 8081 is the operator-visible contract; absent already rendered 8081; a fresh install now seeds it',
 		],
 
 		// DNSBL lighttpd HTTPS port. Default '8443' (the page/save contract since 3.2).
@@ -1246,7 +1248,7 @@ function pfb_cfg_registry(): array
 			'default'       => '8443',
 			'read_adapter'  => NULL,
 			'write_adapter' => NULL,
-			'no_grandfather' => '#2994 page/save default 8443 is the operator-visible contract; absent already rendered 8443',
+			'no_grandfather' => '#2994 page/save default 8443 is the operator-visible contract; absent already rendered 8443; a fresh install now seeds it',
 		],
 
 		// TOP1M whitelist enable. Default ''.
@@ -1646,11 +1648,13 @@ function pfb_cfg_registry(): array
 		],
 
 		// Aliaslog (logging mode). Default 'enabled' (the page/save/help contract).
+		// pfb_registry_pass seeds this on a fresh install, so DNSBLIP firewall-rule
+		// logging matches the page Default Enable without a first save.
 		'dnsbl/aliaslog' => [
 			'default'       => 'enabled',
 			'read_adapter'  => NULL,
 			'write_adapter' => NULL,
-			'no_grandfather' => '#2994 page select/help/save default enabled; registry empty was not a valid option',
+			'no_grandfather' => '#2994 page select/help/save default enabled; a fresh install now seeds it so apply logs',
 		],
 
 		// ADR-36: NAT DNS-redirect enable: 'on' | '' (checkbox). Default '' (off).

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -1233,20 +1233,20 @@ function pfb_cfg_registry(): array
 			'no_grandfather' => 'v3.2.16 absent-key fallback equals current default',
 		],
 
-		// DNSBL lighttpd HTTP port. Default '' (system default).
+		// DNSBL lighttpd HTTP port. Default '8081' (the page/save contract since 3.2).
 		'dnsbl/pfb_dnsport' => [
-			'default'       => '',
+			'default'       => '8081',
 			'read_adapter'  => NULL,
 			'write_adapter' => NULL,
-			'no_grandfather' => 'v3.2.16 absent-key fallback equals current default',
+			'no_grandfather' => '#2994 page/save default 8081 is the operator-visible contract; absent already rendered 8081',
 		],
 
-		// DNSBL lighttpd HTTPS port. Default ''.
+		// DNSBL lighttpd HTTPS port. Default '8443' (the page/save contract since 3.2).
 		'dnsbl/pfb_dnsport_ssl' => [
-			'default'       => '',
+			'default'       => '8443',
 			'read_adapter'  => NULL,
 			'write_adapter' => NULL,
-			'no_grandfather' => 'v3.2.16 absent-key fallback equals current default',
+			'no_grandfather' => '#2994 page/save default 8443 is the operator-visible contract; absent already rendered 8443',
 		],
 
 		// TOP1M whitelist enable. Default ''.
@@ -1645,12 +1645,12 @@ function pfb_cfg_registry(): array
 			'no_grandfather' => 'v3.2.16 absent-key fallback equals current default (as pfb_tld)',
 		],
 
-		// Aliaslog (logging mode). Default ''.
+		// Aliaslog (logging mode). Default 'enabled' (the page/save/help contract).
 		'dnsbl/aliaslog' => [
-			'default'       => '',
+			'default'       => 'enabled',
 			'read_adapter'  => NULL,
 			'write_adapter' => NULL,
-			'no_grandfather' => 'v3.2.16 absent-key fallback equals current default',
+			'no_grandfather' => '#2994 page select/help/save default enabled; registry empty was not a valid option',
 		],
 
 		// ADR-36: NAT DNS-redirect enable: 'on' | '' (checkbox). Default '' (off).

--- a/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
@@ -50,19 +50,20 @@ $default_tlds = array('arpa',$local_tld,'com','net','org','edu','ca','co','io');
 
 $pconfig = array();
 $pconfig['pfb_dnsbl']		= PfbConfig::read('dnsbl/pfb_dnsbl');
-$pconfig['tld_wildcard']		= $pfb['dconfig']['tld_wildcard']				?: '';
-$pconfig['pfb_control']		= $pfb['dconfig']['pfb_control']			?: '';
-$pconfig['pfb_control_legacy']	= $pfb['dconfig']['pfb_control_legacy']			?: '';
-$pconfig['pfb_dnsvip4'] = $pfb['dconfig']['pfb_dnsvip4'] ?: 'none';
-$pconfig['pfb_dnsvip6'] = $pfb['dconfig']['pfb_dnsvip6'] ?: 'none';
+$pconfig['tld_wildcard']		= PfbConfig::read('dnsbl/tld_wildcard');
+$pconfig['pfb_control']		= PfbConfig::read('dnsbl/pfb_control');
+$pconfig['pfb_control_legacy']	= PfbConfig::read('dnsbl/pfb_control_legacy');
+// Widget empty-option sentinel 'none'; stored default is '' (save maps none to '').
+$pconfig['pfb_dnsvip4'] = PfbConfig::read('dnsbl/pfb_dnsvip4') ?: 'none';
+$pconfig['pfb_dnsvip6'] = PfbConfig::read('dnsbl/pfb_dnsvip6') ?: 'none';
 $pconfig['pfb_dnsvip_auto']	= PfbConfig::read('dnsbl/pfb_dnsvip_auto');
 $pconfig['pfb_dnsbl_nonat']	= PfbConfig::read('dnsbl/pfb_dnsbl_nonat');
-$pconfig['pfb_dnsport']		= $pfb['dconfig']['pfb_dnsport']			?: '8081';
-$pconfig['pfb_dnsport_ssl']	= $pfb['dconfig']['pfb_dnsport_ssl']			?: '8443';
-$pconfig['dnsbl_interface']	= $pfb['dconfig']['dnsbl_interface']			?: 'lo0';
-$pconfig['pfb_dnsbl_rule']	= $pfb['dconfig']['pfb_dnsbl_rule']			?: '';
+$pconfig['pfb_dnsport']		= PfbConfig::read('dnsbl/pfb_dnsport');
+$pconfig['pfb_dnsport_ssl']	= PfbConfig::read('dnsbl/pfb_dnsport_ssl');
+$pconfig['dnsbl_interface']	= PfbConfig::read('dnsbl/dnsbl_interface');
+$pconfig['pfb_dnsbl_rule']	= PfbConfig::read('dnsbl/pfb_dnsbl_rule');
 $pconfig['dnsbl_allow_int']	= pfb_csv_list($pfb['dconfig']['dnsbl_allow_int'] ?? NULL);
-$pconfig['global_log']		= $pfb['dconfig']['global_log']				?: '';
+$pconfig['global_log']		= PfbConfig::read('dnsbl/global_log');
 $pconfig['dnsbl_webpage']	= $pfb['dconfig']['dnsbl_webpage']			?: 'dnsbl_default.php';
 // Default 'on' owned by the registry (ADR-29, issue #1907); PfbConfig::read applies it
 // when absent.
@@ -87,26 +88,26 @@ $pconfig['pfb_idn']		= PfbConfig::read('dnsbl/pfb_idn')->value;
 // Default 'on' owned by the registry (ADR-29); PfbConfig::read applies it when absent.
 $pconfig['pfb_idn_block_malicious']	= PfbConfig::read('dnsbl/pfb_idn_block_malicious');
 $pconfig['pfb_idn_escalate_suspicious']	= PfbConfig::read('dnsbl/pfb_idn_escalate_suspicious');
-$pconfig['pfb_regex']		= $pfb['dconfig']['pfb_regex']				?: '';
+$pconfig['pfb_regex']		= PfbConfig::read('dnsbl/pfb_regex');
 $pconfig['pfb_regex_cap']	= PfbConfig::read('dnsbl/pfb_regex_cap');
-$pconfig['pfb_cname']		= $pfb['dconfig']['pfb_cname']				?: '';
+$pconfig['pfb_cname']		= PfbConfig::read('dnsbl/pfb_cname');
 // ADR-22: lenient scheme parsing. Absent = unchecked (strict) for new installs; existing
 // installs are grandfathered to 'on' by the registry pass at install/upgrade (issue #1921).
 $pconfig['pfb_dnsbl_lenient']	= PfbConfig::read('dnsbl/pfb_dnsbl_lenient');
-$pconfig['pfb_noaaaa']		= $pfb['dconfig']['pfb_noaaaa']				?: '';
-$pconfig['pfb_gp']		= $pfb['dconfig']['pfb_gp']				?: '';
-$pconfig['tld_allow']		= $pfb['dconfig']['tld_allow']				?: '';
-$pconfig['tld_allow_sort']	= $pfb['dconfig']['tld_allow_sort']			?: '';
+$pconfig['pfb_noaaaa']		= PfbConfig::read('dnsbl/pfb_noaaaa');
+$pconfig['pfb_gp']		= PfbConfig::read('dnsbl/pfb_gp');
+$pconfig['tld_allow']		= PfbConfig::read('dnsbl/tld_allow');
+$pconfig['tld_allow_sort']	= PfbConfig::read('dnsbl/tld_allow_sort');
 $pconfig['tld_allow_gtld']	= pfb_csv_list($pfb['dconfig']['tld_allow_gtld'] ?? NULL, $default_tlds);
 $pconfig['tld_allow_cctld']	= pfb_csv_list($pfb['dconfig']['tld_allow_cctld'] ?? NULL);
 $pconfig['tld_allow_itld']	= pfb_csv_list($pfb['dconfig']['tld_allow_itld'] ?? NULL);
 $pconfig['tld_allow_bgtld']	= pfb_csv_list($pfb['dconfig']['tld_allow_bgtld'] ?? NULL);
-$pconfig['pfb_py_nolog']	= $pfb['dconfig']['pfb_py_nolog']			?: '';
+$pconfig['pfb_py_nolog']	= PfbConfig::read('dnsbl/pfb_py_nolog');
 $pconfig['pfb_regex_list']	= pfb_b64_text($pfb['dconfig']['pfb_regex_list'] ?? NULL);
 $pconfig['pfb_noaaaa_list']	= pfb_b64_text($pfb['dconfig']['pfb_noaaaa_list'] ?? NULL);
 $pconfig['pfb_gp_bypass_list']	= pfb_b64_text($pfb['dconfig']['pfb_gp_bypass_list'] ?? NULL);
-$pconfig['action']		= $pfb['dconfig']['action']				?: 'Disabled';
-$pconfig['aliaslog']		= $pfb['dconfig']['aliaslog']				?: 'enabled';
+$pconfig['action']		= PfbConfig::read('dnsbl/action');
+$pconfig['aliaslog']		= PfbConfig::read('dnsbl/aliaslog');
 
 // issue #2123: the eight Advanced In/Outbound rule checkbox defaults are owned by the
 // registry (ADR-29), not restated here. A validation-error redisplay replaces $pconfig
@@ -132,13 +133,13 @@ $pconfig['agateway_out']	= $pfb['dconfig']['agateway_out']			?: 'default';
 
 $pconfig['whitelist']		= pfb_b64_text($pfb['dconfig']['whitelist'] ?? NULL);
 
-$pconfig['top1m_enable']	= $pfb['dconfig']['top1m_enable']			?: '';
+$pconfig['top1m_enable']	= PfbConfig::read('dnsbl/top1m_enable');
 // Routed via the gateway (not the section array) so a stored legacy 'alexa'
 // (dead TOP1M source, #872/#877) coalesces to 'tranco' for the form select.
 // ->toStored() unwraps the PfbTop1mSource enum to its scalar option key (a
 // Form_Select selected-value must be the scalar, not the enum instance).
 $pconfig['top1m_source']		= PfbConfig::read('dnsbl/top1m_source')->toStored();
-$pconfig['top1m_count']		= $pfb['dconfig']['top1m_count']			?: '1000';
+$pconfig['top1m_count']		= PfbConfig::read('dnsbl/top1m_count');
 // 0 (unlimited) is meaningful, so don't use the ?: idiom (0 is falsy -> would reset to default).
 $pconfig['pfb_py_cache_max']	= (isset($pfb['dconfig']['pfb_py_cache_max']) && $pfb['dconfig']['pfb_py_cache_max'] !== '') ? $pfb['dconfig']['pfb_py_cache_max'] : '10000';
 $pconfig['top1m_inclusion']	= pfb_csv_list($pfb['dconfig']['top1m_inclusion'] ?? NULL, array('com','net','org','ca','co','io'));

--- a/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
@@ -2919,7 +2919,7 @@ $group->add(new Form_Select(
 $group->add(new Form_Select(
 	'pfb_dnsvip6',
 	gettext('IPv6 VIP'),
-	(!empty($pconfig['pfb_dnsvip6']) ? $pconfig['pfb_dnsvip6'] : 'none'),
+	$pconfig['pfb_dnsvip6'],
 	pfb_get_vip_options(AF_INET6)
 ))->setWidth(4)->setHelp('IPv6 Virtual IP (optional)');
 

--- a/src/usr/local/www/pfblockerng/pfblockerng_safesearch.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_safesearch.php
@@ -30,8 +30,8 @@ pfb_global();
 $pfb['bconfig']	= PfbConfig::readSection('installedpackages/pfblockerngsafesearch');
 
 $pconfig = array();
-$pconfig['safesearch_enable']		= $pfb['bconfig']['safesearch_enable']			?: 'Disable';
-$pconfig['safesearch_youtube']		= $pfb['bconfig']['safesearch_youtube']			?: 'Disable';
+$pconfig['safesearch_enable']		= PfbConfig::read('ss/safesearch_enable');
+$pconfig['safesearch_youtube']		= PfbConfig::read('ss/safesearch_youtube');
 
 // Select field options
 $options_safesearch_enable	= ['Disable' => 'Disable', 'Enable' => 'Enable'];

--- a/tests/php/CfgGatewayTest.php
+++ b/tests/php/CfgGatewayTest.php
@@ -2975,11 +2975,18 @@ final class CfgGatewayTest extends TestCase
 			);
 			$actual = $registry[$path_key];
 
-			if ($bare !== 'skipfeed') {
-				$this->assertSame($expected['default'], $actual['default'], "{$path_key}: default must match the fixture");
+			$deliberate = [
+				'skipfeed' => ['0', '3', 'historical skipfeed fixture remains unlimited / fresh-install default is 3'],
+				'pfb_dnsport' => ['', '8081', '#2994 page/save default 8081'],
+				'pfb_dnsport_ssl' => ['', '8443', '#2994 page/save default 8443'],
+				'aliaslog' => ['', 'enabled', '#2994 page/save/help default enabled'],
+			];
+			if (isset($deliberate[$bare])) {
+				[$historical, $current, $why] = $deliberate[$bare];
+				$this->assertSame($historical, $expected['default'], "{$path_key}: historical fixture remains {$historical}");
+				$this->assertSame($current, $actual['default'], $why);
 			} else {
-				$this->assertSame('0', $expected['default'], 'historical skipfeed fixture remains unlimited');
-				$this->assertSame('3', $actual['default'], 'fresh-install skipfeed default is 3');
+				$this->assertSame($expected['default'], $actual['default'], "{$path_key}: default must match the fixture");
 			}
 			$this->assertSame($expected['read_adapter'], $actual['read_adapter'], "{$path_key}: read_adapter must match the fixture");
 			$this->assertSame($expected['write_adapter'], $actual['write_adapter'], "{$path_key}: write_adapter must match the fixture");

--- a/tests/php/CfgScalarRegistryPageParityTest.php
+++ b/tests/php/CfgScalarRegistryPageParityTest.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * issue #2994 — registered plain-scalar page/registry default divergences.
+ *
+ * Each quoted site needs an authority decision before RULE 2 can widen off
+ * toggles. The gateway absent-read is the registry side of that agreement;
+ * the pre-change page expression is `$blob[$key] ?: '<page default>'`.
+ *
+ * Decisions (page render of an absent key is the operator-visible contract):
+ *
+ *   pfb_dnsport / pfb_dnsport_ssl — PAGE. The DNSBL form, the save-site
+ *     `?: '8081'`/`?: '8443'`, and the smoke harness all treat those as the
+ *     listening ports; registry `''` would empty the inputs and abort DNSBL
+ *     (`DNSBL Ports are not defined`) on a never-saved config.
+ *   aliaslog — PAGE. The select options are only `enabled`/`disabled`, the
+ *     help text says Default Enable, and the save-site falls back to
+ *     `enabled`. Registry `''` is not a valid option.
+ *   pfb_dnsbl_rule — REGISTRY. The apply path coalesces with `?: 'Disabled'`
+ *     and compares `!= 'Disabled'`. The page checkbox runs the value through
+ *     `pfb_cfg_toggle_read(...) === PfbToggle::On`, so both `''` and
+ *     `Disabled` render unchecked. Routing the page through the gateway keeps
+ *     the apply-path Off token.
+ *   pfb_dnsvip4 / pfb_dnsvip6 — REGISTRY `''`. Page `'none'` is the Form_Select
+ *     empty-option sentinel (save maps `none` → `''` before persist). The
+ *     widget mapping stays next to the control; it is not the stored default.
+ */
+final class CfgScalarRegistryPageParityTest extends TestCase
+{
+	private const DNSBL = 'installedpackages/pfblockerngdnsblsettings/config/0';
+
+	protected function setUp(): void
+	{
+		$GLOBALS['config'] = [];
+	}
+
+	/**
+	 * @return iterable<string,array{0:string,1:string,2:string}>
+	 */
+	public static function absentDefaults(): iterable
+	{
+		yield 'pfb_dnsport' => ['dnsbl/pfb_dnsport', self::DNSBL . '/pfb_dnsport', '8081'];
+		yield 'pfb_dnsport_ssl' => ['dnsbl/pfb_dnsport_ssl', self::DNSBL . '/pfb_dnsport_ssl', '8443'];
+		yield 'aliaslog' => ['dnsbl/aliaslog', self::DNSBL . '/aliaslog', 'enabled'];
+		yield 'pfb_dnsbl_rule' => ['dnsbl/pfb_dnsbl_rule', self::DNSBL . '/pfb_dnsbl_rule', 'Disabled'];
+		yield 'pfb_dnsvip4' => ['dnsbl/pfb_dnsvip4', self::DNSBL . '/pfb_dnsvip4', ''];
+		yield 'pfb_dnsvip6' => ['dnsbl/pfb_dnsvip6', self::DNSBL . '/pfb_dnsvip6', ''];
+		yield 'dnsbl_interface' => ['dnsbl/dnsbl_interface', self::DNSBL . '/dnsbl_interface', 'lo0'];
+		yield 'action' => ['dnsbl/action', self::DNSBL . '/action', 'Disabled'];
+	}
+
+	/**
+	 * Scenario:
+	 *   Given a DNSBL settings key is absent from config.xml.
+	 *   When PfbConfig::read() resolves it.
+	 *   Then the result is the authoritative default for that site
+	 *        (page for ports/aliaslog, registry for vip/rule/interface/action).
+	 */
+	#[DataProvider('absentDefaults')]
+	public function testAbsentKeyReadsTheAuthoritativeDefault(
+		string $path_key,
+		string $config_path,
+		string $expected
+	): void {
+		$this->assertNull(config_get_path($config_path), "before: {$path_key} must be absent");
+		$this->assertSame($expected, PfbConfig::read($path_key), "{$path_key} absent -> {$expected}");
+	}
+
+	/**
+	 * Scenario:
+	 *   Given the DNSBL page save writes '' for an unchecked Permit Firewall
+	 *     Rules checkbox (pfb_filter ON_OFF ?: '').
+	 *   When PfbConfig::read('dnsbl/pfb_dnsbl_rule') resolves that stored empty.
+	 *   Then the checkbox still reads Off — '' and the registry default
+	 *        'Disabled' are the same toggle state.
+	 */
+	public function testDnsblRuleEmptyAndDisabledBothReadOff(): void
+	{
+		$this->assertSame(PfbToggle::Off, pfb_cfg_toggle_read(''));
+		$this->assertSame(PfbToggle::Off, pfb_cfg_toggle_read('Disabled'));
+
+		config_set_path(self::DNSBL . '/pfb_dnsbl_rule', '');
+		$this->assertSame(
+			PfbToggle::Off,
+			pfb_cfg_toggle_read(PfbConfig::read('dnsbl/pfb_dnsbl_rule')),
+			'stored empty Off token still renders the checkbox unchecked'
+		);
+	}
+
+	/**
+	 * Scenario:
+	 *   Given a stored empty string on a plain-scalar port key (the page
+	 *     `?: '8081'` treated '' as missing).
+	 *   When PfbConfig::read() resolves it.
+	 *   Then the registry default fills it the same way the page did.
+	 */
+	public function testEmptyPortStringResolvesToThePageDefault(): void
+	{
+		config_set_path(self::DNSBL . '/pfb_dnsport', '');
+		$this->assertSame('8081', PfbConfig::read('dnsbl/pfb_dnsport'));
+		config_set_path(self::DNSBL . '/pfb_dnsport_ssl', '');
+		$this->assertSame('8443', PfbConfig::read('dnsbl/pfb_dnsport_ssl'));
+	}
+}

--- a/tests/php/RegistryPassTest.php
+++ b/tests/php/RegistryPassTest.php
@@ -137,6 +137,11 @@ final class RegistryPassTest extends TestCase
 		$this->assertSame('', $result[self::DNSBL_SECTION]['pfb_psl_feed_private_policy'] ?? NULL);
 		$this->assertSame('', $result[self::DNSBL_SECTION]['pfb_psl_feed_icann_policy'] ?? NULL);
 		$this->assertSame('Disable', $result[self::SS_SECTION]['safesearch_enable'] ?? NULL);
+		// issue #2994: page/save defaults materialise on a fresh install, so apply
+		// sees 8081/8443 ports (no "Ports are not defined" abort) and aliaslog Enable.
+		$this->assertSame('8081', $result[self::DNSBL_SECTION]['pfb_dnsport'] ?? NULL);
+		$this->assertSame('8443', $result[self::DNSBL_SECTION]['pfb_dnsport_ssl'] ?? NULL);
+		$this->assertSame('enabled', $result[self::DNSBL_SECTION]['aliaslog'] ?? NULL);
 		$this->assertSame('', $result[self::IP_SECTION]['v6suppression'] ?? NULL);
 		$this->assertSame('', $result[self::REP_SECTION]['enable_rep'] ?? NULL);
 		// issue #2123: alertrefresh is the only default-ON key among the seventeen, so a

--- a/tests/smoke/ui/test_toggle_registry_default_render.py
+++ b/tests/smoke/ui/test_toggle_registry_default_render.py
@@ -69,6 +69,29 @@ def _checkbox_is_checked(html: str, name: str) -> bool:
     return re.search(r'\bchecked\b(?!\s*=\s*"?[^">]*")', tag) is not None or 'checked="checked"' in tag
 
 
+def _input_value(html: str, name: str) -> str:
+    """The ``value`` attribute of the named ``<input>``, or '' if omitted."""
+    match = re.search(rf'<input[^>]*\bname="{re.escape(name)}"[^>]*>', html)
+    assert match is not None, f'input name="{name}" not found in the rendered page'
+    val = re.search(r'\bvalue="([^"]*)"', match.group(0))
+    return val.group(1) if val else ""
+
+
+def _select_selected(html: str, name: str) -> str:
+    """The selected option value of the named ``<select>``."""
+    match = re.search(
+        rf'<select[^>]*\bname="{re.escape(name)}"[^>]*>(.*?)</select>',
+        html,
+        re.DOTALL,
+    )
+    assert match is not None, f'select name="{name}" not found in the rendered page'
+    selected = re.search(r'<option[^>]*\bselected\b[^>]*\bvalue="([^"]*)"', match.group(1))
+    if selected is None:
+        selected = re.search(r'<option[^>]*\bvalue="([^"]*)"[^>]*\bselected\b', match.group(1))
+    assert selected is not None, f'select name="{name}" has no selected option'
+    return selected.group(1)
+
+
 def _node_state(vm: SmokeVM, path: str) -> str:
     """Serialise the node's raw state so an ABSENT key is restored as absent."""
     result = helpers.php_eval(
@@ -279,3 +302,56 @@ def test_swept_general_enable_cb_renders_on_when_stored_and_off_when_absent(
         "an absent enable_cb must render UNCHECKED -- the registered '' default "
         "must reproduce the page default #2812 deleted"
     )
+
+
+# ---------------------------------------------------------------------------
+# issue #2994: registered plain-scalar absent-key render. The six divergences
+# were aligned so an absent key still renders the operator-visible value the
+# page used to declare itself. Dual-marked ui_e2e: each case mutates config.xml.
+# ---------------------------------------------------------------------------
+
+_CFG_DNSBL = "installedpackages/pfblockerngdnsblsettings/config/0"
+
+
+@pytest.mark.ui_e2e
+def test_absent_dnsbl_ports_render_the_page_defaults(
+    smoke_vm: SmokeVM, webui: WebUI, node_state: Callable[[str, str | None], None]
+) -> None:
+    """issue #2994: absent pfb_dnsport/ssl still render 8081/8443 from the registry."""
+    node_state(f"{_CFG_DNSBL}/pfb_dnsport", None)
+    node_state(f"{_CFG_DNSBL}/pfb_dnsport_ssl", None)
+    html = _render(smoke_vm, webui, _DNSBL_SETTINGS_PAGE, "DNSBL")
+    assert _input_value(html, "pfb_dnsport") == "8081"
+    assert _input_value(html, "pfb_dnsport_ssl") == "8443"
+
+
+@pytest.mark.ui_e2e
+def test_absent_aliaslog_renders_enabled(
+    smoke_vm: SmokeVM, webui: WebUI, node_state: Callable[[str, str | None], None]
+) -> None:
+    """issue #2994: absent aliaslog still selects Enable (the page/help default)."""
+    node_state(f"{_CFG_DNSBL}/aliaslog", None)
+    html = _render(smoke_vm, webui, _DNSBL_SETTINGS_PAGE, "DNSBL")
+    assert _select_selected(html, "aliaslog") == "enabled"
+
+
+@pytest.mark.ui_e2e
+def test_absent_dnsbl_rule_renders_unchecked(
+    smoke_vm: SmokeVM, webui: WebUI, node_state: Callable[[str, str | None], None]
+) -> None:
+    """issue #2994: absent pfb_dnsbl_rule stays Off under the registry Disabled token."""
+    node_state(f"{_CFG_DNSBL}/pfb_dnsbl_rule", None)
+    html = _render(smoke_vm, webui, _DNSBL_SETTINGS_PAGE, "DNSBL")
+    assert not _checkbox_is_checked(html, "pfb_dnsbl_rule")
+
+
+@pytest.mark.ui_e2e
+def test_absent_dnsbl_vips_render_the_none_sentinel(
+    smoke_vm: SmokeVM, webui: WebUI, node_state: Callable[[str, str | None], None]
+) -> None:
+    """issue #2994: absent pfb_dnsvip4/6 still select the widget none sentinel."""
+    node_state(f"{_CFG_DNSBL}/pfb_dnsvip4", None)
+    node_state(f"{_CFG_DNSBL}/pfb_dnsvip6", None)
+    html = _render(smoke_vm, webui, _DNSBL_SETTINGS_PAGE, "DNSBL")
+    assert _select_selected(html, "pfb_dnsvip4") == "none"
+    assert _select_selected(html, "pfb_dnsvip6") == "none"

--- a/tests/smoke/ui/test_toggle_registry_default_render.py
+++ b/tests/smoke/ui/test_toggle_registry_default_render.py
@@ -320,7 +320,7 @@ def test_absent_dnsbl_ports_render_the_page_defaults(
     """issue #2994: absent pfb_dnsport/ssl still render 8081/8443 from the registry."""
     node_state(f"{_CFG_DNSBL}/pfb_dnsport", None)
     node_state(f"{_CFG_DNSBL}/pfb_dnsport_ssl", None)
-    html = _render(smoke_vm, webui, _DNSBL_SETTINGS_PAGE, "DNSBL")
+    html = _render(smoke_vm, webui, _DNSBL_SETTINGS_PAGE, "DNSBL Webserver Configuration")
     assert _input_value(html, "pfb_dnsport") == "8081"
     assert _input_value(html, "pfb_dnsport_ssl") == "8443"
 
@@ -331,7 +331,7 @@ def test_absent_aliaslog_renders_enabled(
 ) -> None:
     """issue #2994: absent aliaslog still selects Enable (the page/help default)."""
     node_state(f"{_CFG_DNSBL}/aliaslog", None)
-    html = _render(smoke_vm, webui, _DNSBL_SETTINGS_PAGE, "DNSBL")
+    html = _render(smoke_vm, webui, _DNSBL_SETTINGS_PAGE, "DNSBL Webserver Configuration")
     assert _select_selected(html, "aliaslog") == "enabled"
 
 
@@ -341,7 +341,7 @@ def test_absent_dnsbl_rule_renders_unchecked(
 ) -> None:
     """issue #2994: absent pfb_dnsbl_rule stays Off under the registry Disabled token."""
     node_state(f"{_CFG_DNSBL}/pfb_dnsbl_rule", None)
-    html = _render(smoke_vm, webui, _DNSBL_SETTINGS_PAGE, "DNSBL")
+    html = _render(smoke_vm, webui, _DNSBL_SETTINGS_PAGE, "DNSBL Webserver Configuration")
     assert not _checkbox_is_checked(html, "pfb_dnsbl_rule")
 
 
@@ -352,6 +352,6 @@ def test_absent_dnsbl_vips_render_the_none_sentinel(
     """issue #2994: absent pfb_dnsvip4/6 still select the widget none sentinel."""
     node_state(f"{_CFG_DNSBL}/pfb_dnsvip4", None)
     node_state(f"{_CFG_DNSBL}/pfb_dnsvip6", None)
-    html = _render(smoke_vm, webui, _DNSBL_SETTINGS_PAGE, "DNSBL")
+    html = _render(smoke_vm, webui, _DNSBL_SETTINGS_PAGE, "DNSBL Webserver Configuration")
     assert _select_selected(html, "pfb_dnsvip4") == "none"
     assert _select_selected(html, "pfb_dnsvip6") == "none"

--- a/tests/test_toggle_registry_check.py
+++ b/tests/test_toggle_registry_check.py
@@ -8,7 +8,7 @@ The load-bearing assertions are:
 
 * a NEW `PFB_FILTER_ON_OFF` save into a registered section with no registry entry FAILS
   (RULE 1) -- this is the regrowth the sweep exists to stop;
-* a registered TOGGLE whose page still declares its own default FAILS (RULE 2);
+* a registered field (toggle or plain scalar) whose page still declares its own default FAILS (RULE 2);
 * the same shapes are clean once registered / routed through `PfbConfig::read()`;
 * the real tree is clean, so the gate is blocking rather than pre-broken;
 * a broken registry parse FAILS CLOSED rather than reporting every key unregistered.
@@ -110,7 +110,7 @@ def test_commented_out_save_is_not_flagged() -> None:
 
 
 # --------------------------------------------------------------------------- #
-# RULE 2 -- a registered toggle's default belongs to the registry
+# RULE 2 -- a registered field's default belongs to the registry
 # --------------------------------------------------------------------------- #
 
 
@@ -137,14 +137,16 @@ def test_gateway_read_is_clean() -> None:
     assert _find(text) == []
 
 
-def test_registered_plain_scalar_page_default_is_not_rule_twos_business() -> None:
-    """RULE 2 is toggle-scoped: a plain scalar's page default is issue #2812's backlog.
+def test_registered_plain_scalar_page_default_is_flagged() -> None:
+    """issue #2994: RULE 2 covers registered plain scalars, not just toggles.
 
-    Several of those page defaults genuinely disagree with their registry entry, so
-    flagging them here would push a behaviour change through a lint.
+    The six page/registry divergences were aligned first, so flagging a scalar
+    page default no longer pushes a behaviour change through a lint.
     """
     text = MIRROR + "$pconfig['maxmind_locale'] = $pfb['iconfig']['maxmind_locale'] ?: 'en';\n"
-    assert _find(text) == []
+    violations = _find(text)
+    assert [v.rule for v in violations] == ["page-level-default"]
+    assert "ip/maxmind_locale" in violations[0].detail
 
 
 def test_page_default_for_an_unregistered_key_is_not_rule_twos_business() -> None:
@@ -356,3 +358,24 @@ def test_www_tree_is_clean_with_the_exempt_table_emptied(
     assert ctr.main([]) == 0, (
         "src/usr/local/www/pfblockerng still carries page-level toggle defaults: issue #2812's sweep is incomplete"
     )
+
+
+# --------------------------------------------------------------------------- #
+# Issue #2994 -- RULE 2 widened to registered plain scalars
+# --------------------------------------------------------------------------- #
+
+
+def test_gateway_read_of_a_plain_scalar_is_clean() -> None:
+    """The fixed form for a scalar is the same as for a toggle: PfbConfig::read()."""
+    text = MIRROR + "$pconfig['maxmind_locale'] = PfbConfig::read('ip/maxmind_locale');\n"
+    assert _find(text) == []
+
+
+def test_widget_sentinel_after_a_gateway_read_is_not_a_page_default() -> None:
+    """`$x = PfbConfig::read(...) ?: 'none'` is widget mapping, not a mirror restatement.
+
+    pfb_dnsvip4/6 store '' and the Form_Select empty option is the token 'none'.
+    That mapping must sit on the gateway result, not on `$pfb['dconfig'][...]`.
+    """
+    text = MIRROR + "$pconfig['maxmind_locale'] = PfbConfig::read('ip/maxmind_locale') ?: 'none';\n"
+    assert _find(text) == []

--- a/tests/test_toggle_registry_check.py
+++ b/tests/test_toggle_registry_check.py
@@ -184,8 +184,8 @@ def test_exempt_entry_suppresses_rule_two(monkeypatch: pytest.MonkeyPatch) -> No
 # --------------------------------------------------------------------------- #
 
 
-def test_registry_parse_finds_every_alias_and_the_toggle_entries() -> None:
-    """The parse must see all PFB_SECTIONS aliases and mark toggles as toggles."""
+def test_registry_parse_finds_every_alias_and_registered_key() -> None:
+    """The parse must see all PFB_SECTIONS aliases and the registered keys."""
     text = (_REPO_ROOT / ctr.REGISTRY_FILE).read_text(encoding="utf-8")
     sections = ctr.parse_sections(text)
     keys = ctr.parse_registry_keys(text)
@@ -195,13 +195,11 @@ def test_registry_parse_finds_every_alias_and_the_toggle_entries() -> None:
     assert sections["installedpackages/pfblockerngsync/config/0"] == "sync"
     assert len(keys) >= ctr._MIN_REGISTRY_KEYS
 
-    # issue #2123's own entries, and their adapter classification.
-    assert keys[("ip", "enable_dup")] is True
-    assert keys[("global", "alertrefresh")] is True
-    assert keys[("sync", "syncinterfaces")] is True
-    assert keys[("dnsbl", "autoaddrnot_in")] is True
-    # A registered plain scalar must NOT be classified as a toggle.
-    assert keys[("ip", "v4suppression")] is False
+    assert ("ip", "enable_dup") in keys
+    assert ("global", "alertrefresh") in keys
+    assert ("sync", "syncinterfaces") in keys
+    assert ("dnsbl", "autoaddrnot_in") in keys
+    assert ("ip", "v4suppression") in keys
 
 
 def test_every_exempt_row_still_names_a_live_site(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -285,34 +283,6 @@ def test_exempt_row_does_not_suppress_rule_one(monkeypatch: pytest.MonkeyPatch) 
 def test_unreadable_explicit_path_fails_closed() -> None:
     """A named page the checker cannot read must exit 2, never 0."""
     assert ctr.main(["src/usr/local/www/pfblockerng/does_not_exist.php"]) == 2
-
-
-def test_every_2123_key_is_classified_as_a_toggle() -> None:
-    """All seventeen, not a sample: a plain-scalar slip would let RULE 2 skip the key."""
-    text = (_REPO_ROOT / ctr.REGISTRY_FILE).read_text(encoding="utf-8")
-    keys = ctr.parse_registry_keys(text)
-    expected = [
-        ("ip", "enable_dup"),
-        ("ip", "enable_agg"),
-        ("ip", "enable_log"),
-        ("ip", "enable_rdns"),
-        ("ip", "database_cc"),
-        ("ip", "enable_float"),
-        ("ip", "killstates"),
-        ("dnsbl", "autoaddrnot_in"),
-        ("dnsbl", "autoports_in"),
-        ("dnsbl", "autoaddr_in"),
-        ("dnsbl", "autonot_in"),
-        ("dnsbl", "autoaddrnot_out"),
-        ("dnsbl", "autoports_out"),
-        ("dnsbl", "autoaddr_out"),
-        ("dnsbl", "autonot_out"),
-        ("sync", "syncinterfaces"),
-        ("global", "alertrefresh"),
-    ]
-    assert len(expected) == 17
-    plain = [f"{a}/{b}" for a, b in expected if keys.get((a, b)) is not True]
-    assert not plain, f"issue #2123 keys not carrying the toggle read adapter: {plain}"
 
 
 def test_whitespace_between_brackets_does_not_evade_either_rule() -> None:

--- a/tests/test_toggle_registry_check.py
+++ b/tests/test_toggle_registry_check.py
@@ -38,11 +38,11 @@ _spec.loader.exec_module(ctr)
 IP_SECTION = "installedpackages/pfblockerngipsettings/config/0"
 GLOBAL_SECTION = "installedpackages/pfblockerngglobal"
 
-# A minimal stand-in for the parsed registry: (alias, bare key) -> is-a-toggle.
-FAKE_KEYS: dict[tuple[str, str], bool] = {
-    ("ip", "enable_dup"): True,
-    ("ip", "maxmind_locale"): False,
-    ("global", "alertrefresh"): True,
+# A minimal stand-in for the parsed registry: registered (alias, bare key) pairs.
+FAKE_KEYS: set[tuple[str, str]] = {
+    ("ip", "enable_dup"),
+    ("ip", "maxmind_locale"),
+    ("global", "alertrefresh"),
 }
 FAKE_SECTIONS = {IP_SECTION: "ip", GLOBAL_SECTION: "global"}
 


### PR DESCRIPTION
Fixes #2994.

## What

Aligns the registered **plain-scalar** page/registry default divergences that RULE 2 used to skip (issue #2812 work item 2), then widens RULE 2 to every registered key.

23 RULE-2-shape scalar sites on `pfblockerng_dnsbl.php` and `pfblockerng_safesearch.php` now read through `PfbConfig::read()`.

## Authority decisions (executed)

Absent-key render today is the page `?:` expression. After this change the gateway absent-read matches that observable except where the stored token and the widget token already differed:

| Key | Page | Registry before | Decision | After |
| --- | --- | --- | --- | --- |
| `dnsbl/pfb_dnsport` | `8081` | `''` | **page** | registry `8081`; `pfb_registry_pass` seeds it on a fresh install so apply no longer hits "DNSBL Ports are not defined" |
| `dnsbl/pfb_dnsport_ssl` | `8443` | `''` | **page** | registry `8443`; same seed |
| `dnsbl/aliaslog` | `enabled` | `''` | **page** | registry `enabled`; a fresh install seeds it so DNSBLIP firewall-rule logging matches Default Enable |
| `dnsbl/pfb_dnsbl_rule` | `''` | `Disabled` | **registry** | page reads `Disabled`; checkbox still Off (`pfb_cfg_toggle_read` of both tokens) |
| `dnsbl/pfb_dnsvip4` | `none` | `''` | **registry** `''` | widget sentinel `none` applied *after* `PfbConfig::read()` |
| `dnsbl/pfb_dnsvip6` | `none` | `''` | **registry** `''` | same sentinel |
| remaining 17 (interface `lo0`, action `Disabled`, top1m_count `1000`, safesearch `Disable`, empty-string siblings) | equal | equal | route through gateway | no render change |

RULE 2 widens to every registered key. `$x = PfbConfig::read(...) ?: 'none'` is widget mapping, not a mirror restatement. `EXEMPT` stays `{}`. Matchers require a literal key; a dynamic `$pfb['gconfig']['log_max_' . $suffix]` restatement is a documented ceiling.

`dnsbl/pfb_py_cache_max` (`isset(...) && ... !== '' ? ... : '10000'`) is **not** RULE-2 shape and stays out of this PR.

## Verification

- `python3 scripts/check_toggle_registry.py` exits 0; `--self-test` still fires both rules.
- Focused PHPUnit: `CfgScalarRegistryPageParityTest`; `testPathKeyedRegistryMatchesPre1931ParityFixture` (deliberate-default carve-out); `testFreshEmptySectionsSeedEveryRegisteredFieldAtDefault` (8081/8443/enabled seeds).
- `uv run pytest tests/test_toggle_registry_check.py` — 26 passed.
- Tier-A `ui_render`: four new cases pin absent-key render of ports, aliaslog, dnsbl_rule, and vip sentinels. Executed by the labelled `ui-tests` CI row.

### Frozen RED evidence

| Frozen RED test | git hash-object | RED run tail |
| --- | --- | --- |
| `tests/php/CfgScalarRegistryPageParityTest.php` | `c1651a2341b5e8cb1706963b7228d37cad22ed9f` | Parent tree: `4 failed` — `pfb_dnsport` absent `''` vs `8081`, `pfb_dnsport_ssl` `''` vs `8443`, `aliaslog` `''` vs `enabled`, empty stored port `''` vs `8081`. |
| `tests/test_toggle_registry_check.py` | `10c6cd8ac0afff7afcc1823220b52655c621fd85` | Parent tree: `test_registered_plain_scalar_page_default_is_flagged` fails `assert [] == ['page-level-default']`. |
| `tests/smoke/ui/test_toggle_registry_default_render.py` | `a6d213af07b2b987fa2be3b0cb7b6c51d12369dd` | NOT executed locally: Tier-A needs a leased CE box. Collect-only: 15 tests. End-state pin of the absent-key observable. |
| `tests/php/CfgGatewayTest.php` | `240db45cc536030a945ded9017df6af0ec71cc32` | First head without the carve-out: `testPathKeyedRegistryMatchesPre1931ParityFixture` `dnsbl/pfb_dnsport` expected `''` actual `8081`. |
| `tests/php/RegistryPassTest.php` | `bb278bf16ce329f5d4fdd714fff231f8aa2b4180` | GREEN-on-arrival pin of the #2994 seeds. Mutation: registry default `pfb_dnsport` `8081`→`''` fails `assertSame('8081', ...)`. |



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - DNSBL settings now consistently use the standard defaults: HTTP port `8081`, HTTPS port `8443`, and alias logging enabled.
  - DNSBL and SafeSearch pages more reliably display configured values and appropriate defaults when settings are missing or empty.
  - DNSBL interface, action, rule, and DNS VIP fields now retain expected default display behavior.
- **Quality Improvements**
  - Added coverage to verify configuration defaults, page rendering, and fresh-install behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->