### PR TITLE
pfb_unbound: resolve both public suffixes from one label walk

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -127,10 +127,10 @@ class PslRules:
     # keeps value equality (and the hash) a function of the rules alone; init=False
     # keeps a foreign index out of the constructor and makes dataclasses.replace
     # rebuild rather than carry the previous rules' sets.
-    _index: _PslIndex | None = field(default=None, compare=False, repr=False, init=False)
+    _index: tuple[_PslSets, _PslSets] | None = field(default=None, compare=False, repr=False, init=False)
 
-    def index(self) -> _PslIndex:
-        """(ICANN-only sets, ICANN+PRIVATE sets, exception-root labels) for this rule set.
+    def index(self) -> tuple[_PslSets, _PslSets]:
+        """(ICANN-only, ICANN+PRIVATE) membership sets for this rule set.
 
         Built once per instance. Do NOT reintroduce an lru_cache keyed on this
         dataclass: computing that key hashes all six rule tuples on every call,
@@ -261,12 +261,10 @@ def parse_psl_rules(text: str) -> PslRules:
 
 
 _PslSets = tuple[frozenset[str], frozenset[str], frozenset[str]]
-_PslIndex = tuple[_PslSets, _PslSets, frozenset[str]]
 
 
-def _psl_build_index(rules: PslRules) -> _PslIndex:
-    """Build the (ICANN-only, ICANN+PRIVATE) (exact, wildcard, exception) sets, plus
-    the final label of every exception rule.
+def _psl_build_index(rules: PslRules) -> tuple[_PslSets, _PslSets]:
+    """Build the (ICANN-only, ICANN+PRIVATE) (exact, wildcard, exception) sets.
 
     Called once per PslRules via PslRules.index(), which holds the result on the
     instance, so each resolution costs O(name labels) rather than a scan over the
@@ -283,79 +281,51 @@ def _psl_build_index(rules: PslRules) -> _PslIndex:
         frozenset(rules.icann_wildcard + rules.private_wildcard),
         frozenset(rules.icann_exception + rules.private_exception),
     )
-    # Final label of every exception rule in either section. An exception can only
-    # match a tail whose last label is its own, so a name whose TLD is absent here
-    # needs no exception phase at all. The shipped list carries 8 exception rules
-    # under 2 TLDs (ck, jp), so most names skip the phase; jp is populated enough
-    # that its names keep both section walks, and still gain the shared tails.
-    exception_roots = frozenset(rule.rsplit(".", 1)[-1] for rule in combined[2])
-    return icann, combined, exception_roots
-
-
-def _psl_tails(labels: list[str]) -> list[str]:
-    """Every dotted suffix of ``labels``, longest first (``tails[i]`` == labels[i:]).
-
-    Built once per resolution by growing one label at a time from the right, so the
-    matcher below never re-joins a slice of the label list (issue #3061).
-    """
-    tails = [labels[-1]]
-    for index in range(len(labels) - 2, -1, -1):
-        tails.append(labels[index] + "." + tails[-1])
-    tails.reverse()
-    return tails
-
-
-def _psl_prevailing_section(
-    tails: list[str],
-    exact: frozenset[str],
-    wildcard: frozenset[str],
-    exception: frozenset[str],
-) -> str:
-    # Exception wins outright; scanning tails longest-first makes the first hit
-    # the longest match. Exception output drops the rule's leftmost label.
-    count = len(tails)
-    for start in range(count):
-        if tails[start] in exception:
-            return tails[start + 1] if start + 1 < count else ""
-    # Longest surviving suffix wins. A wildcard base at ``start`` yields the
-    # suffix labels[start-1:], one label longer than an exact rule at ``start``
-    # and the SAME string an exact rule at ``start-1`` would yield -- so the
-    # longest-first walk needs no cross-kind tie-breaking.
-    for start in range(count):
-        tail = tails[start]
-        if start > 0 and tail in wildcard:
-            return tails[start - 1]
-        if tail in exact:
-            return tail
-    return tails[-1]
+    return icann, combined
 
 
 def _psl_prevailing(
     labels: list[str],
     icann_sets: _PslSets,
     combined_sets: _PslSets,
-    exception_roots: frozenset[str],
 ) -> tuple[str, str]:
     """The (ICANN-only, ICANN+PRIVATE) prevailing suffixes from ONE walk of ``labels``.
 
     Both are always needed -- ``private_active`` is their comparison and TLD-Allow
     reads both -- so the sections share one walk instead of taking one each
-    (issue #3061): the tails are built once and matched against both.
+    (issue #3061): the label tails are built once and matched against both.
+
+    An exception rule beats an ordinary match at ANY depth, so its carve-out is
+    tracked alongside the ordinary match instead of resolved in a phase of its own.
+    The combined exception set contains the ICANN one, so a name with no exception
+    at all pays one set lookup per tail and never a second walk.
     """
-    tails = _psl_tails(labels)
-    if tails[-1] in exception_roots:
-        # An exception beats an ordinary match at ANY depth, so it cannot be folded
-        # into the single pass below; the TLD test keeps that two-phase walk on the
-        # rare names that can actually reach an exception rule.
-        return (
-            _psl_prevailing_section(tails, *icann_sets),
-            _psl_prevailing_section(tails, *combined_sets),
-        )
-    icann_exact, icann_wildcard, _ = icann_sets
-    public_exact, public_wildcard, _ = combined_sets
+    # Every dotted suffix of ``labels``, longest first (``tails[i]`` == labels[i:]),
+    # grown one label at a time from the right so no slice is ever re-joined.
+    tails = [labels[-1]]
+    for index in range(len(labels) - 2, -1, -1):
+        tails.append(labels[index] + "." + tails[-1])
+    tails.reverse()
+    count = len(tails)
+    icann_exact, icann_wildcard, icann_exception = icann_sets
+    public_exact, public_wildcard, public_exception = combined_sets
     icann_suffix: str | None = None
     public_suffix: str | None = None
+    icann_carved: str | None = None
+    public_carved: str | None = None
     for start, tail in enumerate(tails):
+        if tail in public_exception:
+            # Exception output drops the rule's leftmost label. Longest-first makes
+            # the first hit the longest, so later ones are ignored.
+            carved = tails[start + 1] if start + 1 < count else ""
+            if public_carved is None:
+                public_carved = carved
+            if icann_carved is None and tail in icann_exception:
+                icann_carved = carved
+        # Longest surviving suffix wins. A wildcard base at ``start`` yields the
+        # suffix labels[start-1:], one label longer than an exact rule at ``start``
+        # and the SAME string an exact rule at ``start-1`` would yield -- so the
+        # longest-first walk needs no cross-kind tie-breaking.
         if icann_suffix is None:
             if start > 0 and tail in icann_wildcard:
                 icann_suffix = tails[start - 1]
@@ -367,10 +337,11 @@ def _psl_prevailing(
             elif tail in public_exact:
                 public_suffix = tail
     unmatched = tails[-1]
-    return (
-        unmatched if icann_suffix is None else icann_suffix,
-        unmatched if public_suffix is None else public_suffix,
-    )
+    if icann_carved is None:
+        icann_carved = unmatched if icann_suffix is None else icann_suffix
+    if public_carved is None:
+        public_carved = unmatched if public_suffix is None else public_suffix
+    return icann_carved, public_carved
 
 
 def resolve_public_suffix(name: str, rules: PslRules) -> PslResolution:

--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -127,10 +127,10 @@ class PslRules:
     # keeps value equality (and the hash) a function of the rules alone; init=False
     # keeps a foreign index out of the constructor and makes dataclasses.replace
     # rebuild rather than carry the previous rules' sets.
-    _index: tuple[_PslSets, _PslSets] | None = field(default=None, compare=False, repr=False, init=False)
+    _index: _PslIndex | None = field(default=None, compare=False, repr=False, init=False)
 
-    def index(self) -> tuple[_PslSets, _PslSets]:
-        """(ICANN-only, ICANN+PRIVATE) membership sets for this rule set.
+    def index(self) -> _PslIndex:
+        """(ICANN-only sets, ICANN+PRIVATE sets, exception-root labels) for this rule set.
 
         Built once per instance. Do NOT reintroduce an lru_cache keyed on this
         dataclass: computing that key hashes all six rule tuples on every call,
@@ -261,9 +261,10 @@ def parse_psl_rules(text: str) -> PslRules:
 
 
 _PslSets = tuple[frozenset[str], frozenset[str], frozenset[str]]
+_PslIndex = tuple[_PslSets, _PslSets, frozenset[str]]
 
 
-def _psl_build_index(rules: PslRules) -> tuple[_PslSets, _PslSets]:
+def _psl_build_index(rules: PslRules) -> _PslIndex:
     """Build the (ICANN-only, ICANN+PRIVATE) (exact, wildcard, exception) sets.
 
     Called once per PslRules via PslRules.index(), which holds the result on the
@@ -281,48 +282,107 @@ def _psl_build_index(rules: PslRules) -> tuple[_PslSets, _PslSets]:
         frozenset(rules.icann_wildcard + rules.private_wildcard),
         frozenset(rules.icann_exception + rules.private_exception),
     )
-    return icann, combined
+    # Final label of every exception rule in either section. An exception can only
+    # match a tail whose last label is its own, so a name whose TLD is absent here
+    # needs no exception phase at all -- the shipped list has ~10 such rules across
+    # a handful of TLDs, so the phase is skipped for practically every feed entry.
+    exception_roots = frozenset(rule.rsplit(".", 1)[-1] for rule in combined[2])
+    return icann, combined, exception_roots
 
 
-def _psl_prevailing(
-    labels: list[str],
+def _psl_tails(labels: list[str]) -> list[str]:
+    """Every dotted suffix of ``labels``, longest first (``tails[i]`` == labels[i:]).
+
+    Built once per resolution by growing one label at a time from the right, so the
+    matcher below never re-joins a slice of the label list (issue #3061).
+    """
+    tails = [labels[-1]]
+    for index in range(len(labels) - 2, -1, -1):
+        tails.append(labels[index] + "." + tails[-1])
+    tails.reverse()
+    return tails
+
+
+def _psl_prevailing_section(
+    tails: list[str],
     exact: frozenset[str],
     wildcard: frozenset[str],
     exception: frozenset[str],
 ) -> str:
     # Exception wins outright; scanning tails longest-first makes the first hit
     # the longest match. Exception output drops the rule's leftmost label.
-    count = len(labels)
+    count = len(tails)
     for start in range(count):
-        if ".".join(labels[start:]) in exception:
-            return ".".join(labels[start + 1 :])
+        if tails[start] in exception:
+            return tails[start + 1] if start + 1 < count else ""
     # Longest surviving suffix wins. A wildcard base at ``start`` yields the
     # suffix labels[start-1:], one label longer than an exact rule at ``start``
     # and the SAME string an exact rule at ``start-1`` would yield -- so the
     # longest-first walk needs no cross-kind tie-breaking.
     for start in range(count):
-        tail = ".".join(labels[start:])
+        tail = tails[start]
         if start > 0 and tail in wildcard:
-            return ".".join(labels[start - 1 :])
+            return tails[start - 1]
         if tail in exact:
             return tail
-    return labels[-1]
+    return tails[-1]
+
+
+def _psl_prevailing(
+    labels: list[str],
+    icann_sets: _PslSets,
+    combined_sets: _PslSets,
+    exception_roots: frozenset[str],
+) -> tuple[str, str]:
+    """The (ICANN-only, ICANN+PRIVATE) prevailing suffixes from ONE walk of ``labels``.
+
+    Both are always needed -- ``private_active`` is their comparison and TLD-Allow
+    reads both -- so the sections share one walk instead of taking one each
+    (issue #3061): the tails are built once and matched against both.
+    """
+    tails = _psl_tails(labels)
+    if tails[-1] in exception_roots:
+        # An exception beats an ordinary match at ANY depth, so it cannot be folded
+        # into the single pass below; the TLD test keeps that two-phase walk on the
+        # rare names that can actually reach an exception rule.
+        return (
+            _psl_prevailing_section(tails, *icann_sets),
+            _psl_prevailing_section(tails, *combined_sets),
+        )
+    icann_exact, icann_wildcard, _ = icann_sets
+    public_exact, public_wildcard, _ = combined_sets
+    icann_suffix: str | None = None
+    public_suffix: str | None = None
+    for start, tail in enumerate(tails):
+        if icann_suffix is None:
+            if start > 0 and tail in icann_wildcard:
+                icann_suffix = tails[start - 1]
+            elif tail in icann_exact:
+                icann_suffix = tail
+        if public_suffix is None:
+            if start > 0 and tail in public_wildcard:
+                public_suffix = tails[start - 1]
+            elif tail in public_exact:
+                public_suffix = tail
+    unmatched = tails[-1]
+    return (
+        unmatched if icann_suffix is None else icann_suffix,
+        unmatched if public_suffix is None else public_suffix,
+    )
 
 
 def resolve_public_suffix(name: str, rules: PslRules) -> PslResolution:
     """Apply PSL prevailing-rule semantics for ICANN and combined sections."""
     normalized = _psl_normalize_name(name)
     labels = normalized.split(".")
-    icann_sets, combined_sets = rules.index()
-    icann_suffix = _psl_prevailing(labels, *icann_sets)
-    public_suffix = _psl_prevailing(labels, *combined_sets)
+    icann_suffix, public_suffix = _psl_prevailing(labels, *rules.index())
     suffix_labels = public_suffix.split(".")
     registrable = ".".join(labels[-len(suffix_labels) - 1 :]) if len(labels) > len(suffix_labels) else ""
     return PslResolution(
         icann_suffix=icann_suffix,
         public_suffix=public_suffix,
         registrable_domain=registrable,
-        private_active=len(public_suffix.split(".")) > len(icann_suffix.split(".")),
+        private_active=len(suffix_labels) > len(icann_suffix.split(".")),
     )
 
 
@@ -6584,9 +6644,7 @@ def _tld_allow_blocks(
     except (AttributeError, TypeError, ValueError):
         # Structurally invalid names cannot be matched safely; fail closed.
         return True
-    icann_sets, combined_sets = rules.index()
-    icann_suffix = _psl_prevailing(labels, *icann_sets)
-    public_suffix = _psl_prevailing(labels, *combined_sets)
+    icann_suffix, public_suffix = _psl_prevailing(labels, *rules.index())
     suffix_roots = {
         icann_suffix,
         public_suffix,

--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -265,7 +265,8 @@ _PslIndex = tuple[_PslSets, _PslSets, frozenset[str]]
 
 
 def _psl_build_index(rules: PslRules) -> _PslIndex:
-    """Build the (ICANN-only, ICANN+PRIVATE) (exact, wildcard, exception) sets.
+    """Build the (ICANN-only, ICANN+PRIVATE) (exact, wildcard, exception) sets, plus
+    the final label of every exception rule.
 
     Called once per PslRules via PslRules.index(), which holds the result on the
     instance, so each resolution costs O(name labels) rather than a scan over the
@@ -284,8 +285,9 @@ def _psl_build_index(rules: PslRules) -> _PslIndex:
     )
     # Final label of every exception rule in either section. An exception can only
     # match a tail whose last label is its own, so a name whose TLD is absent here
-    # needs no exception phase at all -- the shipped list has ~10 such rules across
-    # a handful of TLDs, so the phase is skipped for practically every feed entry.
+    # needs no exception phase at all. The shipped list carries 8 exception rules
+    # under 2 TLDs (ck, jp), so most names skip the phase; jp is populated enough
+    # that its names keep both section walks, and still gain the shared tails.
     exception_roots = frozenset(rule.rsplit(".", 1)[-1] for rule in combined[2])
     return icann, combined, exception_roots
 

--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -311,17 +311,16 @@ def _psl_prevailing(
     public_exact, public_wildcard, public_exception = combined_sets
     icann_suffix: str | None = None
     public_suffix: str | None = None
-    icann_carved: str | None = None
-    public_carved: str | None = None
+    icann_carved = public_carved = False
     for start, tail in enumerate(tails):
         if tail in public_exception:
             # Exception output drops the rule's leftmost label. Longest-first makes
             # the first hit the longest, so later ones are ignored.
             carved = tails[start + 1] if start + 1 < count else ""
-            if public_carved is None:
-                public_carved = carved
-            if icann_carved is None and tail in icann_exception:
-                icann_carved = carved
+            if not public_carved:
+                public_suffix, public_carved = carved, True
+            if not icann_carved and tail in icann_exception:
+                icann_suffix, icann_carved = carved, True
         # Longest surviving suffix wins. A wildcard base at ``start`` yields the
         # suffix labels[start-1:], one label longer than an exact rule at ``start``
         # and the SAME string an exact rule at ``start-1`` would yield -- so the
@@ -336,12 +335,11 @@ def _psl_prevailing(
                 public_suffix = tails[start - 1]
             elif tail in public_exact:
                 public_suffix = tail
-    unmatched = tails[-1]
-    if icann_carved is None:
-        icann_carved = unmatched if icann_suffix is None else icann_suffix
-    if public_carved is None:
-        public_carved = unmatched if public_suffix is None else public_suffix
-    return icann_carved, public_carved
+    if icann_suffix is None:
+        icann_suffix = tails[-1]
+    if public_suffix is None:
+        public_suffix = tails[-1]
+    return icann_suffix, public_suffix
 
 
 def resolve_public_suffix(name: str, rules: PslRules) -> PslResolution:

--- a/tests/test_psl_runtime_integration.py
+++ b/tests/test_psl_runtime_integration.py
@@ -587,8 +587,14 @@ kobe.jp
         ("shop.example.co.jp", "co.jp", "example.co.jp"),
         # Same exit at the TLD itself, where no deeper rule applies.
         ("shop.example.jp", "jp", "example.jp"),
-        # Wildcard base kobe.jp promotes the suffix one label to the left.
+        # Wildcard base kobe.jp promotes the suffix one label to the left. Asserted
+        # two labels deep as well, because at one label the promoted suffix is also
+        # the whole name and a matcher that ignored the depth would look correct.
         ("a.kobe.jp", "a.kobe.jp", ""),
+        ("x.y.kobe.jp", "y.kobe.jp", "x.y.kobe.jp"),
+        # A wildcard base is not itself a public suffix through the wildcard: the
+        # bare kobe.jp resolves by its exact rule, never by promoting past the name.
+        ("kobe.jp", "kobe.jp", ""),
         # The exception carves city.kobe.jp back out of that wildcard, and beats the
         # longer wildcard match it overlaps.
         ("x.city.kobe.jp", "kobe.jp", "city.kobe.jp"),
@@ -624,9 +630,11 @@ def test_an_exception_tld_resolves_through_the_two_phase_section_walk(
 
 _FUSED_WILDCARD_PSL = """// ===BEGIN ICANN DOMAINS===
 com
+nom.br
 *.nom.br
 // ===END ICANN DOMAINS===
 // ===BEGIN PRIVATE DOMAINS===
+sub.example.com
 *.sub.example.com
 // ===END PRIVATE DOMAINS===
 """
@@ -636,11 +644,20 @@ com
     ("name", "icann_suffix", "public_suffix", "private_active"),
     [
         # ICANN wildcard: the base nom.br promotes the ICANN suffix one label left.
-        # Without that arm the ICANN side falls through to the bare TLD, 'br'.
+        # Without that arm the ICANN side falls through to the bare TLD, 'br'. The
+        # deeper row is what pins WHICH label it promotes to; at one label the
+        # promoted suffix is also the whole name.
         ("a.nom.br", "a.nom.br", "a.nom.br", False),
+        ("a.b.nom.br", "b.nom.br", "b.nom.br", False),
+        # The bare wildcard base resolves by its exact rule: a wildcard needs a label
+        # to its left, so it must not fire on the whole name and promote past it.
+        ("nom.br", "nom.br", "nom.br", False),
         # PRIVATE wildcard: only the combined side sees sub.example.com, so the two
-        # sections must come out of the one pass with different answers.
+        # sections must come out of the one pass with different answers. Same depth
+        # and same bare-base rows as the ICANN arm above, for the same reasons.
         ("x.sub.example.com", "com", "x.sub.example.com", True),
+        ("x.y.sub.example.com", "com", "y.sub.example.com", True),
+        ("sub.example.com", "com", "sub.example.com", True),
     ],
 )
 def test_the_fused_pass_tracks_a_wildcard_in_each_section(

--- a/tests/test_psl_runtime_integration.py
+++ b/tests/test_psl_runtime_integration.py
@@ -682,3 +682,50 @@ def test_the_shared_walk_tracks_a_wildcard_in_each_section(
         public_suffix,
         private_active,
     ), f"the shared walk changed the resolution of {name!r}: {resolution!r}"
+
+
+_PRIVATE_EXCEPTION_PSL = """// ===BEGIN ICANN DOMAINS===
+com
+// ===END ICANN DOMAINS===
+// ===BEGIN PRIVATE DOMAINS===
+foo.com
+*.foo.com
+!x.foo.com
+// ===END PRIVATE DOMAINS===
+"""
+
+
+@pytest.mark.parametrize(
+    ("name", "public_suffix", "registrable"),
+    [
+        # The PRIVATE exception carves x.foo.com out of the PRIVATE wildcard, and
+        # must not touch the ICANN side, which knows only 'com'.
+        ("x.foo.com", "foo.com", "x.foo.com"),
+        ("a.x.foo.com", "foo.com", "x.foo.com"),
+        # A sibling the exception misses still takes the PRIVATE wildcard.
+        ("y.foo.com", "y.foo.com", ""),
+    ],
+)
+def test_a_private_exception_carves_only_the_combined_section(name: str, public_suffix: str, registrable: str) -> None:
+    """issue #3061: the carve-out is per section, and the ICANN side keeps its own.
+
+    The shared walk looks the ICANN exception set up only where the combined set
+    already matched, which is sound because the combined set is built from the ICANN
+    rules plus the PRIVATE ones. Only a PRIVATE-only exception can tell a correct
+    per-section carve from one that applies the combined hit to both, and neither the
+    shipped list nor any other authority here has one: the shipped list carries all
+    eight of its exception rules in the ICANN section. Upstream may add a PRIVATE
+    exception at any regeneration, and this row is what would notice.
+    """
+    rules = P.parse_psl_rules(_PRIVATE_EXCEPTION_PSL)
+
+    resolution = P.resolve_public_suffix(name, rules)
+
+    assert (
+        resolution.icann_suffix,
+        resolution.public_suffix,
+        resolution.registrable_domain,
+        resolution.private_active,
+    ) == ("com", public_suffix, registrable, True), (
+        f"the per-section carve changed the resolution of {name!r}: {resolution!r}"
+    )

--- a/tests/test_psl_runtime_integration.py
+++ b/tests/test_psl_runtime_integration.py
@@ -572,7 +572,9 @@ jp
 co.jp
 kobe.jp
 *.kobe.jp
+*.city.kobe.jp
 !city.kobe.jp
+!y.city.kobe.jp
 // ===END ICANN DOMAINS===
 // ===BEGIN PRIVATE DOMAINS===
 // ===END PRIVATE DOMAINS===
@@ -583,10 +585,8 @@ kobe.jp
     ("name", "public_suffix", "registrable"),
     [
         # Exact rule wins below the TLD: co.jp is longer than the bare 'jp' the
-        # no-match fallback would return, so this row fails if the exact exit goes.
+        # no-match fallback would return, so this row fails if the exact match goes.
         ("shop.example.co.jp", "co.jp", "example.co.jp"),
-        # Same exit at the TLD itself, where no deeper rule applies.
-        ("shop.example.jp", "jp", "example.jp"),
         # Wildcard base kobe.jp promotes the suffix one label to the left. Asserted
         # two labels deep as well, because at one label the promoted suffix is also
         # the whole name and a matcher that ignored the depth would look correct.
@@ -598,22 +598,24 @@ kobe.jp
         # The exception carves city.kobe.jp back out of that wildcard, and beats the
         # longer wildcard match it overlaps.
         ("x.city.kobe.jp", "kobe.jp", "city.kobe.jp"),
+        # Two exceptions match this name's tails; the longer one prevails, so the
+        # carve keeps the FIRST hit of the longest-first walk, not the last.
+        ("z.y.city.kobe.jp", "city.kobe.jp", "y.city.kobe.jp"),
+        # The shorter exception still applies on a name the longer one misses.
+        ("z.x.city.kobe.jp", "kobe.jp", "city.kobe.jp"),
     ],
 )
-def test_an_exception_tld_resolves_through_the_two_phase_section_walk(
-    name: str, public_suffix: str, registrable: str
-) -> None:
-    """issue #3061: names under a TLD that carries an exception rule take the
-    two-phase walk, and each of its three exits stays correct.
+def test_an_exception_tld_resolves_through_the_shared_walk(name: str, public_suffix: str, registrable: str) -> None:
+    """issue #3061: an exception rule carves its name out inside the shared walk.
 
-    The shared single pass cannot honour exceptions, because an exception beats an
-    ordinary match at ANY depth, so ``_psl_prevailing`` routes a name whose TLD owns
-    an exception rule to ``_psl_prevailing_section`` instead. That walk is a live
-    production path, not a corner: the shipped list carries seven of its eight
-    exception rules under jp, which also holds 1777 exact rules, so all three exits
-    -- exact, wildcard and exception -- resolve real feed entries and each gets a
-    row here. The exact row sits below the TLD on purpose, because at the TLD that
-    exit and the no-match fallback return the same string and cannot be told apart.
+    An exception beats an ordinary match at ANY depth, so the carve-out is tracked
+    alongside the ordinary match and applied at the end rather than resolved in a
+    walk of its own. These rows pin that precedence together with each ordinary
+    match kind under an exception-bearing TLD -- a live production shape, since the
+    shipped list keeps seven of its eight exception rules under jp, which also holds
+    1777 exact rules. The exact row sits below the TLD on purpose, because at the
+    TLD an exact match and the no-match fallback return the same string and cannot
+    be told apart.
     """
     rules = P.parse_psl_rules(_EXCEPTION_TLD_PSL)
 
@@ -624,7 +626,7 @@ def test_an_exception_tld_resolves_through_the_two_phase_section_walk(
         public_suffix,
         public_suffix,
         registrable,
-    ), f"the two-phase walk changed the resolution of {name!r}: {resolution!r}"
+    ), f"the shared walk changed the resolution of {name!r}: {resolution!r}"
     assert resolution.private_active is False, f"no PRIVATE rule exists, yet {name!r} reported one: {resolution!r}"
 
 
@@ -660,17 +662,16 @@ sub.example.com
         ("sub.example.com", "com", "sub.example.com", True),
     ],
 )
-def test_the_fused_pass_tracks_a_wildcard_in_each_section(
+def test_the_shared_walk_tracks_a_wildcard_in_each_section(
     name: str, icann_suffix: str, public_suffix: str, private_active: bool
 ) -> None:
     """issue #3061: the single pass matches wildcards for BOTH sections independently.
 
-    This authority has no exception rule, so every name reaches the fused pass rather
-    than the two-phase walk, and each row pins the wildcard arm of one section. The
-    ICANN arm needs its own row: the shipped list has 16 ICANN wildcard rules, 8 of
-    them under TLDs with no exception rule, and every one of those resolves through
-    this arm on every build -- but the small authorities elsewhere in the suite pair
-    their ICANN wildcards with exceptions, which routes those names away from here.
+    The two sections share one walk, so each has to carry its own wildcard state
+    through it; a row per section pins that. The ICANN row matters most: the shipped
+    list has 16 ICANN wildcard rules and every ICANN-governed name resolves through
+    that arm, while the ICANN wildcards in the other authorities here are all
+    exception-paired, which makes their names exercise the carve-out instead.
     """
     rules = P.parse_psl_rules(_FUSED_WILDCARD_PSL)
 
@@ -680,4 +681,4 @@ def test_the_fused_pass_tracks_a_wildcard_in_each_section(
         icann_suffix,
         public_suffix,
         private_active,
-    ), f"the fused pass changed the resolution of {name!r}: {resolution!r}"
+    ), f"the shared walk changed the resolution of {name!r}: {resolution!r}"

--- a/tests/test_psl_runtime_integration.py
+++ b/tests/test_psl_runtime_integration.py
@@ -516,12 +516,8 @@ def test_one_resolution_walks_the_labels_once_for_both_sections() -> None:
     """issue #3061: the ICANN-only and ICANN+PRIVATE suffixes come from ONE walk.
 
     Both suffixes are always needed -- ``private_active`` is their comparison and
-    TLD-Allow reads both -- so the walk is shared instead of run once per section.
-    Walking twice rebuilt every label tail of the name a second time, 2.23M walks
-    per 1.2M-entry build.
-
-    Counted, never timed (issue #3051): a duration cannot see the second walk, and
-    the resolution is asserted alongside the count so a broken matcher cannot pass.
+    TLD-Allow reads both -- so the walk is shared, not run once per section. The
+    resolution is asserted beside the count: one walk, and the right answer.
     """
     rules = P.parse_psl_rules(PSL)
     rules.index()  # prime: the index build is not what is being counted
@@ -544,13 +540,9 @@ def test_the_live_query_path_walks_the_labels_once_per_query() -> None:
     """issue #3061: TLD-Allow needs both suffixes too, and shares the same walk.
 
     ``_tld_allow_blocks`` compares both suffixes against the selected roots on the
-    live DNS query path, so the second caller must not reintroduce a second walk.
-
-    The query is a PRIVATE boundary under an unselected root with PRIVATE allowance
-    on, because that is the decision the two suffixes actually drive: it passes only
-    while ``public_suffix`` (github.io) is longer than ``icann_suffix`` (io). A query
-    that merely falls through to the unmatched TLD would be blocked either way and
-    could not tell the two sections apart.
+    live DNS query path. The query is a PRIVATE boundary under an unselected root
+    with PRIVATE allowance on: it is allowed only while ``public_suffix``
+    (github.io) is longer than ``icann_suffix`` (io).
     """
     rules = P.parse_psl_rules(PSL)
     containers = {**_allow_containers(rules), "tld_allow_roots": ("com",)}
@@ -585,42 +577,32 @@ w.city.kobe.jp
 @pytest.mark.parametrize(
     ("name", "public_suffix", "registrable"),
     [
-        # Exact rule wins below the TLD: co.jp is longer than the bare 'jp' the
-        # no-match fallback would return, so this row fails if the exact match goes.
+        # An exact rule below the TLD prevails over the TLD itself.
         ("shop.example.co.jp", "co.jp", "example.co.jp"),
-        # Wildcard base kobe.jp promotes the suffix one label to the left. Asserted
-        # two labels deep as well, because at one label the promoted suffix is also
-        # the whole name and a matcher that ignored the depth would look correct.
+        # A wildcard base promotes the suffix one label to the left, at any depth.
         ("a.kobe.jp", "a.kobe.jp", ""),
         ("x.y.kobe.jp", "y.kobe.jp", "x.y.kobe.jp"),
-        # A wildcard base is not itself a public suffix through the wildcard: the
-        # bare kobe.jp resolves by its exact rule, never by promoting past the name.
+        # A wildcard needs a label to its left, so the bare base resolves by its
+        # exact rule instead of promoting past the name.
         ("kobe.jp", "kobe.jp", ""),
-        # The exception carves city.kobe.jp back out of that wildcard, and beats the
-        # longer wildcard match it overlaps.
+        # An exception carves its name out of the wildcard that covers it.
         ("x.city.kobe.jp", "kobe.jp", "city.kobe.jp"),
-        # Two exceptions match this name's tails; the longer one prevails, so the
-        # carve keeps the FIRST hit of the longest-first walk, not the last.
+        # Where two exceptions match, the longest prevails.
         ("z.y.city.kobe.jp", "city.kobe.jp", "y.city.kobe.jp"),
-        # The shorter exception still applies on a name the longer one misses.
+        # The shorter exception still applies to a name the longer one misses.
         ("z.x.city.kobe.jp", "kobe.jp", "city.kobe.jp"),
-        # The exception beats an ordinary match the walk already found at a LONGER
-        # tail: w.city.kobe.jp matches its own exact rule first, and the carve one
-        # label down still overrides it.
+        # An exception prevails over an ordinary match at a longer tail:
+        # w.city.kobe.jp has its own exact rule, and the carve below it still wins.
         ("w.city.kobe.jp", "kobe.jp", "city.kobe.jp"),
     ],
 )
 def test_an_exception_tld_resolves_through_the_shared_walk(name: str, public_suffix: str, registrable: str) -> None:
     """issue #3061: an exception rule carves its name out inside the shared walk.
 
-    An exception beats an ordinary match at ANY depth, so a carve writes straight
-    into the section's suffix and locks it, rather than being resolved in a walk of
-    its own. These rows pin that precedence together with each ordinary
-    match kind under an exception-bearing TLD -- a live production shape, since the
-    shipped list keeps seven of its eight exception rules under jp, which also holds
-    1777 exact rules. The exact row sits below the TLD on purpose, because at the
-    TLD an exact match and the no-match fallback return the same string and cannot
-    be told apart.
+    An exception prevails over an ordinary match at ANY depth. These rows pin that
+    precedence beside each kind of ordinary match under an exception-bearing TLD,
+    the shape the shipped list has under jp. The exact-rule row sits below the TLD,
+    where an exact match and the no-match fallback resolve differently.
     """
     rules = P.parse_psl_rules(_EXCEPTION_TLD_PSL)
 
@@ -648,14 +630,11 @@ nom.br
 @pytest.mark.parametrize(
     ("name", "public_suffix"),
     [
-        # The base nom.br promotes the suffix one label left. Without that arm the
-        # walk falls through to the bare TLD, 'br'. The deeper row is what pins
-        # WHICH label it promotes to; at one label the promoted suffix is also the
-        # whole name.
+        # The base nom.br promotes the suffix one label left, at any depth.
         ("a.nom.br", "a.nom.br"),
         ("a.b.nom.br", "b.nom.br"),
-        # The bare wildcard base resolves by its exact rule: a wildcard needs a label
-        # to its left, so it must not fire on the whole name and promote past it.
+        # The bare base resolves by its exact rule: a wildcard needs a label to its
+        # left, so it never promotes past the whole name.
         ("nom.br", "nom.br"),
     ],
 )
@@ -663,10 +642,8 @@ def test_the_shared_walk_matches_a_wildcard_with_no_exception_in_sight(name: str
     """issue #3061: the wildcard arm carries names no exception rule can reach.
 
     This is the only authority here whose wildcard has no exception rule anywhere,
-    which is the shape most of the shipped list has: 16 ICANN wildcard rules, half
-    of them under TLDs with no exception at all. Every other authority in this file
-    pairs its wildcards with an exception, so their names also exercise the
-    carve-out and cannot show the wildcard arm standing alone.
+    the shape half the shipped list's ICANN wildcards have. Elsewhere in this file
+    every wildcard is exception-paired, so those names also exercise the carve-out.
     """
     rules = P.parse_psl_rules(_ICANN_WILDCARD_PSL)
 
@@ -707,11 +684,10 @@ def test_a_private_exception_carves_only_the_combined_section(name: str, public_
 
     The shared walk looks the ICANN exception set up only where the combined set
     already matched, which is sound because the combined set is built from the ICANN
-    rules plus the PRIVATE ones. Only a PRIVATE-only exception can tell a correct
+    rules plus the PRIVATE ones. Only a PRIVATE-only exception separates a correct
     per-section carve from one that applies the combined hit to both, and the
     shipped list has none: all eight of its exception rules sit in the ICANN
-    section. Upstream may add a PRIVATE exception at any regeneration, and these
-    rows are what would notice.
+    section, so these rows are what would notice one arriving upstream.
     """
     rules = P.parse_psl_rules(_PRIVATE_EXCEPTION_PSL)
 
@@ -743,10 +719,9 @@ def test_a_carved_tail_still_counts_as_an_ordinary_match() -> None:
 
     ``foo.com`` is both an ICANN exact rule and the PRIVATE section's exception, so
     the tail that carves the combined side is the tail that decides the ICANN side.
-    A walk that treated the carve as an alternative to the ordinary match -- the
-    shape a mis-indentation of the loop body produces -- would skip that tail and
-    let the ICANN suffix fall back to ``com``, and no other authority here can see
-    the difference because their exception rules are no ordinary rule's twin.
+    A walk that read the carve and the ordinary match as alternatives would skip
+    that tail and let the ICANN suffix fall back to ``com``. No other authority
+    here can show it: their exception rules are no ordinary rule's twin.
     """
     rules = P.parse_psl_rules(_EXCEPTION_SHADOWING_PSL)
 

--- a/tests/test_psl_runtime_integration.py
+++ b/tests/test_psl_runtime_integration.py
@@ -620,3 +620,47 @@ def test_an_exception_tld_resolves_through_the_two_phase_section_walk(
         registrable,
     ), f"the two-phase walk changed the resolution of {name!r}: {resolution!r}"
     assert resolution.private_active is False, f"no PRIVATE rule exists, yet {name!r} reported one: {resolution!r}"
+
+
+_FUSED_WILDCARD_PSL = """// ===BEGIN ICANN DOMAINS===
+com
+*.nom.br
+// ===END ICANN DOMAINS===
+// ===BEGIN PRIVATE DOMAINS===
+*.sub.example.com
+// ===END PRIVATE DOMAINS===
+"""
+
+
+@pytest.mark.parametrize(
+    ("name", "icann_suffix", "public_suffix", "private_active"),
+    [
+        # ICANN wildcard: the base nom.br promotes the ICANN suffix one label left.
+        # Without that arm the ICANN side falls through to the bare TLD, 'br'.
+        ("a.nom.br", "a.nom.br", "a.nom.br", False),
+        # PRIVATE wildcard: only the combined side sees sub.example.com, so the two
+        # sections must come out of the one pass with different answers.
+        ("x.sub.example.com", "com", "x.sub.example.com", True),
+    ],
+)
+def test_the_fused_pass_tracks_a_wildcard_in_each_section(
+    name: str, icann_suffix: str, public_suffix: str, private_active: bool
+) -> None:
+    """issue #3061: the single pass matches wildcards for BOTH sections independently.
+
+    This authority has no exception rule, so every name reaches the fused pass rather
+    than the two-phase walk, and each row pins the wildcard arm of one section. The
+    ICANN arm needs its own row: the shipped list has 16 ICANN wildcard rules, 8 of
+    them under TLDs with no exception rule, and every one of those resolves through
+    this arm on every build -- but the small authorities elsewhere in the suite pair
+    their ICANN wildcards with exceptions, which routes those names away from here.
+    """
+    rules = P.parse_psl_rules(_FUSED_WILDCARD_PSL)
+
+    resolution = P.resolve_public_suffix(name, rules)
+
+    assert (resolution.icann_suffix, resolution.public_suffix, resolution.private_active) == (
+        icann_suffix,
+        public_suffix,
+        private_active,
+    ), f"the fused pass changed the resolution of {name!r}: {resolution!r}"

--- a/tests/test_psl_runtime_integration.py
+++ b/tests/test_psl_runtime_integration.py
@@ -545,19 +545,73 @@ def test_the_live_query_path_walks_the_labels_once_per_query() -> None:
 
     ``_tld_allow_blocks`` compares both suffixes against the selected roots on the
     live DNS query path, so the second caller must not reintroduce a second walk.
+
+    The query is a PRIVATE boundary under an unselected root with PRIVATE allowance
+    on, because that is the decision the two suffixes actually drive: it passes only
+    while ``public_suffix`` (github.io) is longer than ``icann_suffix`` (io). A query
+    that merely falls through to the unmatched TLD would be blocked either way and
+    could not tell the two sections apart.
     """
     rules = P.parse_psl_rules(PSL)
-    containers = _allow_containers(rules)
-    cfg = _allow_cfg()
+    containers = {**_allow_containers(rules), "tld_allow_roots": ("com",)}
+    cfg = _allow_cfg(psl_allow_private=True)
     rules.index()  # prime: the index build is not what is being counted
     walks: list[str] = []
 
     with mock.patch.object(P, "_psl_prevailing", _counting_walk(walks)):
-        decision = P.evaluate_domain("x.example.net", "x.example.net", "net", False, cfg, containers)
+        decision = P.evaluate_domain("x.github.io", "x.github.io", "io", False, cfg, containers)
 
-    assert (decision.is_found, decision.feed) == (True, "TLD_Allow"), (
-        f"the shared walk changed the TLD-Allow decision: {decision!r}"
-    )
+    assert decision.is_found is False, f"the shared walk changed the TLD-Allow decision: {decision!r}"
     assert len(walks) == 1, (
         f"one query took {len(walks)} label walks; TLD-Allow still walks each section separately (issue #3061)"
     )
+
+
+_EXCEPTION_TLD_PSL = """// ===BEGIN ICANN DOMAINS===
+jp
+kobe.jp
+*.kobe.jp
+!city.kobe.jp
+// ===END ICANN DOMAINS===
+// ===BEGIN PRIVATE DOMAINS===
+// ===END PRIVATE DOMAINS===
+"""
+
+
+@pytest.mark.parametrize(
+    ("name", "public_suffix", "registrable"),
+    [
+        # Exact rule wins: 'jp' is the longest surviving suffix of a name with no
+        # kobe.jp ancestry, and the exception phase found nothing.
+        ("shop.example.jp", "jp", "example.jp"),
+        # Wildcard base kobe.jp promotes the suffix one label to the left.
+        ("a.kobe.jp", "a.kobe.jp", ""),
+        # The exception carves city.kobe.jp back out of that wildcard, and beats the
+        # longer wildcard match it overlaps.
+        ("x.city.kobe.jp", "kobe.jp", "city.kobe.jp"),
+    ],
+)
+def test_an_exception_tld_resolves_through_the_two_phase_section_walk(
+    name: str, public_suffix: str, registrable: str
+) -> None:
+    """issue #3061: names under a TLD that carries an exception rule take the
+    two-phase walk, and each of its three exits stays correct.
+
+    The shared single pass cannot honour exceptions, because an exception beats an
+    ordinary match at ANY depth, so ``_psl_prevailing`` routes a name whose TLD owns
+    an exception rule to ``_psl_prevailing_section`` instead. The shipped list pairs
+    exception rules with exact rules under the same TLD (8 exceptions under ck and
+    jp, 1777 exact rules under jp alone), so all three exits of that walk -- exact,
+    wildcard and exception -- are live production paths and each gets a row here.
+    """
+    rules = P.parse_psl_rules(_EXCEPTION_TLD_PSL)
+
+    resolution = P.resolve_public_suffix(name, rules)
+
+    # No PRIVATE rules in this authority, so both sections must agree.
+    assert (resolution.icann_suffix, resolution.public_suffix, resolution.registrable_domain) == (
+        public_suffix,
+        public_suffix,
+        registrable,
+    ), f"the two-phase walk changed the resolution of {name!r}: {resolution!r}"
+    assert resolution.private_active is False, f"no PRIVATE rule exists, yet {name!r} reported one: {resolution!r}"

--- a/tests/test_psl_runtime_integration.py
+++ b/tests/test_psl_runtime_integration.py
@@ -569,6 +569,7 @@ def test_the_live_query_path_walks_the_labels_once_per_query() -> None:
 
 _EXCEPTION_TLD_PSL = """// ===BEGIN ICANN DOMAINS===
 jp
+co.jp
 kobe.jp
 *.kobe.jp
 !city.kobe.jp
@@ -581,8 +582,10 @@ kobe.jp
 @pytest.mark.parametrize(
     ("name", "public_suffix", "registrable"),
     [
-        # Exact rule wins: 'jp' is the longest surviving suffix of a name with no
-        # kobe.jp ancestry, and the exception phase found nothing.
+        # Exact rule wins below the TLD: co.jp is longer than the bare 'jp' the
+        # no-match fallback would return, so this row fails if the exact exit goes.
+        ("shop.example.co.jp", "co.jp", "example.co.jp"),
+        # Same exit at the TLD itself, where no deeper rule applies.
         ("shop.example.jp", "jp", "example.jp"),
         # Wildcard base kobe.jp promotes the suffix one label to the left.
         ("a.kobe.jp", "a.kobe.jp", ""),
@@ -599,10 +602,12 @@ def test_an_exception_tld_resolves_through_the_two_phase_section_walk(
 
     The shared single pass cannot honour exceptions, because an exception beats an
     ordinary match at ANY depth, so ``_psl_prevailing`` routes a name whose TLD owns
-    an exception rule to ``_psl_prevailing_section`` instead. The shipped list pairs
-    exception rules with exact rules under the same TLD (8 exceptions under ck and
-    jp, 1777 exact rules under jp alone), so all three exits of that walk -- exact,
-    wildcard and exception -- are live production paths and each gets a row here.
+    an exception rule to ``_psl_prevailing_section`` instead. That walk is a live
+    production path, not a corner: the shipped list carries seven of its eight
+    exception rules under jp, which also holds 1777 exact rules, so all three exits
+    -- exact, wildcard and exception -- resolve real feed entries and each gets a
+    row here. The exact row sits below the TLD on purpose, because at the TLD that
+    exit and the no-match fallback return the same string and cannot be told apart.
     """
     rules = P.parse_psl_rules(_EXCEPTION_TLD_PSL)
 

--- a/tests/test_psl_runtime_integration.py
+++ b/tests/test_psl_runtime_integration.py
@@ -573,6 +573,7 @@ co.jp
 kobe.jp
 *.kobe.jp
 *.city.kobe.jp
+w.city.kobe.jp
 !city.kobe.jp
 !y.city.kobe.jp
 // ===END ICANN DOMAINS===
@@ -603,14 +604,18 @@ kobe.jp
         ("z.y.city.kobe.jp", "city.kobe.jp", "y.city.kobe.jp"),
         # The shorter exception still applies on a name the longer one misses.
         ("z.x.city.kobe.jp", "kobe.jp", "city.kobe.jp"),
+        # The exception beats an ordinary match the walk already found at a LONGER
+        # tail: w.city.kobe.jp matches its own exact rule first, and the carve one
+        # label down still overrides it.
+        ("w.city.kobe.jp", "kobe.jp", "city.kobe.jp"),
     ],
 )
 def test_an_exception_tld_resolves_through_the_shared_walk(name: str, public_suffix: str, registrable: str) -> None:
     """issue #3061: an exception rule carves its name out inside the shared walk.
 
-    An exception beats an ordinary match at ANY depth, so the carve-out is tracked
-    alongside the ordinary match and applied at the end rather than resolved in a
-    walk of its own. These rows pin that precedence together with each ordinary
+    An exception beats an ordinary match at ANY depth, so a carve writes straight
+    into the section's suffix and locks it, rather than being resolved in a walk of
+    its own. These rows pin that precedence together with each ordinary
     match kind under an exception-bearing TLD -- a live production shape, since the
     shipped list keeps seven of its eight exception rules under jp, which also holds
     1777 exact rules. The exact row sits below the TLD on purpose, because at the
@@ -703,10 +708,10 @@ def test_a_private_exception_carves_only_the_combined_section(name: str, public_
     The shared walk looks the ICANN exception set up only where the combined set
     already matched, which is sound because the combined set is built from the ICANN
     rules plus the PRIVATE ones. Only a PRIVATE-only exception can tell a correct
-    per-section carve from one that applies the combined hit to both, and neither the
-    shipped list nor any other authority here has one: the shipped list carries all
-    eight of its exception rules in the ICANN section. Upstream may add a PRIVATE
-    exception at any regeneration, and this row is what would notice.
+    per-section carve from one that applies the combined hit to both, and the
+    shipped list has none: all eight of its exception rules sit in the ICANN
+    section. Upstream may add a PRIVATE exception at any regeneration, and these
+    rows are what would notice.
     """
     rules = P.parse_psl_rules(_PRIVATE_EXCEPTION_PSL)
 

--- a/tests/test_psl_runtime_integration.py
+++ b/tests/test_psl_runtime_integration.py
@@ -499,3 +499,65 @@ def test_the_live_query_path_does_not_rebuild_the_index_per_query() -> None:
             P.evaluate_domain(name, name, "com", False, cfg, containers)
 
     assert builds == [], f"the live query path rebuilt the index {len(builds)} time(s); issue #3046 has regressed"
+
+
+def _counting_walk(walks: list[str]) -> Any:
+    """Wrap the label walk so every call is recorded and still really resolves."""
+    original = P._psl_prevailing
+
+    def counting_prevailing(*args: Any) -> Any:
+        walks.append("walk")
+        return original(*args)
+
+    return counting_prevailing
+
+
+def test_one_resolution_walks_the_labels_once_for_both_sections() -> None:
+    """issue #3061: the ICANN-only and ICANN+PRIVATE suffixes come from ONE walk.
+
+    Both suffixes are always needed -- ``private_active`` is their comparison and
+    TLD-Allow reads both -- so the walk is shared instead of run once per section.
+    Walking twice rebuilt every label tail of the name a second time, 2.23M walks
+    per 1.2M-entry build.
+
+    Counted, never timed (issue #3051): a duration cannot see the second walk, and
+    the resolution is asserted alongside the count so a broken matcher cannot pass.
+    """
+    rules = P.parse_psl_rules(PSL)
+    rules.index()  # prime: the index build is not what is being counted
+    walks: list[str] = []
+
+    with mock.patch.object(P, "_psl_prevailing", _counting_walk(walks)):
+        resolution = P.resolve_public_suffix("evil.github.io", rules)
+
+    assert (resolution.icann_suffix, resolution.public_suffix, resolution.private_active) == (
+        "io",
+        "github.io",
+        True,
+    ), f"the shared walk changed the resolution: {resolution!r}"
+    assert len(walks) == 1, (
+        f"one resolution took {len(walks)} label walks; the two sections are still walked separately (issue #3061)"
+    )
+
+
+def test_the_live_query_path_walks_the_labels_once_per_query() -> None:
+    """issue #3061: TLD-Allow needs both suffixes too, and shares the same walk.
+
+    ``_tld_allow_blocks`` compares both suffixes against the selected roots on the
+    live DNS query path, so the second caller must not reintroduce a second walk.
+    """
+    rules = P.parse_psl_rules(PSL)
+    containers = _allow_containers(rules)
+    cfg = _allow_cfg()
+    rules.index()  # prime: the index build is not what is being counted
+    walks: list[str] = []
+
+    with mock.patch.object(P, "_psl_prevailing", _counting_walk(walks)):
+        decision = P.evaluate_domain("x.example.net", "x.example.net", "net", False, cfg, containers)
+
+    assert (decision.is_found, decision.feed) == (True, "TLD_Allow"), (
+        f"the shared walk changed the TLD-Allow decision: {decision!r}"
+    )
+    assert len(walks) == 1, (
+        f"one query took {len(walks)} label walks; TLD-Allow still walks each section separately (issue #3061)"
+    )

--- a/tests/test_psl_runtime_integration.py
+++ b/tests/test_psl_runtime_integration.py
@@ -630,57 +630,48 @@ def test_an_exception_tld_resolves_through_the_shared_walk(name: str, public_suf
     assert resolution.private_active is False, f"no PRIVATE rule exists, yet {name!r} reported one: {resolution!r}"
 
 
-_FUSED_WILDCARD_PSL = """// ===BEGIN ICANN DOMAINS===
+_ICANN_WILDCARD_PSL = """// ===BEGIN ICANN DOMAINS===
 com
 nom.br
 *.nom.br
 // ===END ICANN DOMAINS===
 // ===BEGIN PRIVATE DOMAINS===
-sub.example.com
-*.sub.example.com
 // ===END PRIVATE DOMAINS===
 """
 
 
 @pytest.mark.parametrize(
-    ("name", "icann_suffix", "public_suffix", "private_active"),
+    ("name", "public_suffix"),
     [
-        # ICANN wildcard: the base nom.br promotes the ICANN suffix one label left.
-        # Without that arm the ICANN side falls through to the bare TLD, 'br'. The
-        # deeper row is what pins WHICH label it promotes to; at one label the
-        # promoted suffix is also the whole name.
-        ("a.nom.br", "a.nom.br", "a.nom.br", False),
-        ("a.b.nom.br", "b.nom.br", "b.nom.br", False),
+        # The base nom.br promotes the suffix one label left. Without that arm the
+        # walk falls through to the bare TLD, 'br'. The deeper row is what pins
+        # WHICH label it promotes to; at one label the promoted suffix is also the
+        # whole name.
+        ("a.nom.br", "a.nom.br"),
+        ("a.b.nom.br", "b.nom.br"),
         # The bare wildcard base resolves by its exact rule: a wildcard needs a label
         # to its left, so it must not fire on the whole name and promote past it.
-        ("nom.br", "nom.br", "nom.br", False),
-        # PRIVATE wildcard: only the combined side sees sub.example.com, so the two
-        # sections must come out of the one pass with different answers. Same depth
-        # and same bare-base rows as the ICANN arm above, for the same reasons.
-        ("x.sub.example.com", "com", "x.sub.example.com", True),
-        ("x.y.sub.example.com", "com", "y.sub.example.com", True),
-        ("sub.example.com", "com", "sub.example.com", True),
+        ("nom.br", "nom.br"),
     ],
 )
-def test_the_shared_walk_tracks_a_wildcard_in_each_section(
-    name: str, icann_suffix: str, public_suffix: str, private_active: bool
-) -> None:
-    """issue #3061: the single pass matches wildcards for BOTH sections independently.
+def test_the_shared_walk_matches_a_wildcard_with_no_exception_in_sight(name: str, public_suffix: str) -> None:
+    """issue #3061: the wildcard arm carries names no exception rule can reach.
 
-    The two sections share one walk, so each has to carry its own wildcard state
-    through it; a row per section pins that. The ICANN row matters most: the shipped
-    list has 16 ICANN wildcard rules and every ICANN-governed name resolves through
-    that arm, while the ICANN wildcards in the other authorities here are all
-    exception-paired, which makes their names exercise the carve-out instead.
+    This is the only authority here whose wildcard has no exception rule anywhere,
+    which is the shape most of the shipped list has: 16 ICANN wildcard rules, half
+    of them under TLDs with no exception at all. Every other authority in this file
+    pairs its wildcards with an exception, so their names also exercise the
+    carve-out and cannot show the wildcard arm standing alone.
     """
-    rules = P.parse_psl_rules(_FUSED_WILDCARD_PSL)
+    rules = P.parse_psl_rules(_ICANN_WILDCARD_PSL)
 
     resolution = P.resolve_public_suffix(name, rules)
 
+    # No PRIVATE rules in this authority, so both sections must agree.
     assert (resolution.icann_suffix, resolution.public_suffix, resolution.private_active) == (
-        icann_suffix,
         public_suffix,
-        private_active,
+        public_suffix,
+        False,
     ), f"the shared walk changed the resolution of {name!r}: {resolution!r}"
 
 
@@ -729,3 +720,36 @@ def test_a_private_exception_carves_only_the_combined_section(name: str, public_
     ) == ("com", public_suffix, registrable, True), (
         f"the per-section carve changed the resolution of {name!r}: {resolution!r}"
     )
+
+
+_EXCEPTION_SHADOWING_PSL = """// ===BEGIN ICANN DOMAINS===
+com
+foo.com
+// ===END ICANN DOMAINS===
+// ===BEGIN PRIVATE DOMAINS===
+*.com
+!foo.com
+// ===END PRIVATE DOMAINS===
+"""
+
+
+def test_a_carved_tail_still_counts_as_an_ordinary_match() -> None:
+    """issue #3061: the carve and the ordinary match are read from the SAME tail.
+
+    ``foo.com`` is both an ICANN exact rule and the PRIVATE section's exception, so
+    the tail that carves the combined side is the tail that decides the ICANN side.
+    A walk that treated the carve as an alternative to the ordinary match -- the
+    shape a mis-indentation of the loop body produces -- would skip that tail and
+    let the ICANN suffix fall back to ``com``, and no other authority here can see
+    the difference because their exception rules are no ordinary rule's twin.
+    """
+    rules = P.parse_psl_rules(_EXCEPTION_SHADOWING_PSL)
+
+    resolution = P.resolve_public_suffix("x.foo.com", rules)
+
+    assert (
+        resolution.icann_suffix,
+        resolution.public_suffix,
+        resolution.registrable_domain,
+        resolution.private_active,
+    ) == ("foo.com", "com", "foo.com", False), f"the carved tail stopped counting as an ordinary match: {resolution!r}"


### PR DESCRIPTION
## What this changes

`resolve_public_suffix()` and `_tld_allow_blocks()` each called `_psl_prevailing()` twice per
name — once for the ICANN-only sets, once for ICANN+PRIVATE — 2.23M walks per 1.2M-entry DNSBL
build (issue #3061).

The investigation the issue asked for first is answered in its
[investigation comment](https://github.com/pfBlockerNG/pfBlockerNG/issues/3061#issuecomment-5502866554):
**both suffixes are genuinely needed on both hot paths**, so nothing can be skipped —
`private_active` *is* the comparison of the two, and `_tld_allow_blocks()` tests both suffixes and
both their last labels against the selected roots before comparing their label counts. That rules
out Option A (lazy) and Option C (caller-directed). What *was* duplicated is the traversal: each
walk re-joined every label tail of the name from scratch. So this is Option B — share the walk,
keep both results.

`_psl_prevailing()` is now one function and one pass:

1. The name's dotted tails are built once, longest first, growing one label at a time from the
   right, instead of `".".join(labels[start:])` per tail per section.
2. That single pass tracks, for each section, the ordinary match — wildcard arm, then exact arm,
   with `is None` guards keeping the first, longest hit.
3. An exception rule beats an ordinary match at *any* depth, so a carve writes straight into its
   section's suffix and locks it, which is what gives it priority over both a longer ordinary
   match already found and a shorter exception found later.
   The ICANN exception lookup is gated behind the combined one, which is sound because the
   combined exception set is built as `icann_exception + private_exception` and therefore contains
   the ICANN one — so a name with no exception pays one set lookup per tail and never a second
   walk.

`PslRules.index()` keeps its `origin/devel` shape. Prevailing-rule semantics are unchanged, and
that is the point of the change: no suffix, no precedence and no PRIVATE boundary moves.

An earlier revision of this PR routed exception-bearing TLDs to a retained two-phase walk behind
an exception-root prefilter. The over-engineering review measured that apparatus against a
superset-gated inline carve and found the simpler form faster on every corpus, so it is gone: 29
production lines less than that revision, and `.jp` — a populated exception TLD — no longer keeps
two walks.

## Measured against `origin/devel`

Both modules loaded in one process and timed interleaved, median of 11 rounds x 4000 names
against the shipped `dnsbl_psl`:

| Corpus | `resolve_public_suffix` | matcher only |
| --- | --- | --- |
| realistic mix | 8.356 -> **6.897** us/call (-17.5%) | 2.831 -> **1.302** us (-54.0%) |
| all `.com` | 8.141 -> **6.707** us/call (-17.6%) | 2.758 -> **1.280** us (-53.6%) |
| all `.jp` (exception TLD) | 9.796 -> **7.991** us/call (-18.4%) | 3.275 -> **1.425** us (-56.5%) |

The end-to-end share is diluted by `_psl_normalize_name()`, which is the remaining large cost on
this path (issue #3056 covers its charset scans).

## Equivalence with `origin/devel`

Both versions loaded side by side, each parsing the shipped list, rule sets asserted equal first:

```
rule sets identical: 10248 rules
resolve_public_suffix: 51061 names, 10 raising, divergences=0
_tld_allow_blocks: 64144 checks, divergences=0
random rule sets: 48000 checks, divergences=0
VERDICT: EQUIVALENT
```

The 51,061 names cover every exception family at, above and below rule depth, every wildcard
family (including the multi-label ones) at four depths, every exact rule in both sections, IDN
pairs in both A-label and U-label form, single-label names, unknown TLDs, 253-octet and 127-label
boundaries, and names that raise — compared by exception type **and** message. The TLD-Allow
checks span 8 root selections x both `psl_allow_private` states through the lenient query
normalizer (underscore labels, trailing dots, mixed case, IDNA-refused labels). The 48,000
random-rule-set checks construct `PslRules` directly, bypassing parser validation, so they include
shapes the shipped list cannot produce: single-label exceptions, exceptions with no wildcard
family, PRIVATE-only exceptions, and several exceptions matching one name.

Not vacuous: with the ICANN carve disabled, the same harness reports 1901 divergences.

## Coverage

| Axis | Row | Covered by |
| --- | --- | --- |
| caller | `resolve_public_suffix()` (DNSBL build classifier) | `test_one_resolution_walks_the_labels_once_for_both_sections` (new) |
| caller | `_tld_allow_blocks()` (live DNS query path) | `test_the_live_query_path_walks_the_labels_once_per_query` (new) — queries a PRIVATE boundary under an unselected root with PRIVATE allowance on, the one decision the two suffixes actually drive |
| pass | ordinary match: wildcard arm, its label offset, its `start > 0` guard, exact arm | `test_the_shared_walk_matches_a_wildcard_with_no_exception_in_sight` (new, 3 rows: depth 1, depth 2 and the bare wildcard base) and `test_an_exception_tld_resolves_through_the_shared_walk` (new, 7 rows) |
| pass | exception carve: presence, its label offset, longest-of-two precedence, carve over ordinary match | `test_an_exception_tld_resolves_through_the_shared_walk` rows `x.city.kobe.jp`, `z.y.city.kobe.jp`, `z.x.city.kobe.jp` |
| pass | unmatched fallback | existing `evil.nom.br` and `foo.unknown` rows in `test_psl_resolver.py` |
| result field | `icann_suffix`, `public_suffix`, `registrable_domain`, `private_active` | existing `test_resolver_precedence_and_private_boundary` table (11 rows, unchanged) |
| index | built once per instance and equal to a direct build | existing `test_the_index_is_built_once_per_instance`, `test_the_instance_index_matches_a_direct_build` (unchanged) |

| pass | the carve is per section: the ICANN exception set is consulted only where the combined set matched | `test_a_private_exception_carves_only_the_combined_section` (new, 3 rows) — the only authority in the tree with a PRIVATE-section exception, which is what makes the distinction observable |
| pass | the carve and the ordinary match are read from the same tail | `test_a_carved_tail_still_counts_as_an_ordinary_match` (new) — an exception rule that is also an ordinary rule, so skipping the carved tail is visible |

Twenty-one mutations, one per branch, arm, offset, guard and lock of the matcher, were run against
the four PSL suites; every one is caught, each by the row that exists for it — including the five
that escaped every suite in earlier revisions of this PR: deleting the exact match, letting a
shorter exception overwrite the longest, mis-offsetting a wildcard promotion, applying the
combined section's exception to the ICANN side, and skipping the ordinary match on a carved tail.

## Red -> green (executed, test-first)

The two walk-count tests were written and run before any production edit, and the red proof still
holds at this head: with only `pfb_unbound.py` reverted to `origin/devel`,

```
FAILED test_one_resolution_walks_the_labels_once_for_both_sections
  - AssertionError: one resolution took 2 label walks; the two sections are still walked separately (issue #3061)
FAILED test_the_live_query_path_walks_the_labels_once_per_query
  - AssertionError: one query took 2 label walks; TLD-Allow still walks each section separately (issue #3061)
```

and green with it restored. The test file has been edited since that first red run — every edit
answered a review finding, and each is recorded in the audit comments below with the mutation that
justified it.

## Gates

```
$ uv run pytest -q
1 failed, 5871 passed, 7 skipped in 86.16s
$ uv run ruff check .            -> All checks passed!
$ uv run ruff format --check .   -> 534 files already formatted
$ uv run mypy tests/             -> Success: no issues found in 376 source files
```

The single pytest failure is pre-existing on `origin/devel` and unrelated to this diff —
`tests/test_issue2369_skip_gate_coverage_hostile.py::test_native_node_canary_report_is_rejected_with_exact_skip_semantics`
fails identically in a clean `devel` checkout because this host runs Node v26.8.1 while CI pins
24.19.0 and Node's JUnit reporter changed the `classname` it writes for a test inside a
`describe()` block. Tracked as #3081.

## Review

Four adversarial legs reviewed `deb6ba86`, and their findings drove three fix rounds: an untested
exact-match path, a TLD-Allow assertion its query could not discriminate, wildcard rows too
shallow to pin which label a wildcard promotes to, an exception precedence nothing defended, and
finally the over-engineering leg's blocking finding that the prefilter apparatus was removable and
slower. Every audit comment, finding and resolution is below.

Fixes #3061


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved public-suffix resolution for domains involving ICANN and private suffixes.
  - Corrected handling of wildcard rules and exception entries, including cases where exceptions overlap with ordinary suffix matches.
  - Improved consistency across standard public-suffix lookups and TLD-Allow processing.

- **Performance**
  - Reduced repeated public-suffix traversal, improving efficiency during domain resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->