### PR TITLE
noopener: scan pkg help text, not just www

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -238,7 +238,8 @@ fi
 
 # --- Forbid a target="_blank" link with no adjacent rel="noopener noreferrer"
 #     (issue #1217, reverse-tabnabbing defence). Relevant to the Web UI surface:
-#     PHP/inc pages and the wizard XML under src/usr/local/www. ---
+#     PHP/inc pages and the wizard XML under src/usr/local/www, plus the pkg help
+#     text that renders on those same pages (issue #3075). ---
 if [ "$staged_php" = 1 ] || [ "$staged_xml" = 1 ]; then
 	if exempted scripts/check_noopener.py; then
 		exempt noopener

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -310,7 +310,8 @@ jobs:
       - name: Forbid target="_blank" links with no adjacent rel="noopener noreferrer"
         # Reverse-tabnabbing defence-in-depth (issue #1217): a new-tab link whose
         # page can reach back via window.opener. Scans tracked src/usr/local/www
-        # .php/.inc/.xml (the checker's defaults). ubuntu-latest ships python3.
+        # and src/usr/local/pkg .php/.inc/.xml (the checker's defaults; pkg holds
+        # help text rendering on those pages, issue #3075). ubuntu-latest ships python3.
         run: python3 scripts/check_noopener.py
 
       - name: Forbid an on/off toggle declaring its default in the page

--- a/scripts/check_noopener.py
+++ b/scripts/check_noopener.py
@@ -35,9 +35,11 @@ tag genuinely exempt (e.g. a `target=…` inside a `<textarea>` code sample).
 The detection logic lives in :func:`find_violations` (pure, importable) so it
 is unit-tested directly without a subprocess. The :func:`main` CLI, with no
 args, resolves the file list via ``git ls-files`` — every tracked
-``src/usr/local/www/**`` file ending ``.php``/``.inc``/``.xml`` (the Web UI
-surface `target="_blank"` links live in; deliberately excludes ``tests/`` so
-this checker's own bad-input fixtures never trip its tree scan) — or scans
+``src/usr/local/www/**`` and ``src/usr/local/pkg/**`` file ending
+``.php``/``.inc``/``.xml`` (the Web UI surface `target="_blank"` links live in;
+pkg holds help text that renders on those same pages, issue #3075; deliberately
+excludes ``tests/`` so this checker's own bad-input fixtures never trip its
+tree scan) — or scans
 the explicit paths passed as args. It prints ``path:line: <message>`` to
 stderr, exiting 1 if any violation is found, or 2 if the default (argless)
 scan set could not be enumerated (git absent / not a checkout) — failing
@@ -99,11 +101,15 @@ def find_violations(text: str, source: str) -> list[Violation]:
     return violations
 
 
-def _git_tracked_www() -> list[str]:
-    """Return tracked src/usr/local/www files ending .php/.inc/.xml (sorted)."""
+def _git_tracked_ui() -> list[str]:
+    """Return tracked www + pkg files ending .php/.inc/.xml (sorted).
+
+    pkg carries help text that renders on the www pages, so it is the same
+    link surface and needs the same gate (issue #3075).
+    """
     try:
         out = subprocess.run(
-            ["git", "ls-files", "-z", "src/usr/local/www"],
+            ["git", "ls-files", "-z", "src/usr/local/www", "src/usr/local/pkg"],
             capture_output=True,
             text=True,
             check=True,
@@ -130,13 +136,14 @@ def main(argv: list[str] | None = None) -> int:
     if args:
         paths = args
     else:
-        paths = _git_tracked_www()
+        paths = _git_tracked_ui()
         # Fail CLOSED: an empty default scan set means `git ls-files` could not
-        # enumerate the Web UI tree (git absent / not a checkout) -- this repo always
+        # enumerate the UI trees (git absent / not a checkout) -- this repo always
         # has such files -- so error rather than exit 0 and silently skip the gate.
         if not paths:
             print(
-                "check_noopener: `git ls-files src/usr/local/www` returned nothing "
+                "check_noopener: `git ls-files src/usr/local/www src/usr/local/pkg` "
+                "returned nothing "
                 "(git unavailable or not a checkout) -- failing closed rather than "
                 "skipping the gate.",
                 file=sys.stderr,

--- a/scripts/check_noopener.py
+++ b/scripts/check_noopener.py
@@ -38,9 +38,8 @@ args, resolves the file list via ``git ls-files`` — every tracked
 ``src/usr/local/www/**`` and ``src/usr/local/pkg/**`` file ending
 ``.php``/``.inc``/``.xml`` (the Web UI surface `target="_blank"` links live in;
 pkg holds help text that renders on those same pages, issue #3075; deliberately
-excludes ``tests/`` so this checker's own bad-input fixtures never trip its
-tree scan) — or scans
-the explicit paths passed as args. It prints ``path:line: <message>`` to
+excludes ``tests/`` so this checker's own bad-input fixtures never trip its tree
+scan) — or scans the explicit paths passed as args. It prints ``path:line: <message>`` to
 stderr, exiting 1 if any violation is found, or 2 if the default (argless)
 scan set could not be enumerated (git absent / not a checkout) — failing
 closed rather than silently passing a gate it could not run.

--- a/scripts/check_noopener.py
+++ b/scripts/check_noopener.py
@@ -102,11 +102,7 @@ def find_violations(text: str, source: str) -> list[Violation]:
 
 
 def _git_tracked_ui() -> list[str]:
-    """Return tracked www + pkg files ending .php/.inc/.xml (sorted).
-
-    pkg carries help text that renders on the www pages, so it is the same
-    link surface and needs the same gate (issue #3075).
-    """
+    """Return tracked www + pkg files ending .php/.inc/.xml (sorted)."""
     try:
         out = subprocess.run(
             ["git", "ls-files", "-z", "src/usr/local/www", "src/usr/local/pkg"],
@@ -142,8 +138,7 @@ def main(argv: list[str] | None = None) -> int:
         # has such files -- so error rather than exit 0 and silently skip the gate.
         if not paths:
             print(
-                "check_noopener: `git ls-files src/usr/local/www src/usr/local/pkg` "
-                "returned nothing "
+                "check_noopener: `git ls-files src/usr/local/www src/usr/local/pkg` returned nothing "
                 "(git unavailable or not a checkout) -- failing closed rather than "
                 "skipping the gate.",
                 file=sys.stderr,

--- a/tests/test_noopener_check.py
+++ b/tests/test_noopener_check.py
@@ -294,13 +294,11 @@ def test_main_returns_0_on_clean_file(tmp_path: Path, capsys: pytest.CaptureFixt
 def test_default_scan_set_covers_both_ui_trees(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    # issue #3075: help text under src/usr/local/pkg renders on the same pages as
-    # src/usr/local/www and carries the same external links, but the ARGLESS default
-    # scan set -- the one the pre-commit hook and CI both run -- saw only www.
-    #
-    # A violation is planted in BOTH trees and both paths are asserted in stderr, so
-    # dropping either pathspec fails: rc alone cannot tell "both scanned" from
-    # "one scanned", and the rc-only form let a www-dropping regression ship green.
+    # issue #3075: pkg help text renders on the www pages and carries the same
+    # external links, so the ARGLESS default set -- the one the pre-commit hook and
+    # CI both run -- must cover both trees. A violation is planted in each and both
+    # paths are asserted, because the exit code alone cannot distinguish "both
+    # scanned" from "one scanned".
     env = scrubbed_git_env(drop_git_vars=True)
     for name in [k for k in os.environ if k.startswith("GIT_")]:
         monkeypatch.delenv(name)
@@ -315,8 +313,8 @@ def test_default_scan_set_covers_both_ui_trees(
     pkg.mkdir(parents=True)
     (www / "dirty.php").write_text('<a target="_blank" href="https://example.invalid">\n')
     (pkg / "help.inc").write_text('<a target="_blank" href="https://example.invalid">\n')
-    # A violation OUTSIDE both trees: the set must be limited to www + pkg, not
-    # merely include them -- dropping the pathspec entirely would scan this too.
+    # docs/ is outside the default scan set: the set must be LIMITED to www + pkg,
+    # not merely include them.
     outside = tmp_path / "docs"
     outside.mkdir()
     (outside / "stray.php").write_text('<a target="_blank" href="https://example.invalid">\n')
@@ -350,8 +348,8 @@ def test_main_fails_closed_when_default_scan_set_unenumerable(
 def test_ui_trees_clean(monkeypatch: pytest.MonkeyPatch) -> None:
     """Every tracked www + pkg .php/.inc/.xml file is noopener-clean.
 
-    Enumerated by the production helper, not a copy of its pathspec, so this guard
-    cannot drift from the set the gate actually scans (issue #3075).
+    Enumerated by the production helper rather than a copy of its pathspec
+    (issue #3075).
     """
     monkeypatch.chdir(_REPO_ROOT)
     files = cno._git_tracked_ui()

--- a/tests/test_noopener_check.py
+++ b/tests/test_noopener_check.py
@@ -288,6 +288,25 @@ def test_main_returns_0_on_clean_file(tmp_path: Path, capsys: pytest.CaptureFixt
     assert capsys.readouterr().err == ""
 
 
+def test_default_scan_set_covers_pkg_help_text(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # issue #3075: help text under src/usr/local/pkg renders on the same pages as
+    # src/usr/local/www and carries the same external links, but the ARGLESS default
+    # scan set -- the one the pre-commit hook and CI both run -- saw only www, so a
+    # missing rel= on a live link shipped ungated. A clean www file is present so the
+    # set is non-empty: this pins that pkg is scanned, not merely that something was.
+    monkeypatch.chdir(tmp_path)
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+    www = tmp_path / "src/usr/local/www/pfblockerng"
+    pkg = tmp_path / "src/usr/local/pkg/pfblockerng"
+    www.mkdir(parents=True)
+    pkg.mkdir(parents=True)
+    (www / "clean.php").write_text('<a target="_blank" rel="noopener noreferrer" href="x">\n')
+    (pkg / "help.inc").write_text('<a target="_blank" href="https://example.invalid">\n')
+    subprocess.run(["git", "add", "-A"], cwd=tmp_path, check=True)
+
+    assert cno.main([]) == 1
+
+
 def test_main_fails_closed_when_default_scan_set_unenumerable(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:

--- a/tests/test_noopener_check.py
+++ b/tests/test_noopener_check.py
@@ -315,12 +315,18 @@ def test_default_scan_set_covers_both_ui_trees(
     pkg.mkdir(parents=True)
     (www / "dirty.php").write_text('<a target="_blank" href="https://example.invalid">\n')
     (pkg / "help.inc").write_text('<a target="_blank" href="https://example.invalid">\n')
+    # A violation OUTSIDE both trees: the set must be limited to www + pkg, not
+    # merely include them -- dropping the pathspec entirely would scan this too.
+    outside = tmp_path / "docs"
+    outside.mkdir()
+    (outside / "stray.php").write_text('<a target="_blank" href="https://example.invalid">\n')
     subprocess.run(["git", "add", "-A"], cwd=tmp_path, check=True)
 
     assert cno.main([]) == 1
     err = capsys.readouterr().err
     assert "src/usr/local/www/pfblockerng/dirty.php:1:" in err
     assert "src/usr/local/pkg/pfblockerng/help.inc:1:" in err
+    assert "docs/stray.php" not in err
 
 
 def test_main_fails_closed_when_default_scan_set_unenumerable(
@@ -341,22 +347,14 @@ def test_main_fails_closed_when_default_scan_set_unenumerable(
 # --------------------------------------------------------------------------- #
 
 
-def test_ui_trees_clean() -> None:
+def test_ui_trees_clean(monkeypatch: pytest.MonkeyPatch) -> None:
     """Every tracked www + pkg .php/.inc/.xml file is noopener-clean.
 
-    Routed through the production helper (issue #3075) so this guard cannot drift
-    from the set the gate actually scans, as it did while it hand-copied the
-    pathspec.
+    Enumerated by the production helper, not a copy of its pathspec, so this guard
+    cannot drift from the set the gate actually scans (issue #3075).
     """
-    monkeypatch_free_cwd = _REPO_ROOT
-    out = subprocess.run(
-        ["git", "ls-files", "-z", "src/usr/local/www", "src/usr/local/pkg"],
-        cwd=monkeypatch_free_cwd,
-        capture_output=True,
-        text=True,
-        check=True,
-    ).stdout
-    files = sorted(p for p in out.split("\0") if p and p.endswith((".php", ".inc", ".xml")))
+    monkeypatch.chdir(_REPO_ROOT)
+    files = cno._git_tracked_ui()
     assert len(files) >= 26  # sanity: 16 www coverage-matrix files + the pkg tree
 
     all_violations: list[Any] = []

--- a/tests/test_noopener_check.py
+++ b/tests/test_noopener_check.py
@@ -13,12 +13,15 @@ importable directly by path via importlib.
 from __future__ import annotations
 
 import importlib.util
+import os
 import subprocess
 import sys
 from pathlib import Path
 from typing import Any
 
 import pytest
+
+from tests.gitenv import scrubbed_git_env
 
 # --------------------------------------------------------------------------- #
 # Load the script as a module.
@@ -288,23 +291,36 @@ def test_main_returns_0_on_clean_file(tmp_path: Path, capsys: pytest.CaptureFixt
     assert capsys.readouterr().err == ""
 
 
-def test_default_scan_set_covers_pkg_help_text(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_default_scan_set_covers_both_ui_trees(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
     # issue #3075: help text under src/usr/local/pkg renders on the same pages as
     # src/usr/local/www and carries the same external links, but the ARGLESS default
-    # scan set -- the one the pre-commit hook and CI both run -- saw only www, so a
-    # missing rel= on a live link shipped ungated. A clean www file is present so the
-    # set is non-empty: this pins that pkg is scanned, not merely that something was.
+    # scan set -- the one the pre-commit hook and CI both run -- saw only www.
+    #
+    # A violation is planted in BOTH trees and both paths are asserted in stderr, so
+    # dropping either pathspec fails: rc alone cannot tell "both scanned" from
+    # "one scanned", and the rc-only form let a www-dropping regression ship green.
+    env = scrubbed_git_env(drop_git_vars=True)
+    for name in [k for k in os.environ if k.startswith("GIT_")]:
+        monkeypatch.delenv(name)
+    monkeypatch.setenv("GIT_CONFIG_GLOBAL", env["GIT_CONFIG_GLOBAL"])
+    monkeypatch.setenv("GIT_CONFIG_SYSTEM", env["GIT_CONFIG_SYSTEM"])
     monkeypatch.chdir(tmp_path)
+
     subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
     www = tmp_path / "src/usr/local/www/pfblockerng"
     pkg = tmp_path / "src/usr/local/pkg/pfblockerng"
     www.mkdir(parents=True)
     pkg.mkdir(parents=True)
-    (www / "clean.php").write_text('<a target="_blank" rel="noopener noreferrer" href="x">\n')
+    (www / "dirty.php").write_text('<a target="_blank" href="https://example.invalid">\n')
     (pkg / "help.inc").write_text('<a target="_blank" href="https://example.invalid">\n')
     subprocess.run(["git", "add", "-A"], cwd=tmp_path, check=True)
 
     assert cno.main([]) == 1
+    err = capsys.readouterr().err
+    assert "src/usr/local/www/pfblockerng/dirty.php:1:" in err
+    assert "src/usr/local/pkg/pfblockerng/help.inc:1:" in err
 
 
 def test_main_fails_closed_when_default_scan_set_unenumerable(
@@ -325,17 +341,23 @@ def test_main_fails_closed_when_default_scan_set_unenumerable(
 # --------------------------------------------------------------------------- #
 
 
-def test_www_tree_clean() -> None:
-    """Every tracked src/usr/local/www .php/.inc/.xml file is noopener-clean."""
+def test_ui_trees_clean() -> None:
+    """Every tracked www + pkg .php/.inc/.xml file is noopener-clean.
+
+    Routed through the production helper (issue #3075) so this guard cannot drift
+    from the set the gate actually scans, as it did while it hand-copied the
+    pathspec.
+    """
+    monkeypatch_free_cwd = _REPO_ROOT
     out = subprocess.run(
-        ["git", "ls-files", "-z", "src/usr/local/www"],
-        cwd=_REPO_ROOT,
+        ["git", "ls-files", "-z", "src/usr/local/www", "src/usr/local/pkg"],
+        cwd=monkeypatch_free_cwd,
         capture_output=True,
         text=True,
         check=True,
     ).stdout
     files = sorted(p for p in out.split("\0") if p and p.endswith((".php", ".inc", ".xml")))
-    assert len(files) >= 16  # sanity: the coverage-matrix file set must be present
+    assert len(files) >= 26  # sanity: 16 www coverage-matrix files + the pkg tree
 
     all_violations: list[Any] = []
     for rel_path in files:


### PR DESCRIPTION
Fixes #3075

`scripts/check_noopener.py` resolved its argless default set from
`git ls-files src/usr/local/www`, and **both** callers invoke it argless —
`.githooks/pre-commit:247` and `.github/workflows/test.yml:314`. Help text under
`src/usr/local/pkg` renders on those same pages and carries the same external
links, so a missing `rel="noopener noreferrer"` there passed the repo-wide gate.

## What changed

The default now enumerates both trees. Neither call site needed editing — they
rely on the default, which is what made the narrow set invisible.

The helper is renamed `_git_tracked_www` → `_git_tracked_ui`. It has no other
callers (`grep` across `*.py`/`*.sh`/`*.yml` returns only its definition and its
one use), and a name saying `www` while enumerating two trees is how the next
reader gets misled. The fail-closed diagnostic now names both paths too,
otherwise it would tell an operator to check a command that is not the one that
ran.

## Test-first proof

Executed. The reproduction seeds a **clean** `www` file alongside the violating
`pkg` file, so the default set is non-empty — this pins that `pkg` is scanned,
not merely that something was.

```
$ git show origin/devel:scripts/check_noopener.py > scripts/check_noopener.py
$ uv run --locked pytest tests/test_noopener_check.py -q -p no:randomly
FAILED tests/test_noopener_check.py::test_default_scan_set_covers_both_ui_trees
FAILED tests/test_noopener_check.py::test_ui_trees_clean
2 failed, 143 passed

$ # production file restored
$ uv run --locked pytest tests/test_noopener_check.py -q -p no:randomly
145 passed
```

The test plants a violation in **both** trees and asserts both paths in stderr,
so it fails in either direction: a www-only default omits the pkg path, and a
pkg-only default omits the www path. Exit code alone cannot distinguish "both
scanned" from "one scanned" — see round 1.

| Frozen RED test | git hash-object | RED run tail |
| --- | --- | --- |
| `tests/test_noopener_check.py` | `8894237ae9edcbc6197835b12acaebe2e72a557d` | `2 failed, 143 passed` — `test_default_scan_set_covers_both_ui_trees` FAILED on the pkg path being absent from stderr under the www-only default (the discriminating signal), and `test_ui_trees_clean` FAILED with `AttributeError` because it calls `_git_tracked_ui()`, which does not exist under devel's `_git_tracked_www` |

## Verified independently, not taken from the issue

- Argless gate on the real repo after widening: **rc=0**. Widening is
  frictionless; nothing needed fixing first.
- Scan coverage grows **25 → 35 files** (+10 under `pkg`).
- Two pkg files carry HTML `target="_blank"` and were ungated:
  `pfblockerng.inc`, `pfblockerng_geoip.inc`.

**Correction to the issue:** it states "Three files under `pkg/` already carry
`target="_blank"`". The third is `pfb_unbound.py`, whose matches are
`threading.Thread(target=…)` — a Python keyword argument, not an HTML attribute.
It is also a `.py`, which this checker's extension filter never scanned and
still does not. The real figure is two.

## Not in this PR

While confirming the above I found a **detection gap unrelated to the scan set**:
`find_violations` does not match backslash-escaped quotes, the form HTML takes
inside a PHP double-quoted string.

```
target=\"_blank\" href=\"…\"   -> []            (missed)
target="_blank" href="…"       -> 1 violation
```

There is a live instance at `pfblockerng_geoip.inc:681` with no adjacent `rel=`.
Its destination is same-origin (`/firewall_aliases.php`), so reverse tabnabbing
is not the threat there and this PR does not need to fix anything — but an
*external* link written that way would be missed just as silently, and widening
the scan into `pkg` makes that shape far more likely to appear, since `.inc`
help text is exactly where escaped-quote HTML lives. Filed separately rather
than folded in.

## Review round 1

Four adversarial legs per `landing.md`, each sandboxed, audits posted above.

| Leg | Model | Outcome |
| --- | --- | --- |
| Contract conformance | `claude-opus-5` | 1 blocking, 2 nitpick, 2 outside-diff |
| Correctness + hostile inputs | `claude-fable-5` | 0 blocking, 3 nitpick, 2 outside-diff |
| Test honesty | `claude-sonnet-5` | 0 blocking, 1 nitpick (a real coverage hole) |
| Over-engineering | `claude-fable-5` | 0 blocking, 4 nitpick, 11 lines removable |

All three findings I took were mine, and two are worth naming plainly.

**The test proved the wrong half.** It asserted only the exit code, so a
regression dropping `www` while keeping `pkg` passed the full suite 145/0 —
it pinned that pkg was *added*, never that www *stayed*. This is the same shape
as a guard arm missed on #3010 earlier: widen a set to two members, test only
the new one. Both directions are now pinned, verified by mutation:

| Mutation | Result |
| --- | --- |
| www-only (pre-fix) | fails — pkg path absent from stderr |
| pkg-only (drop www) | fails — www path absent from stderr; **shipped green before** |

**The scratch repo could destroy a developer's index.** It used bare `git init` /
`git add -A` with no environment scrub. The correctness leg demonstrated that
under a leaked `GIT_INDEX_FILE` — exactly what git exports to `pre-commit` — the
test rewrites the real repository's index *and still passes*. `tests/gitenv.py`
is the repo's stated mechanism for this and I did not use it. Now scrubbed via
`monkeypatch`, which matters because the checker under test also shells out to
git inheriting `os.environ`, so `env=` on the fixture calls alone would not have
covered it.

Also fixed: `test_www_tree_clean` hand-copied the www pathspec, leaving the
in-suite guard narrow while the gate widened (renamed `test_ui_trees_clean`); both
callers' comments still described the www-only default — my own justification for
renaming the helper indicted them; and the `:228` citation above was from a stale
local `devel`, corrected to `:247`.

Declined one nitpick with reason: dropping the extra fixture file would still be
red→green, but its RED would say "the set was empty and fail-closed fired" rather
than naming the actual defect.

**Two outside-diff findings filed rather than folded in:** `check_toggle_registry.py`
has the same narrow-default shape (root `src/usr/local/www/pfblockerng`, with two
qualifying files outside it), and #3085's severity was under-graded — see that
issue, updated with corrected evidence.

## Review round 2

All four legs re-run on small tier at `c8ab4ed2`, each given its round-1 audit to re-check. Audits posted above. **No blocking findings**; every round-1 finding verified fixed by execution rather than by reading my audit.

Two verifications worth calling out, because they checked *me* rather than the code:

- The correctness leg **re-ran the original exploit**: a real outer repo with a tracked file, the test invoked under a leaked `GIT_INDEX_FILE`, `GIT_DIR`, `GIT_WORK_TREE`, `GIT_PREFIX`, and a hostile global config pointing `core.hooksPath` at a live hook. The outer index survives all of them and the hostile hook never runs. It also proved the scrub reaches the *checker*, not just the fixture, by asserting on `os.environ` immediately before `cno.main([])`.
- The over-engineering leg found I had recorded a round-1 nitpick as **taken when it never landed** — the module-docstring reflow — by diffing the two heads instead of trusting the audit. Applied in `0650de18`.

**Two further findings, both taken:**

**The docstring I wrote while fixing the hand-copied pathspec was itself false.** It claimed `test_ui_trees_clean` was "routed through the production helper"; it still hand-rolled both the pathspec and the extension filter. A leg proved it by narrowing the production filter and watching the guard stay green. It now actually calls `_git_tracked_ui()`.

**The rewritten test proved membership, not bounds.** Dropping the pathspec entirely — scanning the whole repository — still passed, because the fixture contained only the two planted files. A violation outside both trees, asserted absent from stderr, closes it.

Every pathspec and filter mutation now fails, and two of them did not before:

| Mutation | Round 1 | Round 2 | Now |
| --- | --- | --- | --- |
| www-only (pre-fix) | caught | caught | caught |
| pkg-only | **green** | caught | caught |
| no pathspec (scan all) | — | **green** | caught |
| narrowed extension filter | — | **green** | caught |

One leg's proposal was **probed and declined by the leg itself**: the 4-line env-scrub cannot be shortened to the `env=scrubbed_git_env(...)` form other tests use, because `_git_tracked_ui()`'s `subprocess.run` has no `env=` and inherits the real process environment. `monkeypatch.setattr(os, "environ", ...)` was also tried and fails for the same reason. The current form is minimal.

The `>= 26` sanity floor was independently checked by two legs: www = 25, pkg = 10, combined = 35, so it fails if either tree drops out and cannot be tripped by adding files.

## CodeRabbit

FINISHED on this head. Zero inline comments; one nitpick in the review body — enumerated across all three surfaces (`pulls/N/comments`, `pulls/N/reviews`, `issues/N/comments`) rather than read off the summary.

**Nitpick: gate-facing narration in changed source comments.** It maps to a real repo rule — `coding.md` bans "correctness argument aimed at gate/reviewer" in committed comments. Four locations named; **three taken, one declined.**

Taken, because they described mutation behaviour and review history rather than the contract under test:

- `test_noopener_check.py:297-303` — dropped "the rc-only form let a www-dropping regression ship green"; kept why both paths are asserted.
- `:318-319` — dropped "dropping the pathspec entirely would scan this too"; kept the bound it pins (the set must be **limited** to www + pkg, not merely include them).
- `:353-354` — dropped the gate-drift clause; kept that enumeration comes from the production helper.

**Declined: `check_noopener.py:41-42`.** That prose is **pre-existing** — it appears in the diff only because my paragraph reflow re-wrapped the line it sits on. It states a constraint the code cannot show (why `tests/` is excluded from the tree scan), which `coding.md` explicitly permits, and rewriting untouched prose under a nitpick would widen the diff for no gain.

`check_comment_narration.py --diff origin/devel` exits 0 both before and after — this was a budget/style judgement, not a gate violation.

Per `coderabbit.md` this PR does not earn a second ask: nothing about product behaviour changed, only comments.
