### PR TITLE
install: serialise package installation against an in-flight feed pass

### DIFF
--- a/docs/misc/architecture-notes.md
+++ b/docs/misc/architecture-notes.md
@@ -1576,7 +1576,7 @@ are deliberately unguarded (`bls` runs synchronously inside a pass — a pass-le
 deadlock the parent). The lock is kernel-released on process death; a crashed pass never wedges
 scheduling.
 
-**The package install is the third holder (issue #3062).** `pfblockerng_install.inc` restages the
+**The package install holds it too (issue #3062).** `pfblockerng_install.inc` restages the
 Unbound chroot (`pfblockerng.sh dnsbl_cache stage`), drops cache databases, and stops/starts the pfB
 services — the same files and daemon a pass publishes into — so it takes the same lock before it
 touches any of them (`pfb_install_feed_pass_hold()`, right after `pfb_global()`) and keeps it until
@@ -1586,8 +1586,11 @@ one holder that **waits** rather than skipping: `pfb_feed_pass_acquire()`'s opti
 `PFB_INSTALL_FEED_PASS_WAIT` (300 s). The wait is bounded and failure is non-fatal, because a
 half-installed package is worse than an overlap: on expiry the install proceeds and logs
 `Package install proceeding WITHOUT the feed-pass lock` to `pfblockerng.log` and syslog
-(`LOG_WARNING`). While the hold stands, a tick firing mid-install defers exactly like any other
-contender.
+(`LOG_WARNING`) — so a pass longer than the budget (a large multi-feed download) still overlaps, it
+is just no longer silent. While the hold stands, a tick firing mid-install defers exactly like any
+other contender. It is also the one holder that takes this lock **without** the dispatcher lock
+first; that inverts the order every other holder uses, and cannot deadlock only because every
+non-install feed-pass acquire is non-blocking and every dispatcher acquire is bounded.
 
 **The due-ledger** is a single JSON sidecar `pfb_due_ledger.json` under `$pfb['dbdir']`, one entry
 per job/feed: `{last_run, next_due, jitter}`. Pure, clock+seed-injectable helpers in

--- a/docs/misc/architecture-notes.md
+++ b/docs/misc/architecture-notes.md
@@ -1559,11 +1559,12 @@ job's next due slot. `clearip`/`cleardnsbl` (ADR-30) and
 non-pfB cron jobs are left untouched; install/teardown stays idempotent via `pfblockerng_cron_exists`,
 and a pre-ADR-43 install's old fleet jobs are removed on the next `sync_package_pfblockerng()`.
 
-**Feed-pass serialization (issue #1175):** feed passes are mutually exclusive via a cross-process,
-non-blocking flock (`pfb_feed_pass.lock` under `$pfb['dbdir']`; helpers `pfb_feed_pass_*` in
+**Feed-pass serialization (issue #1175):** feed passes are mutually exclusive via a cross-process
+flock (`pfb_feed_pass.lock` under `$pfb['dbdir']`; helpers `pfb_feed_pass_*` in
 `pfblockerng.inc`). Both funnels — `sync_package_pfblockerng()` and `pfblockerng_sync_cron()` —
-acquire it at entry (`pfb_feed_pass_begin()`) and skip with a logged message when another pass
-holds it; the tick pre-checks a busy probe and **defers** (not skips) a busy feed-cron dispatch via
+acquire it **non-blocking** at entry (`pfb_feed_pass_begin()`) and skip with a logged message when
+another pass holds it; the tick pre-checks a busy probe and **defers** (not skips) a busy feed-cron
+dispatch via
 the existing `pending` mechanism, so the run retries next tick. A lock deferral (dispatcher or
 feed-pass) exits **0** for the unattended shapes — the array request `trigger=cron force=false`
 (issue #2505) and the bare `cron` verb (issue #2491) — because the pass stands down with its durable
@@ -1574,6 +1575,19 @@ outside `pfblockerng.log`. The `bl`/`bls`/`dcc` download verbs
 are deliberately unguarded (`bls` runs synchronously inside a pass — a pass-level lock there would
 deadlock the parent). The lock is kernel-released on process death; a crashed pass never wedges
 scheduling.
+
+**The package install is the third holder (issue #3062).** `pfblockerng_install.inc` restages the
+Unbound chroot (`pfblockerng.sh dnsbl_cache stage`), drops cache databases, and stops/starts the pfB
+services — the same files and daemon a pass publishes into — so it takes the same lock before it
+touches any of them (`pfb_install_feed_pass_hold()`, right after `pfb_global()`) and keeps it until
+the install process exits, which is what lets the post-install resync reenter the hold. It is the
+one holder that **waits** rather than skipping: `pfb_feed_pass_acquire()`'s optional `$timeout_s`
+(default `0.0` — the single non-blocking attempt every dispatcher must keep) is set to
+`PFB_INSTALL_FEED_PASS_WAIT` (300 s). The wait is bounded and failure is non-fatal, because a
+half-installed package is worse than an overlap: on expiry the install proceeds and logs
+`Package install proceeding WITHOUT the feed-pass lock` to `pfblockerng.log` and syslog
+(`LOG_WARNING`). While the hold stands, a tick firing mid-install defers exactly like any other
+contender.
 
 **The due-ledger** is a single JSON sidecar `pfb_due_ledger.json` under `$pfb['dbdir']`, one entry
 per job/feed: `{last_run, next_due, jitter}`. Pure, clock+seed-injectable helpers in

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -19157,17 +19157,13 @@ function pfb_feed_pass_begin(string $label, ?bool &$contended = NULL): bool {
 	return FALSE;
 }
 
+
 // Seconds a package install waits for an in-flight feed pass before it proceeds anyway.
 define('PFB_INSTALL_FEED_PASS_WAIT', 300.0);
 
-// issue #3062: a package install restages the Unbound chroot ('dnsbl_cache stage'),
-// drops caches, and stops/starts the pfB services -- the same files and daemon a feed
-// pass publishes into, and nothing serialised the two. Take the feed-pass lock and keep
-// it for the rest of the install process (pfb_feed_pass_release() runs at shutdown), so
-// an in-flight pass finishes first and a tick firing mid-install defers like any other
-// contender. Bounded, and FALSE never aborts the caller: a half-installed package is
-// worse than an overlap, so the install proceeds and the overlap is logged as the
-// evidence a post-install DNS failure is traced with.
+// issue #3062: the install's hold on the feed-pass lock -- waits, then keeps it until this
+// process exits (pfb_feed_pass_release() at shutdown). FALSE never aborts the caller: an
+// install may not be abandoned. architecture-notes.md "The package install is the third holder".
 function pfb_install_feed_pass_hold(float $timeout_s = PFB_INSTALL_FEED_PASS_WAIT): bool {
 	if (pfb_feed_pass_busy()) {
 		pfb_logger("\nPackage install: waiting up to {$timeout_s}s for the in-flight feed pass to finish.\n", 1);

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -19062,12 +19062,15 @@ function pfb_feed_pass_deferral_message(string $deferred_by): string {
 	return "pfBlockerNG feed pass deferred: {$lock} is held\n";
 }
 
-// issue #1175: cross-process, non-blocking mutual exclusion for a feed pass --
+// issue #1175: cross-process mutual exclusion for a feed pass --
 // pfb_feed_task_running()/pfb_update_pass_running() above are ps-scan guards
 // (advisory-by-process-list); this flock-based sibling actually serializes two
 // overlapping passes so they cannot corrupt shared recompute staging. Reentrant
 // within a process: a second acquire by the same process is a no-op success.
-function pfb_feed_pass_acquire(?bool &$contended = NULL): bool {
+// $timeout_s defaults to 0.0 -- one non-blocking attempt, the only shape a feed-pass
+// dispatcher may use (it defers instead of queueing). Package installation waits
+// (issue #3062, pfb_install_feed_pass_hold()) because it cannot be deferred.
+function pfb_feed_pass_acquire(?bool &$contended = NULL, float $timeout_s = 0.0): bool {
 	global $pfb;
 	$contended = FALSE;
 
@@ -19084,10 +19087,8 @@ function pfb_feed_pass_acquire(?bool &$contended = NULL): bool {
 		pfb_logger("\n Feed pass lock: open failed [ {$lockpath} ]; feed pass aborted.\n", 2);
 		return FALSE;
 	}
-	$would_block = 0;
-	if (!@flock($lock, LOCK_EX | LOCK_NB, $would_block)) {
+	if (!pfb_flock_bounded($lock, LOCK_EX, $timeout_s, $contended)) {
 		@fclose($lock);
-		$contended = $would_block === 1;
 		if (!$contended) {
 			pfb_logger("\n Feed pass lock: acquire failed [ {$lockpath} ]; feed pass aborted.\n", 2);
 		}
@@ -19153,6 +19154,41 @@ function pfb_feed_pass_begin(string $label, ?bool &$contended = NULL): bool {
 	pfb_logger("\nFeed pass [ {$label} ] skipped -- another pfBlockerNG feed pass is running.\n", 1);
 	logger(LOG_NOTICE, localize_text('Feed pass [ %s ] skipped - another pfBlockerNG feed pass is running.', $label),
 		LOG_PREFIX_PKG_PFBLOCKERNG);
+	return FALSE;
+}
+
+// Seconds a package install waits for an in-flight feed pass before it proceeds anyway.
+define('PFB_INSTALL_FEED_PASS_WAIT', 300.0);
+
+// issue #3062: a package install restages the Unbound chroot ('dnsbl_cache stage'),
+// drops caches, and stops/starts the pfB services -- the same files and daemon a feed
+// pass publishes into, and nothing serialised the two. Take the feed-pass lock and keep
+// it for the rest of the install process (pfb_feed_pass_release() runs at shutdown), so
+// an in-flight pass finishes first and a tick firing mid-install defers like any other
+// contender. Bounded, and FALSE never aborts the caller: a half-installed package is
+// worse than an overlap, so the install proceeds and the overlap is logged as the
+// evidence a post-install DNS failure is traced with.
+function pfb_install_feed_pass_hold(float $timeout_s = PFB_INSTALL_FEED_PASS_WAIT): bool {
+	if (pfb_feed_pass_busy()) {
+		pfb_logger("\nPackage install: waiting up to {$timeout_s}s for the in-flight feed pass to finish.\n", 1);
+		logger(LOG_NOTICE, localize_text('Package install waiting for the in-flight feed pass to finish.'),
+			LOG_PREFIX_PKG_PFBLOCKERNG);
+	}
+
+	$contended = FALSE;
+	if (pfb_feed_pass_acquire($contended, $timeout_s)) {
+		return TRUE;
+	}
+
+	if ($contended) {
+		pfb_logger("\nPackage install proceeding WITHOUT the feed-pass lock: a feed pass is still running.\n", 2);
+		logger(LOG_WARNING, localize_text('Package install proceeding without the feed-pass lock - a feed pass is still running.'),
+			LOG_PREFIX_PKG_PFBLOCKERNG);
+	} else {
+		pfb_logger("\nPackage install proceeding WITHOUT the feed-pass lock: it could not be acquired.\n", 2);
+		logger(LOG_WARNING, localize_text('Package install proceeding without the feed-pass lock - it could not be acquired.'),
+			LOG_PREFIX_PKG_PFBLOCKERNG);
+	}
 	return FALSE;
 }
 

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -19163,7 +19163,7 @@ define('PFB_INSTALL_FEED_PASS_WAIT', 300.0);
 
 // issue #3062: the install's hold on the feed-pass lock -- waits, then keeps it until this
 // process exits (pfb_feed_pass_release() at shutdown). FALSE never aborts the caller: an
-// install may not be abandoned. architecture-notes.md "The package install is the third holder".
+// install may not be abandoned. architecture-notes.md "The package install holds it too".
 function pfb_install_feed_pass_hold(float $timeout_s = PFB_INSTALL_FEED_PASS_WAIT): bool {
 	if (pfb_feed_pass_busy()) {
 		pfb_logger("\nPackage install: waiting up to {$timeout_s}s for the in-flight feed pass to finish.\n", 1);

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_install.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_install.inc
@@ -26,6 +26,12 @@ require_once('/usr/local/pkg/pfblockerng/pfblockerng.inc');
 global $g, $pfb;
 pfb_global();
 
+// issue #3062: serialise this install against feed passes BEFORE anything it shares with
+// one is touched (config surgery, service restarts, the chroot restage below). The hold
+// lasts until this process exits, so the post-install resync reenters it.
+update_status("\nChecking for an in-flight pfBlockerNG feed pass...");
+update_status(pfb_install_feed_pass_hold() ? " none.\n" : " still running; continuing anyway.\n");
+
 // issue #2371: capture DNSBL freshness before settings-family restore or migrations mutate it.
 $pfb_psl_feed_policy_fresh_install = pfb_psl_feed_policy_is_fresh_install(
 	PfbConfig::readSection(PFB_SECTIONS['dnsbl'])

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_install.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_install.inc
@@ -29,8 +29,8 @@ pfb_global();
 // issue #3062: serialise this install against feed passes BEFORE anything it shares with
 // one is touched (config surgery, service restarts, the chroot restage below). The hold
 // lasts until this process exits, so the post-install resync reenters it.
-update_status("\nChecking for an in-flight pfBlockerNG feed pass...");
-update_status(pfb_install_feed_pass_hold() ? " none.\n" : " still running; continuing anyway.\n");
+update_status("\nSerialising against any in-flight pfBlockerNG feed pass...");
+update_status(pfb_install_feed_pass_hold() ? " done.\n" : " lock not taken; continuing anyway.\n");
 
 // issue #2371: capture DNSBL freshness before settings-family restore or migrations mutate it.
 $pfb_psl_feed_policy_fresh_install = pfb_psl_feed_policy_is_fresh_install(

--- a/tests/php/InstallFeedPassInterlockTest.php
+++ b/tests/php/InstallFeedPassInterlockTest.php
@@ -121,18 +121,14 @@ final class InstallFeedPassInterlockTest extends TestCase
 	}
 
 	/**
-	 * Scenario: a feed pass is in flight and finishes while the install waits.
-	 * Given a child process holding the lock at the moment the install asks for it,
-	 * When the install takes its hold with a wait budget,
-	 * Then it blocks until the pass releases and then takes the lock -- it does not
-	 * charge ahead over the running pass (the non-blocking acquire() would).
+	 * Scenario: a feed pass in another process is in flight, then finishes.
+	 * Given a child process holding the lock, When the install asks for it,
+	 * Then it is refused while the pass runs and takes the lock once the pass releases.
+	 * Both halves are ordered by the child's own pipe, never by a sleep: the refusal is
+	 * asserted while the child provably still holds, the acquisition only after EOF.
 	 */
-	public function testHoldWaitsForAnInFlightPassAndTakesTheLockWhenItFinishes(): void
+	public function testHoldIsRefusedWhileAnotherProcessHoldsAndSucceedsOnceItReleases(): void
 	{
-		// The child holds the lock, reports ready, and keeps holding for 200ms past the
-		// parent's go-ahead: that hold-over IS the simulated in-flight pass (it makes the
-		// parent's FIRST acquisition attempt land while the lock is genuinely held), not a
-		// synchronisation device -- the assertion below is on the acquisition, not on timing.
 		$childCode = <<<'PHP'
 			$fp = fopen($argv[1], 'c');
 			if ($fp === false) { fwrite(STDOUT, "openfail\n"); exit(1); }
@@ -140,37 +136,46 @@ final class InstallFeedPassInterlockTest extends TestCase
 			fwrite(STDOUT, "ready\n");
 			fflush(STDOUT);
 			fgets(STDIN);	// blocks until the parent closes our stdin (EOF)
-			usleep(200000);	// the pass is still finishing when the install first asks
 			flock($fp, LOCK_UN);
 			fclose($fp);
 			exit(0);
 			PHP;
 
 		$descriptors = [0 => ['pipe', 'r'], 1 => ['pipe', 'w'], 2 => ['file', '/dev/null', 'w']];
-		$proc = proc_open([PHP_BINARY, '-r', $childCode, $this->lockPath()], $descriptors, $pipes);
-		$this->assertTrue(is_resource($proc), 'test setup: failed to spawn the feed-pass holder');
-
+		$proc = NULL;
+		$pipes = [];
 		try {
+			$proc = proc_open([PHP_BINARY, '-r', $childCode, $this->lockPath()], $descriptors, $pipes);
+			$this->assertTrue(is_resource($proc), 'test setup: failed to spawn the feed-pass holder');
+
+			// 10s is a salvage cap for a stuck run, never the behaviour under test.
 			$read = [$pipes[1]];
 			$write = $except = NULL;
 			$this->assertSame(1, stream_select($read, $write, $except, 10),
 				'deadlock guard: the holder never signalled readiness within 10s');
 			$this->assertSame("ready\n", fgets($pipes[1]), 'the holder did not report holding the lock');
 
-			fclose($pipes[0]);	// EOF -> the holder starts winding the pass down
+			// The child cannot release before EOF, so this half is race-free.
+			$this->assertFalse(pfb_install_feed_pass_hold(0.2),
+				'the install must NOT take a lock another process is holding');
+
+			fclose($pipes[0]);	// EOF -> the holder releases and exits
 			$pipes[0] = NULL;
 
-			// 10s is a salvage cap for a stuck run, not the behaviour under test.
 			$this->assertTrue(pfb_install_feed_pass_hold(10.0),
-				'the install must WAIT for the in-flight pass and then take the lock');
+				'the install must take the lock once the in-flight pass releases it');
 			$this->assertTrue(is_resource($GLOBALS['pfb_feed_pass_lock'] ?? NULL),
 				'the install must hold the lock it waited for');
 		} finally {
 			if (is_resource($pipes[0] ?? NULL)) {
 				fclose($pipes[0]);
 			}
-			fclose($pipes[1]);
-			$this->assertSame(0, proc_close($proc), 'the holder process must have exited cleanly');
+			if (is_resource($pipes[1] ?? NULL)) {
+				fclose($pipes[1]);
+			}
+			if (is_resource($proc)) {
+				$this->assertSame(0, proc_close($proc), 'the holder process must have exited cleanly');
+			}
 		}
 	}
 
@@ -178,24 +183,52 @@ final class InstallFeedPassInterlockTest extends TestCase
 	 * Scenario: the in-flight pass outlasts the install's wait budget.
 	 * Given another handle holding the lock for longer than the budget,
 	 * When the install takes its hold,
-	 * Then it gives up rather than stalling the install forever, leaves the holder
-	 * untouched, and records the overlap so a later failure can be traced to it.
+	 * Then it spends the budget waiting, gives up rather than stalling the install
+	 * forever, leaves the holder untouched, and records THAT it gave up -- the evidence
+	 * a later post-install failure is traced with.
 	 */
-	public function testHoldGivesUpAndLetsTheInstallProceedWhenThePassOutlastsTheWait(): void
+	public function testHoldSpendsItsBudgetThenLetsTheInstallProceed(): void
 	{
 		$holder = fopen($this->lockPath(), 'c');
 		$this->rawFps[] = $holder;
 		$this->assertTrue(flock($holder, LOCK_EX), 'test setup: failed to flock the holder fd');
 
-		$this->assertFalse(pfb_install_feed_pass_hold(0.2),
-			'the install must not block forever on a pass that will not finish');
+		$started = microtime(TRUE);
+		$held = pfb_install_feed_pass_hold(0.3);
+		$elapsed = microtime(TRUE) - $started;
+
+		$this->assertFalse($held, 'the install must not block forever on a pass that will not finish');
+		// Floor, not a duration assertion: a hold that returned instantly never waited at
+		// all, which is the regression (an ignored budget / a non-blocking acquire).
+		$this->assertGreaterThanOrEqual(0.25, $elapsed,
+			"the hold must spend its 0.3s budget waiting; it returned after {$elapsed}s");
 
 		$this->assertFalse(isset($GLOBALS['pfb_feed_pass_lock']),
 			'a failed hold must not leave a half-owned lock behind');
-		$this->assertTrue(flock($holder, LOCK_EX | LOCK_NB),
+		$this->assertTrue($this->rawProbeStillLocked(),
 			'the running feed pass must keep its own lock undisturbed');
-		$this->assertStringContainsString('feed pass', $this->logContents(),
-			'the overlap must be logged -- it is the evidence a post-install failure is traced with');
+		$this->assertStringContainsString('proceeding WITHOUT the feed-pass lock', $this->logContents(),
+			'the give-up itself must be logged, not merely the decision to wait');
+	}
+
+	/**
+	 * Every feed-pass dispatcher must keep deferring INSTANTLY -- the install's wait is the
+	 * one exception. Pins the default: a contended acquire with no budget returns at once.
+	 */
+	public function testFeedPassAcquireStaysNonBlockingByDefault(): void
+	{
+		$holder = fopen($this->lockPath(), 'c');
+		$this->rawFps[] = $holder;
+		$this->assertTrue(flock($holder, LOCK_EX), 'test setup: failed to flock the holder fd');
+
+		$started = microtime(TRUE);
+		$acquired = pfb_feed_pass_acquire($contended);
+		$elapsed = microtime(TRUE) - $started;
+
+		$this->assertFalse($acquired, 'a contended acquire must fail');
+		$this->assertTrue($contended, 'contention must be reported as contention, not as an error');
+		$this->assertLessThan(0.05, $elapsed,
+			"the default acquire must make ONE non-blocking attempt; it took {$elapsed}s");
 	}
 
 	/**

--- a/tests/php/InstallFeedPassInterlockTest.php
+++ b/tests/php/InstallFeedPassInterlockTest.php
@@ -1,0 +1,241 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * issue #3062 -- a package install must not run on top of an in-flight feed pass.
+ *
+ * The install restages the Unbound chroot ('pfblockerng.sh dnsbl_cache stage'),
+ * deletes caches, and stops/starts pfB services; a feed pass publishes into the
+ * same chroot and wakes the ADR-10 reload watcher. Nothing serialised the two:
+ * every feed-pass dispatcher takes the flock in "{dbdir}/pfb_feed_pass.lock"
+ * (issue #1175) but pfblockerng_install.inc never did, so a scheduled pass and
+ * an install could touch the same files and the same daemon at once.
+ *
+ * pfb_install_feed_pass_hold() closes that: it waits a bounded time for an
+ * in-flight pass to finish, then holds the lock for the rest of the install
+ * process so a tick firing mid-install defers with the usual skip line. The
+ * wait is bounded because an install may never be abandoned -- on expiry it
+ * logs and lets the install proceed.
+ */
+final class InstallFeedPassInterlockTest extends TestCase
+{
+	private string $dbdir = '';
+	private bool $hadPfb = FALSE;
+	private array $originalPfb = [];
+
+	/** Raw fds opened directly by a test (bypassing the helpers) -- closed in tearDown. */
+	private array $rawFps = [];
+
+	protected function setUp(): void
+	{
+		$this->hadPfb      = array_key_exists('pfb', $GLOBALS);
+		$this->originalPfb = $GLOBALS['pfb'] ?? [];
+
+		$this->dbdir = sys_get_temp_dir() . '/pfb_install_interlock_' . uniqid('', TRUE);
+		mkdir($this->dbdir, 0755, TRUE);
+
+		$GLOBALS['pfb'] = array_merge($GLOBALS['pfb'] ?? [], [
+			'dbdir'  => $this->dbdir,
+			'log'    => "{$this->dbdir}/pfblockerng.log",
+			'errlog' => "{$this->dbdir}/error.log",
+		]);
+	}
+
+	protected function tearDown(): void
+	{
+		foreach ($this->rawFps as $fp) {
+			if (is_resource($fp)) {
+				@flock($fp, LOCK_UN);
+				@fclose($fp);
+			}
+		}
+		$this->rawFps = [];
+
+		// Never leave this process holding the lock across tests (self-encapsulation).
+		pfb_feed_pass_release();
+
+		if ($this->hadPfb) {
+			$GLOBALS['pfb'] = $this->originalPfb;
+		} else {
+			unset($GLOBALS['pfb']);
+		}
+		$this->rrmdir($this->dbdir);
+	}
+
+	private function rrmdir(string $dir): void
+	{
+		if (!is_dir($dir)) {
+			return;
+		}
+		foreach (scandir($dir) as $entry) {
+			if ($entry === '.' || $entry === '..') {
+				continue;
+			}
+			$path = "{$dir}/{$entry}";
+			is_dir($path) ? $this->rrmdir($path) : @unlink($path);
+		}
+		@rmdir($dir);
+	}
+
+	private function lockPath(): string
+	{
+		return "{$this->dbdir}/pfb_feed_pass.lock";
+	}
+
+	/** TRUE when a second, independent fd cannot take the lock -- i.e. somebody holds it. */
+	private function rawProbeStillLocked(): bool
+	{
+		$probe = fopen($this->lockPath(), 'c');
+		$this->assertIsResource($probe, 'test setup: could not open the lock path for probing');
+		$held = !flock($probe, LOCK_EX | LOCK_NB);
+		if (!$held) {
+			flock($probe, LOCK_UN);
+		}
+		fclose($probe);
+		return $held;
+	}
+
+	private function logContents(): string
+	{
+		return (string) @file_get_contents($GLOBALS['pfb']['log']);
+	}
+
+	/**
+	 * Scenario: no feed pass is running when the install starts.
+	 * Given a free feed-pass lock, When the install takes its hold,
+	 * Then it succeeds and every other process is locked out for the rest of the install.
+	 */
+	public function testHoldTakesTheFeedPassLockWhenNoPassIsInFlight(): void
+	{
+		$this->assertFalse($this->rawProbeStillLocked(), 'test setup: the lock must start free');
+
+		$this->assertTrue(pfb_install_feed_pass_hold(0.1), 'the install must take the free feed-pass lock');
+
+		$this->assertTrue(is_resource($GLOBALS['pfb_feed_pass_lock'] ?? NULL),
+			'the install must KEEP the lock (held for the remainder of the install process)');
+		$this->assertTrue($this->rawProbeStillLocked(),
+			'a feed pass starting mid-install must find the lock held and defer');
+	}
+
+	/**
+	 * Scenario: a feed pass is in flight and finishes while the install waits.
+	 * Given a child process holding the lock at the moment the install asks for it,
+	 * When the install takes its hold with a wait budget,
+	 * Then it blocks until the pass releases and then takes the lock -- it does not
+	 * charge ahead over the running pass (the non-blocking acquire() would).
+	 */
+	public function testHoldWaitsForAnInFlightPassAndTakesTheLockWhenItFinishes(): void
+	{
+		// The child holds the lock, reports ready, and keeps holding for 200ms past the
+		// parent's go-ahead: that hold-over IS the simulated in-flight pass (it makes the
+		// parent's FIRST acquisition attempt land while the lock is genuinely held), not a
+		// synchronisation device -- the assertion below is on the acquisition, not on timing.
+		$childCode = <<<'PHP'
+			$fp = fopen($argv[1], 'c');
+			if ($fp === false) { fwrite(STDOUT, "openfail\n"); exit(1); }
+			if (!flock($fp, LOCK_EX)) { fwrite(STDOUT, "lockfail\n"); exit(1); }
+			fwrite(STDOUT, "ready\n");
+			fflush(STDOUT);
+			fgets(STDIN);	// blocks until the parent closes our stdin (EOF)
+			usleep(200000);	// the pass is still finishing when the install first asks
+			flock($fp, LOCK_UN);
+			fclose($fp);
+			exit(0);
+			PHP;
+
+		$descriptors = [0 => ['pipe', 'r'], 1 => ['pipe', 'w'], 2 => ['file', '/dev/null', 'w']];
+		$proc = proc_open([PHP_BINARY, '-r', $childCode, $this->lockPath()], $descriptors, $pipes);
+		$this->assertTrue(is_resource($proc), 'test setup: failed to spawn the feed-pass holder');
+
+		try {
+			$read = [$pipes[1]];
+			$write = $except = NULL;
+			$this->assertSame(1, stream_select($read, $write, $except, 10),
+				'deadlock guard: the holder never signalled readiness within 10s');
+			$this->assertSame("ready\n", fgets($pipes[1]), 'the holder did not report holding the lock');
+
+			fclose($pipes[0]);	// EOF -> the holder starts winding the pass down
+			$pipes[0] = NULL;
+
+			// 10s is a salvage cap for a stuck run, not the behaviour under test.
+			$this->assertTrue(pfb_install_feed_pass_hold(10.0),
+				'the install must WAIT for the in-flight pass and then take the lock');
+			$this->assertTrue(is_resource($GLOBALS['pfb_feed_pass_lock'] ?? NULL),
+				'the install must hold the lock it waited for');
+		} finally {
+			if (is_resource($pipes[0] ?? NULL)) {
+				fclose($pipes[0]);
+			}
+			fclose($pipes[1]);
+			$this->assertSame(0, proc_close($proc), 'the holder process must have exited cleanly');
+		}
+	}
+
+	/**
+	 * Scenario: the in-flight pass outlasts the install's wait budget.
+	 * Given another handle holding the lock for longer than the budget,
+	 * When the install takes its hold,
+	 * Then it gives up rather than stalling the install forever, leaves the holder
+	 * untouched, and records the overlap so a later failure can be traced to it.
+	 */
+	public function testHoldGivesUpAndLetsTheInstallProceedWhenThePassOutlastsTheWait(): void
+	{
+		$holder = fopen($this->lockPath(), 'c');
+		$this->rawFps[] = $holder;
+		$this->assertTrue(flock($holder, LOCK_EX), 'test setup: failed to flock the holder fd');
+
+		$this->assertFalse(pfb_install_feed_pass_hold(0.2),
+			'the install must not block forever on a pass that will not finish');
+
+		$this->assertFalse(isset($GLOBALS['pfb_feed_pass_lock']),
+			'a failed hold must not leave a half-owned lock behind');
+		$this->assertTrue(flock($holder, LOCK_EX | LOCK_NB),
+			'the running feed pass must keep its own lock undisturbed');
+		$this->assertStringContainsString('feed pass', $this->logContents(),
+			'the overlap must be logged -- it is the evidence a post-install failure is traced with');
+	}
+
+	/**
+	 * Scenario: the hold runs in a process that already owns the lock.
+	 * Given this process holds the feed-pass lock, When the install takes its hold,
+	 * Then it reuses the existing hold instead of deadlocking against itself.
+	 */
+	public function testHoldIsReentrantWhenThisProcessAlreadyHoldsTheLock(): void
+	{
+		$this->assertTrue(pfb_feed_pass_acquire(), 'test setup: failed to take the lock first');
+		$outer = $GLOBALS['pfb_feed_pass_lock'];
+
+		$this->assertTrue(pfb_install_feed_pass_hold(0.1), 'a reentrant hold must succeed');
+		$this->assertSame($outer, $GLOBALS['pfb_feed_pass_lock'] ?? NULL,
+			'a reentrant hold must reuse the existing handle, not replace it');
+	}
+
+	/**
+	 * The interlock has to be WIRED, not merely available: pfblockerng_install.inc must
+	 * take the hold before it touches anything a feed pass shares -- the pfB services and
+	 * the 'dnsbl_cache stage' chroot restage.
+	 *
+	 * install.inc is a procedural migration script (host-absolute requires, sqlite, exec,
+	 * real Unbound control) and is not loadable by the unit harness, so this pin scans
+	 * executable tokens only; comments/docblocks cannot satisfy it.
+	 */
+	public function testInstallScriptTakesTheHoldBeforeTouchingSharedState(): void
+	{
+		$path = dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng_install.inc';
+		$src = (string) @php_strip_whitespace($path);
+		$this->assertNotSame('', $src, "could not read {$path}");
+
+		$hold = strpos($src, 'pfb_install_feed_pass_hold(');
+		$this->assertNotFalse($hold, 'install.inc never takes the feed-pass interlock (issue #3062)');
+
+		foreach (['stop_service(', "dnsbl_cache stage"] as $shared) {
+			$first = strpos($src, $shared);
+			$this->assertNotFalse($first, "install.inc no longer contains [ {$shared} ]");
+			$this->assertLessThan($first, $hold,
+				"the interlock must be taken BEFORE install.inc reaches [ {$shared} ]");
+		}
+	}
+}

--- a/tests/php/fixtures/function_inventory.json
+++ b/tests/php/fixtures/function_inventory.json
@@ -4532,6 +4532,13 @@
                 "variadic": false,
                 "type": "?bool",
                 "default": "NULL"
+            },
+            {
+                "name": "timeout_s",
+                "byRef": false,
+                "variadic": false,
+                "type": "float",
+                "default": "0.0"
             }
         ]
     },
@@ -5716,6 +5723,19 @@
                 "variadic": false,
                 "type": "string",
                 "default": null
+            }
+        ]
+    },
+    "pfb_install_feed_pass_hold": {
+        "returnsRef": false,
+        "returnType": "bool",
+        "params": [
+            {
+                "name": "timeout_s",
+                "byRef": false,
+                "variadic": false,
+                "type": "float",
+                "default": "300.0"
             }
         ]
     },


### PR DESCRIPTION
Fixes #3062

## What the source says

#3062 asked whether anything serialises a package install against an in-flight DNSBL feed pass. It does not, and that is answerable from the tree without the box logs:

- Every feed-pass dispatcher takes the issue #1175 flock at `{dbdir}/pfb_feed_pass.lock` — `pfblockerng_sync_cron()` (`pfblockerng_cron.inc:286`), `sync_package_pfblockerng()` (`pfblockerng_apply.inc:760`), the extras/punch paths, the Alerts live punch.
- `pfblockerng_install.inc` took no lock at all. Before the post-install resync ever runs, it stops/starts `pfb_filter` and `pfb_dnsbl`, deletes cache databases, restages the Unbound chroot (`pfblockerng.sh dnsbl_cache stage`, `install.inc:760`), and may call `pfb_stop_start_unbound()` — the same files and the same daemon a feed pass publishes into and reload-signals.

So the interlock the issue hypothesised is genuinely missing. Whether that overlap is what produced the #3055 bind failure on the maintainer's box is still unestablished — that part still needs the 13:01-13:10 logs, and this PR does not claim it.

## The change

- `pfb_feed_pass_acquire()` grew an optional `$timeout_s`, defaulting to `0.0` — one non-blocking attempt, behaviour-equivalent to today for every existing caller (it now routes through the existing `pfb_flock_bounded()` instead of an inline `flock(LOCK_NB)`). A feed-pass dispatcher must never queue; it defers.
- New `pfb_install_feed_pass_hold()`: logs the overlap, waits up to `PFB_INSTALL_FEED_PASS_WAIT` (300 s) for an in-flight pass, and keeps the lock for the rest of the install process (released by the existing shutdown handler, and reentered by the post-install resync).
- `pfblockerng_install.inc` takes the hold immediately after `pfb_global()`, before any shared state is touched.

A tick firing mid-install now defers with the usual `Feed pass [ cron ] skipped` line and retries on its next occurrence, exactly like any other contender.

**Bounded on purpose:** a half-installed package is worse than an overlap, so an expired wait does not abort the install. It proceeds and logs `Package install proceeding WITHOUT the feed-pass lock` to both the pfBlockerNG log and syslog (LOG_WARNING) — which is also the log line that would have answered #3062's question directly.

Not in scope: the pre-deinstall teardown path (`pkg delete`) has the same shape but is not what #3062 reports, and `pkg` extracts the new files before any PHP hook runs, so the window before `custom_php_install_command` is not reachable from this package.

## Verification

Test-first, `tests/php/InstallFeedPassInterlockTest.php` frozen at `git hash-object adc3e08227b08e7c83fc8e1c1c6e7048087ad0ab` across both runs.

RED (untouched `src/`):

```text
EEEEF                                                               5 / 5 (100%)
1) ...testInstallScriptTakesTheHoldBeforeTouchingSharedState
install.inc never takes the feed-pass interlock (issue #3062)
Tests: 5, Assertions: 10, Errors: 4, Failures: 1.
```

GREEN (same file, zero edits):

```text
adc3e08227b08e7c83fc8e1c1c6e7048087ad0ab
.....                                                               5 / 5 (100%)
OK (5 tests, 26 assertions)
```

Coverage: hold on a free lock (and the exclusion it buys), a hold that waits out a real child-process holder and then takes the lock, a hold that expires and lets the install proceed with the holder undisturbed and the overlap logged, reentrancy inside a process that already owns the lock, and an ordering pin that install.inc takes the hold before `stop_service(` and before `dnsbl_cache stage` (install.inc is not loadable by the unit harness — the same constraint `InstallDnsblMoveRestartGuardTest` documents).

Full PHPUnit, baseline vs branch on this host: `Tests: 6421, Errors: 54, Failures: 30` -> `Tests: 6426, Errors: 54, Failures: 30`; the failing-name sets are identical (`comm` diff empty in both directions) — those 84 are pre-existing host-environment failures (no `/sbin/mount`, no `pfctl`). PHPStan `[OK] No errors`; PHPCS clean; `scripts/agent/run-gates.sh` clean apart from those same pre-existing rows.

Not verified on a live appliance: the install-time behaviour needs a smoke seat (package install with a feed pass in flight).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Installations now wait for in-progress feed updates before modifying shared configuration or restarting services.
  * If the wait period expires, installation proceeds with a warning instead of remaining blocked.
  * Feed update locking remains non-blocking by default while supporting bounded waits when needed.

* **Tests**
  * Added coverage for lock acquisition, contention, timeout handling, reentrant behavior, and installation ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->