### PR TITLE
agent: converge worktree cuts on wt and rule out unsafe scratch trees

### DIFF
--- a/.agents/context/repository-intelligence.md
+++ b/.agents/context/repository-intelligence.md
@@ -34,9 +34,8 @@ Load when: every agent session, from `AGENTS.md`.
   When the graph is absent it prints a notice and builds nothing; first-build scope
   is a judgement call handled by a `/graphify` run. `wt --yes switch --create <branch>`
   runs it from `.config/wt.toml`'s `pre-start` hook. `work-branch.sh --worktree` cuts
-  through `wt`, so that hook normally does the initializing; it calls the initializer
-  itself only when the worktree came back without a CodeGraph index (the `git worktree`
-  fallback, or a pre-start that did not run), and rolls back a failed cut either way.
+  through `wt`, skips the initializer when pre-start already left a CodeGraph index,
+  and rolls back a failed cut — reclaiming a tree `wt` left behind when its hook failed.
 - Graphify's suffix map parses `.inc` as Pascal, collapsing this repository's PHP
   includes from roughly 767 nodes to roughly 30 while extraction still succeeds.
   Until a release includes Graphify-Labs/graphify#3075, the fix rides as

--- a/.agents/context/repository-intelligence.md
+++ b/.agents/context/repository-intelligence.md
@@ -32,9 +32,11 @@ Load when: every agent session, from `AGENTS.md`.
   `scripts/agent/ensure-codegraph.sh` for the exact-root CodeGraph index, reapplies
   the Graphify patch, then runs `graphify update <root>` when the root graph exists.
   When the graph is absent it prints a notice and builds nothing; first-build scope
-  is a judgement call handled by a `/graphify` run. `work-branch.sh --worktree`
-  routes through this initializer and rolls back a failed cut;
-  `wt --yes switch --create <branch>` runs it from `.config/wt.toml`.
+  is a judgement call handled by a `/graphify` run. `wt --yes switch --create <branch>`
+  runs it from `.config/wt.toml`'s `pre-start` hook. `work-branch.sh --worktree` cuts
+  through `wt`, so that hook normally does the initializing; it calls the initializer
+  itself only when the worktree came back without a CodeGraph index (the `git worktree`
+  fallback, or a pre-start that did not run), and rolls back a failed cut either way.
 - Graphify's suffix map parses `.inc` as Pascal, collapsing this repository's PHP
   includes from roughly 767 nodes to roughly 30 while extraction still succeeds.
   Until a release includes Graphify-Labs/graphify#3075, the fix rides as

--- a/.agents/policy/git.md
+++ b/.agents/policy/git.md
@@ -19,9 +19,9 @@ fetch + rebase. Anything touching `src/`, `tests/`, or CI — ADR *implementatio
 included — requires the full PR flow. The reviewed signed local fast-forward allowed by
 `landing.md` happens only after every PR gate; it is never a shortcut around the PR.
 
-**Every worktree operation goes through `wt`.** Plain `git worktree` is the fallback,
-used only when `wt` is absent, exits non-zero, or reports success without leaving a
-worktree behind — never as a first choice.
+**Agents cut and remove worktrees through `wt`.** Plain `git worktree` is the fallback,
+never a first choice, used only when `wt` is absent, exits non-zero, or reports success
+without leaving a worktree — including when recovering from a `wt` cut that half-ran.
 
 ```sh
 wt --yes switch --create <branch> --base origin/devel   # cut off the latest base
@@ -30,9 +30,10 @@ wt remove --foreground --yes <branch>   # run from any directory OUTSIDE it
 ```
 
 `wt` runs the tracked `.config/wt.toml` `pre-start` hook, so a `wt`-cut worktree
-initializes CodeGraph, Graphify, and enabled Serena tools on its own. Only the fallback
-route runs `sh scripts/agent/init-worktree-tools.sh <path>` by hand; CodeGraph and
-Graphify are mandatory, while Serena is skipped when absent or under OMP.
+initializes CodeGraph, Graphify, and enabled Serena tools on its own. `init-worktree-tools.sh <path>` is run by hand
+only for a cut that came back without a CodeGraph index — the fallback route, or a
+pre-start that did not run. CodeGraph and Graphify are mandatory; Serena is skipped when
+absent or under OMP.
 
 `work-branch.sh … --worktree` fetches, cuts below
 `<repo-parent>/.<repo-name>_worktrees/<sanitized-branch>`, and initializes tools. It
@@ -46,9 +47,8 @@ For matching Worktrunk placement, set:
 worktree-path = "{{ repo_path }}/../.{{ repo }}_worktrees/{{ branch | sanitize }}"
 ```
 
-The tracked `.config/wt.toml` initializes tools during `wt --yes switch --create <branch>`
-and prunes metadata after merge/removal. `wt remove` deletes only branches it verifies
-as integrated; landing observes the foreground result.
+`.config/wt.toml` also prunes metadata after merge/removal. `wt remove` deletes only
+branches it verifies as integrated; landing observes the foreground result.
 
 **Scratch trees** (probe, mutation, review lanes) have two sanctioned shapes. Needs git
 (history, diffing, committing) → a throwaway worktree, `wt --yes switch --create
@@ -58,7 +58,7 @@ structurally cannot touch the repository. Prefer it whenever the lane never comm
 
 `cp -a`/`cp -R`/`rsync` **of a worktree is forbidden** — the copy keeps the source's
 `.git` *pointer file*, so its git commands drive the ORIGINAL worktree's index, `HEAD`,
-and refs (a survey found nine such copies, five aimed at worktrees in active use).
+and refs.
 
 **Never the system temp directory**: semantics differ per platform (Linux `/tmp` is
 commonly RAM-backed tmpfs; macOS resolves it to disk-backed `/private/tmp` and defaults
@@ -68,7 +68,7 @@ scratch goes under the worktrees root; extraction scratch under `/var/tmp/agents
 disk-backed on both platforms.
 
 **Scratch is reaped by its owner** when the lane ends — including agent session scratch,
-which no worktree rule covers (1.7 GB across four dead sessions on one host). Delete
+which no worktree rule covers. Delete
 someone else's only when it is stale by mtime **and** unreferenced by any live process
 (`/proc/*/cwd` on Linux, `lsof +D` on macOS): an idle session looks dead by mtime alone.
 
@@ -88,7 +88,7 @@ someone else's only when it is stale by mtime **and** unreferenced by any live p
   or legacy `WIP`/`Waiting PR` labels ⇒ another session owns it: wait, cooperate, or start
   NEW branch after merge). **Never force-push over another session's in-flight PR.**
 - Name branch for its work item — `adr/{NN}-{slug}` / `issue/{NN}-{slug}`.
-- Gotchas: `git worktree remove` fails from inside tree — run from any directory
+- Gotchas: `wt remove` / `git worktree remove` fail from inside tree — run from any directory
   outside tree being removed (primary checkout works; session worktree too).
   Never pass `--delete-branch`; after terminal verification use the expected-value cleanup:
   `git push --force-with-lease=refs/heads/<head>:<reviewed_sha> origin --delete <head>`.

--- a/.agents/policy/git.md
+++ b/.agents/policy/git.md
@@ -19,19 +19,25 @@ fetch + rebase. Anything touching `src/`, `tests/`, or CI — ADR *implementatio
 included — requires the full PR flow. The reviewed signed local fast-forward allowed by
 `landing.md` happens only after every PR gate; it is never a shortcut around the PR.
 
+**Every worktree operation goes through `wt`.** Plain `git worktree` is the fallback,
+used only when `wt` is absent, exits non-zero, or reports success without leaving a
+worktree behind — never as a first choice.
+
 ```sh
-git worktree add -b <branch> <path> origin/devel   # branch off the latest base
-sh scripts/agent/init-worktree-tools.sh <path>      # mandatory per-worktree indexes
-# … work, commit, push, open the PR from inside <path> …
-git worktree remove <path>            # run from any directory OUTSIDE <path>
+wt --yes switch --create <branch> --base origin/devel   # cut off the latest base
+# … work, commit, push, open the PR from inside the worktree …
+wt remove --foreground --yes <branch>   # run from any directory OUTSIDE it
 ```
 
-`work-branch.sh … --worktree` fetches, adds below
-`<repo-parent>/.<repo-name>_worktrees/<sanitized-branch>`, and initializes tools.
-Relative paths stay below that root; absolute paths stay exact; initialization failure
-rolls back the worktree and branch. It uses Git directly. Manual adds must run
-`init-worktree-tools.sh`; CodeGraph and Graphify are mandatory, while Serena is skipped
-when absent or under OMP.
+`wt` runs the tracked `.config/wt.toml` `pre-start` hook, so a `wt`-cut worktree
+initializes CodeGraph, Graphify, and enabled Serena tools on its own. Only the fallback
+route runs `sh scripts/agent/init-worktree-tools.sh <path>` by hand; CodeGraph and
+Graphify are mandatory, while Serena is skipped when absent or under OMP.
+
+`work-branch.sh … --worktree` fetches, cuts below
+`<repo-parent>/.<repo-name>_worktrees/<sanitized-branch>`, and initializes tools. It
+routes through `wt` under the same fallback rule. Relative paths stay below that root;
+absolute paths stay exact; initialization failure rolls back the worktree and branch.
 
 For matching Worktrunk placement, set:
 
@@ -43,6 +49,28 @@ worktree-path = "{{ repo_path }}/../.{{ repo }}_worktrees/{{ branch | sanitize }
 The tracked `.config/wt.toml` initializes tools during `wt --yes switch --create <branch>`
 and prunes metadata after merge/removal. `wt remove` deletes only branches it verifies
 as integrated; landing observes the foreground result.
+
+**Scratch trees** (probe, mutation, review lanes) have two sanctioned shapes. Needs git
+(history, diffing, committing) → a throwaway worktree, `wt --yes switch --create
+<branch> --base <ref>`, `wt remove` when the lane ends. Read-only → `git archive <ref> |
+tar -x -C "$SCRATCH"`: no `.git`, so it cannot commit, cannot share refs, and
+structurally cannot touch the repository. Prefer it whenever the lane never commits.
+
+`cp -a`/`cp -R`/`rsync` **of a worktree is forbidden** — the copy keeps the source's
+`.git` *pointer file*, so its git commands drive the ORIGINAL worktree's index, `HEAD`,
+and refs (a survey found nine such copies, five aimed at worktrees in active use).
+
+**Never the system temp directory**: semantics differ per platform (Linux `/tmp` is
+commonly RAM-backed tmpfs; macOS resolves it to disk-backed `/private/tmp` and defaults
+`TMPDIR` under `/var/folders`), and an unregistered tree is invisible to
+`git worktree list`, so no prune, `wt remove`, or landing step can reclaim it. Worktree
+scratch goes under the worktrees root; extraction scratch under `/var/tmp/agents`,
+disk-backed on both platforms.
+
+**Scratch is reaped by its owner** when the lane ends — including agent session scratch,
+which no worktree rule covers (1.7 GB across four dead sessions on one host). Delete
+someone else's only when it is stale by mtime **and** unreferenced by any live process
+(`/proc/*/cwd` on Linux, `lsof +D` on macOS): an idle session looks dead by mtime alone.
 
 - Branch off **current** base (`git fetch` first); stale-tip worktree needs rebase
   before it can land.

--- a/.agents/policy/git.md
+++ b/.agents/policy/git.md
@@ -50,15 +50,20 @@ worktree-path = "{{ repo_path }}/../.{{ repo }}_worktrees/{{ branch | sanitize }
 `.config/wt.toml` also prunes metadata after merge/removal. `wt remove` deletes only
 branches it verifies as integrated; landing observes the foreground result.
 
-**Scratch trees** (probe, mutation, review lanes) have two sanctioned shapes. Needs git
-(history, diffing, committing) → a throwaway worktree, `wt --yes switch --create
-<branch> --base <ref>`, `wt remove` when the lane ends. Read-only → `git archive <ref> |
-tar -x -C "$SCRATCH"`: no `.git`, so it cannot commit, cannot share refs, and
-structurally cannot touch the repository. Prefer it whenever the lane never commits.
+**Scratch trees** (probe, mutation, review lanes) have two sanctioned shapes, both
+taking a SHA — what "an isolated tree at commit X" needs, the recurring review case
+where four legs read one worktree and one must re-run a red half without disturbing
+it. Needs git (history, diffing, committing) → a throwaway worktree,
+`wt --yes switch --create <branch> --base <sha>`, `wt remove` when the lane ends.
+Read-only → `git archive <sha> | tar -x -C "$SCRATCH"`: no `.git`, so it cannot commit,
+cannot share refs, and structurally cannot touch the repository. Prefer the extraction
+unless the suite needs real git history. **Never mutate a checkout another agent is
+reading** — worse than any copy.
 
-`cp -a`/`cp -R`/`rsync` **of a worktree is forbidden** — the copy keeps the source's
-`.git` *pointer file*, so its git commands drive the ORIGINAL worktree's index, `HEAD`,
-and refs.
+**Copying a worktree is forbidden** — `cp -a`, `cp -R`, `cp -al`, `rsync`. The copy
+keeps the source's `.git` *pointer file*, so its git commands drive the ORIGINAL
+worktree's index, `HEAD`, and refs; `cp -al` additionally hardlinks the content, so an
+in-place write lands in the original's files.
 
 **Never the system temp directory**: semantics differ per platform (Linux `/tmp` is
 commonly RAM-backed tmpfs; macOS resolves it to disk-backed `/private/tmp` and defaults
@@ -67,10 +72,10 @@ commonly RAM-backed tmpfs; macOS resolves it to disk-backed `/private/tmp` and d
 scratch goes under the worktrees root; extraction scratch under `/var/tmp/agents`,
 disk-backed on both platforms.
 
-**Scratch is reaped by its owner** when the lane ends — including agent session scratch,
-which no worktree rule covers. Delete
-someone else's only when it is stale by mtime **and** unreferenced by any live process
-(`/proc/*/cwd` on Linux, `lsof +D` on macOS): an idle session looks dead by mtime alone.
+**Scratch is reaped by its owner** when the lane ends — agent session scratch included,
+which no worktree rule covers. Delete someone else's only when it is stale by mtime
+**and** unreferenced by a live process (`/proc/*/cwd` on Linux, `lsof +D` on macOS):
+an idle session looks dead by mtime alone.
 
 - Branch off **current** base (`git fetch` first); stale-tip worktree needs rebase
   before it can land.

--- a/.agents/skills/subsystem-sweep/SKILL.md
+++ b/.agents/skills/subsystem-sweep/SKILL.md
@@ -40,7 +40,7 @@ issues, process improvements become a PR against this skill.
    parity across siblings — v4/v6, CE/Plus, channels, languages). For each, find
    where the code enforces it and try to break it with an EXECUTED probe (`uv run
    pytest`, `vendor/bin/phpunit` or `shellspec --shell dash` for suites, after
-   `uv sync --locked --group dev` / `composer install`; scratch dirs under `/tmp`;
+   `uv sync --locked --group dev` / `composer install`; scratch dirs under `/var/tmp/agents`;
    never the live boxes from the cloud). Also run `/code-review` at `medium`
    effort over the roots when the delta is large — its findings enter the same dedupe below. That
    command is a Claude Code client built-in, not a repo skill under

--- a/.github/agents/adversarial-reviewer-mid.agent.md
+++ b/.github/agents/adversarial-reviewer-mid.agent.md
@@ -9,6 +9,6 @@ disable-model-invocation: true
 
 Independently re-derive claims; never trust a handoff or review finding at face value. Follow the parent review brief, inspect complete diffs and surrounding code, run targeted discriminating probes, test hostile inputs, check coverage-matrix rows and test honesty, and report only evidence-backed findings. Do not edit, commit, push, or downgrade a real pre-existing defect: route it to a tracked follow-up.
 
-Read-only: never edit, commit, or push, and keep scratch files under `/tmp`, never inside the checkout.
+Read-only: never edit, commit, or push, and keep scratch files under `/var/tmp/agents`, never `/tmp`, never inside the checkout.
 
 `AGENTS.md` and the `.agents/policy/` files it routes to are binding here as well; `.agents/policy/agent-roles.md` holds this role's contract and pins it to the mid tier in `.agents/model-tiers.conf`.

--- a/.github/agents/adversarial-reviewer-top.agent.md
+++ b/.github/agents/adversarial-reviewer-top.agent.md
@@ -9,6 +9,6 @@ disable-model-invocation: true
 
 Independently re-derive claims; never trust a handoff or review finding at face value. Follow the parent review brief, inspect complete diffs and surrounding code, run targeted discriminating probes, test hostile inputs, check coverage-matrix rows and test honesty, and report only evidence-backed findings. Do not edit, commit, push, or downgrade a real pre-existing defect: route it to a tracked follow-up.
 
-Read-only: never edit, commit, or push, and keep scratch files under `/tmp`, never inside the checkout.
+Read-only: never edit, commit, or push, and keep scratch files under `/var/tmp/agents`, never `/tmp`, never inside the checkout.
 
 `AGENTS.md` and the `.agents/policy/` files it routes to are binding here as well; `.agents/policy/agent-roles.md` holds this role's contract and pins it to the top tier in `.agents/model-tiers.conf`.

--- a/.github/agents/adversarial-reviewer.agent.md
+++ b/.github/agents/adversarial-reviewer.agent.md
@@ -9,6 +9,6 @@ disable-model-invocation: true
 
 Independently re-derive claims; never trust a handoff or review finding at face value. Follow the parent review brief, inspect complete diffs and surrounding code, run targeted discriminating probes, test hostile inputs, check coverage-matrix rows and test honesty, and report only evidence-backed findings. Do not edit, commit, push, or downgrade a real pre-existing defect: route it to a tracked follow-up.
 
-Read-only: never edit, commit, or push, and keep scratch files under `/tmp`, never inside the checkout.
+Read-only: never edit, commit, or push, and keep scratch files under `/var/tmp/agents`, never `/tmp`, never inside the checkout.
 
 `AGENTS.md` and the `.agents/policy/` files it routes to are binding here as well; `.agents/policy/agent-roles.md` holds this role's contract and pins it to the small tier in `.agents/model-tiers.conf`.

--- a/.github/agents/analyst-top.agent.md
+++ b/.github/agents/analyst-top.agent.md
@@ -9,6 +9,6 @@ disable-model-invocation: true
 
 Follow the parent task and output contract exactly. Investigate the named scope, verify claims against current evidence, distinguish verified facts from assumptions, and return the requested schema without editing, committing, or pushing. Do not turn an area report or triage record into a different planning artifact.
 
-Read-only: never edit, commit, or push, and keep scratch files under `/tmp`, never inside the checkout.
+Read-only: never edit, commit, or push, and keep scratch files under `/var/tmp/agents`, never `/tmp`, never inside the checkout.
 
 `AGENTS.md` and the `.agents/policy/` files it routes to are binding here as well; `.agents/policy/agent-roles.md` holds this role's contract and pins it to the top tier in `.agents/model-tiers.conf`.

--- a/.github/agents/analyst.agent.md
+++ b/.github/agents/analyst.agent.md
@@ -9,6 +9,6 @@ disable-model-invocation: true
 
 Follow the parent task and output contract exactly. Investigate the named scope, verify claims against current evidence, distinguish verified facts from assumptions, and return the requested schema without editing, committing, or pushing. Do not turn an area report or triage record into a different planning artifact.
 
-Read-only: never edit, commit, or push, and keep scratch files under `/tmp`, never inside the checkout.
+Read-only: never edit, commit, or push, and keep scratch files under `/var/tmp/agents`, never `/tmp`, never inside the checkout.
 
 `AGENTS.md` and the `.agents/policy/` files it routes to are binding here as well; `.agents/policy/agent-roles.md` holds this role's contract and pins it to the small tier in `.agents/model-tiers.conf`.

--- a/.github/agents/planner.agent.md
+++ b/.github/agents/planner.agent.md
@@ -9,6 +9,6 @@ disable-model-invocation: true
 
 Write a self-contained brief, not code. Verify every factual premise against the current worktree, enumerate sibling axes from source, name hostile inputs, define runnable acceptance checks, and stop on contradictions. Follow AGENTS.md exactly. Return the brief and the evidence needed to audit it.
 
-Read-only: never edit, commit, or push, and keep scratch files under `/tmp`, never inside the checkout.
+Read-only: never edit, commit, or push, and keep scratch files under `/var/tmp/agents`, never `/tmp`, never inside the checkout.
 
 `AGENTS.md` and the `.agents/policy/` files it routes to are binding here as well; `.agents/policy/agent-roles.md` holds this role's contract and pins it to the top tier in `.agents/model-tiers.conf`.

--- a/scripts/agent/work-branch.sh
+++ b/scripts/agent/work-branch.sh
@@ -4,8 +4,9 @@
 #
 # Usage: work-branch.sh <issue|adr> <NN> [TITLE ...] [--worktree] [--claim] [--path PATH] [--base REF]
 #   Prints the branch name (`issue/NN-slug` / `adr/NN-slug`; empty slug -> bare `type/NN`).
-#   --worktree  also `git fetch origin` + `git worktree add -b BRANCH PATH BASE` at an
-#               ABSOLUTE path (default <repo-parent>/.<repo-name>_worktrees/<branch
+#   --worktree  also `git fetch origin` + cut the worktree through `wt` (falling
+#               back to `git worktree add` when wt is absent, fails, or leaves no
+#               worktree) at an ABSOLUTE path (default <repo-parent>/.<repo-name>_worktrees/<branch
 #               with '/' replaced by '-'>; a relative --path anchors below that sibling
 #               root, while an absolute --path stays exact). An existing branch or path
 #               gets a `-<epoch>` suffix (collision rule). Every created worktree
@@ -82,6 +83,25 @@ claim_gate() {
 	fi
 	echo "work-branch.sh: issue #$cg_nn is not claimed (no assignee) — the assignee IS the claim and is set before any work (workflow.md \"Claim\"); re-run with --claim to assign it to $cg_me, or \`gh issue edit $cg_nn --add-assignee @me\`" >&2
 	exit 3
+}
+
+# Cut one worktree for an already-reserved branch. Worktree operations converge
+# on `wt` (git.md); plain `git worktree add` is the fallback for wt being absent,
+# failing, or reporting success without leaving a worktree behind.
+# `--config-set` pins the exact path this script derived instead of trusting the
+# caller's `worktree-path` template; TOML basic strings escape \ and " only.
+cut_worktree() {
+	cw_path=$1
+	cw_branch=$2
+	if command -v wt >/dev/null 2>&1; then
+		cw_toml=$(printf '%s' "$cw_path" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g')
+		if wt --yes --config-set "worktree-path=\"$cw_toml\"" switch "$cw_branch" >&2 &&
+		   [ -d "$cw_path" ]; then
+			return 0
+		fi
+		echo "work-branch.sh: wt could not cut '$cw_path'; falling back to git worktree add" >&2
+	fi
+	git worktree add "$cw_path" "$cw_branch" >/dev/null
 }
 
 main() {
@@ -236,7 +256,7 @@ main() {
 	done
 
 	while true; do
-		git worktree add "$path" "$branch" >/dev/null
+		cut_worktree "$path" "$branch"
 		worktree_status=$?
 		[ "$worktree_status" -eq 0 ] && break
 		if [ "$path_set" -eq 1 ] && [ "$absolute_path" -eq 0 ] &&
@@ -258,8 +278,15 @@ main() {
 		exit "$worktree_status"
 	done
 	initializer=${PFB_INIT_WORKTREE_TOOLS:-$(dirname "$0")/init-worktree-tools.sh}
-	sh "$initializer" "$path"
-	initializer_status=$?
+	# A `wt` cut already ran the initializer through `.config/wt.toml`'s pre-start hook,
+	# and the CodeGraph index it leaves is the marker that the tools are in place. Only
+	# the fallback route (and a pre-start that did not run) still needs the direct call;
+	# a second `graphify update` here is pure duplicated work.
+	initializer_status=0
+	if [ ! -f "$path/.codegraph/codegraph.db" ]; then
+		sh "$initializer" "$path"
+		initializer_status=$?
+	fi
 	if [ "$initializer_status" -ne 0 ]; then
 		echo "work-branch.sh: removing worktree and branch after tool initialization failure" >&2
 		git worktree remove --force "$path" >/dev/null 2>&1 || {

--- a/scripts/agent/work-branch.sh
+++ b/scripts/agent/work-branch.sh
@@ -85,6 +85,20 @@ claim_gate() {
 	exit 3
 }
 
+# wt renders `worktree-path` as a minijinja TEMPLATE, so a marker anywhere in the
+# value makes wt cut somewhere this script never reports — and the value is not only
+# what the caller typed: the sibling root is derived from the CHECKOUT's own directory
+# name. A control character breaks the TOML the same way. Validate every component
+# this script will hand to wt, before a branch is reserved.
+reject_wt_template_chars() {
+	case "$1" in
+		*'{{'* | *'{%'* | *'{#'* | *[[:cntrl:]]*)
+			echo "work-branch.sh: $2 must not contain control characters or template markers" >&2
+			exit 2
+			;;
+	esac
+}
+
 # Cut one worktree for an already-reserved branch. Worktree operations converge
 # on `wt` (git.md); plain `git worktree add` is the fallback for wt being absent,
 # failing, or reporting success without leaving a worktree behind.
@@ -109,6 +123,8 @@ cut_worktree() {
 		# half-run hook left, so the retry initializes for real. Reclaim ONLY a tree
 		# holding the branch this call just reserved: at a shared explicit --path a
 		# concurrent creator may already own the tree, and removing that destroys it.
+		# Anything else left at the path is deliberately not reclaimed — it cannot be
+		# told apart from a concurrent creator's, so the caller collision-suffixes.
 		if [ -e "$cw_path" ] || [ -L "$cw_path" ]; then
 			cw_head=$(git -C "$cw_path" symbolic-ref --quiet HEAD 2>/dev/null) || cw_head=''
 			if [ "$cw_head" = "refs/heads/$cw_branch" ]; then
@@ -144,18 +160,7 @@ main() {
 		exit 0
 	fi
 
-	# wt's `worktree-path` is a minijinja TEMPLATE, so `{{ … }}` in a --path renders
-	# instead of being taken literally, and a trailing newline is eaten by the command
-	# substitution that builds the TOML: either way wt cuts somewhere this script never
-	# reports. Reject both shapes before a branch is reserved.
-	if [ "$path_set" -eq 1 ]; then
-		case "$path" in
-			*'{{'* | *'{%'* | *'{#'* | *[[:cntrl:]]*)
-				echo "work-branch.sh: --path must not contain control characters or template markers" >&2
-				exit 2
-				;;
-		esac
-	fi
+	[ "$path_set" -eq 0 ] || reject_wt_template_chars "$path" '--path'
 	if [ "$path_set" -eq 1 ]; then
 		case "$path" in
 			'')
@@ -206,6 +211,7 @@ main() {
 	repo_name=${root##*/}
 	repo_parent=${root%/*}
 	worktree_root="$repo_parent/.${repo_name}_worktrees"
+	reject_wt_template_chars "$worktree_root" 'the worktree root'
 	if [ "$absolute_path" -eq 1 ]; then
 		mkdir -p "$(dirname "$path")" || exit 1
 	else

--- a/scripts/agent/work-branch.sh
+++ b/scripts/agent/work-branch.sh
@@ -90,16 +90,31 @@ claim_gate() {
 # failing, or reporting success without leaving a worktree behind.
 # `--config-set` pins the exact path this script derived instead of trusting the
 # caller's `worktree-path` template; TOML basic strings escape \ and " only.
+# A worktree checkout always has a `.git` FILE, so that is the success probe: a bare
+# directory at the path is not a cut.
 cut_worktree() {
 	cw_path=$1
 	cw_branch=$2
 	if command -v wt >/dev/null 2>&1; then
 		cw_toml=$(printf '%s' "$cw_path" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g')
 		if wt --yes --config-set "worktree-path=\"$cw_toml\"" switch "$cw_branch" >&2 &&
-		   [ -d "$cw_path" ]; then
+		   [ -f "$cw_path/.git" ]; then
 			return 0
 		fi
 		echo "work-branch.sh: wt could not cut '$cw_path'; falling back to git worktree add" >&2
+		# wt registers the worktree BEFORE running its pre-start hook and leaves the
+		# tree behind when that hook fails. Falling back over the top of it would hit
+		# `already exists`, and the reserved branch could then not be deleted because
+		# the orphan has it checked out. Reclaim it — that also discards the marker a
+		# half-run hook left, so the retry initializes for real. Reclaim ONLY a tree
+		# holding the branch this call just reserved: at a shared explicit --path a
+		# concurrent creator may already own the tree, and removing that destroys it.
+		if [ -e "$cw_path" ] || [ -L "$cw_path" ]; then
+			cw_head=$(git -C "$cw_path" symbolic-ref --quiet HEAD 2>/dev/null) || cw_head=''
+			if [ "$cw_head" = "refs/heads/$cw_branch" ]; then
+				git worktree remove --force "$cw_path" >/dev/null 2>&1 || :
+			fi
+		fi
 	fi
 	git worktree add "$cw_path" "$cw_branch" >/dev/null
 }
@@ -129,6 +144,18 @@ main() {
 		exit 0
 	fi
 
+	# wt's `worktree-path` is a minijinja TEMPLATE, so `{{ … }}` in a --path renders
+	# instead of being taken literally, and a trailing newline is eaten by the command
+	# substitution that builds the TOML: either way wt cuts somewhere this script never
+	# reports. Reject both shapes before a branch is reserved.
+	if [ "$path_set" -eq 1 ]; then
+		case "$path" in
+			*'{{'* | *'{%'* | *'{#'* | *[[:cntrl:]]*)
+				echo "work-branch.sh: --path must not contain control characters or template markers" >&2
+				exit 2
+				;;
+		esac
+	fi
 	if [ "$path_set" -eq 1 ]; then
 		case "$path" in
 			'')

--- a/scripts/git-env-scrub-guard.sh
+++ b/scripts/git-env-scrub-guard.sh
@@ -79,7 +79,7 @@ check_fixture_manifest() {
     done <<'EOF'
 agent_run_gates_git_spec.sh:2
 agent_run_gates_spec.sh:4
-agent_work_branch_spec.sh:24
+agent_work_branch_spec.sh:28
 composer_cloud_install_spec.sh:4
 git_no_docs_spec.sh:5
 githooks_pre_push_lease_spec.sh:54

--- a/scripts/git-env-scrub-guard.sh
+++ b/scripts/git-env-scrub-guard.sh
@@ -79,7 +79,7 @@ check_fixture_manifest() {
     done <<'EOF'
 agent_run_gates_git_spec.sh:2
 agent_run_gates_spec.sh:4
-agent_work_branch_spec.sh:28
+agent_work_branch_spec.sh:31
 composer_cloud_install_spec.sh:4
 git_no_docs_spec.sh:5
 githooks_pre_push_lease_spec.sh:54

--- a/tests/shell/agent_codegraph_spec.sh
+++ b/tests/shell/agent_codegraph_spec.sh
@@ -128,6 +128,30 @@ GRAPHIFY
 [ "$#" -eq 3 ] && [ "$1" = project ] && [ "$2" = index ] || exit 9
 exit 0
 SERENA
+    # Hermetic `wt`: work-branch.sh cuts through wt, and this spec must exercise
+    # work-branch.sh on every host — with or without Worktrunk installed.
+    cat > "$stubdir/wt" <<'WT'
+#!/bin/sh
+wt_path=''
+wt_branch=''
+while [ "$#" -gt 0 ]; do
+  case $1 in
+    --config-set)
+      wt_path=${2#worktree-path=\"}
+      wt_path=${wt_path%\"}
+      shift 2
+      ;;
+    switch)
+      shift
+      wt_branch=${1:-}
+      [ "$#" -eq 0 ] || shift
+      ;;
+    *) shift ;;
+  esac
+done
+exec git worktree add "$wt_path" "$wt_branch"
+WT
+    chmod +x "$stubdir/wt"
     chmod +x "$stubdir/codegraph" "$stubdir/graphify" "$stubdir/serena"
     export CODEGRAPH_LOG="$codegraph_log" CODEGRAPH_GRAPHIFY_PACKAGE="$graphify_package"
     PATH="$stubdir:$PATH"; export PATH

--- a/tests/shell/agent_codegraph_spec.sh
+++ b/tests/shell/agent_codegraph_spec.sh
@@ -128,30 +128,7 @@ GRAPHIFY
 [ "$#" -eq 3 ] && [ "$1" = project ] && [ "$2" = index ] || exit 9
 exit 0
 SERENA
-    # Hermetic `wt`: work-branch.sh cuts through wt, and this spec must exercise
-    # work-branch.sh on every host — with or without Worktrunk installed.
-    cat > "$stubdir/wt" <<'WT'
-#!/bin/sh
-wt_path=''
-wt_branch=''
-while [ "$#" -gt 0 ]; do
-  case $1 in
-    --config-set)
-      wt_path=${2#worktree-path=\"}
-      wt_path=${wt_path%\"}
-      shift 2
-      ;;
-    switch)
-      shift
-      wt_branch=${1:-}
-      [ "$#" -eq 0 ] || shift
-      ;;
-    *) shift ;;
-  esac
-done
-exec git worktree add "$wt_path" "$wt_branch"
-WT
-    chmod +x "$stubdir/wt"
+    make_wt_stub "$stubdir"
     chmod +x "$stubdir/codegraph" "$stubdir/graphify" "$stubdir/serena"
     export CODEGRAPH_LOG="$codegraph_log" CODEGRAPH_GRAPHIFY_PACKAGE="$graphify_package"
     PATH="$stubdir:$PATH"; export PATH
@@ -192,7 +169,7 @@ WT
     When call create_unmarked_worktree
     The status should equal 0
     The output should equal "$(printf 'adr/9-codegraph\t%s/agent-worktree' "$fixture")"
-    The stderr should include 'Preparing worktree'
+    The stderr should include 'Created worktree for'
     The contents of file "$codegraph_log" should equal "init $fixture/agent-worktree"
     Assert [ -f "$fixture/agent-worktree/.codegraph/codegraph.db" ]
   End
@@ -230,7 +207,7 @@ WT
     When call create_marked_worktree "$1"
     The status should equal 0
     The output should equal "$(printf 'adr/9-codegraph\t%s/agent-worktree' "$fixture")"
-    The stderr should include 'Preparing worktree'
+    The stderr should include 'Created worktree for'
     The contents of file "$codegraph_log" should equal "init $fixture/agent-worktree"
     Assert [ -f "$fixture/agent-worktree/.codegraph/codegraph.db" ]
   End

--- a/tests/shell/agent_work_branch_spec.sh
+++ b/tests/shell/agent_work_branch_spec.sh
@@ -151,12 +151,23 @@ while [ "$#" -gt 0 ]; do
 done
 # WB_WT_EMPTY reproduces a wt that reports success and leaves no worktree.
 [ "${WB_WT_EMPTY:-0}" -eq 0 ] || exit 0
-"$WB_REAL_GIT" worktree add "$wt_path" "$wt_branch" || exit $?
+# Real wt reformats git's progress away and prints its own line; a stub that let
+# git's raw stderr through would let assertions pass on text real wt never emits.
+"$WB_REAL_GIT" worktree add "$wt_path" "$wt_branch" >/dev/null 2>&1 || exit $?
+printf '%s\n' "✓ Created worktree for $wt_branch @ $wt_path" >&2
 # Real wt runs the tracked .config/wt.toml `pre-start` hook, which initializes the
 # worktree's tools. WB_WT_PRESTART reproduces that already-initialized result.
 [ "${WB_WT_PRESTART:-0}" -eq 0 ] || {
   mkdir -p "$wt_path/.codegraph"
   true > "$wt_path/.codegraph/codegraph.db"
+}
+# WB_WT_HOOKFAIL reproduces real wt's worst shape: the worktree is created and
+# REGISTERED, the pre-start hook then fails part-way, and wt exits non-zero while
+# leaving the tree — including a half-written CodeGraph marker — behind.
+[ "${WB_WT_HOOKFAIL:-0}" -eq 0 ] || {
+  mkdir -p "$wt_path/.codegraph"
+  true > "$wt_path/.codegraph/codegraph.db"
+  exit 1
 }
 WT
     chmod +x "$stubdir/wt"
@@ -183,7 +194,7 @@ WT
     When run sh -c 'cd "$1" && exec sh "$2" adr 41 tools --worktree --base HEAD --path nested/worktree' _ "$primary" "$script_abs"
     The status should equal 0
     The output should equal "$(printf 'adr/41-tools\t%s/nested/worktree' "$worktree_root")"
-    The stderr should include 'Preparing worktree'
+    The stderr should include 'Created worktree for'
     The contents of file "$events" should equal "$(printf 'fetch\nwt\ninit:%s/nested/worktree' "$worktree_root")"
     The path "$worktree_root" should be directory
   End
@@ -194,7 +205,7 @@ WT
     When run env OMP_CLI=1 sh -c 'cd "$1" && exec sh "$2" adr 44 tools --worktree --base HEAD --path "$3"' _ "$primary" "$script_abs" "$fixture/default-init"
     The status should equal 0
     The output should equal "$(printf 'adr/44-tools\t%s/default-init' "$fixture")"
-    The stderr should include 'Preparing worktree'
+    The stderr should include 'Created worktree for'
     The stderr should include 'Initializing CodeGraph in'
     The contents of file "$events" should equal "$(printf 'fetch\nwt')"
     The contents of file "$default_tool_log" should equal "codegraph:init:$fixture/default-init"
@@ -246,12 +257,51 @@ WT
     The path "$fixture/wt-empty" should be directory
   End
 
+  It 'reclaims the worktree wt registered before its pre-start hook failed'
+    # Real wt creates and registers the worktree BEFORE running pre-start, and leaves
+    # it on disk when the hook fails. Falling back over the top of it would hit
+    # `fatal: already exists`, and the branch rollback would then fail because the
+    # branch is checked out in the orphan: an orphan worktree squatting the canonical
+    # path plus an undeletable branch. Its half-written CodeGraph marker must go with
+    # it, or the retry inherits a tree that only looks initialized.
+    add_origin || return 1
+    export WB_WT_HOOKFAIL=1
+    When run sh -c 'cd "$1" && exec sh "$2" adr 58 hookfail --worktree --base HEAD --path "$3"' _ "$primary" "$script_abs" "$fixture/wt-hookfail"
+    The status should equal 0
+    The output should equal "$(printf 'adr/58-hookfail\t%s/wt-hookfail' "$fixture")"
+    The stderr should include 'wt could not cut'
+    The contents of file "$events" should equal "$(printf 'fetch\nwt\nadd\ninit:%s/wt-hookfail' "$fixture")"
+    The path "$fixture/wt-hookfail" should be directory
+    Assert [ -n "$(git_fixture -C "$primary" worktree list | grep -F "$fixture/wt-hookfail")" ]
+    Assert [ "$(git_fixture -C "$primary" worktree list | grep -cF "$fixture/wt-hookfail")" -eq 1 ]
+  End
+
+  It 'rejects a --path bearing a wt template marker before reserving a branch'
+    # wt renders `worktree-path` as a minijinja template, so `{{ repo }}` in the path
+    # would place the worktree somewhere this script never reports.
+    add_origin || return 1
+    When run sh -c 'cd "$1" && exec sh "$2" adr 59 template --worktree --base HEAD --path "$3"' _ "$primary" "$script_abs" "$fixture/wt-{{ repo }}"
+    The status should equal 2
+    The stderr should include 'control characters or template markers'
+    The output should equal ''
+    Assert [ -z "$(git_fixture -C "$primary" branch --list 'adr/59-template')" ]
+  End
+
+  It 'rejects a --path bearing a control character before reserving a branch'
+    add_origin || return 1
+    When run sh -c 'cd "$1" && exec sh "$2" adr 60 ctrl --worktree --base HEAD --path "$3"' _ "$primary" "$script_abs" "$(printf '%s/wt-ctrl\t2' "$fixture")"
+    The status should equal 2
+    The stderr should include 'control characters or template markers'
+    The output should equal ''
+    Assert [ -z "$(git_fixture -C "$primary" branch --list 'adr/60-ctrl')" ]
+  End
+
   It 'does not re-initialize a worktree wt already initialized through its pre-start hook'
     add_origin || return 1
     export WB_WT_PRESTART=1
     When run sh -c 'cd "$1" && exec sh "$2" adr 57 prestart --worktree --base HEAD --path "$3"' _ "$primary" "$script_abs" "$fixture/wt-prestart"
     The status should equal 0
-    The stderr should include 'Preparing worktree'
+    The stderr should include 'Created worktree for'
     The output should equal "$(printf 'adr/57-prestart\t%s/wt-prestart' "$fixture")"
     The contents of file "$events" should equal "$(printf 'fetch\nwt')"
     Assert [ -f "$fixture/wt-prestart/.codegraph/codegraph.db" ]
@@ -323,29 +373,7 @@ mkdir -p "$1/.codegraph"
 true > "$1/.codegraph/codegraph.db"
 INIT
     chmod +x "$stubdir/init-worktree-tools"
-    # Hermetic `wt`: the spec must exercise work-branch.sh, never the host's wt.
-    cat > "$stubdir/wt" <<'WT'
-#!/bin/sh
-wt_path=''
-wt_branch=''
-while [ "$#" -gt 0 ]; do
-  case $1 in
-    --config-set)
-      wt_path=${2#worktree-path=\"}
-      wt_path=${wt_path%\"}
-      shift 2
-      ;;
-    switch)
-      shift
-      wt_branch=${1:-}
-      [ "$#" -eq 0 ] || shift
-      ;;
-    *) shift ;;
-  esac
-done
-exec git worktree add "$wt_path" "$wt_branch"
-WT
-    chmod +x "$stubdir/wt"
+    make_wt_stub "$stubdir"
     export PFB_INIT_WORKTREE_TOOLS="$stubdir/init-worktree-tools"
     PATH="$stubdir:$PATH"; export PATH
   }
@@ -361,7 +389,7 @@ WT
     The status should equal 0
     The output should equal "$(printf 'issue/7-tld\t%s/issue-7-tld' "$worktree_root")"
     The output should not include "$primary/"
-    The stderr should include 'Preparing worktree'
+    The stderr should include 'Created worktree for'
     The path "$worktree_root" should be directory
   End
 
@@ -371,7 +399,7 @@ WT
     The output should equal "$(printf 'issue/7-tld\t%s/issue-7-tld' "$worktree_root")"
     The output should not include "$primary/"
     The output should not include "$fixture/pfblockerng-issue-7"
-    The stderr should include 'Preparing worktree'
+    The stderr should include 'Created worktree for'
     The contents of file "$codegraph_log" should equal "init $worktree_root/issue-7-tld"
     Assert [ -f "$worktree_root/issue-7-tld/.codegraph/codegraph.db" ]
   End
@@ -381,7 +409,7 @@ WT
     The status should equal 0
     The output should equal "$(printf 'issue/8-tld\t%s/wt/x' "$worktree_root")"
     The output should not include "$primary/"
-    The stderr should include 'Preparing worktree'
+    The stderr should include 'Created worktree for'
   End
 
   It 'rejects a parent-traversing relative --path before creating a branch or worktree'
@@ -425,7 +453,7 @@ WT
     The status should equal 0
     The output should equal "$(printf 'issue/9-tld\t%s/issue-9-tld' "$worktree_root")"
     The output should not include "$primary/"
-    The stderr should include 'Preparing worktree'
+    The stderr should include 'Created worktree for'
   End
 
   It 'is immune to an inherited CDPATH when resolving the sibling root'
@@ -435,7 +463,7 @@ WT
     The status should equal 0
     The output should equal "$(printf 'issue/10-tld\t%s/issue-10-tld' "$worktree_root")"
     The output should not include "$primary/"
-    The stderr should include 'Preparing worktree'
+    The stderr should include 'Created worktree for'
   End
 
   It 'uses the suffixed branch name for a colliding default worktree'
@@ -444,7 +472,7 @@ WT
     The status should equal 0
     The output should equal "$(printf 'issue/14-tld-1700000000\t%s/issue-14-tld-1700000000' "$worktree_root")"
     The output should not include "$primary/"
-    The stderr should include 'Preparing worktree'
+    The stderr should include 'Created worktree for'
   End
 
   It 'advances past repeated deterministic branch collisions'
@@ -452,7 +480,7 @@ WT
     git_fixture -C "$primary" branch adr/48-collide-1700000000
     When run sh -c 'cd "$1" && exec sh "$2" adr 48 collide --worktree --base HEAD' _ "$fixture/session" "$script_abs"
     The status should equal 0
-    The stderr should include 'Preparing worktree'
+    The stderr should include 'Created worktree for'
     The output should equal "$(printf 'adr/48-collide-1700000000-2\t%s/adr-48-collide-1700000000-2' "$worktree_root")"
     The path "$worktree_root/adr-48-collide-1700000000-2" should be directory
   End
@@ -542,7 +570,7 @@ WT
     When run sh -c 'cd "$1" && exec sh "$2" issue 12 tld --worktree --base HEAD --path "$3"' _ "$fixture/session" "$script_abs" "$fixture/abs-target"
     The status should equal 0
     The output should equal "$(printf 'issue/12-tld\t%s/abs-target' "$fixture")"
-    The stderr should include 'Preparing worktree'
+    The stderr should include 'Created worktree for'
   End
 
   It 'fails an occupied explicit absolute --path without suffixing or leaking a branch'
@@ -568,7 +596,7 @@ WT
   It 'advances the branch when only its default worktree path is occupied'
     mkdir -p "$worktree_root/adr-53-path-only"
     When run sh -c 'cd "$1" && exec sh "$2" adr 53 path-only --worktree --base HEAD' _ "$fixture/session" "$script_abs"
-    The stderr should include 'Preparing worktree'
+    The stderr should include 'Created worktree for'
     The status should equal 0
     The output should equal "$(printf 'adr/53-path-only-1700000000\t%s/adr-53-path-only-1700000000' "$worktree_root")"
     The path "$worktree_root/adr-53-path-only-1700000000" should be directory
@@ -578,7 +606,7 @@ WT
     When run sh -c 'cd "$1" && exec sh "$2" issue 13 tld --worktree --base HEAD --path "$3"' _ "$fixture/session" "$script_abs" "$fixture/offline"
     The status should equal 0
     The output should equal "$(printf 'issue/13-tld\t%s/offline' "$fixture")"
-    The stderr should include 'Preparing worktree'
+    The stderr should include 'Created worktree for'
     Assert [ -f "$fixture/offline/.codegraph/codegraph.db" ]
   End
 End
@@ -636,29 +664,7 @@ CODEGRAPH
 exit 0
 INIT
     chmod +x "$stubdir/init-worktree-tools"
-    # Hermetic `wt`: the spec must exercise work-branch.sh, never the host's wt.
-    cat > "$stubdir/wt" <<'WT'
-#!/bin/sh
-wt_path=''
-wt_branch=''
-while [ "$#" -gt 0 ]; do
-  case $1 in
-    --config-set)
-      wt_path=${2#worktree-path=\"}
-      wt_path=${wt_path%\"}
-      shift 2
-      ;;
-    switch)
-      shift
-      wt_branch=${1:-}
-      [ "$#" -eq 0 ] || shift
-      ;;
-    *) shift ;;
-  esac
-done
-exec git worktree add "$wt_path" "$wt_branch"
-WT
-    chmod +x "$stubdir/wt"
+    make_wt_stub "$stubdir"
     export PFB_INIT_WORKTREE_TOOLS="$stubdir/init-worktree-tools"
     PATH="$stubdir:$codegraph_dir:$PATH"; export PATH
   }
@@ -688,14 +694,14 @@ WT
     When run sh -c 'cd "$1" && WB_ASSIGNEES=other,me exec sh "$2" issue 7 tld --worktree --base HEAD' _ "$primary" "$script_abs"
     The status should equal 0
     The output should equal "$(printf 'issue/7-tld\t%s/issue-7-tld' "$worktree_root")"
-    The stderr should include 'Preparing worktree'
+    The stderr should include 'Created worktree for'
   End
 
   It '--claim assigns an unclaimed issue to the caller and proceeds'
     When run sh -c 'cd "$1" && WB_ASSIGNEES= exec sh "$2" issue 7 tld --worktree --base HEAD --claim' _ "$primary" "$script_abs"
     The status should equal 0
     The output should equal "$(printf 'issue/7-tld\t%s/issue-7-tld' "$worktree_root")"
-    The stderr should include 'Preparing worktree'
+    The stderr should include 'Created worktree for'
     The contents of file "$gh_log" should include 'issue edit 7 --add-assignee @me'
   End
 
@@ -725,7 +731,7 @@ WT
     When run sh -c 'cd "$1" && WB_GH_RC=1 exec sh "$2" adr 9 x --worktree --base HEAD' _ "$primary" "$script_abs"
     The status should equal 0
     The output should equal "$(printf 'adr/9-x\t%s/adr-9-x' "$worktree_root")"
-    The stderr should include 'Preparing worktree'
+    The stderr should include 'Created worktree for'
     Assert [ ! -e "$gh_log" ]
   End
 

--- a/tests/shell/agent_work_branch_spec.sh
+++ b/tests/shell/agent_work_branch_spec.sh
@@ -125,6 +125,41 @@ esac
 exec "$WB_REAL_GIT" "$@"
 GIT
     chmod +x "$stubdir/git"
+    # `wt` stub: records the call, then cuts the worktree the way real wt does.
+    # It reaches the REAL git on purpose — the `add` event exists to catch
+    # work-branch.sh calling `git worktree add` itself, i.e. taking the fallback.
+    cat > "$stubdir/wt" <<'WT'
+#!/bin/sh
+printf '%s\n' wt >> "$WB_TOOL_EVENTS"
+[ "${WB_WT_RC:-0}" -eq 0 ] || exit "$WB_WT_RC"
+wt_path=''
+wt_branch=''
+while [ "$#" -gt 0 ]; do
+  case $1 in
+    --config-set)
+      wt_path=${2#worktree-path=\"}
+      wt_path=${wt_path%\"}
+      shift 2
+      ;;
+    switch)
+      shift
+      wt_branch=${1:-}
+      [ "$#" -eq 0 ] || shift
+      ;;
+    *) shift ;;
+  esac
+done
+# WB_WT_EMPTY reproduces a wt that reports success and leaves no worktree.
+[ "${WB_WT_EMPTY:-0}" -eq 0 ] || exit 0
+"$WB_REAL_GIT" worktree add "$wt_path" "$wt_branch" || exit $?
+# Real wt runs the tracked .config/wt.toml `pre-start` hook, which initializes the
+# worktree's tools. WB_WT_PRESTART reproduces that already-initialized result.
+[ "${WB_WT_PRESTART:-0}" -eq 0 ] || {
+  mkdir -p "$wt_path/.codegraph"
+  true > "$wt_path/.codegraph/codegraph.db"
+}
+WT
+    chmod +x "$stubdir/wt"
     export WB_TOOL_EVENTS="$events"
     default_tool_log="$fixture/default-tools"
     export WB_DEFAULT_TOOL_LOG="$default_tool_log" WB_GRAPHIFY_PACKAGE="$graphify_package"
@@ -149,7 +184,7 @@ GIT
     The status should equal 0
     The output should equal "$(printf 'adr/41-tools\t%s/nested/worktree' "$worktree_root")"
     The stderr should include 'Preparing worktree'
-    The contents of file "$events" should equal "$(printf 'fetch\nadd\ninit:%s/nested/worktree' "$worktree_root")"
+    The contents of file "$events" should equal "$(printf 'fetch\nwt\ninit:%s/nested/worktree' "$worktree_root")"
     The path "$worktree_root" should be directory
   End
 
@@ -161,7 +196,7 @@ GIT
     The output should equal "$(printf 'adr/44-tools\t%s/default-init' "$fixture")"
     The stderr should include 'Preparing worktree'
     The stderr should include 'Initializing CodeGraph in'
-    The contents of file "$events" should equal "$(printf 'fetch\nadd')"
+    The contents of file "$events" should equal "$(printf 'fetch\nwt')"
     The contents of file "$default_tool_log" should equal "codegraph:init:$fixture/default-init"
     The stderr should include 'run /graphify'
   End
@@ -184,9 +219,42 @@ GIT
     The status should equal 17
     The output should equal ''
     The stderr should include 'tool initialization failure'
-    The contents of file "$events" should equal "$(printf 'fetch\nadd\ninit:%s/init-fail' "$fixture")"
+    The contents of file "$events" should equal "$(printf 'fetch\nwt\ninit:%s/init-fail' "$fixture")"
     Assert [ ! -e "$fixture/init-fail" ]
     Assert [ -z "$(git_fixture -C "$primary" branch --list 'adr/43-tools')" ]
+  End
+
+  It 'falls back to git worktree add when wt fails'
+    add_origin || return 1
+    export WB_WT_RC=1
+    When run sh -c 'cd "$1" && exec sh "$2" adr 55 wtfail --worktree --base HEAD --path "$3"' _ "$primary" "$script_abs" "$fixture/wt-fail"
+    The status should equal 0
+    The output should equal "$(printf 'adr/55-wtfail\t%s/wt-fail' "$fixture")"
+    The stderr should include 'wt could not cut'
+    The contents of file "$events" should equal "$(printf 'fetch\nwt\nadd\ninit:%s/wt-fail' "$fixture")"
+    The path "$fixture/wt-fail" should be directory
+  End
+
+  It 'falls back when wt reports success without leaving a worktree'
+    add_origin || return 1
+    export WB_WT_EMPTY=1
+    When run sh -c 'cd "$1" && exec sh "$2" adr 56 wtempty --worktree --base HEAD --path "$3"' _ "$primary" "$script_abs" "$fixture/wt-empty"
+    The status should equal 0
+    The output should equal "$(printf 'adr/56-wtempty\t%s/wt-empty' "$fixture")"
+    The stderr should include 'wt could not cut'
+    The contents of file "$events" should equal "$(printf 'fetch\nwt\nadd\ninit:%s/wt-empty' "$fixture")"
+    The path "$fixture/wt-empty" should be directory
+  End
+
+  It 'does not re-initialize a worktree wt already initialized through its pre-start hook'
+    add_origin || return 1
+    export WB_WT_PRESTART=1
+    When run sh -c 'cd "$1" && exec sh "$2" adr 57 prestart --worktree --base HEAD --path "$3"' _ "$primary" "$script_abs" "$fixture/wt-prestart"
+    The status should equal 0
+    The stderr should include 'Preparing worktree'
+    The output should equal "$(printf 'adr/57-prestart\t%s/wt-prestart' "$fixture")"
+    The contents of file "$events" should equal "$(printf 'fetch\nwt')"
+    Assert [ -f "$fixture/wt-prestart/.codegraph/codegraph.db" ]
   End
 End
 
@@ -255,6 +323,29 @@ mkdir -p "$1/.codegraph"
 true > "$1/.codegraph/codegraph.db"
 INIT
     chmod +x "$stubdir/init-worktree-tools"
+    # Hermetic `wt`: the spec must exercise work-branch.sh, never the host's wt.
+    cat > "$stubdir/wt" <<'WT'
+#!/bin/sh
+wt_path=''
+wt_branch=''
+while [ "$#" -gt 0 ]; do
+  case $1 in
+    --config-set)
+      wt_path=${2#worktree-path=\"}
+      wt_path=${wt_path%\"}
+      shift 2
+      ;;
+    switch)
+      shift
+      wt_branch=${1:-}
+      [ "$#" -eq 0 ] || shift
+      ;;
+    *) shift ;;
+  esac
+done
+exec git worktree add "$wt_path" "$wt_branch"
+WT
+    chmod +x "$stubdir/wt"
     export PFB_INIT_WORKTREE_TOOLS="$stubdir/init-worktree-tools"
     PATH="$stubdir:$PATH"; export PATH
   }
@@ -545,6 +636,29 @@ CODEGRAPH
 exit 0
 INIT
     chmod +x "$stubdir/init-worktree-tools"
+    # Hermetic `wt`: the spec must exercise work-branch.sh, never the host's wt.
+    cat > "$stubdir/wt" <<'WT'
+#!/bin/sh
+wt_path=''
+wt_branch=''
+while [ "$#" -gt 0 ]; do
+  case $1 in
+    --config-set)
+      wt_path=${2#worktree-path=\"}
+      wt_path=${wt_path%\"}
+      shift 2
+      ;;
+    switch)
+      shift
+      wt_branch=${1:-}
+      [ "$#" -eq 0 ] || shift
+      ;;
+    *) shift ;;
+  esac
+done
+exec git worktree add "$wt_path" "$wt_branch"
+WT
+    chmod +x "$stubdir/wt"
     export PFB_INIT_WORKTREE_TOOLS="$stubdir/init-worktree-tools"
     PATH="$stubdir:$codegraph_dir:$PATH"; export PATH
   }

--- a/tests/shell/agent_work_branch_spec.sh
+++ b/tests/shell/agent_work_branch_spec.sh
@@ -151,6 +151,12 @@ while [ "$#" -gt 0 ]; do
 done
 # WB_WT_EMPTY reproduces a wt that reports success and leaves no worktree.
 [ "${WB_WT_EMPTY:-0}" -eq 0 ] || exit 0
+# WB_WT_BAREDIR reproduces success reported over a stray directory that is not a
+# worktree: no `.git` file, so the cut did not actually happen.
+[ "${WB_WT_BAREDIR:-0}" -eq 0 ] || {
+  mkdir -p "$wt_path"
+  exit 0
+}
 # Real wt reformats git's progress away and prints its own line; a stub that let
 # git's raw stderr through would let assertions pass on text real wt never emits.
 "$WB_REAL_GIT" worktree add "$wt_path" "$wt_branch" >/dev/null 2>&1 || exit $?
@@ -255,6 +261,36 @@ WT
     The stderr should include 'wt could not cut'
     The contents of file "$events" should equal "$(printf 'fetch\nwt\nadd\ninit:%s/wt-empty' "$fixture")"
     The path "$fixture/wt-empty" should be directory
+  End
+
+  It 'rejects a bare directory as a successful cut'
+    # `[ -d ]` would accept any directory; a worktree checkout always has a `.git`
+    # FILE. Without that distinction wt reporting success over a stray directory is
+    # taken as a cut, and the branch is reported against a tree that does not exist.
+    add_origin || return 1
+    export WB_WT_BAREDIR=1
+    When run sh -c 'cd "$1" && exec sh "$2" adr 61 baredir --worktree --base HEAD --path "$3"' _ "$primary" "$script_abs" "$fixture/wt-baredir"
+    The status should equal 0
+    The output should equal "$(printf 'adr/61-baredir\t%s/wt-baredir' "$fixture")"
+    The stderr should include 'wt could not cut'
+    The contents of file "$events" should equal "$(printf 'fetch\nwt\nadd\ninit:%s/wt-baredir' "$fixture")"
+    Assert [ -f "$fixture/wt-baredir/.git" ]
+  End
+
+  It 'rejects a derived worktree root bearing a template marker, with no --path at all'
+    # The sibling root comes from the CHECKOUT's own directory name, so validating
+    # only what the caller typed leaves wt's template renderer reachable through an
+    # ancestor: the cut lands somewhere this script never reports.
+    marked="$fixture/pf{{ repo }}"
+    git_fixture init -q -b devel "$marked" &&
+      git_fixture -C "$marked" -c user.email=t@t -c user.name=t -c commit.gpgsign=false \
+        commit -q --allow-empty -m init || return 1
+    When run sh -c 'cd "$1" && exec sh "$2" adr 62 marker --worktree --base HEAD' _ "$marked" "$script_abs"
+    The status should equal 2
+    The stderr should include 'control characters or template markers'
+    The output should equal ''
+    Assert [ -z "$(git_fixture -C "$marked" branch --list 'adr/62-marker')" ]
+    Assert [ ! -e "$fixture/.pf{{ repo }}_worktrees" ]
   End
 
   It 'reclaims the worktree wt registered before its pre-start hook failed'

--- a/tests/shell/spec_helper.sh
+++ b/tests/shell/spec_helper.sh
@@ -72,6 +72,36 @@ EOF
 	chmod +x "$1"
 }
 
+# Hermetic `wt` in $1/wt for specs that exercise work-branch.sh's worktree cut. The
+# specs must not depend on whether the host has Worktrunk installed, and must not let
+# git's raw progress output stand in for wt's — real wt swallows it and prints its own
+# line, so an assertion keyed to git's text would pass on a string wt never emits.
+make_wt_stub() {
+	cat > "$1/wt" <<'WTSTUB'
+#!/bin/sh
+wt_path=''
+wt_branch=''
+while [ "$#" -gt 0 ]; do
+  case $1 in
+    --config-set)
+      wt_path=${2#worktree-path=\"}
+      wt_path=${wt_path%\"}
+      shift 2
+      ;;
+    switch)
+      shift
+      wt_branch=${1:-}
+      [ "$#" -eq 0 ] || shift
+      ;;
+    *) shift ;;
+  esac
+done
+git worktree add "$wt_path" "$wt_branch" >/dev/null 2>&1 || exit $?
+printf '%s\n' "✓ Created worktree for $wt_branch @ $wt_path" >&2
+WTSTUB
+	chmod +x "$1/wt"
+}
+
 # Call exitnow() against a caller-supplied tmpdir. Always run via \`When run\` so
 # the exit() lands in a subshell; afterwards the directory should be gone.
 run_exitnow_on() {


### PR DESCRIPTION
Fixes #3089.

## What changed

`scripts/agent/work-branch.sh --worktree` cut worktrees with `git worktree add` while
`wt` was the documented convention, so agents saw two sanctioned routes and picked
either. It now cuts through
`wt --yes --config-set 'worktree-path="<path>"' switch <branch>`, falling back to
`git worktree add` only when `wt` is absent, exits non-zero, or reports success without
leaving a worktree at the expected path.

`wt` runs the tracked `.config/wt.toml` `pre-start` hook, which is
`init-worktree-tools.sh`. The direct initializer call therefore now runs only when the
cut came back without a CodeGraph index — the `git worktree` fallback, or a pre-start
that did not run — so neither route initializes twice. Without this the `wt` route would
have paid for a second full `graphify update` on every cut.

`.agents/policy/git.md` gains the scratch-tree rule the policy never had, and the
`wt`-first rule with its fallback replaces the old text that documented the divergence
as intended ("It uses Git directly").

## Test-first proof

Reproduction tests were authored and executed RED before any production edit, frozen
byte-identical, and re-run GREEN unchanged.

Red, before touching `work-branch.sh` — `git hash-object` of the spec at red time was
`cded8d933d5628fb7699177698c87a51e5e69b30`:

```
46 examples, 5 failures
 1) … fetches before add and initializes a relative worktree beneath the sibling root FAILED
 2) … uses the co-located default initializer when no test seam is configured FAILED
 3) … force-removes a dirty worktree and preserves the tool initialization status FAILED
 4) … falls back to git worktree add when wt fails FAILED
 5) … falls back when wt reports success without leaving a worktree FAILED
```

Green after the edit, spec hash unchanged at `cded8d93`:

```
46 examples, 0 failures
```

The double-initialization defect got the same treatment. Red at spec hash
`c8cb157bb6fcbc6d483d12084d5ec861bb53051b`:

```
47 examples, 1 failure
 1) … does not re-initialize a worktree wt already initialized through its pre-start hook FAILED
```

Green after gating the initializer on the CodeGraph marker, same hash:

```
47 examples, 0 failures
```

## Spec hermeticity

The specs stubbed `git` but not `wt`, so once `work-branch.sh` routed through `wt` they
exercised whichever Worktrunk the host happened to have installed —
`tests/shell/agent_codegraph_spec.sh` failed exactly that way against the real binary.
Both worktree-cutting specs now carry a hermetic `wt` stub, including the two shapes that
trigger the fallback: non-zero exit, and success with no worktree left behind. In
`agent_work_branch_spec.sh` the stub reaches the real `git` on purpose, so the `add` event
still means "work-branch.sh took the fallback itself".

## Coverage

| Route | Covered by |
| --- | --- |
| `wt` succeeds, pre-start did not initialize | `fetches before add and initializes a relative worktree…` |
| `wt` succeeds, pre-start initialized | `does not re-initialize a worktree wt already initialized…` |
| `wt` exits non-zero | `falls back to git worktree add when wt fails` |
| `wt` exits 0, no worktree | `falls back when wt reports success without leaving a worktree` |
| `wt` absent from PATH | `warns and proceeds when gh is not installed at all` (PATH excludes the stub dir) |

## Frozen RED test evidence

Re-proved against the **final shipped** spec files after the verifier round: `git checkout origin/devel -- scripts/agent/work-branch.sh`, run, restore. 65 examples → 31 failures with production reverted, 0 failures with it restored, and `git hash-object` identical before and after both runs.

| Frozen RED test | git hash-object | RED run tail |
| --- | --- | --- |
| `tests/shell/agent_work_branch_spec.sh` | 8218075501467db914d803d6fc69ac0868b3b795 | `65 examples, 31 failures` — incl. `reclaims the worktree wt registered before its pre-start hook failed FAILED`, `falls back to git worktree add when wt fails FAILED`, `rejects a --path bearing a wt template marker before reserving a branch FAILED` |
| `tests/shell/agent_codegraph_spec.sh` | 4519cbaaaf0bfdf8e661bdf7da52ce81380d8fec | `65 examples, 31 failures` — incl. `initializes a new worktree without relying on a client marker FAILED` and the six agent-marker examples at :206 |
| `tests/shell/spec_helper.sh` | 682b5e7701c39a7adbf1f0e81797cedf48f67637 | `65 examples, 31 failures` — supplies `make_wt_stub` to both specs above; every failure listed for them exercises it |

## Second review round (independent verifier, `agent://DeltaVerifier`)

Verdict was BLOCK on two defects inside this PR's own stated scope, both fixed in `8a9e6174`:

- **The `--path` guard enforced the wrong invariant.** It validated the caller's argument, not the `$cw_path` handed to wt's minijinja template. The sibling root is derived from the *checkout's own directory name*, so a checkout at `<parent>/pf{{ repo }}` reached the renderer on the default and relative routes with no `--path` at all — recorded argv: `worktree-path="…/.pf{{ repo }}_worktrees/adr-1-marker"`. Validation now runs against every component passed to wt, in one function rather than a duplicate `case` block.
- **Six `.github/agents/*.agent.md` role files still named `/tmp`** as the sanctioned scratch location, including all three `adversarial-reviewer*` roles — the same roles whose `landing.md` contract this PR corrects. The previous commit message claimed there were two documents; there were eight. All eight now name `/var/tmp/agents`.

Non-blocking, also fixed: `[ -f "$cw_path/.git" ]` was a mutation survivor — reverting it to `[ -d ]` left the suite green, so it now has a covering example. The verifier's remaining finding (three synthetic wt-leftover shapes the ownership gate declines to reclaim) is answered in-code: anything not holding the branch this call reserved cannot be told apart from a concurrent creator's tree, so the caller collision-suffixes instead. That narrowness is now a comment, not an accident.

Confirmed by the verifier's own execution, not by reading: the frozen hashes reproduce; the concurrency gate and the reclaim block are each load-bearing under targeted mutation; all 18 re-keyed stub assertions fail when the stub's line changes; `Preparing worktree` appears nowhere in the tree.

## Gates

`sh scripts/agent/run-gates.sh --diff origin/devel`: markdownlint PASS; shellspec reports 5 failures, all pre-existing and environmental. Verified by extracting pristine
`origin/devel` and running the same two specs there:

```
69 examples, 5 failures
 pfblockerng_processet_exit_spec.sh:118,150,206,224
 precommit_identity_spec.sh:240
```

Identical set, no diff applied. They are permission-denial tests, and this runner is
root, for which `chmod 000` is not enforced.

## End-to-end smoke

Specs use stubs, so the real route was exercised against real `wt` 0.75.0:

```
$ sh scripts/agent/work-branch.sh adr 99 wt smoke --worktree --base origin/devel
✓ Created worktree for adr/99-wt-smoke @ ~/git/.pfBlockerNG_worktrees/adr-99-wt-smoke
adr/99-wt-smoke	/root/git/.pfBlockerNG_worktrees/adr-99-wt-smoke
```

Stdout is exactly the `BRANCH<TAB>PATH` contract — all of wt's chatter went to stderr —
the tree landed at the conventional path, and the graph rebuilt once, not twice. The
smoke worktree was removed afterwards.

That smoke run also surfaced #3091: the pre-start `graphify update` rewrites tracked
`graphify-out/graph.json`, so every fresh worktree is born with an 830k-line dirty diff
that makes the landing-time `wt remove` refuse without `--force`. Filed separately; not
addressed here.

`pfblockerng_reentry_bounds_spec.sh` failed 5 examples on one gate run and passed on the next two, and passes in isolation on both this branch and a pristine base — a timing flake under load on a box running ten agents, not a regression.
