### PR TITLE
unbound: refuse to start a second resolver when the stop wait times out (#3055)

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -11459,10 +11459,8 @@ function pfb_stop_start_unbound($type) {
 		}
 	}
 
-	// The wait above is bounded, so it can expire with Unbound still up (issue #3055:
-	// a large DNSBL keeps the daemon inside pythonmod init past the budget). Falling
-	// through to the start below is what produces 'bind: address already in use' and a
-	// box that needs kill -9 plus a PEM rebuild. Escalate to KILL, then refuse to start.
+	// issue #3055: the bounded wait above can expire with Unbound still up (a large DNSBL
+	// keeps it inside pythonmod init); starting anyway double-binds :53.
 	if (is_process_running('unbound')) {
 		pfb_logger("\nUnbound did not stop in " . PFB_UNBOUND_STOP_WAIT .
 			" sec; escalating to KILL", 2);

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -11428,6 +11428,9 @@ if (!defined('PFB_UNBOUND_START_CMD')) {
 if (!defined('PFB_UNBOUND_STOP_WAIT')) {
 	define('PFB_UNBOUND_STOP_WAIT', 30);
 }
+if (!defined('PFB_UNBOUND_KILL_WAIT')) {
+	define('PFB_UNBOUND_KILL_WAIT', 5);
+}
 if (!defined('PFB_UNBOUND_START_WAIT')) {
 	define('PFB_UNBOUND_START_WAIT', 30);
 }
@@ -11453,6 +11456,33 @@ function pfb_stop_start_unbound($type) {
 		} else {
 			pfb_logger("\nUnbound stopped in {$i} sec.", 1);
 			break;
+		}
+	}
+
+	// The wait above is bounded, so it can expire with Unbound still up (issue #3055:
+	// a large DNSBL keeps the daemon inside pythonmod init past the budget). Falling
+	// through to the start below is what produces 'bind: address already in use' and a
+	// box that needs kill -9 plus a PEM rebuild. Escalate to KILL, then refuse to start.
+	if (is_process_running('unbound')) {
+		pfb_logger("\nUnbound did not stop in " . PFB_UNBOUND_STOP_WAIT .
+			" sec; escalating to KILL", 2);
+		sigkillbyname('unbound', 'KILL');
+		for ($i=1; $i <= PFB_UNBOUND_KILL_WAIT; $i++) {
+			if (!is_process_running('unbound')) {
+				pfb_logger("\nUnbound killed after {$i} sec.", 2);
+				break;
+			}
+			sleep(1);
+		}
+		// ponytail: process-liveness only. 'bind' is really about :53 and a socket can
+		// outlive the pid -- add a `sockstat -46l` check here if the double-bind is ever
+		// seen with no surviving unbound process.
+		if (is_process_running('unbound')) {
+			$final['result'] = array('Unbound could not be stopped; Resolver not restarted');
+			$final['retval'] = -1;
+			pfb_logger("\nUnbound still running after TERM and KILL; not starting a " .
+				"second instance. Resolver NOT restarted", 2);
+			return $final;
 		}
 	}
 

--- a/tests/php/UnboundRestartSeamTest.php
+++ b/tests/php/UnboundRestartSeamTest.php
@@ -47,7 +47,7 @@ final class UnboundRestartSeamTest extends TestCase
 		];
 
 		// varrun_path holds no unbound.pid, so the TERM half is skipped; the stop-wait
-		// loop and the daemon start are what this file exercises.
+		// loop, the KILL escalation and the daemon start are what this file exercises.
 		$GLOBALS['pfb'] = array_replace($GLOBALS['pfb'], [
 			'log'                  => "{$this->dir}/pfblockerng.log",
 			'errlog'               => "{$this->dir}/error.log",
@@ -262,7 +262,6 @@ final class UnboundRestartSeamTest extends TestCase
 	{
 		$before = $this->doubleInvocations();
 		$GLOBALS['pfb_test_process_running']['unbound'] = TRUE;
-		$GLOBALS['pfb_test_sigkillbyname_calls'] = array();
 		$GLOBALS['pfb_test_sigkillbyname_effect'] = static function (string $name, string $sig): void {
 			if ($name === 'unbound' && $sig === 'KILL') {
 				$GLOBALS['pfb_test_process_running']['unbound'] = FALSE;

--- a/tests/php/UnboundRestartSeamTest.php
+++ b/tests/php/UnboundRestartSeamTest.php
@@ -72,7 +72,8 @@ final class UnboundRestartSeamTest extends TestCase
 		} else {
 			unset($GLOBALS['g']['varrun_path']);
 		}
-		unset($GLOBALS['pfb_test_process_running']);
+		unset($GLOBALS['pfb_test_process_running'], $GLOBALS['pfb_test_sigkillbyname_calls'],
+			$GLOBALS['pfb_test_sigkillbyname_effect']);
 		rmdir_recursive($this->dir);
 	}
 
@@ -200,7 +201,8 @@ final class UnboundRestartSeamTest extends TestCase
 	 * Scenario: the stop-wait must not cost a test the appliance's full budget.
 	 *   Given a process-running double that never reports the daemon gone,
 	 *   When pfb_stop_start_unbound() waits for it to terminate,
-	 *   Then it polls only the harness budget -- 30 one-second polls per call otherwise.
+	 *   Then the stop-wait loop polls only the harness budget -- 30 one-second polls
+	 *   per call otherwise -- and the KILL escalation adds only its own budget.
 	 */
 	public function testStopWaitIsBoundedWhenTheDaemonNeverExits(): void
 	{
@@ -214,8 +216,69 @@ final class UnboundRestartSeamTest extends TestCase
 
 		$this->assertLessThan(30, $polls,
 			"a test that never reports the daemon gone must not pay the appliance's 30 one-second polls");
-		$this->assertSame(PFB_UNBOUND_STOP_WAIT, $polls,
-			'the wait loop must poll exactly its configured budget when the daemon never exits');
+		// The stop loop polls its budget; the timeout branch then re-checks once, polls
+		// the KILL budget, and re-checks once more before refusing to start.
+		$this->assertSame(PFB_UNBOUND_STOP_WAIT + PFB_UNBOUND_KILL_WAIT + 2, $polls,
+			'both waits must poll exactly their configured budgets when the daemon never exits');
+	}
+
+	/**
+	 * Scenario (#3055): a stop that times out must not be followed by a start.
+	 *   Given Unbound is still running after both the TERM wait and the KILL wait,
+	 *   When pfb_stop_start_unbound() runs,
+	 *   Then no start is attempted, and the refusal is reported and logged.
+	 *
+	 * Starting on top of a live daemon is 'bind: address already in use' -- the owner's
+	 * production failure, recoverable only with kill -9 and a PEM rebuild.
+	 */
+	public function testStopTimeoutRefusesToStartASecondInstance(): void
+	{
+		$before = $this->doubleInvocations();
+		$GLOBALS['pfb_test_process_running']['unbound'] = TRUE;
+		$GLOBALS['pfb_test_sigkillbyname_calls'] = array();
+
+		$final = pfb_stop_start_unbound('');
+
+		$this->assertCount(count($before), $this->doubleInvocations(),
+			'a stop that never completed must not reach the daemon start at all');
+		$this->assertSame(-1, $final['retval'],
+			'the refusal must be reported to the caller as a failure, not a silent success');
+		$this->assertNotEmpty($final['result'],
+			'the caller logs the result, so the refusal must carry a reason');
+		$this->assertSame(array(array('unbound', 'KILL')), $GLOBALS['pfb_test_sigkillbyname_calls'],
+			'the timeout must escalate TERM to KILL exactly once before giving up');
+		$this->assertStringContainsString('not starting a second instance',
+			(string) @file_get_contents($GLOBALS['pfb']['log']),
+			'the refusal must be loud in the log, not inferable only from a return value');
+	}
+
+	/**
+	 * Scenario (#3055): the KILL escalation is the recovery, not just a louder failure.
+	 *   Given Unbound ignores TERM but dies on KILL,
+	 *   When pfb_stop_start_unbound() runs,
+	 *   Then the start proceeds normally.
+	 */
+	public function testDaemonThatOnlyDiesOnKillStillGetsRestarted(): void
+	{
+		$before = $this->doubleInvocations();
+		$GLOBALS['pfb_test_process_running']['unbound'] = TRUE;
+		$GLOBALS['pfb_test_sigkillbyname_calls'] = array();
+		$GLOBALS['pfb_test_sigkillbyname_effect'] = static function (string $name, string $sig): void {
+			if ($name === 'unbound' && $sig === 'KILL') {
+				$GLOBALS['pfb_test_process_running']['unbound'] = FALSE;
+			}
+		};
+
+		try {
+			$final = pfb_stop_start_unbound('');
+		} finally {
+			unset($GLOBALS['pfb_test_sigkillbyname_effect']);
+		}
+
+		$this->assertCount(count($before) + 1, $this->doubleInvocations(),
+			'a daemon that KILL did clear must be restarted, not abandoned');
+		$this->assertSame(127, $final['retval'],
+			'the start must run through the harness double exactly as on the clean-stop path');
 	}
 	public function testDaemonizedStartSurvivesTheBoundedWrapper(): void
 	{
@@ -422,6 +485,8 @@ final class UnboundRestartSeamTest extends TestCase
 			'the appliance must still start the shipped daemon against the shipped config');
 		$this->assertNotFalse(strpos($src, "define('PFB_UNBOUND_STOP_WAIT', 30);"),
 			'the appliance must still wait up to 30 seconds for the outgoing daemon');
+		$this->assertNotFalse(strpos($src, "define('PFB_UNBOUND_KILL_WAIT', 5);"),
+			'the KILL escalation must have its own finite five-second budget');
 		$this->assertNotFalse(strpos($src, "define('PFB_UNBOUND_START_WAIT', 30);"),
 			'the appliance start child must have an explicit finite 30-second budget');
 		$this->assertNotFalse(strpos($src, "define('PFB_UNBOUND_START_SETUP_WAIT', 5);"),
@@ -462,6 +527,17 @@ final class UnboundRestartSeamTest extends TestCase
 			'no branch may reach the daemon binary except through PFB_UNBOUND_START_CMD');
 		$this->assertStringContainsString('$i <= PFB_UNBOUND_STOP_WAIT;', $body,
 			'the stop-wait budget must come from the constant, not a literal');
+		$this->assertStringContainsString('$i <= PFB_UNBOUND_KILL_WAIT;', $body,
+			'the KILL-escalation budget must come from the constant, not a literal');
+		$stopLoop = strpos($body, '$i <= PFB_UNBOUND_STOP_WAIT;');
+		$refusal = strpos($body, 'not starting a ');
+		$start = strpos($body, 'PFB_UNBOUND_START_CMD,');
+		$this->assertNotFalse($refusal, 'the stop timeout must have an explicit refusal branch (#3055)');
+		$this->assertNotFalse($start, 'the daemon start must still be reachable');
+		$this->assertGreaterThan($stopLoop, $refusal,
+			'the refusal must be checked after the stop-wait loop, not inside it');
+		$this->assertLessThan($start, $refusal,
+			'the refusal must precede the daemon start, or the second instance is already launched');
 		$this->assertStringContainsString('posix_setpgid(0, 0)', $body,
 			'the start command must enter its own process group before the release barrier opens');
 		$this->assertStringContainsString('posix_kill(-$pid', $body,

--- a/tests/php/bootstrap.php
+++ b/tests/php/bootstrap.php
@@ -80,6 +80,9 @@ if (!defined('PFB_UNBOUND_START_CMD')) {
 if (!defined('PFB_UNBOUND_STOP_WAIT')) {
 	define('PFB_UNBOUND_STOP_WAIT', 2);
 }
+if (!defined('PFB_UNBOUND_KILL_WAIT')) {
+	define('PFB_UNBOUND_KILL_WAIT', 1);
+}
 if (!defined('PFB_UNBOUND_START_WAIT')) {
 	define('PFB_UNBOUND_START_WAIT', 2);
 }

--- a/tests/php/pfsense_doubles.php
+++ b/tests/php/pfsense_doubles.php
@@ -1173,6 +1173,23 @@ if (!function_exists('is_process_running')) {
 	}
 }
 
+if (!function_exists('sigkillbyname')) {
+	// pfSense util.inc: signal every process matching a name. The stop-timeout
+	// escalation in pfb_stop_start_unbound() (issue #3055) reaches this; tests seed
+	// $GLOBALS['pfb_test_sigkillbyname_effect'] with a callable(string $name, string
+	// $sig): void to model what the signal does to
+	// $GLOBALS['pfb_test_process_running']. Calls are recorded in
+	// $GLOBALS['pfb_test_sigkillbyname_calls'] as [name, signal] pairs.
+	function sigkillbyname($procname, $sig) {
+		$GLOBALS['pfb_test_sigkillbyname_calls'][] = array($procname, $sig);
+		$effect = $GLOBALS['pfb_test_sigkillbyname_effect'] ?? NULL;
+		if (is_callable($effect)) {
+			$effect($procname, $sig);
+		}
+		return 0;
+	}
+}
+
 if (!function_exists('get_single_sysctl')) {
 	// pfSense pfsense-utils.inc: read one sysctl OID as a string. pfb_unbound_py_swap_fits_ram()
 	// reads 'hw.usermem' to project whether a zero-downtime swap fits in RAM. Tests seed


### PR DESCRIPTION
Closes #3055.

## The defect

`pfb_stop_start_unbound()` sends TERM, then polls `is_process_running('unbound')` for up to `PFB_UNBOUND_STOP_WAIT` (30) seconds. **The wait is bounded but the timeout was never handled** — there is no branch for "still running after 30 seconds". The loop simply ends and execution falls through to start a new instance on top of the old one:

```php
for ($i=1; $i <= PFB_UNBOUND_STOP_WAIT; $i++) {
    if (is_process_running('unbound')) { pfb_logger('.', 1); sleep(1); }
    else { pfb_logger("\nUnbound stopped in {$i} sec.", 1); break; }
}
// ...then, unconditionally:
pfb_logger("\nStarting Unbound Resolver", 1);
```

That is the reported `error: bind: address already in use` / `fatal error: could not open ports` — observed twice on a production 25.11 box, recoverable only with `kill -9` plus regenerating the unbound PEM files.

## Why #3046 did not close it

#3046 halved the exposure window; it did not close it. On the reporting box (1,219,390 entries):

| | |
|---|---|
| `PFB_UNBOUND_STOP_WAIT` | 30 s |
| init before #3046 | 93.17 s |
| init after #3046 + #3050 | 42.44 s |

42 s still exceeds the 30 s wait. Anyone whose init passes 30 s — roughly 800k+ entries on that hardware — remains exposed.

## The change

Handle the case the loop already detects.

- If Unbound is still running when the stop wait expires, escalate TERM to **KILL** and wait `PFB_UNBOUND_KILL_WAIT` (new, 5 s) for it.
- If it is **still** running after that, log loudly and `return` with `retval -1` — **no start is attempted**.

A resolver that did not come back is recoverable from the GUI. Two instances fighting over `:53` needs console access. Starting a second instance is the one option that produces an unrecoverable state, so it is the one option removed.

KILL is also attempted rather than only logged, so a daemon that ignores TERM but dies on KILL is restarted instead of abandoned. **That half is untested against a real appliance** — whether an `unbound` wedged inside pythonmod init actually dies on `SIGKILL`, and whether the following start succeeds after a `-9` (chroot, python mounts, PEMs), is not something a checkout can exercise and no smoke-seat run is cited here. The property this PR *guarantees*, and which the doubles do prove, is narrower and is the one that matters: **no second instance is ever started.**

## Verification

All off-appliance — `is_process_running` is a test double, so no live daemon is needed.

| test | asserts |
|---|---|
| `testStopTimeoutRefusesToStartASecondInstance` | no start attempt (the harness daemon-start double records nothing), `retval -1`, exactly one KILL, and the refusal is in the log |
| `testDaemonThatOnlyDiesOnKillStillGetsRestarted` | KILL clears it → the start runs, `retval` unchanged from the clean-stop path |
| `testStopWaitIsBoundedWhenTheDaemonNeverExits` | both waits poll exactly their configured budgets |
| source pins | `PFB_UNBOUND_KILL_WAIT` ships as 5, and the refusal sits **after** the stop loop and **before** `PFB_UNBOUND_START_CMD` |

**Red half.** With `src/usr/local/pkg/pfblockerng/pfblockerng.inc` reverted to `origin/devel` and the tests frozen at the objects below:

```
1) UnboundRestartSeamTest::testStopWaitIsBoundedWhenTheDaemonNeverExits
   Failed asserting that 2 is identical to 5.
2) UnboundRestartSeamTest::testStopTimeoutRefusesToStartASecondInstance
   Failed asserting that actual size 3 matches expected size 2.
3) UnboundRestartSeamTest::testShippedDefaultsStillStartTheApplianceDaemon
   Failed asserting that false is not false.
Tests: 12, Assertions: 58, Failures: 3.
```

Green with the fix: `OK (12 tests, 89 assertions)`.

**Frozen-RED record** (`testing.md` principle 1), at head `713983205`:

```
f23c4b95d961e26e51d6d439de44af5b4e8d5bc1  tests/php/UnboundRestartSeamTest.php
68ddaf47550159b0edd6127d693c9925a9bda386  tests/php/pfsense_doubles.php
33b43d8e7c32968d58d7783b6eabeafd87dfcb52  tests/php/bootstrap.php
```

*Correction, raised by review leg 2 and confirmed:* this section first published `Assertions: 75`, which does not reproduce. That run predated one added assertion — the shipped-default pin for the new constant at `UnboundRestartSeamTest.php:488` — which sits before the pre-existing `START_WAIT` pins and so moves the abort point ~17 assertions earlier on the reverted `.inc`. The tests were therefore **not frozen** between red and green, as principle 1 requires. The numbers above are the re-run against the frozen objects.

`testDaemonThatOnlyDiesOnKillStillGetsRestarted` passes on the parent by construction — it is the regression guard for the existing successful path, not a red-half row.

## Gates

- Full PHP suite: **61 errors / 10 failures**, byte-identical to `origin/devel` measured in the same session. No row moved.
- `phpstan`: no errors. `phpcs`: clean.

## Deliberately not done

**Port liveness.** `bind` is really about `:53` and a socket can outlive its pid, so `sockstat -46l | grep ':53'` is the direct check the issue names. Marked in-source rather than implemented: the one published `pgrep -lf unbound` dump in the issue shows a *surviving unbound process* (pid 56165, which `killall unbound` did not clear), which this fix now catches, and a sockstat probe needs an exec seam this change does not otherwise require. Worth adding if the double-bind is ever seen with no surviving process. Note the evidence is one dump covering one of the two reported observations, not both.

**A corpus-scaled stop timeout.** The issue names it and calls it secondary; the fall-through is the defect and that is what this fixes. Recording the consequence of leaving the 30 s budget alone, because it is not obvious: on the reporting box (42 s init) the KILL branch is now the **routine** path on every restart, not an exception. If that proves undesirable, widening the budget is the follow-up.

**A second TERM before the KILL.** Direction 2 reads "a second TERM, then KILL, then re-verify — *or* abort with a loud ledger entry". This goes straight to KILL: `SIGKILL` strictly dominates a `SIGTERM` the daemon has already ignored for 30 s, and the spec's `or` makes the abort independently sufficient.

🤖 Generated by [Claude Code](https://claude.com/claude-code), posted via @BBcan177's account on their behalf.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Unbound restart reliability by escalating from a normal stop request to a forced termination when the process does not exit in time.
  * Prevented a restart from starting a second Unbound instance if the existing process remains active.
  * Restarts Unbound successfully when forced termination clears the stalled process.

* **Tests**
  * Added coverage for timeout, escalation, refusal, and successful restart scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
