### PR TITLE
agent-tools: own codegraph by its install directory, not by PATH

### DIFF
--- a/scripts/agent/setup-agent-tools.sh
+++ b/scripts/agent/setup-agent-tools.sh
@@ -28,6 +28,16 @@ install_from_url() {
 	return "$installer_status"
 }
 
+seat_owns() {
+	# True when the $1 on PATH is this seat's own: at $2, where this script installs
+	# it (XDG_BIN_HOME / CODEGRAPH_BIN_DIR can place that outside HOME), or anywhere
+	# under HOME. A shared copy elsewhere satisfies `command -v` but is not writable.
+	case "$(command -v "$1" 2>/dev/null)" in
+		"$2/$1"|"$HOME"/*) ;;
+		*) return 1 ;;
+	esac
+}
+
 install_linux_prerequisites() {
 	require_tool dpkg-query
 	set --
@@ -250,23 +260,16 @@ main() {
 
 	case "$platform" in
 		Linux)
-			uv_path=$(command -v uv 2>/dev/null) || uv_path=
-			# $xdg_bin_home is where this script installs uv, and XDG_BIN_HOME can put
-			# it outside HOME; matching the PATH entry verbatim keeps a seat that sets
-			# it converging on self-update instead of reinstalling every run.
-			case "$uv_path" in
-				"$xdg_bin_home"/uv|"$HOME"/*)
-					# `|| true`: self-update is maintenance, not a prerequisite -- every
-					# later use is `uv tool install --upgrade`, which any uv performs -- so
-					# a transient failure must not end the run before a tool is installed.
-					uv self update || true
-					;;
-				*)
-					# issue #3010: a shared root-owned uv outside this seat satisfies
-					# `command -v` but no seat can self-update it -- provision our own.
-					install_from_url 'https://astral.sh/uv/install.sh'
-					;;
-			esac
+			if seat_owns uv "$xdg_bin_home"; then
+				# `|| true`: self-update is maintenance, not a prerequisite -- every
+				# later use is `uv tool install --upgrade`, which any uv performs -- so
+				# a transient failure must not end the run before a tool is installed.
+				uv self update || true
+			else
+				# issue #3010: a shared root-owned uv outside this seat satisfies
+				# `command -v` but no seat can self-update it -- provision our own.
+				install_from_url 'https://astral.sh/uv/install.sh'
+			fi
 			;;
 		Darwin)
 			if brew list --versions uv >/dev/null 2>&1; then
@@ -290,21 +293,14 @@ main() {
 	require_tool ast-grep
 	require_tool semgrep
 
-	cg_path=$(command -v codegraph 2>/dev/null) || cg_path=
-	# $codegraph_bin is where this script installs codegraph, and CODEGRAPH_BIN_DIR
-	# can put it outside HOME; matching the PATH entry verbatim keeps a seat that
-	# sets it converging on upgrade instead of reinstalling every run.
-	case "$cg_path" in
-		"$codegraph_bin"/codegraph|"$HOME"/*)
-			codegraph upgrade
-			;;
-		*)
-			# issue #3070: a shared codegraph outside this seat satisfies `command -v`
-			# but the seat cannot write it, so `upgrade` fails and -- with no `|| true`
-			# here -- ends the run under `set -eu`. Provision our own instead.
-			install_from_url 'https://raw.githubusercontent.com/colbymchenry/codegraph/main/install.sh'
-			;;
-	esac
+	if seat_owns codegraph "$codegraph_bin"; then
+		codegraph upgrade
+	else
+		# issue #3070: a shared codegraph outside this seat satisfies `command -v`
+		# but the seat cannot write it, so `upgrade` fails and -- with no `|| true`
+		# here -- ends the run under `set -eu`. Provision our own instead.
+		install_from_url 'https://raw.githubusercontent.com/colbymchenry/codegraph/main/install.sh'
+	fi
 	require_tool codegraph
 	codegraph install -l global -y -t auto
 

--- a/scripts/agent/setup-agent-tools.sh
+++ b/scripts/agent/setup-agent-tools.sh
@@ -290,11 +290,21 @@ main() {
 	require_tool ast-grep
 	require_tool semgrep
 
-	if command -v codegraph >/dev/null 2>&1; then
-		codegraph upgrade
-	else
-		install_from_url 'https://raw.githubusercontent.com/colbymchenry/codegraph/main/install.sh'
-	fi
+	cg_path=$(command -v codegraph 2>/dev/null) || cg_path=
+	# $codegraph_bin is where this script installs codegraph, and CODEGRAPH_BIN_DIR
+	# can put it outside HOME; matching the PATH entry verbatim keeps a seat that
+	# sets it converging on upgrade instead of reinstalling every run.
+	case "$cg_path" in
+		"$codegraph_bin"/codegraph|"$HOME"/*)
+			codegraph upgrade
+			;;
+		*)
+			# issue #3070: a shared codegraph outside this seat satisfies `command -v`
+			# but the seat cannot write it, so `upgrade` fails and -- with no `|| true`
+			# here -- ends the run under `set -eu`. Provision our own instead.
+			install_from_url 'https://raw.githubusercontent.com/colbymchenry/codegraph/main/install.sh'
+			;;
+	esac
 	require_tool codegraph
 	codegraph install -l global -y -t auto
 

--- a/tests/shell/agent_tools_setup_spec.sh
+++ b/tests/shell/agent_tools_setup_spec.sh
@@ -357,16 +357,11 @@ GROK
   # A uv the seat already owns, at the path the standalone installer uses. The
   # default fixture uv lives in "$activebin" -- outside HOME -- which models the
   # shared root-owned /usr/local/bin/uv (#3010), not a seat's own.
-  seat_uv() {
+  # A tool the seat already owns, at the path the installer uses. The default
+  # fixture copies live in "$activebin", outside HOME, modelling a shared one.
+  seat_tool() {
     mkdir -p "$home/.local/bin"
-    cp "$installables/uv" "$home/.local/bin/uv"
-  }
-
-  # Same idea for codegraph (issue #3070): the default fixture copy lives in
-  # "$activebin", outside HOME, which models a shared one this seat cannot write.
-  seat_codegraph() {
-    mkdir -p "$home/.local/bin"
-    cp "$installables/codegraph" "$home/.local/bin/codegraph"
+    cp "$installables/$1" "$home/.local/bin/$1"
   }
 
   cleanup() {
@@ -473,8 +468,8 @@ GROK
   End
 
   It 'updates existing Linux uv and CodeGraph while rerunning global auto configuration'
-    seat_uv
-    seat_codegraph
+    seat_tool uv
+    seat_tool codegraph
     When run sh "$script_abs" "$repository"
     The status should equal 0
     The contents of file "$curl_log" should equal \
@@ -531,8 +526,9 @@ GROK
   End
 
   It 'installs a per-seat codegraph when the only one on PATH lives outside HOME'
-    # issue #3070: same adoption defect as #3010's uv, and worse -- there is no
-    # `|| true`, so upgrading a copy this seat cannot write ends the run.
+    # issue #3070: the codegraph twin of #3010's uv adoption defect. Like that one,
+    # this example is satisfied in isolation by an "always install" implementation;
+    # the sibling examples below are what rule that out.
     When run sh "$script_abs" "$repository"
     The status should equal 0
     The contents of file "$curl_log" should include 'https://raw.githubusercontent.com/colbymchenry/codegraph/main/install.sh'
@@ -544,30 +540,30 @@ GROK
     # The seat's own codegraph goes to $codegraph_bin, which CODEGRAPH_BIN_DIR can
     # place outside HOME; testing ownership against HOME alone would reinstall it
     # on every run instead of upgrading it.
-    custom_cg_bin="$fixture/custom codegraph bin"
-    When run env CODEGRAPH_BIN_DIR="$custom_cg_bin" \
+    custom_codegraph_bin="$fixture/custom codegraph bin"
+    When run env CODEGRAPH_BIN_DIR="$custom_codegraph_bin" \
       sh -c 'sh "$1" "$2" && sh "$1" "$2"' _ "$script_abs" "$repository"
     The status should equal 0
     Assert [ "$(grep -c '^https://raw.githubusercontent.com/colbymchenry/codegraph/main/install.sh$' "$curl_log")" -eq 1 ]
     Assert [ "$(grep -c '^codegraph:upgrade$' "$tool_log")" -eq 1 ]
-    The path "$custom_cg_bin/codegraph" should be executable
+    The path "$custom_codegraph_bin/codegraph" should be executable
   End
 
   It 'keeps a seat codegraph that lives under HOME but not in the codegraph bin dir'
     # PATH also carries $HOME/.cargo/bin, so a seat can own a codegraph that is not
     # at $codegraph_bin. Dropping the HOME alternative must not ship green.
     rm -f "$activebin/codegraph"
-    custom_cg_bin="$fixture/custom codegraph bin"
+    custom_codegraph_bin="$fixture/custom codegraph bin"
     mkdir -p "$home/.cargo/bin"
     cp "$installables/codegraph" "$home/.cargo/bin/codegraph"
-    When run env CODEGRAPH_BIN_DIR="$custom_cg_bin" sh "$script_abs" "$repository"
+    When run env CODEGRAPH_BIN_DIR="$custom_codegraph_bin" sh "$script_abs" "$repository"
     The status should equal 0
     Assert [ "$(grep -c '^codegraph:upgrade$' "$tool_log")" -eq 1 ]
     Assert [ "$(grep -c '^https://raw.githubusercontent.com/colbymchenry/codegraph/main/install.sh$' "$curl_log")" -eq 0 ]
   End
 
   It 'installs a managed Homebrew uv when an unmanaged Darwin uv command exists'
-    seat_codegraph
+    seat_tool codegraph
     cat > "$activebin/uv" <<'UNMANAGED_UV'
 #!/bin/sh
 printf 'uv-unmanaged:%s\n' "$*" >> "$DEBIAN_TOOL_LOG"
@@ -595,7 +591,7 @@ UNMANAGED_UV
   End
 
   It 'upgrades a managed Homebrew uv from its formula prefix on every Darwin rerun'
-    seat_codegraph
+    seat_tool codegraph
     rm -f "$activebin/uv"
     When run env AGENT_TEST_OS=Darwin sh -c 'sh "$1" "$2" && sh "$1" "$2"' _ "$script_abs" "$repository"
     The status should equal 0
@@ -1108,7 +1104,7 @@ CONFIG
     # run before a single tool was installed. Only a seat-owned uv reaches this
     # call now, so the fixture seeds one.
     export DEBIAN_UV_SELF_UPDATE_FAILS=1
-    seat_uv
+    seat_tool uv
     When run sh "$script_abs" "$repository"
     The status should equal 0
     Assert [ "$(grep -c '^uv:self update$' "$tool_log")" -eq 1 ]

--- a/tests/shell/agent_tools_setup_spec.sh
+++ b/tests/shell/agent_tools_setup_spec.sh
@@ -362,6 +362,13 @@ GROK
     cp "$installables/uv" "$home/.local/bin/uv"
   }
 
+  # Same idea for codegraph (issue #3070): the default fixture copy lives in
+  # "$activebin", outside HOME, which models a shared one this seat cannot write.
+  seat_codegraph() {
+    mkdir -p "$home/.local/bin"
+    cp "$installables/codegraph" "$home/.local/bin/codegraph"
+  }
+
   cleanup() {
     rm -rf "$fixture"
   }
@@ -467,6 +474,7 @@ GROK
 
   It 'updates existing Linux uv and CodeGraph while rerunning global auto configuration'
     seat_uv
+    seat_codegraph
     When run sh "$script_abs" "$repository"
     The status should equal 0
     The contents of file "$curl_log" should equal \
@@ -522,7 +530,44 @@ GROK
     Assert [ "$(grep -c '^https://astral.sh/uv/install.sh$' "$curl_log")" -eq 0 ]
   End
 
+  It 'installs a per-seat codegraph when the only one on PATH lives outside HOME'
+    # issue #3070: same adoption defect as #3010's uv, and worse -- there is no
+    # `|| true`, so upgrading a copy this seat cannot write ends the run.
+    When run sh "$script_abs" "$repository"
+    The status should equal 0
+    The contents of file "$curl_log" should include 'https://raw.githubusercontent.com/colbymchenry/codegraph/main/install.sh'
+    The path "$home/.local/bin/codegraph" should be executable
+    The contents of file "$tool_log" should not include 'codegraph:upgrade'
+  End
+
+  It 'converges on the seat codegraph when CODEGRAPH_BIN_DIR lives outside HOME'
+    # The seat's own codegraph goes to $codegraph_bin, which CODEGRAPH_BIN_DIR can
+    # place outside HOME; testing ownership against HOME alone would reinstall it
+    # on every run instead of upgrading it.
+    custom_cg_bin="$fixture/custom codegraph bin"
+    When run env CODEGRAPH_BIN_DIR="$custom_cg_bin" \
+      sh -c 'sh "$1" "$2" && sh "$1" "$2"' _ "$script_abs" "$repository"
+    The status should equal 0
+    Assert [ "$(grep -c '^https://raw.githubusercontent.com/colbymchenry/codegraph/main/install.sh$' "$curl_log")" -eq 1 ]
+    Assert [ "$(grep -c '^codegraph:upgrade$' "$tool_log")" -eq 1 ]
+    The path "$custom_cg_bin/codegraph" should be executable
+  End
+
+  It 'keeps a seat codegraph that lives under HOME but not in the codegraph bin dir'
+    # PATH also carries $HOME/.cargo/bin, so a seat can own a codegraph that is not
+    # at $codegraph_bin. Dropping the HOME alternative must not ship green.
+    rm -f "$activebin/codegraph"
+    custom_cg_bin="$fixture/custom codegraph bin"
+    mkdir -p "$home/.cargo/bin"
+    cp "$installables/codegraph" "$home/.cargo/bin/codegraph"
+    When run env CODEGRAPH_BIN_DIR="$custom_cg_bin" sh "$script_abs" "$repository"
+    The status should equal 0
+    Assert [ "$(grep -c '^codegraph:upgrade$' "$tool_log")" -eq 1 ]
+    Assert [ "$(grep -c '^https://raw.githubusercontent.com/colbymchenry/codegraph/main/install.sh$' "$curl_log")" -eq 0 ]
+  End
+
   It 'installs a managed Homebrew uv when an unmanaged Darwin uv command exists'
+    seat_codegraph
     cat > "$activebin/uv" <<'UNMANAGED_UV'
 #!/bin/sh
 printf 'uv-unmanaged:%s\n' "$*" >> "$DEBIAN_TOOL_LOG"
@@ -550,6 +595,7 @@ UNMANAGED_UV
   End
 
   It 'upgrades a managed Homebrew uv from its formula prefix on every Darwin rerun'
+    seat_codegraph
     rm -f "$activebin/uv"
     When run env AGENT_TEST_OS=Darwin sh -c 'sh "$1" "$2" && sh "$1" "$2"' _ "$script_abs" "$repository"
     The status should equal 0
@@ -880,8 +926,9 @@ UNMANAGED_UV
     The contents of file "$tool_log" should not include 'grok:mcp'
     The contents of file "$tool_log" should include 'codegraph:install -l global -y -t auto'
     The file "$apt_log" should not be exist
-    The contents of file "$curl_log" should equal "$(printf '%s\n%s' \
+    The contents of file "$curl_log" should equal "$(printf '%s\n%s\n%s' \
       'https://astral.sh/uv/install.sh' \
+      'https://raw.githubusercontent.com/colbymchenry/codegraph/main/install.sh' \
       'https://github.com/max-sixty/worktrunk/releases/latest/download/worktrunk-installer.sh')"
   End
 
@@ -1042,7 +1089,9 @@ CONFIG
     Assert [ "$(grep -c '^uv:tool install --upgrade graphifyy$' "$tool_log")" -eq 2 ]
     Assert [ "$(grep -c '^uv:tool install --upgrade ast-grep-cli$' "$tool_log")" -eq 2 ]
     Assert [ "$(grep -c '^uv:tool install --upgrade semgrep$' "$tool_log")" -eq 2 ]
-    Assert [ "$(grep -c '^codegraph:upgrade$' "$tool_log")" -eq 2 ]
+    # Run 1 provisions the seat codegraph; run 2 finds it under HOME and upgrades.
+    Assert [ "$(grep -c '^codegraph:upgrade$' "$tool_log")" -eq 1 ]
+    Assert [ "$(grep -c '^https://raw.githubusercontent.com/colbymchenry/codegraph/main/install.sh$' "$curl_log")" -eq 1 ]
     Assert [ "$(grep -c '^codegraph:install -l global -y -t auto$' "$tool_log")" -eq 2 ]
     Assert [ "$(grep -c '^wt:config shell install --yes$' "$tool_log")" -eq 2 ]
     Assert [ "$(grep -c '^https://github.com/max-sixty/worktrunk/releases/latest/download/worktrunk-installer.sh$' "$curl_log")" -eq 2 ]


### PR DESCRIPTION
Fixes #3070

`scripts/agent/setup-agent-tools.sh:293` resolved codegraph by existence:

```sh
if command -v codegraph >/dev/null 2>&1; then
        codegraph upgrade
else
        install_from_url 'https://raw.githubusercontent.com/colbymchenry/codegraph/main/install.sh'
fi
```

Any copy on `PATH` satisfies that, including a shared one this seat cannot write. The seat then never gets its own, and `codegraph upgrade` runs against a binary it cannot modify. Unlike the uv branch there is **no `|| true`**, so under `set -eu` that ends the run before the remaining tools are installed — #3008's abort shape, not merely #3010's silent drift.

## What changed

Ownership is now tested against `$codegraph_bin` — the directory this script installs into, which `CODEGRAPH_BIN_DIR` can place outside `HOME` — or anywhere under `$HOME`.

**Both alternatives are load-bearing**, and each is pinned by exactly one example:

| Mutation | Result |
| --- | --- |
| baseline | 50 examples, 0 failures |
| drop the `$codegraph_bin` arm | 50 examples, **1 failure** |
| drop the `$HOME` arm | 50 examples, **1 failure** |
| match everything (`*`) | 50 examples, 7 failures |

`PATH` carries `$HOME/.cargo/bin` as well as `$codegraph_bin`, so a seat can legitimately own a copy that is not at the install directory — which is why the `$HOME` arm exists rather than being redundant. #3010 shipped that exact hole green twice before review caught it; these three examples were written up front to avoid repeating it.

## The `|| true` judgement, made rather than copied

#3070 explicitly left this open: *"unlike `uv self update`, a failed `codegraph upgrade` may be worth failing on. Worth deciding explicitly rather than by copying the uv line."*

**Decision: do not add it — as a deliberate asymmetry, not because the failure mode is gone.**

My first statement of this reasoning was wrong and the contract leg caught it. I argued the ownership check removes the need. It does not: the in-tree justification for uv's own `|| true`, twelve lines above at `:259-261`, is *"self-update is maintenance, not a prerequisite … a transient failure must not end the run before a tool is installed"* — and that reasoning **is** symmetric with codegraph. uv also **kept** its guard after its own ownership fix landed, which directly contradicts what I claimed.

What actually distinguishes them, established by the correctness leg reading the real `codegraph upgrade` implementation rather than reasoning by analogy: uv's guard was earned by a **measured, deterministic** refusal (#3008 — a package-managed uv always refuses). `codegraph upgrade`'s only non-zero exits are a network failure resolving latest, an installer write failure, and an unrecognised layout. After the ownership guard the deterministic-refusal class is effectively unreachable, so there is no measured failure to guard against — only transient ones, which `uv tool install --upgrade` (×4) and both other `install_from_url` calls in this same script already treat as fatal.

So the decision is: **treat a seat-owned codegraph's upgrade failure as a real signal**, consistent with every other unguarded call in the script, rather than as maintenance noise. The honest cost, verified by probe: a failing upgrade aborts before `wt`, worktrunk and agent-client configuration. The case to watch, recorded for the "if a measured failure appears" clause, is transient network — real `codegraph upgrade` contacts the network on **every** run, even when already current.

## Test-first proof

Executed.

```
$ git show origin/devel:scripts/agent/setup-agent-tools.sh > scripts/agent/setup-agent-tools.sh
$ shellspec tests/shell/agent_tools_setup_spec.sh
50 examples, 4 failures
  :533  installs a per-seat codegraph when the only one on PATH lives outside HOME
  :543  converges on the seat codegraph when CODEGRAPH_BIN_DIR lives outside HOME
  :919  ignores agent environment markers when no client executable is present
  :1079 updates tools and keeps one canonical Worktrunk key across repeated installer runs

$ # production file restored
$ shellspec tests/shell/agent_tools_setup_spec.sh
50 examples, 0 failures
```

| Frozen RED test | git hash-object | RED run tail |
| --- | --- | --- |
| `tests/shell/agent_tools_setup_spec.sh` | `193af9ddb123d8f31482c1fbdb4b390ed39fec27` | `50 examples, 4 failures` — `:533`, `:543`, `:919`, `:1079` as listed above |

## Migrated coverage

Five examples encoded "a codegraph on `PATH` is upgraded". A `seat_codegraph()` helper mirrors the existing `seat_uv()`, so "an existing codegraph" can still be expressed now that it means *the seat's own*.

- `updates existing Linux uv and CodeGraph …` — seeds the seat-owned pair; its intent is that existing tools are updated rather than reinstalled.
- The two **Darwin** examples — the codegraph block sits outside the `case "$platform"`, so it runs on Darwin too; their subject is the Homebrew uv path, and seeding keeps that subject in focus.
- `ignores agent environment markers …` — incidental exact-`curl_log` expectation, now including the codegraph fetch. Still exact equality, one more pinned line.
- `updates tools and keeps one canonical Worktrunk key …` — upgrade count 2 → 1, plus an assertion pinning exactly one installer fetch. **Correction:** I called the added assertion "strictly stronger". The contract leg deleted it and re-ran every mutation — nothing changed, because `upgrade == 1` catches them all on its own. It is not redundant *coverage* (it pins the provision/maintain split explicitly, which nothing else states) but it is not what makes the example strong. The `2 → 1` change is itself not a loosening: 2 is simply the wrong count under correct behaviour, and `upgrade == 1` fails against pre-fix code.

No assertion was loosened and no input shape dropped.

## Gates

`shellcheck -s sh` and `dash -n` clean on the changed script; the repository pre-commit gate passes, including `guard-erosion`.

## Not in this PR

The other provisioning sites were re-grepped and are clean: `wt` is an unconditional `install_from_url`; `serena`, `ast-grep` and `semgrep` go through `uv tool install --upgrade` with no adoption path; the `command -v` calls at `:183-204` are agent-client detection, not provisioning; and the Darwin uv branch resolves ownership through `brew list --versions uv`. With uv fixed in #3010 and codegraph here, the class is closed.

## Review round 1

Four legs per `landing.md`, each sandboxed. **No blocking findings.** Audits posted above.

The three findings I took were all mine, and two were false claims in this body — corrected in place above rather than quietly edited, since the issue history is where the next reader looks.

**Shared ownership predicate.** The over-engineering leg wrote and executed a `seat_owns()` helper replacing both guards, and I took it. The deciding argument is that **this PR created the second copy**, so removing the duplication is in scope rather than scope creep — and the ownership rule is precisely the part that took a blocking finding on #3064. Re-verified myself, not on report:

| Mutation | Before (two copies) | After (`seat_owns`) |
| --- | --- | --- |
| baseline | 0 failures | 0 failures |
| drop the install-dir arm | 1 failure | **2 failures** (one per tool) |
| drop the `$HOME` arm | 1 failure | **2 failures** (one per tool) |
| match everything | 7 failures | 9 failures |

Also taken: the two fixture helpers became one parameterised `seat_tool`, matching the file's own `enable_client()`; the codegraph example gained the vacuity note its uv twin already carried; `custom_cg_bin` renamed to the `custom_codegraph_bin` already used in the file.

**Independently confirmed by the legs, not asserted here:** the frozen hash matched the shipped blob; RED reproduced at exactly `:533`, `:543`, `:919`, `:1079`; both guard arms pinned by one *distinct* example each; the "class is closed" claim re-grepped tree-wide and found no unfixed or unnamed site; and the five migrated examples each ruled relocated-with-intent or strengthened, none weakened.

One toolchain caveat worth recording: local `shellspec` is `0.29.0-dev` while CI pins `0.28.1`. No divergence-shaped symptoms were observed, and one leg ran the `0.28.1` path, but CI is authoritative.
