### PR TITLE
unbound: tell a stop failure apart from a broken unbound.conf (#3094)

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -11431,6 +11431,11 @@ if (!defined('PFB_UNBOUND_STOP_WAIT')) {
 if (!defined('PFB_UNBOUND_KILL_WAIT')) {
 	define('PFB_UNBOUND_KILL_WAIT', 5);
 }
+// issue #3094: callers treat any non-zero retval as a bad unbound.conf. A stop that
+// could not be completed is not that, so it gets its own code to branch on.
+if (!defined('PFB_UNBOUND_STOP_FAILED')) {
+	define('PFB_UNBOUND_STOP_FAILED', -2);
+}
 if (!defined('PFB_UNBOUND_START_WAIT')) {
 	define('PFB_UNBOUND_START_WAIT', 30);
 }
@@ -11477,7 +11482,7 @@ function pfb_stop_start_unbound($type) {
 		// seen with no surviving unbound process.
 		if (is_process_running('unbound')) {
 			$final['result'] = array('Unbound could not be stopped; Resolver not restarted');
-			$final['retval'] = -1;
+			$final['retval'] = PFB_UNBOUND_STOP_FAILED;
 			pfb_logger("\nUnbound still running after TERM and KILL; not starting a " .
 				"second instance. Resolver NOT restarted", 2);
 			return $final;
@@ -12028,7 +12033,17 @@ function pfb_reload_unbound($mode, $cache=FALSE, $pfbpython=FALSE, $datapath=FAL
 	$final = pfb_stop_start_unbound($type);
 	pfb_logger('.', 1);
 
-	if ($final['retval'] != 0) {
+	// issue #3094: a refused stop is not a config fault. The recovery below quarantines
+	// unbound.conf, restores unbound.bk and retries -- all wrong here: the config was
+	// never at fault, and a retry cannot succeed where the refusal already stood. The
+	// surviving daemon is also the OLD one, so the confirm block below would read it as
+	// success; skip straight to the ledger tail with the real cause logged.
+	if ($final['retval'] === PFB_UNBOUND_STOP_FAILED) {
+		$log = htmlspecialchars(implode("\n", $final['result']));
+		pfb_logger("\nDNSBL {$mode} FAIL  *** Resolver could not be stopped; " .
+			"config left unchanged ***\n{$log}\n", 2);
+	}
+	elseif ($final['retval'] != 0) {
 
 		@copy("{$pfb['dnsbldir']}/unbound.conf", "{$pfb['dnsbldir']}/unbound.conf.error");
 		if ($mode == 'enabled') {
@@ -12048,8 +12063,9 @@ function pfb_reload_unbound($mode, $cache=FALSE, $pfbpython=FALSE, $datapath=FAL
 		$final = pfb_stop_start_unbound($type);
 	}
 
-	// Confirm that Resolver is running
-	if (is_process_running('unbound')) {
+	// Confirm that Resolver is running. A refused stop is excluded: the process that
+	// answers here is the daemon we failed to replace, not one this pass started (#3094).
+	if ($final['retval'] !== PFB_UNBOUND_STOP_FAILED && is_process_running('unbound')) {
 		pfb_logger('.', 1);
 
 		// $final['result'] will be appended with previous result above

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -12033,15 +12033,12 @@ function pfb_reload_unbound($mode, $cache=FALSE, $pfbpython=FALSE, $datapath=FAL
 	$final = pfb_stop_start_unbound($type);
 	pfb_logger('.', 1);
 
-	// issue #3094: a refused stop is not a config fault. The recovery below quarantines
-	// unbound.conf, restores unbound.bk and retries -- all wrong here: the config was
-	// never at fault, and a retry cannot succeed where the refusal already stood. The
-	// surviving daemon is also the OLD one, so the confirm block below would read it as
-	// success; skip straight to the ledger tail with the real cause logged.
+	// issue #3094: a refused stop is not a config fault -- the quarantine/rollback/retry
+	// below would trash a good config and retry a stop that already failed. The callee
+	// has logged the reason and the shared else-arm logs it again, so say only what is new.
 	if ($final['retval'] === PFB_UNBOUND_STOP_FAILED) {
-		$log = htmlspecialchars(implode("\n", $final['result']));
 		pfb_logger("\nDNSBL {$mode} FAIL  *** Resolver could not be stopped; " .
-			"config left unchanged ***\n{$log}\n", 2);
+			"config left unchanged ***\n", 2);
 	}
 	elseif ($final['retval'] != 0) {
 

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_install.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_install.inc
@@ -767,6 +767,11 @@ exec('/usr/local/pkg/pfblockerng/pfblockerng.sh dnsbl_cache stage >/dev/null 2>&
 
 if ($ufound) {
 	$final = pfb_stop_start_unbound('');
+	// issue #3094: the return value used to be assigned and never read, so an install
+	// could finish "successfully" with the resolver never restarted.
+	if (($final['retval'] ?? 0) != 0) {
+		update_status(" Unbound Resolver did not restart; see the pfBlockerNG log.");
+	}
 }
 
 // Upgrade EasyList to new Format

--- a/tests/php/InstallDnsblMoveRestartGuardTest.php
+++ b/tests/php/InstallDnsblMoveRestartGuardTest.php
@@ -67,4 +67,30 @@ final class InstallDnsblMoveRestartGuardTest extends TestCase
 			'install.inc assigns $u_found — a typo of $ufound that leaves the Unbound-restart guard unreset'
 		);
 	}
+	/**
+	 * issue #3094: the restart's return value must be READ.
+	 *
+	 * `$final = pfb_stop_start_unbound('')` was assigned and never used again in that
+	 * scope, so a package install could finish "successfully" with the resolver never
+	 * restarted -- the refusal (#3055) surfacing only in the pfBlockerNG log. install.inc
+	 * is not loadable by the harness and the update_status() double records nothing, so
+	 * this is pinned the way this file pins its siblings: executable tokens only.
+	 */
+	public function testInstallReportsARestartThatDidNotHappen(): void
+	{
+		$src = self::installSource();
+
+		$call = strpos($src, 'pfb_stop_start_unbound(\'\');');
+		$this->assertNotFalse($call, 'the install restart call is missing');
+
+		$tail = substr($src, $call);
+		$read = strpos($tail, '[\'retval\']');
+		$this->assertNotFalse($read,
+			'the install restart return value must be read, not just assigned (#3094)');
+		$report = strpos($tail, 'update_status', $read);
+		$this->assertNotFalse($report,
+			'a restart that did not happen must be reported to the installing user');
+		$this->assertLessThan(200, $read,
+			'the retval check must sit at the call site, not drift into an unrelated block');
+	}
 }

--- a/tests/php/PfbSyncStatusDnsblWritersTest.php
+++ b/tests/php/PfbSyncStatusDnsblWritersTest.php
@@ -485,14 +485,19 @@ final class PfbSyncStatusDnsblWritersTest extends TestCase
 			static fn (): bool => pfb_dnsbl_apply_ledger_update());
 
 		$after = file_exists($startLog) ? count(file($startLog, FILE_IGNORE_NEW_LINES) ?: []) : 0;
+		// This pins the callee's own guard (it returns before its start section). It does
+		// NOT see a caller-side retry -- a retried refusal refuses again and never reaches
+		// that section either, so the count is unchanged. The KILL count below is what
+		// catches a retry; both are kept because they fail on different regressions.
 		$this->assertSame($before, $after,
-			'a refused stop must attempt no start at all -- neither the first nor the retry');
+			'a refused stop must reach no start section at all');
 
 		// A retry would call pfb_stop_start_unbound() a second time, and each call escalates
 		// to exactly one KILL. Counting the signal catches a restored retry that the
 		// start-log cannot see, because a retried refusal never reaches its start section.
 		$this->assertCount(1, $GLOBALS['pfb_test_sigkillbyname_calls'],
-			'the refusal must be reached once; a second KILL means the caller retried it');
+			'exactly one KILL: a refused stop escalates once, so a second means the stop '
+			. 'path ran twice -- a caller retry, or the callee escalating more than once');
 
 		$this->assertFileDoesNotExist($confirmProbe,
 			'the confirm block must not run for a refused stop: the process still answering '
@@ -515,6 +520,49 @@ final class PfbSyncStatusDnsblWritersTest extends TestCase
 			'the caller must say the config was deliberately left alone, in its own words');
 		$this->assertStringNotContainsString('Fix error(s)', $log,
 			'a stop failure must not tell the operator to fix a config error that does not exist');
+	}
+
+	/**
+	 * Positive control for the recorder the test above relies on (leg 3, round 2, row B).
+	 *
+	 * That test proves the confirm block is SKIPPED on a refused stop by asserting a probe
+	 * file is absent. An absence assertion is only worth the mechanism behind it: if the
+	 * recorder cannot fire -- an unwritable probe path, or a one-character typo in the shell
+	 * fragment -- the assertion passes for the wrong reason while the bug it guards is live.
+	 * Leg 3 demonstrated both. So this pins the other direction with the SAME fragment: when
+	 * the stop succeeds and the resolver answers, the confirm block runs and the probe DOES
+	 * appear. Break the recorder and this test fails, which is what makes the absence
+	 * assertion above mean something.
+	 */
+	public function testConfirmBlockRecorderFiresWhenTheConfirmBlockActuallyRuns(): void
+	{
+		file_put_contents("{$this->dir}/unbound.conf", "server:\n");
+		$GLOBALS['pfb']['dnsbl_file'] = "{$this->dir}/dnsbl_file";
+		$GLOBALS['pfb']['unbound_py_count'] = "{$this->dir}/unbound_py_count";
+		$GLOBALS['pfb']['dnsbl_python_unmount'] = FALSE;
+		$GLOBALS['g']['varrun_path'] = $this->dir;
+
+		$confirmProbe = "{$this->dir}/confirm_ran";
+		$GLOBALS['pfb']['chroot_cmd'] = '/usr/bin/touch ' . escapeshellarg($confirmProbe) . ' ;:';
+
+		// is_process_running('unbound') call sequence for this path, enumerated from a
+		// probe rather than guessed: (1) pfb_reload_unbound's pre-restart check :12022,
+		// (2) the stop-wait loop :11458, (3) the #3055 post-loop guard :11469, (4)/(5) the
+		// same two again on the retry the harness start-double's non-zero status triggers,
+		// (6) the confirm block :12065. Only 6 is TRUE: the stop must succeed so retval is
+		// never PFB_UNBOUND_STOP_FAILED, and the resolver must answer at the confirm check.
+		$calls = 0;
+		$GLOBALS['pfb_test_process_running']['unbound'] = static function () use (&$calls): bool {
+			$calls++;
+			return $calls === 6;
+		};
+
+		pfb_reload_unbound('enabled', FALSE, FALSE, FALSE,
+			static fn (): bool => pfb_dnsbl_apply_ledger_update());
+
+		$this->assertFileExists($confirmProbe,
+			'the confirm-block recorder must actually fire when the confirm block runs -- '
+			. 'otherwise the skip assertion in the refused-stop test proves nothing');
 	}
 
 	// -----------------------------------------------------------------------

--- a/tests/php/PfbSyncStatusDnsblWritersTest.php
+++ b/tests/php/PfbSyncStatusDnsblWritersTest.php
@@ -445,6 +445,76 @@ final class PfbSyncStatusDnsblWritersTest extends TestCase
 		$this->assertSame('apply', $open[0]['stage']);
 	}
 
+	/**
+	 * issue #3094: a stop that could not be completed is NOT a broken unbound.conf.
+	 *
+	 * pfb_stop_start_unbound() refuses to start a second resolver when the daemon
+	 * survives TERM and KILL (#3055). The caller used to read any non-zero retval as
+	 * "the generated config is bad" and respond by saving unbound.conf aside as
+	 * .error, restoring the previous config from unbound.bk, printing "Fix error(s)
+	 * and a Force Reload required!", and retrying the whole restart. None of that is
+	 * right here: the config was never the problem, there is nothing for the user to
+	 * fix, and the retry cannot succeed where the refusal already stood.
+	 */
+	public function testStopFailureNeitherRollsBackTheConfigNorRetries(): void
+	{
+		$newConfig = "server:\n\tmodule-config: \"python validator iterator\"\n";
+		$oldConfig = "server:\n\tmodule-config: \"validator iterator\"\n";
+		file_put_contents("{$this->dir}/unbound.conf", $newConfig);
+		file_put_contents("{$this->dir}/unbound.bk", $oldConfig);
+		$GLOBALS['pfb']['dnsbl_file'] = "{$this->dir}/dnsbl_file";
+		$GLOBALS['pfb']['unbound_py_count'] = "{$this->dir}/unbound_py_count";
+		$GLOBALS['pfb']['chroot_cmd'] = '/bin/echo';
+		$GLOBALS['pfb']['dnsbl_python_unmount'] = FALSE;
+		$GLOBALS['g']['varrun_path'] = $this->dir;
+
+		// The daemon outlives both budgets, so the stop refuses: this is the #3055 path.
+		$GLOBALS['pfb_test_process_running']['unbound'] = TRUE;
+
+		$startLog = (string) $GLOBALS['pfb_test_unbound_start_log'];
+		$before = file_exists($startLog) ? count(file($startLog, FILE_IGNORE_NEW_LINES) ?: []) : 0;
+
+		pfb_reload_unbound('enabled', FALSE, FALSE, FALSE,
+			static fn (): bool => pfb_dnsbl_apply_ledger_update());
+
+		$after = file_exists($startLog) ? count(file($startLog, FILE_IGNORE_NEW_LINES) ?: []) : 0;
+		$this->assertSame($before, $after,
+			'a refused stop must attempt no start at all -- neither the first nor the retry');
+		$this->assertSame($newConfig, file_get_contents("{$this->dir}/unbound.conf"),
+			'the resolver config must survive a stop failure: it was never the fault');
+		$this->assertFileDoesNotExist("{$this->dir}/unbound.conf.error",
+			'no candidate config may be quarantined for a fault that is not the config');
+		$this->assertSame($oldConfig, file_get_contents("{$this->dir}/unbound.bk"),
+			'the last-known-good copy must be left untouched, not consumed by a false rollback');
+	}
+
+	/**
+	 * issue #3094: and the operator must be told what actually happened.
+	 *
+	 * "Fix error(s) and a Force Reload required!" names an action that cannot help
+	 * when the resolver simply would not stop. The log must carry the real cause.
+	 */
+	public function testStopFailureIsReportedAsAStopFailureNotAConfigFault(): void
+	{
+		file_put_contents("{$this->dir}/unbound.conf", "server:\n");
+		$GLOBALS['pfb']['dnsbl_file'] = "{$this->dir}/dnsbl_file";
+		$GLOBALS['pfb']['unbound_py_count'] = "{$this->dir}/unbound_py_count";
+		$GLOBALS['pfb']['chroot_cmd'] = '/bin/echo';
+		$GLOBALS['pfb']['dnsbl_python_unmount'] = FALSE;
+		$GLOBALS['g']['varrun_path'] = $this->dir;
+		$GLOBALS['pfb_test_process_running']['unbound'] = TRUE;
+
+		pfb_reload_unbound('enabled', FALSE, FALSE, FALSE,
+			static fn (): bool => pfb_dnsbl_apply_ledger_update());
+
+		$log = (string) @file_get_contents($GLOBALS['pfb']['log'])
+			. (string) @file_get_contents($GLOBALS['pfb']['errlog']);
+		$this->assertStringContainsString('could not be stopped', $log,
+			'the log must name the real cause -- the resolver would not stop');
+		$this->assertStringNotContainsString('Fix error(s)', $log,
+			'a stop failure must not tell the operator to fix a config error that does not exist');
+	}
+
 	// -----------------------------------------------------------------------
 	// pfb_reload_unbound() -- zero-downtime swap SUCCESS early-return (issue #1024)
 	// -----------------------------------------------------------------------

--- a/tests/php/PfbSyncStatusDnsblWritersTest.php
+++ b/tests/php/PfbSyncStatusDnsblWritersTest.php
@@ -446,6 +446,18 @@ final class PfbSyncStatusDnsblWritersTest extends TestCase
 	}
 
 	/**
+	 * The confirm block is the only reachable `chroot_cmd` caller on the refused-stop path,
+	 * so a command that leaves a file behind is a direct spy on whether it ran. Both the
+	 * absence assertion and its positive control build the fragment HERE, deliberately:
+	 * review leg 3 showed that two copy-pasted fragments let a typo in one escape the
+	 * other, which is how a positive control can certify a mechanism it does not share.
+	 */
+	private static function confirmRecorderCmd(string $probe): string
+	{
+		return '/usr/bin/touch ' . escapeshellarg($probe) . ' ;:';
+	}
+
+	/**
 	 * issue #3094: a stop that could not be completed is NOT a broken unbound.conf.
 	 *
 	 * pfb_stop_start_unbound() refuses to start a second resolver when the daemon
@@ -472,7 +484,7 @@ final class PfbSyncStatusDnsblWritersTest extends TestCase
 		// here is a direct spy on whether it ran at all (leg 3 row 8: skipping it was
 		// previously unasserted -- reverting the guard left every test green).
 		$confirmProbe = "{$this->dir}/confirm_ran";
-		$GLOBALS['pfb']['chroot_cmd'] = '/usr/bin/touch ' . escapeshellarg($confirmProbe) . ' ;:';
+		$GLOBALS['pfb']['chroot_cmd'] = self::confirmRecorderCmd($confirmProbe);
 
 		// The daemon outlives both budgets, so the stop refuses: this is the #3055 path.
 		$GLOBALS['pfb_test_process_running']['unbound'] = TRUE;
@@ -502,6 +514,13 @@ final class PfbSyncStatusDnsblWritersTest extends TestCase
 		$this->assertFileDoesNotExist($confirmProbe,
 			'the confirm block must not run for a refused stop: the process still answering '
 			. 'is the daemon we failed to replace, so crediting it would report success');
+		// That absence is only evidence if THIS test's recorder could have fired. An
+		// unwritable probe path would satisfy the assertion above while proving nothing,
+		// so fire it by hand now and require the file to appear (review leg 3, round 3).
+		exec($GLOBALS['pfb']['chroot_cmd'] . ' status 2>&1');
+		$this->assertFileExists($confirmProbe,
+			'the recorder this test relies on must be capable of creating the probe; '
+			. 'otherwise the absence assertion above passes for the wrong reason');
 
 		$this->assertSame($newConfig, file_get_contents("{$this->dir}/unbound.conf"),
 			'the resolver config must survive a stop failure: it was never the fault');
@@ -543,7 +562,7 @@ final class PfbSyncStatusDnsblWritersTest extends TestCase
 		$GLOBALS['g']['varrun_path'] = $this->dir;
 
 		$confirmProbe = "{$this->dir}/confirm_ran";
-		$GLOBALS['pfb']['chroot_cmd'] = '/usr/bin/touch ' . escapeshellarg($confirmProbe) . ' ;:';
+		$GLOBALS['pfb']['chroot_cmd'] = self::confirmRecorderCmd($confirmProbe);
 
 		// is_process_running('unbound') call sequence for this path, enumerated from a
 		// probe rather than guessed: (1) pfb_reload_unbound's pre-restart check :12022,

--- a/tests/php/PfbSyncStatusDnsblWritersTest.php
+++ b/tests/php/PfbSyncStatusDnsblWritersTest.php
@@ -454,9 +454,10 @@ final class PfbSyncStatusDnsblWritersTest extends TestCase
 	 * .error, restoring the previous config from unbound.bk, printing "Fix error(s)
 	 * and a Force Reload required!", and retrying the whole restart. None of that is
 	 * right here: the config was never the problem, there is nothing for the user to
-	 * fix, and the retry cannot succeed where the refusal already stood.
+	 * fix, and the retry cannot succeed where the refusal already stood -- and the
+	 * daemon still answering is the OLD one, so the confirm block must not credit it.
 	 */
-	public function testStopFailureNeitherRollsBackTheConfigNorRetries(): void
+	public function testStopFailureNeitherRollsBackNorRetriesNorCreditsTheOldDaemon(): void
 	{
 		$newConfig = "server:\n\tmodule-config: \"python validator iterator\"\n";
 		$oldConfig = "server:\n\tmodule-config: \"validator iterator\"\n";
@@ -464,12 +465,18 @@ final class PfbSyncStatusDnsblWritersTest extends TestCase
 		file_put_contents("{$this->dir}/unbound.bk", $oldConfig);
 		$GLOBALS['pfb']['dnsbl_file'] = "{$this->dir}/dnsbl_file";
 		$GLOBALS['pfb']['unbound_py_count'] = "{$this->dir}/unbound_py_count";
-		$GLOBALS['pfb']['chroot_cmd'] = '/bin/echo';
 		$GLOBALS['pfb']['dnsbl_python_unmount'] = FALSE;
 		$GLOBALS['g']['varrun_path'] = $this->dir;
 
+		// The confirm block is the only caller of chroot_cmd on this path, so a recorder
+		// here is a direct spy on whether it ran at all (leg 3 row 8: skipping it was
+		// previously unasserted -- reverting the guard left every test green).
+		$confirmProbe = "{$this->dir}/confirm_ran";
+		$GLOBALS['pfb']['chroot_cmd'] = '/usr/bin/touch ' . escapeshellarg($confirmProbe) . ' ;:';
+
 		// The daemon outlives both budgets, so the stop refuses: this is the #3055 path.
 		$GLOBALS['pfb_test_process_running']['unbound'] = TRUE;
+		$GLOBALS['pfb_test_sigkillbyname_calls'] = array();
 
 		$startLog = (string) $GLOBALS['pfb_test_unbound_start_log'];
 		$before = file_exists($startLog) ? count(file($startLog, FILE_IGNORE_NEW_LINES) ?: []) : 0;
@@ -480,37 +487,32 @@ final class PfbSyncStatusDnsblWritersTest extends TestCase
 		$after = file_exists($startLog) ? count(file($startLog, FILE_IGNORE_NEW_LINES) ?: []) : 0;
 		$this->assertSame($before, $after,
 			'a refused stop must attempt no start at all -- neither the first nor the retry');
+
+		// A retry would call pfb_stop_start_unbound() a second time, and each call escalates
+		// to exactly one KILL. Counting the signal catches a restored retry that the
+		// start-log cannot see, because a retried refusal never reaches its start section.
+		$this->assertCount(1, $GLOBALS['pfb_test_sigkillbyname_calls'],
+			'the refusal must be reached once; a second KILL means the caller retried it');
+
+		$this->assertFileDoesNotExist($confirmProbe,
+			'the confirm block must not run for a refused stop: the process still answering '
+			. 'is the daemon we failed to replace, so crediting it would report success');
+
 		$this->assertSame($newConfig, file_get_contents("{$this->dir}/unbound.conf"),
 			'the resolver config must survive a stop failure: it was never the fault');
 		$this->assertFileDoesNotExist("{$this->dir}/unbound.conf.error",
 			'no candidate config may be quarantined for a fault that is not the config');
 		$this->assertSame($oldConfig, file_get_contents("{$this->dir}/unbound.bk"),
 			'the last-known-good copy must be left untouched, not consumed by a false rollback');
-	}
 
-	/**
-	 * issue #3094: and the operator must be told what actually happened.
-	 *
-	 * "Fix error(s) and a Force Reload required!" names an action that cannot help
-	 * when the resolver simply would not stop. The log must carry the real cause.
-	 */
-	public function testStopFailureIsReportedAsAStopFailureNotAConfigFault(): void
-	{
-		file_put_contents("{$this->dir}/unbound.conf", "server:\n");
-		$GLOBALS['pfb']['dnsbl_file'] = "{$this->dir}/dnsbl_file";
-		$GLOBALS['pfb']['unbound_py_count'] = "{$this->dir}/unbound_py_count";
-		$GLOBALS['pfb']['chroot_cmd'] = '/bin/echo';
-		$GLOBALS['pfb']['dnsbl_python_unmount'] = FALSE;
-		$GLOBALS['g']['varrun_path'] = $this->dir;
-		$GLOBALS['pfb_test_process_running']['unbound'] = TRUE;
-
-		pfb_reload_unbound('enabled', FALSE, FALSE, FALSE,
-			static fn (): bool => pfb_dnsbl_apply_ledger_update());
-
+		// "Fix error(s) and a Force Reload required!" names an action that cannot help when
+		// the resolver simply would not stop, so the log must carry the real cause instead.
 		$log = (string) @file_get_contents($GLOBALS['pfb']['log'])
 			. (string) @file_get_contents($GLOBALS['pfb']['errlog']);
-		$this->assertStringContainsString('could not be stopped', $log,
-			'the log must name the real cause -- the resolver would not stop');
+		// Pins THIS branch's own wording. 'could not be stopped' alone is also produced by
+		// pfb_stop_start_unbound()'s result text, so it would survive a reword here (leg 3 row 6).
+		$this->assertStringContainsString('config left unchanged', $log,
+			'the caller must say the config was deliberately left alone, in its own words');
 		$this->assertStringNotContainsString('Fix error(s)', $log,
 			'a stop failure must not tell the operator to fix a config error that does not exist');
 	}

--- a/tests/php/UnboundRestartSeamTest.php
+++ b/tests/php/UnboundRestartSeamTest.php
@@ -241,8 +241,13 @@ final class UnboundRestartSeamTest extends TestCase
 
 		$this->assertCount(count($before), $this->doubleInvocations(),
 			'a stop that never completed must not reach the daemon start at all');
-		$this->assertSame(-1, $final['retval'],
+		$this->assertSame(PFB_UNBOUND_STOP_FAILED, $final['retval'],
 			'the refusal must be reported to the caller as a failure, not a silent success');
+		// issue #3094: the whole point of the code is that a caller can tell "the daemon
+		// would not stop" from "the generated config is bad". Sharing -1 with the generic
+		// failure would put it straight back into the unbound.bk rollback path.
+		$this->assertNotSame(-1, PFB_UNBOUND_STOP_FAILED,
+			'the stop-failure code must be distinguishable from a generic failure');
 		$this->assertNotEmpty($final['result'],
 			'the caller logs the result, so the refusal must carry a reason');
 		$this->assertSame(array(array('unbound', 'KILL')), $GLOBALS['pfb_test_sigkillbyname_calls'],
@@ -486,6 +491,8 @@ final class UnboundRestartSeamTest extends TestCase
 			'the appliance must still wait up to 30 seconds for the outgoing daemon');
 		$this->assertNotFalse(strpos($src, "define('PFB_UNBOUND_KILL_WAIT', 5);"),
 			'the KILL escalation must have its own finite five-second budget');
+		$this->assertNotFalse(strpos($src, "define('PFB_UNBOUND_STOP_FAILED', -2);"),
+			'the appliance must ship the distinct stop-failure code the callers branch on');
 		$this->assertNotFalse(strpos($src, "define('PFB_UNBOUND_START_WAIT', 30);"),
 			'the appliance start child must have an explicit finite 30-second budget');
 		$this->assertNotFalse(strpos($src, "define('PFB_UNBOUND_START_SETUP_WAIT', 5);"),


### PR DESCRIPTION
Refs #3094 — **not `Closes`**: the issue's Direction 1 asks that the rollback and the "Fix error(s)" message fire *only* for the config case, and this PR carves out one of the three non-config causes. The remainder is #3100. See "Deliberately not done".

## The defect

`pfb_stop_start_unbound()` returns non-zero for at least four distinct causes:

| cause | is the config bad? |
|---|---|
| the daemon would not stop (`-1`, added by #3055) | no |
| output staging failed (`tempnam`) | no |
| the supervised start timed out (`124`) | no |
| the start command itself failed | maybe |

`pfb_reload_unbound()` read all of them as one thing — `pfblockerng.inc:12031` on `origin/devel`:

```php
if ($final['retval'] != 0) {
    @copy(".../unbound.conf", ".../unbound.conf.error");
    if ($mode == 'enabled') {
        $log = "\nDNSBL {$mode} FAIL  *** Fix error(s) and a Force Reload required! ***\n";
        @rename(".../unbound.bk", ".../unbound.conf");   // roll the config back
    }
    ...
    $final = pfb_stop_start_unbound($type);              // and retry the whole restart
}
```

For a refused stop every branch is wrong:

- **The rollback discards a correct config** and quarantines it as `.error`, then tells the operator to "Fix error(s)" — naming a fault that does not exist and an action that cannot help.
- **The retry cannot succeed** where the refusal already stood, and costs another `PFB_UNBOUND_STOP_WAIT + PFB_UNBOUND_KILL_WAIT` of polling plus a second KILL.
- **The confirm block then credits the wrong daemon.** `:12051` (devel) keys on `is_process_running('unbound')`, which is TRUE for the *old* daemon we failed to replace, so a wedged resolver could be logged as `" completed"`.

## The change

Give the refusal its own code and branch on it.

```php
if (!defined('PFB_UNBOUND_STOP_FAILED')) {
    define('PFB_UNBOUND_STOP_FAILED', -2);
}
```

On that code the caller logs the real cause, leaves `unbound.conf` and `unbound.bk` untouched, attempts no retry, and skips the confirm block rather than credit the surviving daemon. **The genuine config-failure path is unchanged** — the pre-existing `testRestartFailurePreservesRollbackRetryAndApplyLedger` still pins rollback, exactly one retry, and the open apply entry, and still passes.

`pfblockerng_install.inc:769` assigned `$final` and never read it, so an install could finish "successfully" with the resolver never restarted. It now reports it.

## Verification — test-first, freeze recorded

The freeze record is the thing review leg 2 caught missing on #3093, so it is here from the start.

**Frozen RED**, taken before any production edit:

```
e9081603f6c79b7a1504877a25aeccbd52c2638d  tests/php/PfbSyncStatusDnsblWritersTest.php
```

*Review leg 2 verified this hash byte-identical and re-executed the red half to the same counts — "unlike #3093, this freeze record reproduces". It also found the record covered only one of the changed test files. **After the review-fix commit `21416c9af`** the full set is:*

```
12d01baf462a3e123ac59929b458579b9d52314c  tests/php/PfbSyncStatusDnsblWritersTest.php
90d0d8a2ce8f238c062d6ad506525ac7fd82d574  tests/php/UnboundRestartSeamTest.php
d9eb0255d7602623e477f77a70f87145f7201cb4  tests/php/InstallDnsblMoveRestartGuardTest.php
```

*And again after the round-2 fix `367d707e9`, which added the recorder's positive control (review leg 3 proved the absence assertion vacuous without one):*

```
3f74cf6dd2c4d3d3f7353d1f3ccc79dd8125d1e4  tests/php/PfbSyncStatusDnsblWritersTest.php
90d0d8a2ce8f238c062d6ad506525ac7fd82d574  tests/php/UnboundRestartSeamTest.php   (unchanged)
d9eb0255d7602623e477f77a70f87145f7201cb4  tests/php/InstallDnsblMoveRestartGuardTest.php   (unchanged)
```

*And after the round-3 fix `520f48621`, which made both tests share one recorder fragment and had the negative test certify its own recorder:*

```
02fa85194375594db828fc770e18486b8e420433  tests/php/PfbSyncStatusDnsblWritersTest.php
90d0d8a2ce8f238c062d6ad506525ac7fd82d574  tests/php/UnboundRestartSeamTest.php   (unchanged)
d9eb0255d7602623e477f77a70f87145f7201cb4  tests/php/InstallDnsblMoveRestartGuardTest.php   (unchanged)
```

**Counts, each measured at the head named — never carried forward:** at `367d707e9`, `OK (22 tests, 68 assertions)` for the writers file and `OK (37 tests, 172 assertions)` across the three touched files. At `520f48621`, **`OK (37 tests, 173 assertions)`**.

```
1) PfbSyncStatusDnsblWritersTest::testStopFailureNeitherRollsBackTheConfigNorRetries
2) PfbSyncStatusDnsblWritersTest::testStopFailureIsReportedAsAStopFailureNotAConfigFault
Tests: 2, Assertions: 4, Failures: 2.
```

The red run's log carried the defect verbatim:

```
DNSBL enabled FAIL  *** Fix error(s) and a Force Reload required! ***
...
Unbound could not be stopped; Resolver not restarted
```

**GREEN**, same file, hash re-verified byte-identical after the fix: `OK (22 tests, 65 assertions)` at `0a5411247`. **At the review-fix head `21416c9af` the two tests were folded into one and three assertions were added, so the file now reads `OK (21 tests, 67 assertions)`** — one test fewer, two assertions more. Whole-PR run at that head: `OK (36 tests, 171 assertions)` across all three touched test files.

| test | asserts |
|---|---|
| `testStopFailureNeitherRollsBackNorRetriesNorCreditsTheOldDaemon` | zero start attempts (first *or* retry); exactly one `sigkillbyname` KILL, which catches a restored retry the start-log cannot see; the confirm block never runs (`chroot_cmd` recorder never fires); `unbound.conf` unchanged; no `.error` written; `unbound.bk` not consumed; the log says `config left unchanged` and **not** "Fix error(s)" |
| `testInstallReportsARestartThatDidNotHappen` | the install caller reads `retval` and reports a restart that did not happen (source-token pin — `install.inc` is not harness-loadable) |

*Row names updated for the fold at `21416c9af`; the two pre-fold methods above became the first row.*
| `testRestartFailurePreservesRollbackRetryAndApplyLedger` (pre-existing) | unchanged: rollback, one retry, one open apply entry |

`UnboundRestartSeamTest`'s retval assertion moves from `-1` to the named constant and gains a pin that the code is **distinct** from `-1` — sharing it would put the refusal straight back into the rollback path — plus a shipped-default pin for `-2`.

## Gates

- Full PHP suite at the final head `520f48621`: **`Tests: 6450, Assertions: 40341, Errors: 61, Failures: 8`** — the same 61/8 as `origin/devel` measured in this session on this box (`6425` tests there). *Corrected: this line previously cited `6449`, measured at the first head `0a5411247`; the fold removed a test and the install pin plus the recorder control each added one, so that figure could not still hold. Re-run, not carried forward.*
- `phpstan`: `[OK] No errors`. `phpcs`: clean.

## Deliberately not done

**The other two non-config causes — this is the narrowing, stated plainly.** `124` (start timeout, `:11740`) and the `tempnam` `-1` (`:11509`) still take the rollback arm and still print "Fix error(s)" for a config that was never at fault. Review leg 1 reproduced it: a valid config rolled back to stale, `.error` written, `unbound.bk` consumed, and the timeout paid twice. `124` is trivially separable; the staging `-1` is **not**, because it shares `-1` with the generic start failure and cannot be told apart without a second constant — a larger change than this one. Split to **#3100** rather than half-done here, and the issue link downgraded from `Closes` to `Refs` accordingly.

Three further items noted on the issue, each its own change with its own seam:

- the `sockstat -46l` port check (`:53` can outlive the pid);
- a `sigkillbyname('unbound','TERM')` fallback when the pidfile is missing but the process is live — the harness has no `sigkillbypid` double, so that arm needs one adding first;
- bounding the `unbound-control status` exec — `:12056` on devel, `:12069` at this head — which has no timeout of its own.

🤖 Generated by [Claude Code](https://claude.com/claude-code), posted via @BBcan177's account on their behalf.







<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling when the DNS resolver cannot be stopped or restarted.
  * Prevented configuration rollback, retry attempts, and unnecessary resolver checks after a confirmed stop failure.
  * Install status now reports when the resolver fails to restart.

* **Tests**
  * Added regression coverage for resolver stop failures, restart reporting, and confirmation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->