### PR TITLE
agent-tools: revert the per-seat uv ownership guard

### DIFF
--- a/scripts/agent/setup-agent-tools.sh
+++ b/scripts/agent/setup-agent-tools.sh
@@ -250,23 +250,16 @@ main() {
 
 	case "$platform" in
 		Linux)
-			uv_path=$(command -v uv 2>/dev/null) || uv_path=
-			# $xdg_bin_home is where this script installs uv, and XDG_BIN_HOME can put
-			# it outside HOME; matching the PATH entry verbatim keeps a seat that sets
-			# it converging on self-update instead of reinstalling every run.
-			case "$uv_path" in
-				"$xdg_bin_home"/uv|"$HOME"/*)
-					# `|| true`: self-update is maintenance, not a prerequisite -- every
-					# later use is `uv tool install --upgrade`, which any uv performs -- so
-					# a transient failure must not end the run before a tool is installed.
-					uv self update || true
-					;;
-				*)
-					# issue #3010: a shared root-owned uv outside this seat satisfies
-					# `command -v` but no seat can self-update it -- provision our own.
-					install_from_url 'https://astral.sh/uv/install.sh'
-					;;
-			esac
+			if command -v uv >/dev/null 2>&1; then
+				# Maintenance, not a prerequisite: every later use is
+				# `uv tool install --upgrade`, which any uv performs. A uv
+				# that did not come from the standalone installer refuses to
+				# self-update and exits non-zero; under `set -eu` that ends
+				# the run before a single tool is installed.
+				uv self update || true
+			else
+				install_from_url 'https://astral.sh/uv/install.sh'
+			fi
 			;;
 		Darwin)
 			if brew list --versions uv >/dev/null 2>&1; then

--- a/tests/shell/agent_tools_setup_spec.sh
+++ b/tests/shell/agent_tools_setup_spec.sh
@@ -157,9 +157,9 @@ CURL
 printf 'uv:%s\n' "$*" >> "$DEBIAN_TOOL_LOG"
 case "$*" in
   'self update')
-    # A self-update can fail -- transient network error, or a uv that did not
-    # come from the standalone installer. The provisioner must treat that as
-    # maintenance, not a prerequisite.
+    # A uv that did not come from the standalone installer refuses to
+    # self-update and exits non-zero (issue: package-managed uv). The
+    # installer must treat that as maintenance, not a prerequisite.
     if [ -n "${DEBIAN_UV_SELF_UPDATE_FAILS:-}" ]; then
       printf 'error: Self-update is only available for uv binaries installed via the standalone installation scripts.\n' >&2
       exit 1
@@ -354,14 +354,6 @@ GROK
     cp "$installables/$1" "$activebin/$1"
   }
 
-  # A uv the seat already owns, at the path the standalone installer uses. The
-  # default fixture uv lives in "$activebin" -- outside HOME -- which models the
-  # shared root-owned /usr/local/bin/uv (#3010), not a seat's own.
-  seat_uv() {
-    mkdir -p "$home/.local/bin"
-    cp "$installables/uv" "$home/.local/bin/uv"
-  }
-
   cleanup() {
     rm -rf "$fixture"
   }
@@ -466,7 +458,6 @@ GROK
   End
 
   It 'updates existing Linux uv and CodeGraph while rerunning global auto configuration'
-    seat_uv
     When run sh "$script_abs" "$repository"
     The status should equal 0
     The contents of file "$curl_log" should equal \
@@ -482,44 +473,6 @@ GROK
       'wt:config shell install --yes' \
       'serena:init')"
     The file "$apt_log" should not be exist
-  End
-
-  It 'installs a per-seat uv when the only uv on PATH lives outside HOME'
-    # issue #3010: a uv outside this seat must not satisfy provisioning of its own.
-    When run sh "$script_abs" "$repository"
-    The status should equal 0
-    The contents of file "$curl_log" should include 'https://astral.sh/uv/install.sh'
-    The path "$home/.local/bin/uv" should be executable
-    # Without this the example also passes an "always install" implementation:
-    # the foreign uv must be left alone, not adopted and self-updated.
-    The contents of file "$tool_log" should not include 'uv:self update'
-  End
-
-  It 'converges on the seat uv when XDG_BIN_HOME lives outside HOME'
-    # The seat's own uv is installed into $xdg_bin_home, which XDG_BIN_HOME can put
-    # outside HOME. Testing ownership against HOME alone re-classifies that uv as
-    # foreign on every later run, so it is reinstalled instead of self-updated.
-    custom_xdg_bin="$fixture/custom xdg bin"
-    When run env XDG_BIN_HOME="$custom_xdg_bin" \
-      sh -c 'sh "$1" "$2" && sh "$1" "$2"' _ "$script_abs" "$repository"
-    The status should equal 0
-    Assert [ "$(grep -c '^https://astral.sh/uv/install.sh$' "$curl_log")" -eq 1 ]
-    Assert [ "$(grep -c '^uv:self update$' "$tool_log")" -eq 1 ]
-    The path "$custom_xdg_bin/uv" should be executable
-  End
-
-  It 'keeps a seat uv that lives under HOME but not in the XDG bin dir'
-    # PATH also carries $HOME/.cargo/bin, so a seat can legitimately own a uv that
-    # is not at $xdg_bin_home. That is what the HOME alternative of the guard
-    # covers, and without this example dropping it ships green.
-    rm -f "$activebin/uv"
-    custom_xdg_bin="$fixture/custom xdg bin"
-    mkdir -p "$home/.cargo/bin"
-    cp "$installables/uv" "$home/.cargo/bin/uv"
-    When run env XDG_BIN_HOME="$custom_xdg_bin" sh "$script_abs" "$repository"
-    The status should equal 0
-    Assert [ "$(grep -c '^uv:self update$' "$tool_log")" -eq 1 ]
-    Assert [ "$(grep -c '^https://astral.sh/uv/install.sh$' "$curl_log")" -eq 0 ]
   End
 
   It 'installs a managed Homebrew uv when an unmanaged Darwin uv command exists'
@@ -880,9 +833,8 @@ UNMANAGED_UV
     The contents of file "$tool_log" should not include 'grok:mcp'
     The contents of file "$tool_log" should include 'codegraph:install -l global -y -t auto'
     The file "$apt_log" should not be exist
-    The contents of file "$curl_log" should equal "$(printf '%s\n%s' \
-      'https://astral.sh/uv/install.sh' \
-      'https://github.com/max-sixty/worktrunk/releases/latest/download/worktrunk-installer.sh')"
+    The contents of file "$curl_log" should equal \
+      'https://github.com/max-sixty/worktrunk/releases/latest/download/worktrunk-installer.sh'
   End
 
   It 'creates the canonical global Worktrunk key when the user config is missing'
@@ -1034,10 +986,7 @@ CONFIG
     The status should equal 0
     The contents of file "$worktrunk_config" should equal "$canonical_worktree_path"
     Assert [ "$(grep -Fxc "$canonical_worktree_path" "$worktrunk_config")" -eq 1 ]
-    # Run 1 has no seat uv and provisions one; run 2 finds it under HOME and
-    # self-updates. Converging on one self-update is the guard working (#3010).
-    Assert [ "$(grep -c '^uv:self update$' "$tool_log")" -eq 1 ]
-    Assert [ "$(grep -c '^https://astral.sh/uv/install.sh$' "$curl_log")" -eq 1 ]
+    Assert [ "$(grep -c '^uv:self update$' "$tool_log")" -eq 2 ]
     Assert [ "$(grep -c '^uv:tool install --upgrade serena-agent$' "$tool_log")" -eq 2 ]
     Assert [ "$(grep -c '^uv:tool install --upgrade graphifyy$' "$tool_log")" -eq 2 ]
     Assert [ "$(grep -c '^uv:tool install --upgrade ast-grep-cli$' "$tool_log")" -eq 2 ]
@@ -1051,15 +1000,13 @@ CONFIG
     Assert [ "$(grep -c "^init-worktree-tools:$repository$" "$helper_log")" -eq 2 ]
   End
 
-  It "continues when the seat's own uv refuses to self-update"
+  It 'continues when a package-managed uv refuses to self-update'
     # `uv self update` is maintenance, not a prerequisite: every later use is
-    # `uv tool install --upgrade`, which any uv performs happily. A self-update
-    # can still fail -- a transient network error, or a uv the seat did not get
-    # from the standalone installer -- and under `set -eu` that aborted the whole
-    # run before a single tool was installed. Only a seat-owned uv reaches this
-    # call now, so the fixture seeds one.
+    # `uv tool install --upgrade`, which a package-managed uv performs happily.
+    # A uv installed by apt/curl-to-/usr/local rather than the standalone script
+    # exits non-zero here, and under `set -eu` that aborted the whole run before
+    # a single tool was installed.
     export DEBIAN_UV_SELF_UPDATE_FAILS=1
-    seat_uv
     When run sh "$script_abs" "$repository"
     The status should equal 0
     Assert [ "$(grep -c '^uv:self update$' "$tool_log")" -eq 1 ]


### PR DESCRIPTION
Refs #3010.

Reverts PR #3064 (`ac23645f`, `93273340`, `83edda78`) at the owner's direction in https://github.com/pfBlockerNG/pfBlockerNG/issues/3010#issuecomment-5505154530.

## Why

#3064 taught `setup-agent-tools.sh` to test a uv on `PATH` for *ownership* — the seat's install directory or anywhere under `$HOME` — and to provision a second, seat-owned uv whenever the one found was foreign. The owner's position is the opposite: uv is a package manager, like `apt` or `pip`; its exact version has little to no importance for us; a system uv on `PATH` is fine to use as-is; and the installer should not try to replace the package manager itself.

The pre-#3064 contract is exactly that position — *"if it does not exist, install it; if it does, it is not a problem"*:

```sh
if command -v uv >/dev/null 2>&1; then
        uv self update || true
else
        install_from_url 'https://astral.sh/uv/install.sh'
fi
```

## What changed

A pure revert of the three #3064 commits. Both files are byte-identical to their state at `ac23645f^`:

```
$ git revert --no-edit --no-commit 83edda78 93273340 ac23645f
$ git diff ac23645f^ -- scripts/agent/setup-agent-tools.sh tests/shell/agent_tools_setup_spec.sh | wc -l
0
```

- `uv self update || true` (#3008) stays: a self-update refusal or transient failure must not abort provisioning.
- `codegraph` is untouched. It already has the `command -v` → upgrade-else-install shape; #3098, which would have applied the same ownership guard to it, was closed unmerged.
- The `seat_uv`/`seat_tool` fixture helpers and the three ownership examples #3064 added go with it; the four examples #3064 migrated return to their original form.

## Test-first proof

Executed. The spec at `ac23645f^` was swapped into place and run against the post-#3064 script on `devel` (RED), then the revert applied and the same byte-identical spec re-run (GREEN).

```
$ git show ac23645f^:tests/shell/agent_tools_setup_spec.sh > tests/shell/agent_tools_setup_spec.sh
$ git hash-object tests/shell/agent_tools_setup_spec.sh
f5a745f730721640ac0c6a85941aeecc09d2f9ac
$ shellspec --shell /usr/bin/dash tests/shell/agent_tools_setup_spec.sh
44 examples, 4 failures
  :460  updates existing Linux uv and CodeGraph while rerunning global auto configuration
  :826  ignores agent environment markers when no client executable is present
  :984  updates tools and keeps one canonical Worktrunk key across repeated installer runs
  :1003 continues when a package-managed uv refuses to self-update

$ # revert applied; spec unchanged
$ git hash-object tests/shell/agent_tools_setup_spec.sh
f5a745f730721640ac0c6a85941aeecc09d2f9ac
$ shellspec --shell /usr/bin/dash tests/shell/agent_tools_setup_spec.sh
44 examples, 0 failures
```

The RED failures are the intended ones: the fixture's uv lives in `$activebin`, a sibling of `$home`, so the post-#3064 script installs instead of self-updating — `:464` expected the worktrunk installer URL next in `curl.log` and got an extra `https://astral.sh/uv/install.sh` fetch, `:474` expected `uv:self update` and got `uv:tool install --upgrade serena-agent`; `:1013` expected the `Self-update is only available` diagnostic and got nothing, because the #3008 path was never reached.

| Frozen RED test | git hash-object | RED run tail |
| --- | --- | --- |
| `tests/shell/agent_tools_setup_spec.sh` | `f5a745f730721640ac0c6a85941aeecc09d2f9ac` | `44 examples, 4 failures` — `:460`, `:826`, `:984`, `:1003` as listed above |

## Gates

`sh scripts/agent/run-gates.sh --diff origin/devel` selects six gates. Five pass; the whole-suite shellspec gate fails on this box:

```
GATE PASS: python3 scripts/check_coverage_pairing.py --name-status-z
GATE PASS: uv run --locked python scripts/check_reentry_bounds.py --self-test && …
GATE PASS: sh -n scripts/agent/setup-agent-tools.sh
GATE PASS: shellcheck scripts/agent/setup-agent-tools.sh
GATE PASS: sh -n tests/shell/agent_tools_setup_spec.sh
GATE FAIL: shellspec --shell $(command -v dash || command -v sh)
1835 examples, 5 failures, 3 skips
```

The five failures are in `pfblockerng_processet_exit_spec.sh` (4) and `precommit_identity_spec.sh` (1), neither touched by this diff, and every one of them asserts that a permission-denied fixture is denied. This seat runs as root, where it is not. Discriminating probe — the same two specs on an untouched `git archive origin/devel` extraction:

```
$ whoami
root
$ shellspec --shell /usr/bin/dash tests/shell/pfblockerng_processet_exit_spec.sh tests/shell/precommit_identity_spec.sh
69 examples, 5 failures   # the identical five
```

Box-local; CI is authoritative. `shellcheck -s sh` and `dash -n` are clean on the changed script, and the pre-commit gate passed on the commit.

## Not in this PR

- The owner's suggestion of a repository-owned venv for the Python tools is a separate design change.
- No change to how `codegraph`, `serena`, `ast-grep` or `semgrep` are provisioned.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Linux agent setup now keeps the `uv` tool current by updating existing installations when possible.
  - If `uv` is unavailable, setup installs it automatically using Astral’s installer.
  - Provisioning continues successfully when an existing, package-managed `uv` cannot self-update.
  - Agent setup now handles `uv` consistently without relying on installation location or ownership markers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->