### PR TITLE
deinstall: serialise package removal against an in-flight feed pass

### DIFF
--- a/docs/misc/architecture-notes.md
+++ b/docs/misc/architecture-notes.md
@@ -1592,6 +1592,16 @@ other contender. It is also the one holder that takes this lock **without** the 
 first; that inverts the order every other holder uses, and cannot deadlock only because every
 non-install feed-pass acquire is non-blocking and every dispatcher acquire is bounded.
 
+**The uninstall holds it too (issue #3090).** `pfblockerng_php_pre_deinstall_command()` tears the
+same state down — stops the pfB services, removes the Unbound chroot module and generated DNSBL
+files, kills the pf tables — through a disable pass whose own feed-pass acquire is the
+non-blocking dispatcher shape: on contention it **defers**, and the teardown after it ran anyway.
+So the teardown branch takes the same hold first (`pfb_install_feed_pass_hold(PFB_INSTALL_FEED_PASS_WAIT,
+'uninstall')`, right after the #697 pkg-operation check so an upgrade never waits), the disable
+pass reenters it, and the same bounded wait / proceed-anyway-with-a-log policy applies — an
+uninstall may not be abandoned either. The `$op` argument only names the operation in the log
+lines (`Package uninstall proceeding WITHOUT the feed-pass lock`).
+
 **The due-ledger** is a single JSON sidecar `pfb_due_ledger.json` under `$pfb['dbdir']`, one entry
 per job/feed: `{last_run, next_due, jitter}`. Pure, clock+seed-injectable helpers in
 `pfblockerng_extra.inc` (`pfb_due_ledger_*`); the tick wrapper `pfb_tick_due_jobs()` decides due-ness:

--- a/docs/misc/architecture-notes.md
+++ b/docs/misc/architecture-notes.md
@@ -1589,9 +1589,10 @@ half-installed package is worse than an overlap: on expiry the install proceeds 
 `Package install proceeding WITHOUT the feed-pass lock` to `pfblockerng.log` and syslog
 (`LOG_WARNING`) — so a pass longer than the budget (a large multi-feed download) still overlaps, it
 is just no longer silent. While the hold stands, a tick firing mid-install defers exactly like any
-other contender. They are also the only holders that take this lock **without** the dispatcher
-lock first; that inverts the order every other holder uses, and cannot deadlock only because every
-other feed-pass acquire is non-blocking and every dispatcher acquire is bounded.
+other contender. They also take this lock **without** the dispatcher lock first (as the GUI Alerts
+live-punch paths do, but those stay non-blocking); that inverts the order every scheduled holder
+uses, and cannot deadlock only because every other feed-pass acquire is non-blocking and every
+dispatcher acquire is bounded.
 
 **The uninstall holds it too (issue #3090).** `pfblockerng_php_pre_deinstall_command()` tears the
 same state down — stops the pfB services, removes the Unbound chroot module and generated DNSBL

--- a/docs/misc/architecture-notes.md
+++ b/docs/misc/architecture-notes.md
@@ -1580,17 +1580,18 @@ scheduling.
 Unbound chroot (`pfblockerng.sh dnsbl_cache stage`), drops cache databases, and stops/starts the pfB
 services — the same files and daemon a pass publishes into — so it takes the same lock before it
 touches any of them (`pfb_install_feed_pass_hold()`, right after `pfb_global()`) and keeps it until
-the install process exits, which is what lets the post-install resync reenter the hold. It is the
-one holder that **waits** rather than skipping: `pfb_feed_pass_acquire()`'s optional `$timeout_s`
+the install process exits, which is what lets the post-install resync reenter the hold. The
+package operations (install here, uninstall below) are the only holders that **wait** rather
+than skipping: `pfb_feed_pass_acquire()`'s optional `$timeout_s`
 (default `0.0` — the single non-blocking attempt every dispatcher must keep) is set to
 `PFB_INSTALL_FEED_PASS_WAIT` (300 s). The wait is bounded and failure is non-fatal, because a
 half-installed package is worse than an overlap: on expiry the install proceeds and logs
 `Package install proceeding WITHOUT the feed-pass lock` to `pfblockerng.log` and syslog
 (`LOG_WARNING`) — so a pass longer than the budget (a large multi-feed download) still overlaps, it
 is just no longer silent. While the hold stands, a tick firing mid-install defers exactly like any
-other contender. It is also the one holder that takes this lock **without** the dispatcher lock
-first; that inverts the order every other holder uses, and cannot deadlock only because every
-non-install feed-pass acquire is non-blocking and every dispatcher acquire is bounded.
+other contender. They are also the only holders that take this lock **without** the dispatcher
+lock first; that inverts the order every other holder uses, and cannot deadlock only because every
+other feed-pass acquire is non-blocking and every dispatcher acquire is bounded.
 
 **The uninstall holds it too (issue #3090).** `pfblockerng_php_pre_deinstall_command()` tears the
 same state down — stops the pfB services, removes the Unbound chroot module and generated DNSBL

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -19202,10 +19202,10 @@ function pfb_feed_pass_begin(string $label, ?bool &$contended = NULL): bool {
 // Seconds a package install/uninstall waits for an in-flight feed pass before it proceeds anyway.
 define('PFB_INSTALL_FEED_PASS_WAIT', 300.0);
 
-// issue #3062: the install's hold on the feed-pass lock -- waits, then keeps it until this
-// process exits (pfb_feed_pass_release() at shutdown). FALSE never aborts the caller: an
-// install may not be abandoned. architecture-notes.md "The package install holds it too".
-// issue #3090: the uninstall takes the same hold, $op = 'uninstall' naming it in the log.
+// issues #3062/#3090: the install's/uninstall's hold ($op names it in the log) on the feed-pass
+// lock -- waits, then keeps it until this process exits (pfb_feed_pass_release() at shutdown).
+// FALSE never aborts the caller: a package operation may not be abandoned. architecture-notes.md
+// "The package install holds it too" / "The uninstall holds it too".
 function pfb_install_feed_pass_hold(float $timeout_s = PFB_INSTALL_FEED_PASS_WAIT, string $op = 'install'): bool {
 	if (pfb_feed_pass_busy()) {
 		pfb_logger("\nPackage {$op}: waiting up to {$timeout_s}s for the in-flight feed pass to finish.\n", 1);
@@ -19975,9 +19975,8 @@ function pfblockerng_php_pre_deinstall_command() {
 	// PFB_PRE_UNINSTALL=1). Context only -- pfBlockerNG does not branch on it.
 	$pfb['hook_lifecycle'] = 'uninstall';
 
-	// issue #3090: the disable pass below takes the feed-pass lock non-blocking and DEFERS on
-	// contention, while the chroot/service teardown after it runs regardless -- so wait for
-	// and hold the lock across the whole removal, exactly as the install does (#3062).
+	// issue #3090: hold the feed-pass lock across the whole removal -- the disable pass below only
+	// DEFERS on contention (#3062 install shape; architecture-notes.md "The uninstall holds it too").
 	update_status("Serialising against any in-flight pfBlockerNG feed pass...");
 	update_status(pfb_install_feed_pass_hold(PFB_INSTALL_FEED_PASS_WAIT, 'uninstall') ? " done.\n" : " lock not taken; continuing anyway.\n");
 

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -19109,8 +19109,8 @@ function pfb_feed_pass_deferral_message(string $deferred_by): string {
 // overlapping passes so they cannot corrupt shared recompute staging. Reentrant
 // within a process: a second acquire by the same process is a no-op success.
 // $timeout_s defaults to 0.0 -- one non-blocking attempt, the only shape a feed-pass
-// dispatcher may use (it defers instead of queueing). Package installation waits
-// (issue #3062, pfb_install_feed_pass_hold()) because it cannot be deferred.
+// dispatcher may use (it defers instead of queueing). A package install/uninstall waits
+// (issues #3062/#3090, pfb_install_feed_pass_hold()) because it cannot be deferred.
 function pfb_feed_pass_acquire(?bool &$contended = NULL, float $timeout_s = 0.0): bool {
 	global $pfb;
 	$contended = FALSE;
@@ -19199,16 +19199,17 @@ function pfb_feed_pass_begin(string $label, ?bool &$contended = NULL): bool {
 }
 
 
-// Seconds a package install waits for an in-flight feed pass before it proceeds anyway.
+// Seconds a package install/uninstall waits for an in-flight feed pass before it proceeds anyway.
 define('PFB_INSTALL_FEED_PASS_WAIT', 300.0);
 
 // issue #3062: the install's hold on the feed-pass lock -- waits, then keeps it until this
 // process exits (pfb_feed_pass_release() at shutdown). FALSE never aborts the caller: an
 // install may not be abandoned. architecture-notes.md "The package install holds it too".
-function pfb_install_feed_pass_hold(float $timeout_s = PFB_INSTALL_FEED_PASS_WAIT): bool {
+// issue #3090: the uninstall takes the same hold, $op = 'uninstall' naming it in the log.
+function pfb_install_feed_pass_hold(float $timeout_s = PFB_INSTALL_FEED_PASS_WAIT, string $op = 'install'): bool {
 	if (pfb_feed_pass_busy()) {
-		pfb_logger("\nPackage install: waiting up to {$timeout_s}s for the in-flight feed pass to finish.\n", 1);
-		logger(LOG_NOTICE, localize_text('Package install waiting for the in-flight feed pass to finish.'),
+		pfb_logger("\nPackage {$op}: waiting up to {$timeout_s}s for the in-flight feed pass to finish.\n", 1);
+		logger(LOG_NOTICE, localize_text('Package %s waiting for the in-flight feed pass to finish.', $op),
 			LOG_PREFIX_PKG_PFBLOCKERNG);
 	}
 
@@ -19218,12 +19219,12 @@ function pfb_install_feed_pass_hold(float $timeout_s = PFB_INSTALL_FEED_PASS_WAI
 	}
 
 	if ($contended) {
-		pfb_logger("\nPackage install proceeding WITHOUT the feed-pass lock: a feed pass is still running.\n", 2);
-		logger(LOG_WARNING, localize_text('Package install proceeding without the feed-pass lock - a feed pass is still running.'),
+		pfb_logger("\nPackage {$op} proceeding WITHOUT the feed-pass lock: a feed pass is still running.\n", 2);
+		logger(LOG_WARNING, localize_text('Package %s proceeding without the feed-pass lock - a feed pass is still running.', $op),
 			LOG_PREFIX_PKG_PFBLOCKERNG);
 	} else {
-		pfb_logger("\nPackage install proceeding WITHOUT the feed-pass lock: it could not be acquired.\n", 2);
-		logger(LOG_WARNING, localize_text('Package install proceeding without the feed-pass lock - it could not be acquired.'),
+		pfb_logger("\nPackage {$op} proceeding WITHOUT the feed-pass lock: it could not be acquired.\n", 2);
+		logger(LOG_WARNING, localize_text('Package %s proceeding without the feed-pass lock - it could not be acquired.', $op),
 			LOG_PREFIX_PKG_PFBLOCKERNG);
 	}
 	return FALSE;
@@ -19973,6 +19974,12 @@ function pfblockerng_php_pre_deinstall_command() {
 	// #684: publish the pkg transition to the hooks fired by the disable pass below (they get
 	// PFB_PRE_UNINSTALL=1). Context only -- pfBlockerNG does not branch on it.
 	$pfb['hook_lifecycle'] = 'uninstall';
+
+	// issue #3090: the disable pass below takes the feed-pass lock non-blocking and DEFERS on
+	// contention, while the chroot/service teardown after it runs regardless -- so wait for
+	// and hold the lock across the whole removal, exactly as the install does (#3062).
+	update_status("Serialising against any in-flight pfBlockerNG feed pass...");
+	update_status(pfb_install_feed_pass_hold(PFB_INSTALL_FEED_PASS_WAIT, 'uninstall') ? " done.\n" : " lock not taken; continuing anyway.\n");
 
 	update_status("Removing pfBlockerNG...");
 	sync_package_pfblockerng();

--- a/tests/php/InstallFeedPassInterlockTest.php
+++ b/tests/php/InstallFeedPassInterlockTest.php
@@ -19,6 +19,11 @@ use PHPUnit\Framework\TestCase;
  * process so a tick firing mid-install defers with the usual skip line. The
  * wait is bounded because an install may never be abandoned -- on expiry it
  * logs and lets the install proceed.
+ *
+ * issue #3090 -- the uninstall (pfblockerng_php_pre_deinstall_command()) tears the
+ * same chroot and services down and takes the same hold, named 'uninstall' in
+ * its log lines so an operator reading pfblockerng.log sees which pkg operation
+ * waited or gave up.
  */
 final class InstallFeedPassInterlockTest extends TestCase
 {
@@ -269,6 +274,68 @@ final class InstallFeedPassInterlockTest extends TestCase
 			$this->assertNotFalse($first, "install.inc no longer contains [ {$shared} ]");
 			$this->assertLessThan($first, $hold,
 				"the interlock must be taken BEFORE install.inc reaches [ {$shared} ]");
+		}
+	}
+
+	/**
+	 * Scenario: the uninstall gives up its wait.
+	 * Given another handle holding the lock past the budget, When the uninstall's hold
+	 * expires, Then the give-up line names the UNINSTALL -- an operator reading
+	 * pfblockerng.log during a `pkg delete` must not be told an install is running.
+	 */
+	public function testHoldNamesTheUninstallWhenItGivesUp(): void
+	{
+		$holder = fopen($this->lockPath(), 'c');
+		$this->rawFps[] = $holder;
+		$this->assertTrue(flock($holder, LOCK_EX), 'test setup: failed to flock the holder fd');
+
+		$this->assertFalse(pfb_install_feed_pass_hold(0.1, 'uninstall'),
+			'the uninstall must not block forever on a pass that will not finish');
+
+		$log = $this->logContents();
+		$this->assertStringContainsString('Package uninstall: waiting up to', $log,
+			'the wait line must name the uninstall');
+		$this->assertStringContainsString('Package uninstall proceeding WITHOUT the feed-pass lock', $log,
+			'the give-up line must name the uninstall');
+		$this->assertStringNotContainsString('Package install', $log,
+			'an uninstall must never log itself as an install');
+	}
+
+	/**
+	 * The uninstall has to be WIRED too (issue #3090): pfblockerng_php_pre_deinstall_command()
+	 * must take the hold on its teardown branch -- after the #697 pkg-operation check (an
+	 * upgrade keeps pfBlockerNG live and must not wait) and before the disable pass, which
+	 * takes the feed-pass lock non-blocking and DEFERS on contention while the chroot
+	 * teardown that follows it runs regardless.
+	 *
+	 * The controller runs a full sync plus pfctl/exec teardown and cannot be driven
+	 * off-appliance, so this pins its executable order (comments cannot satisfy it).
+	 */
+	public function testPreDeinstallTakesTheHoldAfterThePkgOpCheckAndBeforeTheSync(): void
+	{
+		$path = dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng.inc';
+		$src = (string) @php_strip_whitespace($path);
+		$this->assertNotSame('', $src, "could not read {$path}");
+
+		$start = strpos($src, 'function pfblockerng_php_pre_deinstall_command');
+		$this->assertNotFalse($start, 'pre-deinstall controller must remain defined');
+		$end = strpos($src, 'function ', $start + 1);
+		$this->assertNotFalse($end, 'pre-deinstall controller must be followed by another function');
+		$body = substr($src, $start, $end - $start);
+
+		$hold = strpos($body, 'pfb_install_feed_pass_hold(');
+		$this->assertNotFalse($hold, 'the pre-deinstall never takes the feed-pass interlock (issue #3090)');
+
+		$opCheck = strpos($body, 'pfb_pkg_op_tears_down(');
+		$this->assertNotFalse($opCheck, 'the pre-deinstall no longer checks the pkg operation');
+		$this->assertLessThan($hold, $opCheck,
+			'the interlock must be taken AFTER the pkg-operation check, so an upgrade never waits');
+
+		foreach (['sync_package_pfblockerng(', 'dnsbl_cache teardown'] as $shared) {
+			$first = strpos($body, $shared);
+			$this->assertNotFalse($first, "the pre-deinstall no longer contains [ {$shared} ]");
+			$this->assertLessThan($first, $hold,
+				"the interlock must be taken BEFORE the pre-deinstall reaches [ {$shared} ]");
 		}
 	}
 }

--- a/tests/php/InstallFeedPassInterlockTest.php
+++ b/tests/php/InstallFeedPassInterlockTest.php
@@ -19,11 +19,6 @@ use PHPUnit\Framework\TestCase;
  * process so a tick firing mid-install defers with the usual skip line. The
  * wait is bounded because an install may never be abandoned -- on expiry it
  * logs and lets the install proceed.
- *
- * issue #3090 -- the uninstall (pfblockerng_php_pre_deinstall_command()) tears the
- * same chroot and services down and takes the same hold, named 'uninstall' in
- * its log lines so an operator reading pfblockerng.log sees which pkg operation
- * waited or gave up.
  */
 final class InstallFeedPassInterlockTest extends TestCase
 {
@@ -212,8 +207,8 @@ final class InstallFeedPassInterlockTest extends TestCase
 			'a failed hold must not leave a half-owned lock behind');
 		$this->assertTrue($this->rawProbeStillLocked(),
 			'the running feed pass must keep its own lock undisturbed');
-		$this->assertStringContainsString('proceeding WITHOUT the feed-pass lock', $this->logContents(),
-			'the give-up itself must be logged, not merely the decision to wait');
+		$this->assertStringContainsString('Package install proceeding WITHOUT the feed-pass lock', $this->logContents(),
+			'the give-up itself must be logged, naming the install, not merely the decision to wait');
 	}
 
 	/**
@@ -302,11 +297,9 @@ final class InstallFeedPassInterlockTest extends TestCase
 	}
 
 	/**
-	 * The uninstall has to be WIRED too (issue #3090): pfblockerng_php_pre_deinstall_command()
-	 * must take the hold on its teardown branch -- after the #697 pkg-operation check (an
-	 * upgrade keeps pfBlockerNG live and must not wait) and before the disable pass, which
-	 * takes the feed-pass lock non-blocking and DEFERS on contention while the chroot
-	 * teardown that follows it runs regardless.
+	 * Wiring pin (issue #3090): pfblockerng_php_pre_deinstall_command() takes the hold AFTER
+	 * the #697 pkg-operation check (an upgrade must not wait) and BEFORE the disable pass and
+	 * chroot teardown, and a refused hold never abandons the uninstall.
 	 *
 	 * The controller runs a full sync plus pfctl/exec teardown and cannot be driven
 	 * off-appliance, so this pins its executable order (comments cannot satisfy it).
@@ -319,20 +312,19 @@ final class InstallFeedPassInterlockTest extends TestCase
 
 		$start = strpos($src, 'function pfblockerng_php_pre_deinstall_command');
 		$this->assertNotFalse($start, 'pre-deinstall controller must remain defined');
-		$end = strpos($src, 'function ', $start + 1);
-		$this->assertNotFalse($end, 'pre-deinstall controller must be followed by another function');
-		$body = substr($src, $start, $end - $start);
 
-		$hold = strpos($body, 'pfb_install_feed_pass_hold(');
+		$hold = strpos($src, 'pfb_install_feed_pass_hold(', $start);
 		$this->assertNotFalse($hold, 'the pre-deinstall never takes the feed-pass interlock (issue #3090)');
+		$this->assertNotFalse(strpos($src, 'update_status(pfb_install_feed_pass_hold(', $start),
+			'a refused hold must be reported and never abandon the uninstall (issue #3090)');
 
-		$opCheck = strpos($body, 'pfb_pkg_op_tears_down(');
+		$opCheck = strpos($src, 'pfb_pkg_op_tears_down(', $start);
 		$this->assertNotFalse($opCheck, 'the pre-deinstall no longer checks the pkg operation');
 		$this->assertLessThan($hold, $opCheck,
 			'the interlock must be taken AFTER the pkg-operation check, so an upgrade never waits');
 
 		foreach (['sync_package_pfblockerng(', 'dnsbl_cache teardown'] as $shared) {
-			$first = strpos($body, $shared);
+			$first = strpos($src, $shared, $start);
 			$this->assertNotFalse($first, "the pre-deinstall no longer contains [ {$shared} ]");
 			$this->assertLessThan($first, $hold,
 				"the interlock must be taken BEFORE the pre-deinstall reaches [ {$shared} ]");

--- a/tests/php/fixtures/function_inventory.json
+++ b/tests/php/fixtures/function_inventory.json
@@ -5736,6 +5736,13 @@
                 "variadic": false,
                 "type": "float",
                 "default": "300.0"
+            },
+            {
+                "name": "op",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": "'install'"
             }
         ]
     },


### PR DESCRIPTION
Fixes #3090

## What

`pfblockerng_php_pre_deinstall_command()` tears down the same shared state a package install touches — pfB services, the Unbound chroot module and generated DNSBL files, the pf tables — but took no feed-pass lock. Its disable pass (`sync_package_pfblockerng()`) acquires the lock non-blocking and **defers** on contention (`pfblockerng_apply.inc:762-780`), while the chroot/service teardown that follows ran regardless, so a scheduled feed pass could keep publishing into a chroot being dismantled.

The teardown branch now takes the same bounded hold the install path takes (#3062 / #3086): `pfb_install_feed_pass_hold(PFB_INSTALL_FEED_PASS_WAIT, 'uninstall')` right after the #697 pkg-operation check (an upgrade keeps pfBlockerNG live and never waits) and before the disable pass, which reenters it. Same 300 s bounded wait, same proceed-anyway-with-a-log policy — an uninstall may not be abandoned either. The hold gains an `$op` label so its wait and give-up lines name the uninstall instead of an install.

## Changes

- `src/usr/local/pkg/pfblockerng/pfblockerng.inc` — the hold in the pre-deinstall teardown branch; `$op` label on `pfb_install_feed_pass_hold()`; comment reconciliation.
- `tests/php/InstallFeedPassInterlockTest.php` — `testHoldNamesTheUninstallWhenItGivesUp` (log lines name the uninstall) and `testPreDeinstallTakesTheHoldAfterThePkgOpCheckAndBeforeTheSync` (wiring pin: hold after `pfb_pkg_op_tears_down(`, before `sync_package_pfblockerng(` and `dnsbl_cache teardown`). The controller cannot be driven off-appliance (it runs a full sync plus pfctl/exec teardown; see `PfbPendingChangesTest`), so wiring is pinned by executable order like the install pin.
- `tests/php/fixtures/function_inventory.json` — golden regenerated for the new parameter.
- `docs/misc/architecture-notes.md` — "The uninstall holds it too (issue #3090)".
- `graphify-out/graph.json` — `graphify update .`.

## Coverage matrix

| Axis | Row | Test |
| --- | --- | --- |
| pkg operation | `delete` / `''` (tears down) → hold taken before sync | `testPreDeinstallTakesTheHoldAfterThePkgOpCheckAndBeforeTheSync` |
| pkg operation | `install` / `reinstall` / `upgrade` (keeps live) → early return precedes the hold | same test (`pfb_pkg_op_tears_down(` < hold) + existing `PfbPkgOperationTest` |
| hold outcome | free lock → taken and kept | existing `testHoldTakesTheFeedPassLockWhenNoPassIsInFlight` |
| hold outcome | busy then released → waits and takes | existing `testHoldIsRefusedWhileAnotherProcessHoldsAndSucceedsOnceItReleases` |
| hold outcome | busy past budget → gives up, logs | existing `testHoldSpendsItsBudgetThenLetsTheInstallProceed` (install label) + `testHoldNamesTheUninstallWhenItGivesUp` (uninstall label) |
| hold outcome | reentrant (sync reenters the held lock) | existing `testHoldIsReentrantWhenThisProcessAlreadyHoldsTheLock` |
| `$op` label | default `'install'` unchanged for `pfblockerng_install.inc` | `testHoldSpendsItsBudgetThenLetsTheInstallProceed` asserts `Package install proceeding WITHOUT the feed-pass lock` (since 22cca43e); the regenerated golden + `FunctionInventoryParityTest` pin the default value |
| hold outcome | refused hold is reported via `update_status()` and never abandons the uninstall | `testPreDeinstallTakesTheHoldAfterThePkgOpCheckAndBeforeTheSync` (positive pin on `update_status(pfb_install_feed_pass_hold(`, since 22cca43e) |

## Review-fix round (22cca43e)

Nitpicks from the four legs applied: install label asserted in the give-up test, positive non-abort pin, offset-form wiring pin, comment/docblock trims, architecture-notes reword. The contract leg's suggested negative token `if(!pfb_install_feed_pass_hold(` was executed and found vacuous (`php_strip_whitespace` keeps `if (!`), so the positive form replaced it; both mutations (aborting guard; hold after sync) turn the pin red on 22cca43e.

## Red → green (test-first, executed)

Test file `git hash-object` at red time: `88aaa71934643d7c4cbdb47d4911606be4fb94b9` (equal at green, unchanged in the commit).

RED (before any production edit):

```text
1) InstallFeedPassInterlockTest::testHoldNamesTheUninstallWhenItGivesUp
the wait line must name the uninstall
Failed asserting that '...Package install: waiting up to 0.1s for the in-flight feed pass to finish...
Package install proceeding WITHOUT the feed-pass lock: a feed pass is still running...' contains "Package uninstall: waiting up to"

2) InstallFeedPassInterlockTest::testPreDeinstallTakesTheHoldAfterThePkgOpCheckAndBeforeTheSync
the pre-deinstall never takes the feed-pass interlock (issue #3090)
Failed asserting that false is not false.

Tests: 8, Assertions: 41, Failures: 2.
```

GREEN (same file, after the edit; with the neighbouring suites):

```text
InstallFeedPassInterlockTest + PfbSettingsFamilyTest: OK
FunctionInventoryParityTest: OK (1 test, 6 assertions)   # after the golden regeneration
```

## Gates

`COMPOSER_ALLOW_SUPERUSER=1 sh scripts/agent/run-gates.sh --diff origin/devel`:

```text
GATE PASS: composer phpstan
GATE PASS: composer phpcs -- --standard=phpcs.xml.dist src/
GATE PASS: npx markdownlint-cli2
GATE FAIL: vendor/bin/phpunit   # Tests: 6452, Errors: 29, Failures: 14 — none in the touched suites
```

The PHPUnit failures are host-only and pre-existing on `origin/devel` (identical set with this diff stashed; identical as `nobody` on a `git archive` extraction of base; CI on the same base SHA is green). Tracked in #3103. Toolchain: PHP 8.4.24 on Debian 13; CI (PHP 8.3/8.5) is authoritative.

`php -l src/usr/local/pkg/pfblockerng/pfblockerng.inc`: no syntax errors. Pre-commit hook steps (markdownlint, php -l, phpcs, comment-narration, version-literals, …) passed on this commit.

## Runtime claim

Live-box behaviour (a `pkg delete` mid-pass on a real appliance) is not exercised here; the issue's black-box reproduction remains a smoke-seat item per `testing.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved coordination between feed processing and package uninstallation by holding the feed-pass lock throughout removal.
  * Uninstall status and wait messages now accurately identify the operation.
  * Uninstallation proceeds safely even if the lock cannot be acquired, with clear status reporting.

* **Tests**
  * Added coverage for uninstall lock handling, timeout messaging, and operation sequencing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->