### PR TITLE
hooks: stop counting untracked files as tree dirt in session-branch-sync

### DIFF
--- a/.claude/hooks/session-branch-sync.sh
+++ b/.claude/hooks/session-branch-sync.sh
@@ -14,7 +14,12 @@
 #                               new commits replay on the live base
 #   shallow history gap      -> unshallow once, then require a visible merge
 #                               base; otherwise report + touch nothing
-#   dirty tree               -> touch nothing; tell the agent to sync by hand
+#   dirty tree               -> touch nothing; tell the agent to sync by hand.
+#                               Only TRACKED changes count: untracked files (fresh
+#                               graphify-out/memory/ records, scratch output) never
+#                               conflict with a fast-forward or rebase unless the
+#                               incoming commits write that same path, and git
+#                               refuses that case on its own -- reported below.
 #   rebase conflict (~1%)    -> abort cleanly; tell the agent to resolve by hand
 #
 # ponytail: base is origin/devel for every non-base branch -- the documented
@@ -78,7 +83,7 @@ before=$(git rev-list --count "${base}..HEAD" 2>/dev/null || echo 0)
 behind=$(git rev-list --count "HEAD..${base}" 2>/dev/null || echo 0)
 [ "$before" -eq 0 ] && [ "$behind" -eq 0 ] && exit 0
 
-if [ -n "$(git status --porcelain 2>/dev/null)" ]; then
+if [ -n "$(git status --porcelain --untracked-files=no 2>/dev/null)" ]; then
 	emit "${kind} '${branch}': ${before} commit(s) ahead of ${base}, ${behind} behind, but the working tree is DIRTY so it was left untouched. Commit or discard your changes, then run: git rebase ${base}  (or, on a base branch, git merge --ff-only ${base}). Rebasing can drop individually patch-equivalent commits, but git log ${base}..HEAD cannot tell whether equivalent changes already landed in a squash commit."
 	exit 0
 fi
@@ -94,6 +99,8 @@ case "$branch" in
 			emit "BASE BRANCH '${branch}': has ${before} local commit(s) not on ${base}. This branch is meant to be PR-only -- reconcile by hand before starting work (push them via a PR, or reset to ${base})."
 		elif git merge --ff-only --quiet "$base" >/dev/null 2>&1; then
 			emit "BASE BRANCH '${branch}': fast-forwarded ${behind} commit(s) up to ${base}. Checkout is current."
+		else
+			emit "BASE BRANCH '${branch}': fast-forward to ${base} FAILED -- branch is unchanged (stderr was suppressed). Usually an untracked file that ${base} now tracks: move it aside, then run: git merge --ff-only ${base}"
 		fi
 		;;
 	*)

--- a/.claude/hooks/session-branch-sync.sh
+++ b/.claude/hooks/session-branch-sync.sh
@@ -6,7 +6,7 @@
 # synchronization step: Git drops individually patch-equivalent commits and
 # replays genuinely new ones. A branch whose PR was squash-merged may instead
 # conflict because its original commit boundaries no longer exist upstream;
-# the hook aborts cleanly and reports that case rather than guessing.
+# the hook aborts when it can and reports what happened rather than guessing.
 #
 #   base branch (devel/main) -> fast-forward only (ff-only) to its own remote;
 #                               a diverged base is surfaced, never rewritten
@@ -15,11 +15,11 @@
 #   shallow history gap      -> unshallow once, then require a visible merge
 #                               base; otherwise report + touch nothing
 #   dirty tree               -> touch nothing; tell the agent to sync by hand. Only
-#                               TRACKED changes count: an untracked file (a fresh
-#                               graphify-out/memory/ record) blocks nothing unless the
-#                               incoming commits track that path -- git refuses that
-#                               itself, and both arms below report it
+#                               TRACKED changes count (untracked graphify-out/memory/
+#                               records never block a sync)
 #   rebase conflict (~1%)    -> abort cleanly; tell the agent to resolve by hand
+#   untracked path collision -> git refuses the ff/rebase itself; reported as such
+#                               (a failed abort is reported as stuck mid-rebase)
 #
 # ponytail: base is origin/devel for every non-base branch -- the documented
 # branch point for adr/issue/claude branches. A rare main-targeting branch

--- a/.claude/hooks/session-branch-sync.sh
+++ b/.claude/hooks/session-branch-sync.sh
@@ -14,12 +14,11 @@
 #                               new commits replay on the live base
 #   shallow history gap      -> unshallow once, then require a visible merge
 #                               base; otherwise report + touch nothing
-#   dirty tree               -> touch nothing; tell the agent to sync by hand.
-#                               Only TRACKED changes count: untracked files (fresh
-#                               graphify-out/memory/ records, scratch output) never
-#                               conflict with a fast-forward or rebase unless the
-#                               incoming commits write that same path, and git
-#                               refuses that case on its own -- reported below.
+#   dirty tree               -> touch nothing; tell the agent to sync by hand. Only
+#                               TRACKED changes count: an untracked file (a fresh
+#                               graphify-out/memory/ record) blocks nothing unless the
+#                               incoming commits track that path -- git refuses that
+#                               itself, and both arms below report it
 #   rebase conflict (~1%)    -> abort cleanly; tell the agent to resolve by hand
 #
 # ponytail: base is origin/devel for every non-base branch -- the documented
@@ -114,8 +113,10 @@ case "$branch" in
 			fi
 		elif git rebase --abort >/dev/null 2>&1; then
 			emit "SESSION BRANCH '${branch}': rebase onto ${base} FAILED and was ABORTED -- branch is unchanged (stderr was suppressed, so the cause is unshown). Re-run by hand to see why: git rebase ${base}  (often a merge conflict; an obsolete squash-merged branch can conflict because upstream no longer has its original commit boundaries), then --force-with-lease push."
-		else
+		elif [ -d "$(git rev-parse --git-path rebase-merge)" ] || [ -d "$(git rev-parse --git-path rebase-apply)" ]; then
 			emit "SESSION BRANCH '${branch}': rebase onto ${base} FAILED and the --abort ALSO failed -- the repo may be stuck mid-rebase. Inspect by hand: git status; git rebase --abort."
+		else
+			emit "SESSION BRANCH '${branch}': rebase onto ${base} could not start -- branch is unchanged (stderr was suppressed). Usually an untracked file that ${base} now tracks (git status shows it): move it aside, then run: git rebase ${base}"
 		fi
 		;;
 esac

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "root=$(git rev-parse --show-toplevel) && python3 -c \"import hashlib,sys; p,e=sys.argv[1:]; a=hashlib.sha256(open(p,'rb').read()).hexdigest(); print(f'codex-hook-integrity: {p} hash {a}, expected {e}',file=sys.stderr) if a != e else None; sys.exit(a != e)\" \"$root/.claude/hooks/session-branch-sync.sh\" 4b11454944ad59c3093f28fecbc74c880e244ff81561e4c2e51112675429015b && exec sh \"$root/.claude/hooks/session-branch-sync.sh\"",
+            "command": "root=$(git rev-parse --show-toplevel) && python3 -c \"import hashlib,sys; p,e=sys.argv[1:]; a=hashlib.sha256(open(p,'rb').read()).hexdigest(); print(f'codex-hook-integrity: {p} hash {a}, expected {e}',file=sys.stderr) if a != e else None; sys.exit(a != e)\" \"$root/.claude/hooks/session-branch-sync.sh\" c8ba6b34c2d59a313a2710d66d4b58ffb8f2386a29f223e629a6ff0e07d9c768 && exec sh \"$root/.claude/hooks/session-branch-sync.sh\"",
             "timeout": 120,
             "statusMessage": "Checking branch freshness"
           }

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "root=$(git rev-parse --show-toplevel) && python3 -c \"import hashlib,sys; p,e=sys.argv[1:]; a=hashlib.sha256(open(p,'rb').read()).hexdigest(); print(f'codex-hook-integrity: {p} hash {a}, expected {e}',file=sys.stderr) if a != e else None; sys.exit(a != e)\" \"$root/.claude/hooks/session-branch-sync.sh\" c8ba6b34c2d59a313a2710d66d4b58ffb8f2386a29f223e629a6ff0e07d9c768 && exec sh \"$root/.claude/hooks/session-branch-sync.sh\"",
+            "command": "root=$(git rev-parse --show-toplevel) && python3 -c \"import hashlib,sys; p,e=sys.argv[1:]; a=hashlib.sha256(open(p,'rb').read()).hexdigest(); print(f'codex-hook-integrity: {p} hash {a}, expected {e}',file=sys.stderr) if a != e else None; sys.exit(a != e)\" \"$root/.claude/hooks/session-branch-sync.sh\" f88571f05d8c0447c45eb701b979c24aa89d00188cb69625e93a3d19d6666150 && exec sh \"$root/.claude/hooks/session-branch-sync.sh\"",
             "timeout": 120,
             "statusMessage": "Checking branch freshness"
           }

--- a/scripts/git-env-scrub-guard.sh
+++ b/scripts/git-env-scrub-guard.sh
@@ -90,7 +90,7 @@ pfblockerng_truncate_survival_spec.sh:4
 precommit_composer_vendor_spec.sh:2
 read_version_matrix_test_spec.sh:5
 release_ci_gate_spec.sh:33
-session_branch_sync_spec.sh:46
+session_branch_sync_spec.sh:64
 sparse_clone_ports_spec.sh:17
 EOF
 }

--- a/scripts/git-env-scrub-guard.sh
+++ b/scripts/git-env-scrub-guard.sh
@@ -90,7 +90,7 @@ pfblockerng_truncate_survival_spec.sh:4
 precommit_composer_vendor_spec.sh:2
 read_version_matrix_test_spec.sh:5
 release_ci_gate_spec.sh:33
-session_branch_sync_spec.sh:64
+session_branch_sync_spec.sh:88
 sparse_clone_ports_spec.sh:17
 EOF
 }

--- a/tests/shell/session_branch_sync_spec.sh
+++ b/tests/shell/session_branch_sync_spec.sh
@@ -166,8 +166,84 @@ Describe 'session-branch-sync base branch with untracked files'
     }
     When run sync_collide
     The status should equal 0
-    The output should include 'fast-forward'
-    The output should include 'FAILED'
+    The output should include 'fast-forward to origin/devel FAILED'
+  End
+End
+
+Describe 'session-branch-sync session branch with untracked files'
+  hook="${PFB_ROOT}/.claude/hooks/session-branch-sync.sh"
+
+  setup() {
+    scrub_git_env
+    base="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/session-sync.XXXXXX")"
+    remote="$base/remote.git"
+    seed="$base/seed"
+    session="$base/session"
+    git_fixture init -q --bare "$remote"
+    git_fixture clone -q "$remote" "$seed" 2>/dev/null
+    git_fixture -C "$seed" config user.email seed@example.com
+    git_fixture -C "$seed" config user.name Seed
+    git_fixture -C "$seed" config commit.gpgsign false
+    git_fixture -C "$seed" checkout -q -b devel
+    printf 'base-1\n' > "$seed/base.txt"
+    git_fixture -C "$seed" add base.txt
+    git_fixture -C "$seed" commit -q -m base-1
+    git_fixture -C "$seed" push -q origin devel
+
+    git_fixture clone -q --branch devel "file://$remote" "$session"
+    git_fixture -C "$session" config user.email agent@example.com
+    git_fixture -C "$session" config user.name Agent
+    git_fixture -C "$session" config commit.gpgsign false
+    git_fixture -C "$session" checkout -q -b topic
+    printf '%s\n' topic > "$session/topic.txt"
+    git_fixture -C "$session" add topic.txt
+    git_fixture -C "$session" commit -q -m topic
+
+    printf 'base-2\n' >> "$seed/base.txt"
+    mkdir -p "$seed/graphify-out/memory"
+    printf 'upstream\n' > "$seed/graphify-out/memory/collide.md"
+    git_fixture -C "$seed" add base.txt graphify-out/memory/collide.md
+    git_fixture -C "$seed" commit -q -m base-2
+    git_fixture -C "$seed" push -q origin devel
+    git_fixture -C "$session" fetch -q origin devel
+  }
+
+  cleanup() {
+    rm -rf "$base"
+  }
+
+  BeforeEach 'setup'
+  AfterEach 'cleanup'
+
+  It 'rebases over an untracked memory record'
+    sync_untracked() {
+      mkdir -p "$session/graphify-out/memory"
+      printf 'local\n' > "$session/graphify-out/memory/query_local.md"
+      cd "$session" || return 1
+      sh "$hook" \
+        && git_fixture merge-base --is-ancestor origin/devel HEAD \
+        && [ "$(git_fixture log -1 --format=%s)" = topic ] \
+        && [ "$(cat graphify-out/memory/query_local.md)" = local ]
+    }
+    When run sync_untracked
+    The status should equal 0
+    The output should include 'rebased onto origin/devel'
+  End
+
+  It 'reports a rebase that could not start over a colliding untracked file'
+    sync_collide() {
+      mkdir -p "$session/graphify-out/memory"
+      printf 'local\n' > "$session/graphify-out/memory/collide.md"
+      cd "$session" || return 1
+      sh "$hook" \
+        && [ "$(git_fixture rev-list --count HEAD..origin/devel)" -eq 1 ] \
+        && [ "$(git_fixture log -1 --format=%s)" = topic ] \
+        && [ "$(cat graphify-out/memory/collide.md)" = local ]
+    }
+    When run sync_collide
+    The status should equal 0
+    The output should include 'rebase onto origin/devel could not start'
+    The output should not include 'stuck mid-rebase'
   End
 End
 

--- a/tests/shell/session_branch_sync_spec.sh
+++ b/tests/shell/session_branch_sync_spec.sh
@@ -76,7 +76,7 @@ Describe 'session-branch-sync shallow-history recovery'
 
   It 'explains dirty divergent history in squash-landing terms'
     sync_dirty() {
-      printf '%s\n' dirty > "$session/dirty.txt"
+      printf '%s\n' dirty >> "$session/topic.txt"
       cd "$session" || return 1
       sh "$hook"
     }
@@ -84,6 +84,90 @@ Describe 'session-branch-sync shallow-history recovery'
     The status should equal 0
     The output should include 'squash commit'
     The output should not include 'rebase-merge'
+  End
+End
+
+# Untracked files never conflict with a fast-forward or rebase unless the incoming
+# commits write the same path, so they must not count as tree dirt: a session that
+# only queried Graphify leaves untracked graphify-out/memory/ records behind, and a
+# hook that refused to sync over them would stall every later session on that clone.
+Describe 'session-branch-sync base branch with untracked files'
+  hook="${PFB_ROOT}/.claude/hooks/session-branch-sync.sh"
+
+  setup() {
+    scrub_git_env
+    base="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/session-sync.XXXXXX")"
+    remote="$base/remote.git"
+    seed="$base/seed"
+    session="$base/session"
+    git_fixture init -q --bare "$remote"
+    git_fixture clone -q "$remote" "$seed" 2>/dev/null
+    git_fixture -C "$seed" config user.email seed@example.com
+    git_fixture -C "$seed" config user.name Seed
+    git_fixture -C "$seed" config commit.gpgsign false
+    git_fixture -C "$seed" checkout -q -b devel
+    printf 'base-1\n' > "$seed/base.txt"
+    git_fixture -C "$seed" add base.txt
+    git_fixture -C "$seed" commit -q -m base-1
+    git_fixture -C "$seed" push -q origin devel
+
+    git_fixture clone -q --branch devel "file://$remote" "$session"
+
+    printf 'base-2\n' >> "$seed/base.txt"
+    mkdir -p "$seed/graphify-out/memory"
+    printf 'upstream\n' > "$seed/graphify-out/memory/collide.md"
+    git_fixture -C "$seed" add base.txt graphify-out/memory/collide.md
+    git_fixture -C "$seed" commit -q -m base-2
+    git_fixture -C "$seed" push -q origin devel
+    git_fixture -C "$session" fetch -q origin devel
+  }
+
+  cleanup() {
+    rm -rf "$base"
+  }
+
+  BeforeEach 'setup'
+  AfterEach 'cleanup'
+
+  It 'fast-forwards over an untracked memory record'
+    sync_untracked() {
+      mkdir -p "$session/graphify-out/memory"
+      printf 'local\n' > "$session/graphify-out/memory/query_local.md"
+      cd "$session" || return 1
+      sh "$hook" \
+        && [ "$(git_fixture rev-parse HEAD)" = "$(git_fixture rev-parse origin/devel)" ] \
+        && [ "$(cat graphify-out/memory/query_local.md)" = local ]
+    }
+    When run sync_untracked
+    The status should equal 0
+    The output should include 'fast-forwarded 1 commit'
+  End
+
+  It 'still refuses over a modified tracked file'
+    sync_modified() {
+      printf 'local\n' >> "$session/base.txt"
+      cd "$session" || return 1
+      sh "$hook" \
+        && [ "$(git_fixture rev-list --count HEAD..origin/devel)" -eq 1 ]
+    }
+    When run sync_modified
+    The status should equal 0
+    The output should include 'DIRTY'
+  End
+
+  It 'reports a fast-forward blocked by a colliding untracked file'
+    sync_collide() {
+      mkdir -p "$session/graphify-out/memory"
+      printf 'local\n' > "$session/graphify-out/memory/collide.md"
+      cd "$session" || return 1
+      sh "$hook" \
+        && [ "$(git_fixture rev-list --count HEAD..origin/devel)" -eq 1 ] \
+        && [ "$(cat graphify-out/memory/collide.md)" = local ]
+    }
+    When run sync_collide
+    The status should equal 0
+    The output should include 'fast-forward'
+    The output should include 'FAILED'
   End
 End
 


### PR DESCRIPTION
Fixes #3108

## Change

`.claude/hooks/session-branch-sync.sh` gated every sync on `git status --porcelain`, so untracked files counted as a dirty tree. Graphify query records under `graphify-out/memory/` are untracked by design until the work that produced them lands, so a clone that only queried the graph on `devel` reported `DIRTY` at every session start and never fast-forwarded.

- Dirty gate now uses `--untracked-files=no`: only tracked modifications block a sync. Untracked files cannot conflict with a fast-forward or rebase unless the incoming commits write the same path, and git refuses that case itself.
- Base-branch fast-forward failure is now reported (`fast-forward to origin/devel FAILED`) instead of exiting silently, so the untracked-collision case stays visible.
- Session-branch arm: a rebase that git refuses to start (untracked file the base now tracks) is reported as `could not start` naming the cause; the `stuck mid-rebase` message is now gated on an actual rebase-merge/rebase-apply directory.
- `scripts/git-env-scrub-guard.sh`: `git_fixture` pin count for the spec 46 -> 88; `.codex/hooks.json` integrity pin updated for the edited hook.

## Tests

`tests/shell/session_branch_sync_spec.sh`: new `Describe 'session-branch-sync base branch with untracked files'` with three cases (fast-forward over an untracked memory record, still refuse over a modified tracked file, report a fast-forward blocked by a colliding untracked file). The existing dirty case now dirties a tracked file instead of dropping an untracked one, so it keeps guarding the tracked path.

### Red (spec sha256 `2ea225f2…b543`, hook unchanged)

```
6 examples, 2 failures
shellspec tests/shell/session_branch_sync_spec.sh:132 # 1) ... fast-forwards over an untracked memory record FAILED
shellspec tests/shell/session_branch_sync_spec.sh:158 # 2) ... reports a fast-forward blocked by a colliding untracked file FAILED
```

### Green (same spec digest, hook edited)

```
2ea225f2ec32e3d6bb6e2779485dbb499eba3609a404f4bc3c63a76ea479b543  tests/shell/session_branch_sync_spec.sh
Running: /usr/bin/dash [sh]
......
6 examples, 0 failures
shellcheck-ok
```

### Frozen RED evidence

| Frozen RED test | git hash-object | RED run tail |
| --- | --- | --- |
| `tests/shell/session_branch_sync_spec.sh` | `beb22ef20399850fdb48a6cedde5fc4a42a3f0d6` | `6 examples, 2 failures` — `session_branch_sync_spec.sh:132 # 1) ... fast-forwards over an untracked memory record FAILED`; `:158 # 2) ... reports a fast-forward blocked by a colliding untracked file FAILED` |

### Round 2 (review fix, commit 67831d2)

Spec sha256 `aa06a973…e64c` frozen before the hook edit. RED on the round-1 hook:

```
8 examples, 1 failure
shellspec tests/shell/session_branch_sync_spec.sh:233 # 1) session-branch-sync session branch with untracked files reports a rebase that could not start over a colliding untracked file FAILED
  expected "...rebase onto origin/devel FAILED and the --abort ALSO failed -- the repo may be stuck mid-rebase..." to include "rebase onto origin/devel could not start"
```

GREEN after, same digest: `8 examples, 0 failures`, `shellcheck-ok`, `git-env-scrub-guard: clean`, `pytest tests/test_cross_agent_tooling.py` 20 passed.

### Gates

`sh scripts/agent/run-gates.sh --diff origin/devel` (dash, shellcheck, local host as root): the touched specs pass (`git_env_scrub_spec`, `git_fixture_manifest_spec`, `session_branch_sync_spec`: 17 examples, 0 failures). Five unrelated `processet_exit_spec` / `precommit_identity_spec` permission-denial cases fail identically on unmodified `origin/devel` in this uid-0 checkout (known #3052 class); CI is authoritative for those.
