### PR TITLE
tests: allowlist the repo marker's three dispatch-only live-URL skips

### DIFF
--- a/tests/skip-allowlist.txt
+++ b/tests/skip-allowlist.txt
@@ -78,10 +78,7 @@ smoke:tests.smoke.test_smoke_boot::test_control_name_resolves  # baked control n
 smoke:tests.smoke.test_smoke_helpers::test_reset_returns_to_baseline  # baked control name is optional; the reset executes before this scaffold assertion skips
 smoke:tests.smoke.test_smoke_matrix::test_false_green_guard_vm  # strict xfail is the guard's expected outcome and pytest records it as a JUnit skip
 
-# smoke -- the `repo` marker's live-URL cases. The 08:00 repo-install schedule deliberately
-# passes no smoke_*_live_url (issue #2389: it runs before the 09:00 nightly publish, so a live
-# URL would hit yesterday's tree or 404); the file:// proofs always run, and the live checks
-# are dispatch-only.
+# smoke -- the `repo` marker's live-URL cases; the 08:00 repo-install schedule passes no smoke_*_live_url (issue #2389).
 smoke:tests.smoke.test_nightly_install::test_install_from_live_nightly_url  # SMOKE_NIGHTLY_LIVE_URL is dispatch-only; the schedule never passes it (issue #2389)
 smoke:tests.smoke.test_repo_install::test_install_from_live_pages_url  # SMOKE_REPO_LIVE_URL is dispatch-only; the schedule never passes it (issue #2389)
 smoke:tests.smoke.test_repo_install::test_live_nightly_downgrade_requires_selected_semantic_repo  # needs both live URLs; the schedule passes neither (issue #2389)

--- a/tests/skip-allowlist.txt
+++ b/tests/skip-allowlist.txt
@@ -78,5 +78,13 @@ smoke:tests.smoke.test_smoke_boot::test_control_name_resolves  # baked control n
 smoke:tests.smoke.test_smoke_helpers::test_reset_returns_to_baseline  # baked control name is optional; the reset executes before this scaffold assertion skips
 smoke:tests.smoke.test_smoke_matrix::test_false_green_guard_vm  # strict xfail is the guard's expected outcome and pytest records it as a JUnit skip
 
+# smoke -- the `repo` marker's live-URL cases. The 08:00 repo-install schedule deliberately
+# passes no smoke_*_live_url (issue #2389: it runs before the 09:00 nightly publish, so a live
+# URL would hit yesterday's tree or 404); the file:// proofs always run, and the live checks
+# are dispatch-only.
+smoke:tests.smoke.test_nightly_install::test_install_from_live_nightly_url  # SMOKE_NIGHTLY_LIVE_URL is dispatch-only; the schedule never passes it (issue #2389)
+smoke:tests.smoke.test_repo_install::test_install_from_live_pages_url  # SMOKE_REPO_LIVE_URL is dispatch-only; the schedule never passes it (issue #2389)
+smoke:tests.smoke.test_repo_install::test_live_nightly_downgrade_requires_selected_semantic_repo  # needs both live URLs; the schedule passes neither (issue #2389)
+
 # phpunit -- only on a host that carries the pkg(8) port binary (a FreeBSD/pfSense dev box).
 phpunit:SoftwareFailedCheckStateTest::testPkgLatestReportsAFailedAttemptToItsCaller  # drives the real pkg shellout; its outcome is host repository state where /usr/local/sbin/pkg exists


### PR DESCRIPTION
## What this changes

Three lines in `tests/skip-allowlist.txt`, under a one-line `smoke --` header: the `repo` marker's live-URL cases, which skip on the scheduled repo-install fan-out **by design**.

## Why the nightly was red

`Repo install (live pfSense VM)` has failed on every scheduled run since 2026-08-28 (six in a row, tracked in place on #2715). Every leg tells the same story: **44 tests, 0 failures, 0 errors, 3 skips** — and the skip-allowlist gate refusing those three:

```
smoke:tests.smoke.test_nightly_install::test_install_from_live_nightly_url   SMOKE_NIGHTLY_LIVE_URL not set — dispatch-only
smoke:tests.smoke.test_repo_install::test_install_from_live_pages_url        SMOKE_REPO_LIVE_URL not set — dispatch-only
smoke:tests.smoke.test_repo_install::test_live_nightly_downgrade_requires_selected_semantic_repo   both required
```

`repo-install.yml` passes no `smoke_*_live_url` on purpose (issue #2389: the 08:00 schedule runs before the 09:00 nightly publish, so a live URL would hit yesterday's tree or 404); the `file://` proofs always run. The gate was extended to the smoke jobs with the default-scope skip set recorded from the live fan-out (#2629), and the `repo` marker's own three dispatch-only skips were never recorded. Not a devel regression: nothing in the product path changed, and the fix is the allowlist doing its job.

## Red → green, executed against the production artifact

The gate itself is the test. Against the failed run's own `pytest-junit.xml` from all four diagnostics artifacts (run 33630371973):

```
$ uv run python scripts/check_skip_allowlist.py --suite smoke --allowlist tests/skip-allowlist.txt <leg>/smoke-diag/pytest-junit.xml
  before (allowlist blob 1222c0ac): error: 3 skip(s) not on tests/skip-allowlist.txt … rc=1   (ce-2.8, ce-2.9, plus-26.03, plus-26.07)
  after:                            rc=0                                                     (all four legs)
  red canary (tests/fixtures/skip-allowlist-canary.xml) after: rc=1                          (the gate still refuses)
```

Parser suites: `tests/test_check_skip_allowlist.py`, `tests/test_issue2369_skip_gate_coverage.py`, `tests/test_issue2369_skip_gate_coverage_hostile.py` → `97 passed`, plus the one pre-existing #3081 failure (host Node 26 vs the CI pin), which is unrelated and reproduces on clean `devel`.

Each entry carries its own reason naming #2389, as the file's header requires; no existing reason was widened.

The downgrade case turns out to have no CI caller that passes both live URLs, so its skip was permanent before this change too; tracked separately as #3112 (surfaced by the contract review leg).

Fixes #2715



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added three smoke-test cases to the skip allowlist for scheduled nightly runs when required dispatch-only URL configuration is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->