### PR TITLE
smoke: prove pkg delete waits for an in-flight feed pass

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,6 +148,7 @@ ignore = [
 "tests/smoke/test_pkg_op_teardown.py"           = ["F811"]
 "tests/smoke/test_lifecycle_hook_visibility.py" = ["F811"]
 "tests/smoke/test_hook_stream_visibility.py"    = ["F811"]
+"tests/smoke/test_pkg_delete_feed_pass_interlock.py" = ["F811"]
 # issue #999: imports the `clean_ledger` fixture from test_render_widget_ledger.py
 "tests/smoke/ui/test_widget_clear_failed.py"    = ["F811"]
 # issue #1014/#1019: imports the `clean_ledger` fixture from test_render_widget_ledger.py

--- a/tests/smoke/test_pkg_delete_feed_pass_interlock.py
+++ b/tests/smoke/test_pkg_delete_feed_pass_interlock.py
@@ -80,7 +80,7 @@ _HOOK = {
 
 
 def _run_in_background(vm: SmokeVM, command: str, out: str) -> None:
-    """Start ``command`` on the guest detached from this ssh session; output + ``RC=<n>`` land in ``out``."""
+    """Start one simple ``command`` on the guest detached from this ssh session; output + ``RC=<n>`` land in ``out``."""
     vm.ssh(f"nohup /bin/sh -c '{command} > {out} 2>&1; echo RC=$? >> {out}' >/dev/null 2>&1 &")
 
 

--- a/tests/smoke/test_pkg_delete_feed_pass_interlock.py
+++ b/tests/smoke/test_pkg_delete_feed_pass_interlock.py
@@ -13,9 +13,6 @@ With the pass parked, ``pkg delete`` runs in the background and must log that it
 waiting, without having started the teardown; once the hook is released the pass
 finishes and the uninstall proceeds to completion.
 
-Pre-#3090 the uninstall's sync defers at once and the teardown runs while the hook is
-still parked: the waiting line never appears — the red→green discriminator.
-
 NOT A SMOKE TEST: like ``test_pkg_op_teardown`` this is a *lifecycle* mechanic, so it
 carries the ``repo`` marker and reuses ``repo_vm``. Runs only via::
 
@@ -23,6 +20,8 @@ carries the ``repo`` marker and reuses ``repo_vm``. Runs only via::
 """
 
 from __future__ import annotations
+
+import contextlib
 
 import pytest
 
@@ -80,22 +79,17 @@ _HOOK = {
 }
 
 
-def _guest_file_exists(vm: SmokeVM, path: str) -> bool:
-    return vm.ssh("test", "-f", path).returncode == 0
+def _run_in_background(vm: SmokeVM, command: str, out: str) -> None:
+    """Start ``command`` on the guest detached from this ssh session; output + ``RC=<n>`` land in ``out``."""
+    vm.ssh(f"nohup /bin/sh -c '{command} > {out} 2>&1; echo RC=$? >> {out}' >/dev/null 2>&1 &")
 
 
-def _guest_file(vm: SmokeVM, path: str) -> str:
-    return vm.ssh(f"cat {path} 2>/dev/null || true").stdout
+def _finished(vm: SmokeVM, out: str) -> bool:
+    """TRUE once the background process behind ``out`` has appended its ``RC=`` line (or never started)."""
+    return not h.hook_marker_exists(vm, out) or "RC=" in h.read_log_file(vm, out)
 
 
-def _run_in_background(vm: SmokeVM, name: str, command: str, out: str) -> None:
-    """Start ``command`` on the guest detached from this ssh session, output + ``RC=<n>`` to ``out``."""
-    script = f"{_DIR}/{name}.sh"
-    vm.ssh(f"cat > {script} << 'PFBEOF'\n{command} > {out} 2>&1\necho \"RC=$?\" >> {out}\nPFBEOF")
-    vm.ssh(f"nohup /bin/sh {script} >/dev/null 2>&1 &")
-
-
-@pytest.mark.timeout(900)  # install + parked pass + pkg delete; budget ~10 min
+@pytest.mark.timeout(900)  # install + parked pass + pkg delete; budget ~15 min
 def test_pkg_delete_waits_for_the_in_flight_feed_pass(repo_vm: SmokeVM) -> None:
     """UNINSTALL INTERLOCK (#3090): ``pkg delete`` waits for a running feed pass.
 
@@ -125,40 +119,37 @@ def test_pkg_delete_waits_for_the_in_flight_feed_pass(repo_vm: SmokeVM) -> None:
         h.wait_no_active_pfb_task(vm)
 
         # AND: a feed pass parked in its pre hook — inside the feed-pass lock.
-        _run_in_background(
-            vm, "pass", f"{h.PHP_BIN} {h.PFB_CLI} pfb_trigger scope=both force=true trigger=force", _PASS_OUT
-        )
-        parked = h.wait_until(lambda: _guest_file_exists(vm, _STARTED), timeout=120.0, interval=1.0)
-        assert parked, (
-            f"test setup: the feed pass never reached its pre hook; pass output: {_guest_file(vm, _PASS_OUT)!r}"
-        )
+        _run_in_background(vm, f"{h.PHP_BIN} {h.PFB_CLI} pfb_trigger scope=both force=true trigger=force", _PASS_OUT)
+        try:
+            h.wait_until(lambda: h.hook_marker_exists(vm, _STARTED), timeout=120.0, interval=1.0)
+        except RuntimeError as exc:
+            raise AssertionError(
+                f"test setup: the feed pass never reached its pre hook; pass output: {h.read_log_file(vm, _PASS_OUT)!r}"
+            ) from exc
 
         # ---- WHEN: pkg delete while the pass is parked ------------------------- #
         waiting_before = h.count_log_marker(vm, h.PFB_LOG, _WAITING_LINE)
-        _run_in_background(vm, "delete", f"env ASSUME_ALWAYS_YES=yes pkg delete -y {PKG_NAME}", _DELETE_OUT)
+        _run_in_background(vm, f"env ASSUME_ALWAYS_YES=yes pkg delete -y {PKG_NAME}", _DELETE_OUT)
 
         # THEN: the uninstall says it is waiting for the pass. The event consumed here is
         # "the uninstall reacted": either it logged the wait (fixed) or it went ahead and
         # tore down / finished without waiting (pre-#3090) -- one of the two always happens,
         # so the salvage cap only reports a genuinely stuck box.
         def _uninstall_reacted() -> bool:
-            out = _guest_file(vm, _DELETE_OUT)
+            out = h.read_log_file(vm, _DELETE_OUT)
             return (
                 h.count_log_marker(vm, h.PFB_LOG, _WAITING_LINE) > waiting_before
                 or _TEARDOWN_LINE in out
                 or "RC=" in out
             )
 
-        h.wait_until(_uninstall_reacted, timeout=120.0, interval=1.0)
-        delete_so_far = _guest_file(vm, _DELETE_OUT)
+        h.wait_until(_uninstall_reacted, timeout=60.0, interval=1.0)
+        delete_so_far = h.read_log_file(vm, _DELETE_OUT)
         assert h.count_log_marker(vm, h.PFB_LOG, _WAITING_LINE) > waiting_before, (
             f"`pkg delete` did not log {_WAITING_LINE!r} while a feed pass held the lock — the uninstall "
             f"is not serialised against an in-flight pass (issue #3090).\npkg delete output so far:\n{delete_so_far}"
         )
         # ... and has NOT torn anything down yet: the pass is still parked in its hook.
-        assert _guest_file_exists(vm, _STARTED) and not _guest_file_exists(vm, _GO), (
-            "test invariant: the pass must still be parked"
-        )
         assert _TEARDOWN_LINE not in delete_so_far, (
             f"`pkg delete` reached {_TEARDOWN_LINE!r} while the feed pass was still running — "
             f"the hold did not block the teardown:\n{delete_so_far}"
@@ -166,27 +157,26 @@ def test_pkg_delete_waits_for_the_in_flight_feed_pass(repo_vm: SmokeVM) -> None:
 
         # ---- WHEN: the parked pass is released --------------------------------- #
         vm.ssh("touch", _GO)
-        h.wait_until(lambda: "RC=" in _guest_file(vm, _DELETE_OUT), timeout=400.0, interval=2.0)
-        delete_out = _guest_file(vm, _DELETE_OUT)
-        pass_out = _guest_file(vm, _PASS_OUT)
+        h.wait_until(lambda: "RC=" in h.read_log_file(vm, _DELETE_OUT), timeout=400.0, interval=2.0)
+        delete_out = h.read_log_file(vm, _DELETE_OUT)
+        pass_out = h.read_log_file(vm, _PASS_OUT)
 
         # THEN: the pass completed, and the uninstall took the hold, tore down and exited 0.
-        assert "RC=0" in pass_out, f"the released feed pass did not exit 0:\n{pass_out}"
-        assert _SERIALISING_LINE in delete_out, (
-            f"the uninstall did not report serialising against the pass (expected {_SERIALISING_LINE!r}):\n{delete_out}"
+        assert pass_out.rstrip().endswith("RC=0"), f"the released feed pass did not exit 0:\n{pass_out}"
+        assert 0 <= delete_out.find(_SERIALISING_LINE) < delete_out.find(_TEARDOWN_LINE), (
+            f"expected {_SERIALISING_LINE!r} before {_TEARDOWN_LINE!r} on pkg delete's output:\n{delete_out}"
         )
         assert _HOLD_GIVEN_UP not in delete_out, (
             f"the uninstall gave up its wait instead of taking the hold:\n{delete_out}"
         )
-        assert _TEARDOWN_LINE in delete_out, (
-            f"the uninstall never reached the teardown (expected {_TEARDOWN_LINE!r}):\n{delete_out}"
-        )
-        assert delete_out.index(_SERIALISING_LINE) < delete_out.index(_TEARDOWN_LINE), (
-            f"the hold must be taken BEFORE the teardown line:\n{delete_out}"
-        )
         assert delete_out.rstrip().endswith("RC=0"), f"`pkg delete` exited non-zero:\n{delete_out}"
         assert pkg_installed_version(vm) is None, "`pkg delete` did not remove the package"
     finally:
-        # Release anything still parked, then leave the box as the sibling modules expect.
-        vm.ssh(f"touch {_GO}; sleep 2; rm -f {h.HOOK_SCRIPT_DIR}/{_HOOK['script']}; rm -rf {_DIR}")
+        # Release anything still parked and let both background processes finish, then leave
+        # the box as the sibling modules expect (no hook row, no package).
+        vm.ssh(f"mkdir -p {_DIR}; touch {_GO}")
+        with contextlib.suppress(RuntimeError):
+            h.wait_until(lambda: _finished(vm, _PASS_OUT) and _finished(vm, _DELETE_OUT), timeout=400.0, interval=2.0)
+        vm.ssh(f"rm -f {h.HOOK_SCRIPT_DIR}/{_HOOK['script']}; rm -rf {_DIR}")
+        h.clear_update_hooks(vm)
         pkg_delete(vm)

--- a/tests/smoke/test_pkg_delete_feed_pass_interlock.py
+++ b/tests/smoke/test_pkg_delete_feed_pass_interlock.py
@@ -3,9 +3,9 @@
 The pre-deinstall tears down the Unbound chroot, the generated DNSBL files and the pfB
 services. Its disable pass takes the feed-pass lock non-blocking and DEFERS on
 contention, and the teardown after it used to run regardless — on top of a scheduled
-pass still publishing into the chroot. The fix takes the same bounded hold the install
-path takes (#3062) before the disable pass; this is its live proof, which the unit
-suite cannot give (the controller runs a real sync plus pfctl/exec teardown).
+pass still publishing into the chroot. Since #3090 the pre-deinstall takes the same
+bounded hold the install path takes (#3062) before the disable pass. The controller runs
+a real sync plus pfctl/exec teardown, so it is exercised here on the live VM only.
 
 The in-flight pass is a REAL one: an enabled ``pre`` update hook parks the pass — inside
 the feed-pass lock, where ``pfb_run_hooks('pre')`` fires — until the test releases it.

--- a/tests/smoke/test_pkg_delete_feed_pass_interlock.py
+++ b/tests/smoke/test_pkg_delete_feed_pass_interlock.py
@@ -1,0 +1,192 @@
+"""issue #3090 — ``pkg delete`` waits for an in-flight feed pass before tearing down.
+
+The pre-deinstall tears down the Unbound chroot, the generated DNSBL files and the pfB
+services. Its disable pass takes the feed-pass lock non-blocking and DEFERS on
+contention, and the teardown after it used to run regardless — on top of a scheduled
+pass still publishing into the chroot. The fix takes the same bounded hold the install
+path takes (#3062) before the disable pass; this is its live proof, which the unit
+suite cannot give (the controller runs a real sync plus pfctl/exec teardown).
+
+The in-flight pass is a REAL one: an enabled ``pre`` update hook parks the pass — inside
+the feed-pass lock, where ``pfb_run_hooks('pre')`` fires — until the test releases it.
+With the pass parked, ``pkg delete`` runs in the background and must log that it is
+waiting, without having started the teardown; once the hook is released the pass
+finishes and the uninstall proceeds to completion.
+
+Pre-#3090 the uninstall's sync defers at once and the teardown runs while the hook is
+still parked: the waiting line never appears — the red→green discriminator.
+
+NOT A SMOKE TEST: like ``test_pkg_op_teardown`` this is a *lifecycle* mechanic, so it
+carries the ``repo`` marker and reuses ``repo_vm``. Runs only via::
+
+    python -m pytest tests/smoke -m repo --override-ini="addopts="
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from . import helpers as h
+from .conftest import SmokeVM
+from .test_pkg_op_teardown import _TEARDOWN_LINE
+
+# ``repo_vm`` is re-exported (not just imported): pytest resolves fixtures PER-MODULE, so
+# the name must be present here for the case below to request it.
+from .test_repo_install import (  # noqa: F401
+    NETGATE_REPO_NAME,
+    OURS_REPO_DIR,
+    PKG_NAME,
+    pkg_delete,
+    pkg_install_from_repo,
+    pkg_installed_version,
+    pkg_update,
+    repo_priority,
+    repo_vm,
+    write_repo_conf,
+)
+
+pytestmark = pytest.mark.repo
+
+_DIR = "/tmp/pfb_smoke_3090"
+_STARTED = f"{_DIR}/started"  # the parked pass's pre hook is running (lock held)
+_GO = f"{_DIR}/go"  # release the parked hook
+_PASS_OUT = f"{_DIR}/pass.out"
+_DELETE_OUT = f"{_DIR}/delete.out"
+
+# pfb_install_feed_pass_hold() with $op='uninstall' (pfblockerng.inc): the wait line goes
+# to pfblockerng.log; the update_status() progress lines go to pkg's own stdout, where the
+# logger's line interleaves between "Serialising..." and its " done." / give-up suffix.
+_WAITING_LINE = "Package uninstall: waiting up to"
+_SERIALISING_LINE = "Serialising against any in-flight pfBlockerNG feed pass..."
+_HOLD_GIVEN_UP = "lock not taken; continuing anyway"
+
+# The parking hook: on a normal pass it marks itself started and waits for the release
+# file (self-terminating at 180 s so an orphan can never wedge the box; the hook's own
+# config timeout is wider than that). On the uninstall's disable pass
+# (PFB_PRE_UNINSTALL=1) it exits at once, so the uninstall itself never waits on it.
+_HOOK = {
+    "script": "hook_pre_smoke3090.sh",
+    "_body": (
+        "#!/bin/sh\n"
+        '[ "$PFB_PRE_UNINSTALL" = "1" ] && exit 0\n'
+        f"touch {_STARTED}\n"
+        "i=0\n"
+        f'while [ ! -f {_GO} ] && [ "$i" -lt 1800 ]; do sleep 0.1; i=$((i+1)); done\n'
+    ),
+    "when": "pre",
+    "enabled": "on",
+    "description": "smoke 3090 parked pass",
+    "timeout": "240",
+}
+
+
+def _guest_file_exists(vm: SmokeVM, path: str) -> bool:
+    return vm.ssh("test", "-f", path).returncode == 0
+
+
+def _guest_file(vm: SmokeVM, path: str) -> str:
+    return vm.ssh(f"cat {path} 2>/dev/null || true").stdout
+
+
+def _run_in_background(vm: SmokeVM, name: str, command: str, out: str) -> None:
+    """Start ``command`` on the guest detached from this ssh session, output + ``RC=<n>`` to ``out``."""
+    script = f"{_DIR}/{name}.sh"
+    vm.ssh(f"cat > {script} << 'PFBEOF'\n{command} > {out} 2>&1\necho \"RC=$?\" >> {out}\nPFBEOF")
+    vm.ssh(f"nohup /bin/sh {script} >/dev/null 2>&1 &")
+
+
+@pytest.mark.timeout(900)  # install + parked pass + pkg delete; budget ~10 min
+def test_pkg_delete_waits_for_the_in_flight_feed_pass(repo_vm: SmokeVM) -> None:
+    """UNINSTALL INTERLOCK (#3090): ``pkg delete`` waits for a running feed pass.
+
+    Given pfBlockerNG installed from our repo with a ``pre`` hook that parks the pass,
+      and a feed pass parked in that hook (it holds the feed-pass lock),
+    When ``pkg delete`` runs,
+    Then it logs the uninstall's waiting line while the pass is still parked, and has
+      NOT started the teardown (no teardown line on its output yet);
+    When the hook is released,
+    Then the pass completes, and the uninstall reports the hold taken, tears down,
+      exits 0 and removes the package.
+    """
+    vm = repo_vm
+    pfsense_prio = repo_priority(vm, NETGATE_REPO_NAME)
+
+    try:
+        # ---- GIVEN: install from our repo + the parking hook ------------------- #
+        pkg_delete(vm)
+        write_repo_conf(vm, OURS_REPO_DIR, ours_priority=pfsense_prio + 100)
+        pkg_update(vm)
+        assert pkg_installed_version(vm) is None, f"{PKG_NAME} unexpectedly present before the install"
+        pkg_install_from_repo(vm)
+        assert pkg_installed_version(vm) is not None, "the from-repo install did not register the package"
+
+        vm.ssh(f"rm -rf {_DIR} && mkdir -p {_DIR}")
+        h.set_update_hooks(vm, [_HOOK])
+        h.wait_no_active_pfb_task(vm)
+
+        # AND: a feed pass parked in its pre hook — inside the feed-pass lock.
+        _run_in_background(
+            vm, "pass", f"{h.PHP_BIN} {h.PFB_CLI} pfb_trigger scope=both force=true trigger=force", _PASS_OUT
+        )
+        parked = h.wait_until(lambda: _guest_file_exists(vm, _STARTED), timeout=120.0, interval=1.0)
+        assert parked, (
+            f"test setup: the feed pass never reached its pre hook; pass output: {_guest_file(vm, _PASS_OUT)!r}"
+        )
+
+        # ---- WHEN: pkg delete while the pass is parked ------------------------- #
+        waiting_before = h.count_log_marker(vm, h.PFB_LOG, _WAITING_LINE)
+        _run_in_background(vm, "delete", f"env ASSUME_ALWAYS_YES=yes pkg delete -y {PKG_NAME}", _DELETE_OUT)
+
+        # THEN: the uninstall says it is waiting for the pass. The event consumed here is
+        # "the uninstall reacted": either it logged the wait (fixed) or it went ahead and
+        # tore down / finished without waiting (pre-#3090) -- one of the two always happens,
+        # so the salvage cap only reports a genuinely stuck box.
+        def _uninstall_reacted() -> bool:
+            out = _guest_file(vm, _DELETE_OUT)
+            return (
+                h.count_log_marker(vm, h.PFB_LOG, _WAITING_LINE) > waiting_before
+                or _TEARDOWN_LINE in out
+                or "RC=" in out
+            )
+
+        h.wait_until(_uninstall_reacted, timeout=120.0, interval=1.0)
+        delete_so_far = _guest_file(vm, _DELETE_OUT)
+        assert h.count_log_marker(vm, h.PFB_LOG, _WAITING_LINE) > waiting_before, (
+            f"`pkg delete` did not log {_WAITING_LINE!r} while a feed pass held the lock — the uninstall "
+            f"is not serialised against an in-flight pass (issue #3090).\npkg delete output so far:\n{delete_so_far}"
+        )
+        # ... and has NOT torn anything down yet: the pass is still parked in its hook.
+        assert _guest_file_exists(vm, _STARTED) and not _guest_file_exists(vm, _GO), (
+            "test invariant: the pass must still be parked"
+        )
+        assert _TEARDOWN_LINE not in delete_so_far, (
+            f"`pkg delete` reached {_TEARDOWN_LINE!r} while the feed pass was still running — "
+            f"the hold did not block the teardown:\n{delete_so_far}"
+        )
+
+        # ---- WHEN: the parked pass is released --------------------------------- #
+        vm.ssh("touch", _GO)
+        h.wait_until(lambda: "RC=" in _guest_file(vm, _DELETE_OUT), timeout=400.0, interval=2.0)
+        delete_out = _guest_file(vm, _DELETE_OUT)
+        pass_out = _guest_file(vm, _PASS_OUT)
+
+        # THEN: the pass completed, and the uninstall took the hold, tore down and exited 0.
+        assert "RC=0" in pass_out, f"the released feed pass did not exit 0:\n{pass_out}"
+        assert _SERIALISING_LINE in delete_out, (
+            f"the uninstall did not report serialising against the pass (expected {_SERIALISING_LINE!r}):\n{delete_out}"
+        )
+        assert _HOLD_GIVEN_UP not in delete_out, (
+            f"the uninstall gave up its wait instead of taking the hold:\n{delete_out}"
+        )
+        assert _TEARDOWN_LINE in delete_out, (
+            f"the uninstall never reached the teardown (expected {_TEARDOWN_LINE!r}):\n{delete_out}"
+        )
+        assert delete_out.index(_SERIALISING_LINE) < delete_out.index(_TEARDOWN_LINE), (
+            f"the hold must be taken BEFORE the teardown line:\n{delete_out}"
+        )
+        assert delete_out.rstrip().endswith("RC=0"), f"`pkg delete` exited non-zero:\n{delete_out}"
+        assert pkg_installed_version(vm) is None, "`pkg delete` did not remove the package"
+    finally:
+        # Release anything still parked, then leave the box as the sibling modules expect.
+        vm.ssh(f"touch {_GO}; sleep 2; rm -f {h.HOOK_SCRIPT_DIR}/{_HOOK['script']}; rm -rf {_DIR}")
+        pkg_delete(vm)


### PR DESCRIPTION
Refs #3090 (landed in #3104). Live-VM proof of the uninstall feed-pass interlock, which the unit suite cannot give: `pfblockerng_php_pre_deinstall_command()` runs a real sync plus pfctl/exec teardown and has no off-appliance driver.

## Design

An enabled `pre` update hook parks a **real** feed pass inside the feed-pass lock (`pfb_run_hooks('pre')` fires after `pfb_feed_pass_begin()` in `sync_package_pfblockerng()`), waiting for a release file. With the pass parked, `pkg delete` runs in the background:

1. The uninstall must log `Package uninstall: waiting up to …` while the pass is still parked, and must not have reached `Removing pfBlockerNG...` yet.
2. After the release file is touched, the pass exits 0, and the uninstall reports `Serialising against any in-flight pfBlockerNG feed pass...` (without the give-up suffix), reaches the teardown line after it, exits 0 and removes the package.

The hook exits at once on the uninstall's own disable pass (`PFB_PRE_UNINSTALL=1`), so the uninstall never waits on it; it self-terminates at 180 s so an orphan cannot wedge the box. The discriminating wait consumes an event that always arrives (the waiting line, or the uninstall proceeding/finishing), so the helper's salvage cap only ever reports a stuck box.

`repo` marker, reusing `repo_vm`; `pyproject.toml` gains the module's F811 per-file ignore like its siblings.

## Red → green (executed on the live pool, byte-identical test file `7546f48331d03044839641cdcefe59d5e35c7ba7`)

RED — same test file on the pre-fix base `9a1496cd` (scratch ref, since deleted), `scripts/local-smoke.sh --ref 9351bcd7 --marker repo --filter test_pkg_delete_feed_pass_interlock --no-two-vm` on `root@10.0.0.37`:

```text
AssertionError: `pkg delete` did not log 'Package uninstall: waiting up to' while a feed pass held the lock — the uninstall is not serialised against an in-flight pass (issue #3090).
pkg delete output so far:
  ...
  Loading package instructions...
  Removing pfBlockerNG...
  2026-09-02 13:14:15  sync aborted: dispatcher lock unavailable; pending changes retained.
   Removing live firewall objects and generated files... All customizations/data will be retained... done.
  ...
  RC=0
1 failed, 1082 deselected in 82.00s
```

(The pre-fix uninstall deferred its disable pass and tore down while the pass was still parked — the issue's mechanism, verbatim.)

GREEN — `--ref 652d58d0` (this head) on `root@10.0.0.32`:

```text
tests/smoke/test_pkg_delete_feed_pass_interlock.py::test_pkg_delete_waits_for_the_in_flight_feed_pass PASSED
1 passed, 1082 deselected in 88.13s
```

An earlier green iteration showed the fixed uninstall's pkg stdout, for the record:

```text
Serialising against any in-flight pfBlockerNG feed pass...
2026-09-02 13:09:20 Package uninstall: waiting up to 300s for the in-flight feed pass to finish.
 done.
Removing pfBlockerNG...
```

## Gates

`scripts/agent/run-gates.sh --diff origin/devel`: ruff check PASS, ruff format PASS, mypy PASS; pytest 5885 passed, 1 failed — `test_native_node_canary_report_is_rejected_with_exact_skip_semantics`, host-only and pre-existing on the untouched base checkout (Node v26 junit reporter; recorded on #3103). `check_coverage_pairing.py` ran inside the gate.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved package removal behavior so it waits for an in-progress feed update to finish before beginning cleanup.

* **Tests**
  * Added coverage validating that package deletion pauses safely during an active feed pass, then completes successfully once the pass is released.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->