### PR TITLE
agent: stop rewriting the tracked graph on a fresh worktree cut

### DIFF
--- a/.agents/context/repository-intelligence.md
+++ b/.agents/context/repository-intelligence.md
@@ -30,10 +30,10 @@ Load when: every agent session, from `AGENTS.md`.
   before ast-grep and semgrep.
 - Initialize a checkout with `sh scripts/agent/init-worktree-tools.sh .`. It runs
   `scripts/agent/ensure-codegraph.sh` for the exact-root CodeGraph index and reapplies
-  the Graphify patch. It never runs `graphify update`: it leaves the tracked root graph
-  untouched, so a worktree cut on an unmodified base has an empty `git status`
-  (issue #3091). When the graph is absent it prints a notice and builds nothing;
-  first-build scope is a judgement call handled by a `/graphify` run.
+  the Graphify patch. It never runs `graphify update`, so a cut on an unmodified base
+  has an empty `git status` (issue #3091). When the graph is absent it
+  prints a notice and builds nothing; first-build scope is a judgement call handled
+  by a `/graphify` run.
   `wt --yes switch --create <branch>` runs it from `.config/wt.toml`'s `pre-start`
   hook. `work-branch.sh --worktree` cuts through `wt`, skips the initializer when
   pre-start already left a CodeGraph index, and rolls back a failed cut — reclaiming a
@@ -45,7 +45,7 @@ Load when: every agent session, from `AGENTS.md`.
   `.graphifyrc` (`language.inc=php`) activates it. `ensure-graphify.sh` emits the
   validated absolute executable launcher path; `ensure-graphify-merge-driver.sh`
   captures and quotes that path for target-rooted `hook install`;
-  `init-worktree-tools.sh` and `patch-graphify.sh` resolve the same launcher; and
+  `patch-graphify.sh` resolves the same launcher; and
   `.githooks/pre-commit` resolves and patches again
   before its no-staged-files exit, repairing a bare Graphify upgrade in a fresh process
   before the post-commit rebuild. The include-node floor in

--- a/.agents/context/repository-intelligence.md
+++ b/.agents/context/repository-intelligence.md
@@ -29,13 +29,15 @@ Load when: every agent session, from `AGENTS.md`.
   `setup-agent-tools.sh` runs this canonical setup at Graphify's install-order slot,
   before ast-grep and semgrep.
 - Initialize a checkout with `sh scripts/agent/init-worktree-tools.sh .`. It runs
-  `scripts/agent/ensure-codegraph.sh` for the exact-root CodeGraph index, reapplies
-  the Graphify patch, then runs `graphify update <root>` when the root graph exists.
-  When the graph is absent it prints a notice and builds nothing; first-build scope
-  is a judgement call handled by a `/graphify` run. `wt --yes switch --create <branch>`
-  runs it from `.config/wt.toml`'s `pre-start` hook. `work-branch.sh --worktree` cuts
-  through `wt`, skips the initializer when pre-start already left a CodeGraph index,
-  and rolls back a failed cut — reclaiming a tree `wt` left behind when its hook failed.
+  `scripts/agent/ensure-codegraph.sh` for the exact-root CodeGraph index and reapplies
+  the Graphify patch. It never runs `graphify update`: it leaves the tracked root graph
+  untouched, so a worktree cut on an unmodified base has an empty `git status`
+  (issue #3091). When the graph is absent it prints a notice and builds nothing;
+  first-build scope is a judgement call handled by a `/graphify` run.
+  `wt --yes switch --create <branch>` runs it from `.config/wt.toml`'s `pre-start`
+  hook. `work-branch.sh --worktree` cuts through `wt`, skips the initializer when
+  pre-start already left a CodeGraph index, and rolls back a failed cut — reclaiming a
+  tree `wt` left behind when its hook failed.
 - Graphify's suffix map parses `.inc` as Pascal, collapsing this repository's PHP
   includes from roughly 767 nodes to roughly 30 while extraction still succeeds.
   Until a release includes Graphify-Labs/graphify#3075, the fix rides as
@@ -43,7 +45,7 @@ Load when: every agent session, from `AGENTS.md`.
   `.graphifyrc` (`language.inc=php`) activates it. `ensure-graphify.sh` emits the
   validated absolute executable launcher path; `ensure-graphify-merge-driver.sh`
   captures and quotes that path for target-rooted `hook install`;
-  `init-worktree-tools.sh` resolves the same launcher for update; and
+  `init-worktree-tools.sh` and `patch-graphify.sh` resolve the same launcher; and
   `.githooks/pre-commit` resolves and patches again
   before its no-staged-files exit, repairing a bare Graphify upgrade in a fresh process
   before the post-commit rebuild. The include-node floor in

--- a/scripts/agent/init-worktree-tools.sh
+++ b/scripts/agent/init-worktree-tools.sh
@@ -9,8 +9,6 @@ usage() {
 main() {
 	# shellcheck source=scripts/agent/agent_env.sh
 	. "$(dirname "$0")/agent_env.sh"
-	# shellcheck source=scripts/agent/resolve-graphify.sh
-	. "$(dirname "$0")/resolve-graphify.sh"
 	scrub_git_env "$0"
 	[ "$#" -le 1 ] || usage
 	require_tool git
@@ -22,20 +20,13 @@ main() {
 		exit 2
 	}
 	root=$(CDPATH='' cd "$root" && pwd -P) || exit 2
-	# Graphify is mandatory: fail before CodeGraph does any work when it is absent.
-	resolve_graphify_launcher >/dev/null || exit 1
-
 	sh "$(dirname "$0")/ensure-codegraph.sh" "$root" || exit $?
 	# An unpatched Graphify parses this repository's PHP .inc files as Pascal, and a
-	# bare `uv tool upgrade graphifyy` reverts the patch; repair it here so the next
-	# `graphify update` extracts correctly.
+	# bare `uv tool upgrade graphifyy` reverts the patch.
 	sh "$(dirname "$0")/patch-graphify.sh" || exit $?
-	# The tracked root graph is never rewritten here. A fresh cut checks out the tree
-	# the committed graph describes, and `graphify update` on that tree still rewrites
-	# the file wholesale, so the worktree was born dirty and `wt remove` refused it
-	# (issue #3091). Refresh the graph with the change that moves it. Building the
-	# FIRST graph is a judgement call (which trees, whether the semantic layer earns
-	# its cost, what .graphifyignore allows), deferred to an AI-assisted `/graphify` run.
+	# Never `graphify update` here: it rewrites the tracked graph wholesale, so a fresh
+	# cut was born dirty and `wt remove` refused it (issue #3091). The FIRST graph's
+	# scope is a judgement call, deferred to an AI-assisted `/graphify` run.
 	[ -f "$root/graphify-out/graph.json" ] ||
 		echo "No Graphify root graph in $root; run /graphify in your AI assistant to build one." >&2
 

--- a/scripts/agent/init-worktree-tools.sh
+++ b/scripts/agent/init-worktree-tools.sh
@@ -22,21 +22,22 @@ main() {
 		exit 2
 	}
 	root=$(CDPATH='' cd "$root" && pwd -P) || exit 2
-	graphify_bin=$(resolve_graphify_launcher) || exit 1
+	# Graphify is mandatory: fail before CodeGraph does any work when it is absent.
+	resolve_graphify_launcher >/dev/null || exit 1
 
 	sh "$(dirname "$0")/ensure-codegraph.sh" "$root" || exit $?
-	# Before any extraction: an unpatched Graphify parses this repository's PHP .inc
-	# files as Pascal, and a bare `uv tool upgrade graphifyy` reverts the patch.
+	# An unpatched Graphify parses this repository's PHP .inc files as Pascal, and a
+	# bare `uv tool upgrade graphifyy` reverts the patch; repair it here so the next
+	# `graphify update` extracts correctly.
 	sh "$(dirname "$0")/patch-graphify.sh" || exit $?
-	# Refreshing an existing root graph is mechanical, so it stays automated. Building
-	# the FIRST graph is not: its scope (which trees, whether the semantic layer earns
-	# its cost, what .graphifyignore allows) is a judgement call, so defer it to an
-	# AI-assisted `/graphify` run rather than picking a default unattended.
-	if [ -f "$root/graphify-out/graph.json" ]; then
-		"$graphify_bin" update "$root" || exit $?
-	else
+	# The tracked root graph is never rewritten here. A fresh cut checks out the tree
+	# the committed graph describes, and `graphify update` on that tree still rewrites
+	# the file wholesale, so the worktree was born dirty and `wt remove` refused it
+	# (issue #3091). Refresh the graph with the change that moves it. Building the
+	# FIRST graph is a judgement call (which trees, whether the semantic layer earns
+	# its cost, what .graphifyignore allows), deferred to an AI-assisted `/graphify` run.
+	[ -f "$root/graphify-out/graph.json" ] ||
 		echo "No Graphify root graph in $root; run /graphify in your AI assistant to build one." >&2
-	fi
 
 	case "${OMP_CLI:-}${PI_CLI:-}" in
 		'') ;;

--- a/scripts/agent/work-branch.sh
+++ b/scripts/agent/work-branch.sh
@@ -313,8 +313,7 @@ main() {
 	initializer=${PFB_INIT_WORKTREE_TOOLS:-$(dirname "$0")/init-worktree-tools.sh}
 	# A `wt` cut already ran the initializer through `.config/wt.toml`'s pre-start hook,
 	# and the CodeGraph index it leaves is the marker that the tools are in place. Only
-	# the fallback route (and a pre-start that did not run) still needs the direct call;
-	# a second `graphify update` here is pure duplicated work.
+	# the fallback route (and a pre-start that did not run) still needs the direct call.
 	initializer_status=0
 	if [ ! -f "$path/.codegraph/codegraph.db" ]; then
 		sh "$initializer" "$path"

--- a/tests/shell/agent_worktree_tools_spec.sh
+++ b/tests/shell/agent_worktree_tools_spec.sh
@@ -68,14 +68,11 @@ INTERPRETER
     chmod +x "$interpreter"
     printf '#!%s\n' "$interpreter" > "$stubdir/graphify"
     cat >> "$stubdir/graphify" <<'GRAPHIFY'
-case "$1" in
-  update)
-    [ "$#" -eq 2 ] || exit 9
-    printf 'graphify:%s:%s\n' "$1" "$2" >> "$WORKTREE_TOOL_LOG"
-    exit "${GRAPHIFY_RC:-0}"
-    ;;
-  *) exit 9 ;;
-esac
+# Tripwire: no production path may invoke the CLI (issue #3091). Any call is logged,
+# rewrites the root graph the way a real `update` would, and fails.
+printf 'graphify:%s\n' "$*" >> "$WORKTREE_TOOL_LOG"
+[ -z "${2:-}" ] || printf 'regenerated\n' > "$2/graphify-out/graph.json"
+exit 9
 GRAPHIFY
     cat > "$stubdir/serena" <<'SERENA'
 #!/bin/sh
@@ -100,8 +97,8 @@ SERENA
 
     export WORKTREE_TOOL_LOG="$tool_log" WORKTREE_GRAPHIFY_PACKAGE="$graphify_package"
     # The initializer applies the vendored .inc language-override patch (issue #2810)
-    # after CodeGraph, so every log below carries `patch-graphify:probe` after the
-    # CodeGraph line.
+    # after CodeGraph, so every row that reaches it logs `patch-graphify:probe` after
+    # the CodeGraph line.
     PATH="$stubdir:$PATH"; export PATH
   }
   cleanup() { rm -rf "$fixture"; }
@@ -130,9 +127,7 @@ SERENA
     git_fixture -C "$worktree" add graphify-out/graph.json
     git_fixture -C "$worktree" -c user.email=t@t -c user.name=t -c commit.gpgsign=false \
       commit -q -m graph
-    # GRAPHIFY_RC=19 makes any `graphify update` call fail loudly, so a green run
-    # proves the initializer never issued one, not merely that it succeeded.
-    When run env OMP_CLI=1 GRAPHIFY_RC=19 sh "$script_abs" "$worktree"
+    When run env OMP_CLI=1 sh "$script_abs" "$worktree"
     The status should equal 0
     The stderr should include 'already provides'
     The stderr should include 'Initializing CodeGraph in'

--- a/tests/shell/agent_worktree_tools_spec.sh
+++ b/tests/shell/agent_worktree_tools_spec.sh
@@ -100,8 +100,8 @@ SERENA
 
     export WORKTREE_TOOL_LOG="$tool_log" WORKTREE_GRAPHIFY_PACKAGE="$graphify_package"
     # The initializer applies the vendored .inc language-override patch (issue #2810)
-    # before refreshing the graph, so every log below carries `patch-graphify:probe`
-    # between the CodeGraph line and the Graphify one.
+    # after CodeGraph, so every log below carries `patch-graphify:probe` after the
+    # CodeGraph line.
     PATH="$stubdir:$PATH"; export PATH
   }
   cleanup() { rm -rf "$fixture"; }
@@ -124,15 +124,22 @@ SERENA
     The stderr should include 'run /graphify'
   End
 
-  It 'runs the vendored Graphify language override before refreshing an existing graph'
+  It 'leaves a tracked root graph byte-identical so a fresh cut is born clean (issue #3091)'
     mkdir -p "$worktree/graphify-out"
-    true > "$worktree/graphify-out/graph.json"
-    When run env OMP_CLI=1 sh "$script_abs" "$worktree"
+    printf 'committed graph\n' > "$worktree/graphify-out/graph.json"
+    git_fixture -C "$worktree" add graphify-out/graph.json
+    git_fixture -C "$worktree" -c user.email=t@t -c user.name=t -c commit.gpgsign=false \
+      commit -q -m graph
+    # GRAPHIFY_RC=19 makes any `graphify update` call fail loudly, so a green run
+    # proves the initializer never issued one, not merely that it succeeded.
+    When run env OMP_CLI=1 GRAPHIFY_RC=19 sh "$script_abs" "$worktree"
     The status should equal 0
     The stderr should include 'already provides'
-    The contents of file "$tool_log" should equal \
-      "$(printf 'codegraph:init:%s\npatch-graphify:probe\ngraphify:update:%s' "$worktree" "$worktree")"
     The stderr should include 'Initializing CodeGraph in'
+    The stderr should not include 'run /graphify'
+    The contents of file "$tool_log" should equal "$(printf 'codegraph:init:%s\npatch-graphify:probe' "$worktree")"
+    The contents of file "$worktree/graphify-out/graph.json" should equal 'committed graph'
+    Assert [ -z "$(git_fixture -C "$worktree" status --porcelain -- graphify-out)" ]
   End
 
   It 'fails nonzero when mandatory CodeGraph is missing'
@@ -153,16 +160,6 @@ SERENA
     When run env OMP_CLI=1 PATH="$no_graphify" sh "$script_abs" "$worktree"
     The status should not equal 0
     The stderr should include 'graphify'
-  End
-
-  It 'returns nonzero when refreshing an existing Graphify root graph fails'
-    mkdir -p "$worktree/graphify-out"
-    true > "$worktree/graphify-out/graph.json"
-    When run env OMP_CLI=1 GRAPHIFY_RC=19 sh "$script_abs" "$worktree"
-    The status should not equal 0
-    The contents of file "$tool_log" should equal \
-      "$(printf 'codegraph:init:%s\npatch-graphify:probe\ngraphify:update:%s' "$worktree" "$worktree")"
-    The stderr should include 'Initializing CodeGraph in'
   End
 
   It 'runs Serena project indexing at the exact root outside OMP when Serena is present'

--- a/tests/test_cross_agent_tooling.py
+++ b/tests/test_cross_agent_tooling.py
@@ -327,7 +327,6 @@ def test_repository_intelligence_initializes_each_worktree_directly() -> None:
         "temporary detached builder",
         "graphify cluster-only",
         "cluster-only",
-        # The initializer's retired refresh step (issue #3091).
         "then runs `graphify update <root>`",
     ):
         assert obsolete not in folded_routing, f"obsolete Graphify store/refresh recipe remains: {obsolete}"

--- a/tests/test_cross_agent_tooling.py
+++ b/tests/test_cross_agent_tooling.py
@@ -281,6 +281,10 @@ def test_repository_intelligence_initializes_each_worktree_directly() -> None:
         "scripts/agent/init-worktree-tools.sh",
         "scripts/agent/ensure-codegraph.sh",
         "graphify update",
+        # The initializer never rewrites the tracked graph: a fresh cut on an unmodified
+        # base must be born clean (issue #3091).
+        "It never runs `graphify update`",
+        "leaves the tracked root graph",
         # The initializer no longer builds the first graph: the routing document
         # must direct that judgement call to a `/graphify` run instead.
         "prints a notice and builds nothing",

--- a/tests/test_cross_agent_tooling.py
+++ b/tests/test_cross_agent_tooling.py
@@ -280,11 +280,8 @@ def test_repository_intelligence_initializes_each_worktree_directly() -> None:
         "work-branch.sh --worktree",
         "scripts/agent/init-worktree-tools.sh",
         "scripts/agent/ensure-codegraph.sh",
-        "graphify update",
-        # The initializer never rewrites the tracked graph: a fresh cut on an unmodified
-        # base must be born clean (issue #3091).
+        # issue #3091: the initializer never rewrites the tracked graph.
         "It never runs `graphify update`",
-        "leaves the tracked root graph",
         # The initializer no longer builds the first graph: the routing document
         # must direct that judgement call to a `/graphify` run instead.
         "prints a notice and builds nothing",
@@ -330,6 +327,8 @@ def test_repository_intelligence_initializes_each_worktree_directly() -> None:
         "temporary detached builder",
         "graphify cluster-only",
         "cluster-only",
+        # The initializer's retired refresh step (issue #3091).
+        "then runs `graphify update <root>`",
     ):
         assert obsolete not in folded_routing, f"obsolete Graphify store/refresh recipe remains: {obsolete}"
     assert "graphify-out/views" not in routing


### PR DESCRIPTION
Fixes #3091

## Problem

`.config/wt.toml`'s `pre-start` hook runs `scripts/agent/init-worktree-tools.sh`, which ran `graphify update <root>` whenever the tracked root graph existed. On a fresh cut of an unmodified base that rewrites `graphify-out/graph.json` wholesale, so every worktree was born dirty, `git status` was noisy from the first command, and the landing-time `wt remove --foreground --yes <head>` refused without `--force`.

## Cause

Two hypotheses were probed before the edit:

1. Unseeded Louvain churn (the hooks pin `PYTHONHASHSEED=0`; the initializer did not).
2. The committed graph already differs from what the installed Graphify emits for the same tree.

Probe in a fresh `wt` cut of `origin/devel` (e2ae8e0c), graph reverted first:

```
$ PYTHONHASHSEED=0 graphify update . ; git status --porcelain ; git diff --shortstat graphify-out/graph.json
 M graphify-out/graph.json
 1 file changed, 27825 insertions(+), 26743 deletions(-)
$ PYTHONHASHSEED=0 graphify update . ; cmp graphify-out/graph.json <first run>
seeded runs identical
```

Seeding alone leaves the cut dirty, so (2) holds: a refresh on the fresh cut can never be a no-op. The fresh cut checks out exactly the tree the committed graph describes, so the refresh is redundant work; the fix removes it. The routing doc already says the graph is refreshed and committed with the change that moves it.

## Change

- `scripts/agent/init-worktree-tools.sh`: no `graphify update`; the `.inc` patch is still applied through `patch-graphify.sh`, which resolves the Graphify launcher and fails closed when it is absent; the absent-graph notice is unchanged.
- `scripts/agent/work-branch.sh`: comment no longer claims a second `graphify update` is avoided.
- `.agents/context/repository-intelligence.md`: initializer contract updated; launcher-resolution sentence reconciled.
- `tests/shell/agent_worktree_tools_spec.sh`: new row commits a root graph, runs the initializer against a `graphify` stub that logs every call, rewrites the root graph, and exits 9, and asserts status 0, the tool log without `graphify:update`, the graph byte-identical, and `git status --porcelain -- graphify-out` empty. The two rows that asserted the refresh are removed.
- `tests/test_cross_agent_tooling.py`: pins the new doc sentence and guards the retired one.

## Red → green (test-first, executed)

Round 1 (7ce7103a, superseded): red on untouched production code with the spec frozen at `eca01f4f…` failed through the status and tool-log assertions (`got: 19`; extra `graphify:update:` log line); green after the edit at the same hash. Review round 1 revised both test files (tripwire stub, single pin), so the red proof was re-executed against the `origin/devel` script and doc with the revised files, now failing through all four assertions of the new row:

| Frozen RED test | git hash-object | RED run tail |
| --- | --- | --- |
| `tests/shell/agent_worktree_tools_spec.sh` | 4506df2ed7085d7254a3f88067f862e84f678f98 | `1.1) The status should equal 0 — expected: 0, got: 9` · `1.2) … got: "…\ngraphify:update …"` · `1.3) …graph.json should equal committed graph — got: "regenerated"` · `1.4) Assert [ -z  M graphify-out/graph.json ] — assertion failure` · `9 examples, 1 failure` |
| `tests/test_cross_agent_tooling.py` | 4763ef8693015d9c3921d63456a57e38d396ac1d | `FAILED tests/test_cross_agent_tooling.py::test_repository_intelligence_initializes_each_worktree_directly - AssertionError: direct worktree initialization routing lost It never runs \`graphify update\`` |

Green with the same files: `9 examples, 0 failures`; `24 passed` (`test_cross_agent_tooling.py` + `test_worktrunk_config.py`).

## Acceptance (issue) — executed

Cut through `wt` with the fixed script as base (7ce7103a):

```
$ wt --yes switch --create adr/99-probe-3091 --base 7ce7103a
✓ Created branch adr/99-probe-3091 from 7ce7103a and worktree @ ~/git/.pfBlockerNG_worktrees/adr-99-probe-3091
$ git -C ~/git/.pfBlockerNG_worktrees/adr-99-probe-3091 status --porcelain
(empty)
$ wt remove --foreground --format=json --yes adr/99-probe-3091
(succeeded; no --force)
```

Before the fix the same cut of `origin/devel` produced ` M graphify-out/graph.json` and `wt remove` answered `Cannot remove worktree: … has uncommitted changes`. Cut wall time dropped from ~60 s to ~16 s.

## Gates

`scripts/agent/run-gates.sh --diff origin/devel`: 11 PASS; `pytest` and `shellspec` FAIL only on six pre-existing host-divergence rows, reproduced identically on a read-only `git archive origin/devel` extraction and tracked in #3116 (five root-uid permission-denial rows) and #3117 (Node 26 JUnit classname). `pytest`: 1 failed, 5885 passed; `shellspec`: 1838 examples, 5 failures, none in touched specs.

Not included: making Graphify output deterministic across versions (issue option 3) and untracking the graph (option 1) — both outside this fix and the latter conflicts with the merge-driver and tracked-graph contract.
