### PR TITLE
pfblockerng: align the scheduled detector's status rows

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -4907,18 +4907,13 @@ function pfb_log_header_pad($header) {
 	return str_repeat(' ', max(0, 28 - strlen($header)));
 }
 
-// issue #3115: one status row of the Update log, in the two columns the log already
-// uses -- status text in column 53 (pfb_log_header_pad()'s), verdict text in column
-// 80 (where a probe row's appended cURL status lands). Spaces, never tabs: a tab's
-// width is the renderer's choice, so the Update viewer's textarea would place these
-// columns somewhere else. An empty $header indents to the status column instead; a
-// field wider than its column keeps exactly one separating space.
+// issue #3115: one Update-log status row -- status in column 53, verdict in column 80 (where a
+// probe row's appended cURL status sits); 33 = strlen('[  ]') + pad(28) + 1, 27 = 80 - 53. Spaces,
+// never tabs: a tab's width is the renderer's. An over-wide field keeps one space, shifting right.
 function pfb_log_status_line($header, $status, $verdict = '') {
-	$field = ($header === '')
-		? str_repeat(' ', 33)
-		: "[ {$header} ]" . pfb_log_header_pad($header) . ' ';
+	$field = ($header === '') ? str_repeat(' ', 33) : "[ {$header} ]" . pfb_log_header_pad($header) . ' ';
 
-	return $field . $status . str_repeat(' ', max(1, 27 - strlen($status))) . $verdict;
+	return $field . str_pad("{$status} ", 27) . $verdict;
 }
 
 function pfb_logger($log, $logtype) {

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -4900,6 +4900,27 @@ function pfb_logger_format_for_target(string $path, string $raw, int $lead, stri
 		: $raw;
 }
 
+// issue #2989: pad "[ {$header} ]" so the status text a caller writes after its own
+// separating space starts in column 53, after pfb_logger()'s 20-character stamp. A
+// header wider than the field pads to nothing and keeps just that one space.
+function pfb_log_header_pad($header) {
+	return str_repeat(' ', max(0, 28 - strlen($header)));
+}
+
+// issue #3115: one status row of the Update log, in the two columns the log already
+// uses -- status text in column 53 (pfb_log_header_pad()'s), verdict text in column
+// 80 (where a probe row's appended cURL status lands). Spaces, never tabs: a tab's
+// width is the renderer's choice, so the Update viewer's textarea would place these
+// columns somewhere else. An empty $header indents to the status column instead; a
+// field wider than its column keeps exactly one separating space.
+function pfb_log_status_line($header, $status, $verdict = '') {
+	$field = ($header === '')
+		? str_repeat(' ', 33)
+		: "[ {$header} ]" . pfb_log_header_pad($header) . ' ';
+
+	return $field . $status . str_repeat(' ', max(1, 27 - strlen($status))) . $verdict;
+}
+
 function pfb_logger($log, $logtype) {
 	global $g, $pfb;
 
@@ -7124,7 +7145,7 @@ function pfb_determine_list_detail($list='', $header='', $confconfig='', $key=''
 	}
 
 	// issue #2989: fixed spaces keep status columns aligned after the 20-character ISO timestamp.
-	$pfbarr['logtab'] = str_repeat(' ', max(0, 28 - strlen($header)));
+	$pfbarr['logtab'] = pfb_log_header_pad($header);
 
 	// Configure autoports/protocol and auto destination if required.
 	$conf_path = "installedpackages/{$confconfig}/config/{$key}";
@@ -14672,7 +14693,8 @@ function pfb_download_fetch(PfbDownloadRequest $request): PfbDownloadResult {
 
 	// Cron change-detection probe (conditional GET + content hash; legacy name was 'md5')
 	if ($type == 'change_detect') {
-		pfb_logger("\t\t\t\t( change check )\t\t", 1);
+		// No verdict argument: the cURL status appended below is this row's verdict.
+		pfb_logger(pfb_log_status_line('', '( change check )'), 1);
 	}
 
 	$file_dwn_esc	= escapeshellarg("{$file_dwn}.raw");

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_cron.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_cron.inc
@@ -52,7 +52,7 @@ function pfb_update_check($header, $list_url, $pfbfolder, $pfborig, $pflex, $for
 			return NULL;
 		}
 
-		$log = "\t\t\t\t\t\t\tUpdate found\n";
+		$log = pfb_log_status_line('', '', 'Update found') . "\n";
 		pfb_logger("{$log}", 1);
 		$pfb['cron_update'] = TRUE;
 		$pfb['update_cron'] = TRUE;
@@ -98,7 +98,7 @@ function pfb_update_check($header, $list_url, $pfbfolder, $pfborig, $pflex, $for
 
 	// Attempt download, when a previous 'fail' file marker is found.
 	if (file_exists("{$pfbfolder}/{$header}.fail")) {
-		$log = "\t\t\tPrevious download failed.\tRe-attempt download\n";
+		$log = pfb_log_status_line('', 'Previous download failed.', 'Re-attempt download') . "\n";
 		pfb_logger("{$log}", 1);
 		$pfb['update_cron'] = TRUE;
 		touch("{$pfbfolder}/{$header}.update");
@@ -107,7 +107,7 @@ function pfb_update_check($header, $list_url, $pfbfolder, $pfborig, $pflex, $for
 
 	// Check if List file doesn't exist or Format is 'whois'.
 	if (!file_exists("{$pfbfolder}/{$header}.txt") || $format == 'whois') {
-		$log = "\t\t\t\t\t\t\tUpdate found\n";
+		$log = pfb_log_status_line('', '', 'Update found') . "\n";
 		pfb_logger("{$log}", 1);
 		$pfb['update_cron'] = TRUE;
 		return NULL;
@@ -118,7 +118,7 @@ function pfb_update_check($header, $list_url, $pfbfolder, $pfborig, $pflex, $for
 	// Compare previously downloaded file timestamp with remote timestamp
 	if (file_exists($local_file)) {
 		if ($format == 'rsync') {
-			$log = "\t\t\t\t( rsync )\t\tUpdate found\n";
+			$log = pfb_log_status_line('', '( rsync )', 'Update found') . "\n";
 			pfb_logger("{$log}", 1);
 			$pfb['cron_update'] = TRUE;
 			$pfb['update_cron'] = TRUE;
@@ -138,7 +138,7 @@ function pfb_update_check($header, $list_url, $pfbfolder, $pfborig, $pflex, $for
 			// FeedChangeHashHelpersTest.
 			$pfb['cron_update'] = pfb_local_feed_changed($list_download, $local_file);
 			if (!$pfb['cron_update']) {
-				$log = "[ {$header} ] ( local feed unchanged )\tUpdate not required\n";
+				$log = pfb_log_status_line($header, '( local feed unchanged )', 'Update not required') . "\n";
 				pfb_logger("{$log}", 1);
 				return PfbScheduleTerminalResult::Success;
 			}
@@ -167,7 +167,7 @@ function pfb_update_check($header, $list_url, $pfbfolder, $pfborig, $pflex, $for
 
 			if (!$probe_result->success || $probe_result->responseMeta === NULL) {
 				// Probe failed entirely (connection error, bad URL, etc.) → fail-safe.
-				$log = "\n\tFailed to probe feed for change detection!\tUpdate skipped\n";
+				$log = "\n" . pfb_log_status_line('', 'Failed to probe feed for change detection!', 'Update skipped') . "\n";
 				unlink_if_exists("{$pfborig}/{$header}.md5.raw");
 				touch("{$pfbfolder}/{$header}.fail");
 				pfb_logger("{$log}", 1);
@@ -179,7 +179,7 @@ function pfb_update_check($header, $list_url, $pfbfolder, $pfborig, $pflex, $for
 
 			if ($probe_status === '304') {
 				// Server confirmed not-modified via conditional GET → no re-ingest needed.
-				$log = "\n[ {$header} ] ( 304 not modified )\tUpdate not required\n";
+				$log = "\n" . pfb_log_status_line($header, '( 304 not modified )', 'Update not required') . "\n";
 				pfb_logger("{$log}", 1);
 				unlink_if_exists("{$pfborig}/{$header}.md5.raw");
 				// Persist any refreshed validators from the 304 response.
@@ -200,7 +200,7 @@ function pfb_update_check($header, $list_url, $pfbfolder, $pfborig, $pflex, $for
 				$changed = pfb_conditional_get_decision($probe_status, $body_hash, $persisted_hash);
 
 				if ($changed) {
-					$log = "\n[ {$header} ] ( content changed )\tUpdate found\n";
+					$log = "\n" . pfb_log_status_line($header, '( content changed )', 'Update found') . "\n";
 					pfb_logger("{$log}", 1);
 					// Persist the validators from this 200 response so the next run
 					// can send a conditional GET.
@@ -211,7 +211,7 @@ function pfb_update_check($header, $list_url, $pfbfolder, $pfborig, $pflex, $for
 					return PfbScheduleTerminalResult::Success;
 				}
 				else {
-					$log = "\n[ {$header} ] ( content unchanged )\tUpdate not required\n";
+					$log = "\n" . pfb_log_status_line($header, '( content unchanged )', 'Update not required') . "\n";
 					pfb_logger("{$log}", 1);
 					unlink_if_exists("{$pfborig}/{$header}.md5.raw");
 					// Refresh validators even on a spurious 200 so the next run can
@@ -222,7 +222,7 @@ function pfb_update_check($header, $list_url, $pfbfolder, $pfborig, $pflex, $for
 			}
 
 			// Any other status → fail-safe: treat as changed, re-ingest.
-			$log = "\n\tUnexpected probe status [{$probe_status}]!\tUpdate forced (fail-safe)\n";
+			$log = "\n" . pfb_log_status_line('', "Unexpected probe status [{$probe_status}]!", 'Update forced (fail-safe)') . "\n";
 			unlink_if_exists("{$pfborig}/{$header}.md5.raw");
 			pfb_logger("{$log}", 1);
 			$pfb['update_cron'] = TRUE;
@@ -237,7 +237,7 @@ function pfb_update_check($header, $list_url, $pfbfolder, $pfborig, $pflex, $for
 		// Trigger CRON process if updates are found.
 		$pfb['update_cron'] = TRUE;
 
-		$log = "Update found\n";
+		$log = pfb_log_status_line('', '', 'Update found') . "\n";
 		pfb_logger("{$log}", 1);
 		touch("{$pfbfolder}/{$header}.update");
 	}

--- a/tests/php/UpdateCheckLogAlignmentTest.php
+++ b/tests/php/UpdateCheckLogAlignmentTest.php
@@ -12,24 +12,16 @@ require_once __DIR__ . '/../../src/usr/local/pkg/pfblockerng/pfblockerng_cron.in
  * issue #3115 — the scheduled detector's own status rows must land in the two columns the
  * Update log already established, for every feed-header length.
  *
- * Issue #2989 fixed the sync loop's rows (`[ header ]<pad> exists.`) by padding the header
- * field with spaces, which puts their status text in column 53. The detector's rows never
- * got that treatment: they separate `[ header ]` from its status with a single space and
- * reach their verdict with one `\t`, so both columns move with the header's length, and the
- * change-detection probe pads with four tabs and lands in a third column again.
- *
- * The two columns pinned here are the ones already in the log, not new ones: 53 is issue
- * #2989's status column, and 80 is where the probe row's `. 200 OK` already sits.
- *
+ * The two columns are the ones already in the log, not new ones: 53 is the column issue #2989
+ * pinned for the sync loop's rows, and 80 is where the probe row's `. 200 OK` already sits.
  * Tabs are rejected outright because a tab's rendered width belongs to whatever displays the
- * log — the Update viewer's textarea, `cat`, a pager — so a column contract cannot be
- * expressed with them at all.
+ * log, so a column contract cannot be expressed with them at all.
  *
- * Coverage: every detector row whose branch is decidable from the filesystem is driven
- * through pfb_update_check() itself. The four conditional-GET verdicts need a live origin
- * (they are exercised end to end by DownloadRejectValidatorClearTest and
- * tests/smoke/test_smoke_feeds.py), so their status strings are pinned here at the shared
- * formatter instead — one row per parenthetical the detector can emit.
+ * Coverage: every detector row whose branch is decidable from the filesystem is driven through
+ * pfb_update_check() itself, and the change-detection probe row through pfb_download(). The
+ * three conditional-GET parentheticals need a live origin (they are exercised end to end by
+ * DownloadRejectValidatorClearTest and tests/smoke/test_smoke_feeds.py), so those are pinned
+ * at the shared formatter instead.
  */
 #[CoversFunction('pfb_update_check')]
 #[CoversFunction('pfb_log_status_line')]
@@ -55,9 +47,7 @@ final class UpdateCheckLogAlignmentTest extends TestCase
 			$this->saved[$name] = [array_key_exists($name, $GLOBALS), $GLOBALS[$name] ?? NULL];
 		}
 
-		$this->sandbox = (string) tempnam(sys_get_temp_dir(), 'pfb_detector_alignment_');
-		$this->assertNotSame('', $this->sandbox, 'failed to create the sandbox path');
-		$this->assertTrue(unlink($this->sandbox), 'failed to claim the sandbox path');
+		$this->sandbox = sys_get_temp_dir() . '/pfb_detector_alignment_' . getmypid() . '_' . uniqid();
 		$this->folder = "{$this->sandbox}/txt";
 		$this->orig   = "{$this->sandbox}/orig";
 		foreach ([$this->sandbox, $this->folder, $this->orig] as $dir) {
@@ -224,32 +214,85 @@ final class UpdateCheckLogAlignmentTest extends TestCase
 		$this->assertRowColumns($this->rowContaining('Update found'), '', 'Update found');
 	}
 
-	/** @return list<array{string,string,string}> every parenthetical the detector can emit */
-	public static function detectorStatuses(): array
+	/**
+	 * Scenario: the change-detection probe row, driven through its real call site.
+	 *
+	 * Given a local feed the probe can read without a network
+	 * When pfb_download() runs in change-detection mode
+	 * Then the row it logs holds the status column and ends exactly at the verdict column, so
+	 *      the cURL status appended to it later starts there.
+	 *
+	 * pfb_download_fetch() always passes an empty header for this row, so driving it here is
+	 * what pins the argument shape production actually uses. The status itself is appended only
+	 * on the cURL branch, which needs a live origin; the row's own width is what decides where
+	 * it lands, and that is what this pins.
+	 */
+	public function testChangeDetectionProbeRowHoldsBothColumns(): void
+	{
+		$source = "{$this->sandbox}/probefeed.txt";
+		$this->assertNotFalse(file_put_contents($source, "198.51.100.7\n"), 'failed to write the local feed');
+
+		$probe = pfb_download(new PfbDownloadRequest(
+			listUrl: $source,
+			downloadPath: "{$this->orig}/Probe_v4.md5",
+			flex: FALSE,
+			header: 'Probe_v4',
+			format: '',
+			logType: 1,
+			type: 'change_detect',
+		));
+		$this->assertTrue($probe->success, 'the local-feed probe must succeed for its row to be logged whole');
+
+		$line = $this->rowContaining('( change check )');
+		$this->assertStringNotContainsString("\t", $line,
+			"a status row pads with spaces — a tab's width belongs to the renderer: '{$line}'");
+		$this->assertSame(self::STATUS_COL, strpos($line, '( change check )'),
+			'status text must start in column ' . self::STATUS_COL . ": '{$line}'");
+		$this->assertSame(self::VERDICT_COL, strlen($line),
+			'the row must end at column ' . self::VERDICT_COL . ", where the cURL status is appended: '{$line}'");
+	}
+
+	/** @return list<array{string,string}> the conditional-GET parentheticals, which need a live origin */
+	public static function conditionalGetStatuses(): array
 	{
 		return [
-			'change-detection probe' => ['ISC_Block_v4', '( change check )', ''],
-			'rsync'                  => ['', '( rsync )', 'Update found'],
-			'local feed unchanged'   => ['ISC_Block_v4', '( local feed unchanged )', 'Update not required'],
-			'304 not modified'       => ['ISC_Block_v4', '( 304 not modified )', 'Update not required'],
-			'content changed'        => ['ISC_Block_v4', '( content changed )', 'Update found'],
-			'content unchanged'      => ['ISC_Block_v4', '( content unchanged )', 'Update not required'],
+			'304 not modified'  => ['( 304 not modified )', 'Update not required'],
+			'content changed'   => ['( content changed )', 'Update found'],
+			'content unchanged' => ['( content unchanged )', 'Update not required'],
+		];
+	}
+
+	#[DataProvider('conditionalGetStatuses')]
+	public function testConditionalGetVerdictsHoldBothColumns(string $status, string $verdict): void
+	{
+		pfb_logger(pfb_log_status_line('ISC_Block_v4', $status, $verdict) . "\n", 1);
+
+		$this->assertRowColumns($this->rowContaining($status), $status, $verdict);
+	}
+
+	/** @return list<array{string,string}> the two detector statuses wider than the status field */
+	public static function overLongStatuses(): array
+	{
+		return [
+			'probe failed'      => ['Failed to probe feed for change detection!', 'Update skipped'],
+			'unexpected status' => ['Unexpected probe status [418]!', 'Update forced (fail-safe)'],
 		];
 	}
 
 	/**
-	 * The widest parenthetical the detector emits still leaves its verdict in column 80, so
-	 * no status the log can carry pushes the verdict column out of alignment.
+	 * A status wider than the status field cannot put its verdict in column 80, so it keeps
+	 * exactly one separating space and shifts the verdict right — the same rule an over-long
+	 * header follows. Both rows the detector formats this way are real, not hypothetical.
 	 */
-	#[DataProvider('detectorStatuses')]
-	public function testEveryDetectorStatusHoldsBothColumns(string $header, string $status, string $verdict): void
+	#[DataProvider('overLongStatuses')]
+	public function testStatusWiderThanTheFieldKeepsOneSeparatingSpace(string $status, string $verdict): void
 	{
-		// The probe row carries no verdict of its own: pfb_download() appends the cURL
-		// status to it, so stand in for that with the same '. 200 OK' the log shows.
-		$tail = $verdict === '' ? '. 200 OK' : '';
+		pfb_logger(pfb_log_status_line('', $status, $verdict) . "\n", 1);
+		$line = $this->rowContaining($status);
 
-		pfb_logger(pfb_log_status_line($header, $status, $verdict) . $tail . "\n", 1);
-
-		$this->assertRowColumns($this->rowContaining($status), $status, "{$verdict}{$tail}");
+		$this->assertSame(self::STATUS_COL, strpos($line, $status),
+			'status text must start in column ' . self::STATUS_COL . ": '{$line}'");
+		$this->assertSame("{$status} {$verdict}", substr($line, self::STATUS_COL),
+			"an over-wide status keeps exactly one separating space: '{$line}'");
 	}
 }

--- a/tests/php/UpdateCheckLogAlignmentTest.php
+++ b/tests/php/UpdateCheckLogAlignmentTest.php
@@ -1,0 +1,255 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../src/usr/local/pkg/pfblockerng/pfblockerng_cron.inc';
+
+/**
+ * issue #3115 — the scheduled detector's own status rows must land in the two columns the
+ * Update log already established, for every feed-header length.
+ *
+ * Issue #2989 fixed the sync loop's rows (`[ header ]<pad> exists.`) by padding the header
+ * field with spaces, which puts their status text in column 53. The detector's rows never
+ * got that treatment: they separate `[ header ]` from its status with a single space and
+ * reach their verdict with one `\t`, so both columns move with the header's length, and the
+ * change-detection probe pads with four tabs and lands in a third column again.
+ *
+ * The two columns pinned here are the ones already in the log, not new ones: 53 is issue
+ * #2989's status column, and 80 is where the probe row's `. 200 OK` already sits.
+ *
+ * Tabs are rejected outright because a tab's rendered width belongs to whatever displays the
+ * log — the Update viewer's textarea, `cat`, a pager — so a column contract cannot be
+ * expressed with them at all.
+ *
+ * Coverage: every detector row whose branch is decidable from the filesystem is driven
+ * through pfb_update_check() itself. The four conditional-GET verdicts need a live origin
+ * (they are exercised end to end by DownloadRejectValidatorClearTest and
+ * tests/smoke/test_smoke_feeds.py), so their status strings are pinned here at the shared
+ * formatter instead — one row per parenthetical the detector can emit.
+ */
+#[CoversFunction('pfb_update_check')]
+#[CoversFunction('pfb_log_status_line')]
+final class UpdateCheckLogAlignmentTest extends TestCase
+{
+	/** Column (0-based) that carries a row's status text — issue #2989's column. */
+	private const STATUS_COL = 53;
+
+	/** Column (0-based) that carries a row's verdict text — the probe row's `. 200 OK` column. */
+	private const VERDICT_COL = 80;
+
+	/** @var array<string,array{bool,mixed}> */
+	private array $saved = [];
+
+	private string $sandbox;
+	private string $log;
+	private string $folder;
+	private string $orig;
+
+	protected function setUp(): void
+	{
+		foreach (['pfb', 'config'] as $name) {
+			$this->saved[$name] = [array_key_exists($name, $GLOBALS), $GLOBALS[$name] ?? NULL];
+		}
+
+		$this->sandbox = (string) tempnam(sys_get_temp_dir(), 'pfb_detector_alignment_');
+		$this->assertNotSame('', $this->sandbox, 'failed to create the sandbox path');
+		$this->assertTrue(unlink($this->sandbox), 'failed to claim the sandbox path');
+		$this->folder = "{$this->sandbox}/txt";
+		$this->orig   = "{$this->sandbox}/orig";
+		foreach ([$this->sandbox, $this->folder, $this->orig] as $dir) {
+			$this->assertTrue(mkdir($dir, 0777, TRUE), "failed to create {$dir}");
+		}
+
+		$this->log = "{$this->sandbox}/pfblockerng.log";
+		$GLOBALS['pfb']['log']           = $this->log;
+		$GLOBALS['pfb']['errlog']        = "{$this->sandbox}/error.log";
+		$GLOBALS['pfb']['runlog']        = '';
+		$GLOBALS['pfb']['runlog_active'] = FALSE;
+		$GLOBALS['pfb']['skipfeed']      = 0;
+		// A local feed path is accepted by PFB_FILTER_URL when it sits directly in
+		// $pfb['dbdir'] (pfblockerng.inc:2004), which is what makes the local-feed
+		// verdict reachable off-appliance.
+		$GLOBALS['pfb']['dbdir'] = $this->sandbox;
+	}
+
+	protected function tearDown(): void
+	{
+		rmdir_recursive($this->sandbox);
+		foreach ($this->saved as $name => [$existed, $value]) {
+			if ($existed) {
+				$GLOBALS[$name] = $value;
+			} else {
+				unset($GLOBALS[$name]);
+			}
+		}
+	}
+
+	/** @return list<string> */
+	private function loggedLines(): array
+	{
+		$text = is_file($this->log) ? (string) file_get_contents($this->log) : '';
+		return array_values(array_filter(explode("\n", $text), static fn (string $l): bool => $l !== ''));
+	}
+
+	/** The one logged line carrying $marker; fails when none or several do. */
+	private function rowContaining(string $marker): string
+	{
+		$lines = $this->loggedLines();
+		$hits  = array_values(array_filter($lines, static fn (string $l): bool => str_contains($l, $marker)));
+		$this->assertCount(1, $hits, "expected exactly one row carrying '{$marker}', log was:\n" . implode("\n", $lines));
+		return $hits[0];
+	}
+
+	/** Both columns of one status row, plus the no-tabs rule that makes them hold. */
+	private function assertRowColumns(string $line, string $status, string $verdict): void
+	{
+		$this->assertStringNotContainsString("\t", $line,
+			"a status row pads with spaces — a tab's width belongs to the renderer: '{$line}'");
+		if ($status !== '') {
+			$this->assertSame(self::STATUS_COL, strpos($line, $status),
+				'status text must start in column ' . self::STATUS_COL . ": '{$line}'");
+		}
+		$this->assertSame(self::VERDICT_COL, strpos($line, $verdict),
+			'verdict text must start in column ' . self::VERDICT_COL . ": '{$line}'");
+	}
+
+	/** A local feed whose bytes match the last-ingested .orig — the unchanged verdict. */
+	private function seedUnchangedLocalFeed(string $header): string
+	{
+		$source = "{$this->sandbox}/localfeed.txt";
+		$body   = "198.51.100.7\n";
+		$this->assertNotFalse(file_put_contents($source, $body), 'failed to write the local feed');
+		$this->assertNotFalse(file_put_contents("{$this->folder}/{$header}.txt", $body), 'failed to write the .txt');
+		$this->assertNotFalse(file_put_contents("{$this->orig}/{$header}.orig", $body), 'failed to write the .orig');
+		return $source;
+	}
+
+	/** @return list<array{string}> */
+	public static function headerLengths(): array
+	{
+		return [
+			'short'                => ['abc'],
+			'one under a tab stop' => [str_repeat('a', 11)],
+			'on a tab stop'        => [str_repeat('a', 12)],
+			'wide'                 => [str_repeat('a', 19)],
+			'wider'                => [str_repeat('a', 20)],
+			'near the field edge'  => [str_repeat('a', 27)],
+			'at the field edge'    => [str_repeat('a', 28)],
+		];
+	}
+
+	/**
+	 * Scenario: the reported defect — a header-bearing detector verdict.
+	 *
+	 * Given a local feed whose content matches its last-ingested copy
+	 * When the scheduled detector evaluates it under a feed header of any supported length
+	 * Then the verdict's status and verdict text sit in the log's two columns.
+	 */
+	#[DataProvider('headerLengths')]
+	public function testLocalFeedVerdictHoldsBothColumnsAtEveryHeaderLength(string $header): void
+	{
+		$source = $this->seedUnchangedLocalFeed($header);
+
+		pfb_update_check($header, $source, $this->folder, $this->orig, '', '', '_v4');
+
+		$this->assertRowColumns(
+			$this->rowContaining('( local feed unchanged )'),
+			'( local feed unchanged )',
+			'Update not required'
+		);
+	}
+
+	/**
+	 * A header wider than the header field cannot be padded into column 53, so it keeps
+	 * exactly one separating space — the rule issue #2989 set for the sync loop's rows.
+	 */
+	public function testHeaderWiderThanTheFieldKeepsOneSeparatingSpace(): void
+	{
+		$header = str_repeat('a', 29);
+		$source = $this->seedUnchangedLocalFeed($header);
+
+		pfb_update_check($header, $source, $this->folder, $this->orig, '', '', '_v4');
+
+		$this->assertStringContainsString("[ {$header} ] ( local feed unchanged )",
+			$this->rowContaining('( local feed unchanged )'));
+	}
+
+	public function testWhoisUpdateFoundHoldsTheVerdictColumn(): void
+	{
+		pfb_update_check('Whois_v4', 'example.com', $this->folder, $this->orig, '', 'whois', '_v4');
+
+		$this->assertRowColumns($this->rowContaining('Update found'), '', 'Update found');
+	}
+
+	public function testPreviousFailureRetryHoldsBothColumns(): void
+	{
+		$this->assertNotFalse(touch("{$this->folder}/Retry_v4.fail"), 'failed to write the fail marker');
+
+		pfb_update_check('Retry_v4', 'http://203.0.113.10/list.txt', $this->folder, $this->orig, '', '', '_v4');
+
+		$this->assertRowColumns(
+			$this->rowContaining('Previous download failed.'),
+			'Previous download failed.',
+			'Re-attempt download'
+		);
+	}
+
+	public function testMissingFeedFileUpdateFoundHoldsTheVerdictColumn(): void
+	{
+		pfb_update_check('Fresh_v4', 'http://203.0.113.10/list.txt', $this->folder, $this->orig, '', '', '_v4');
+
+		$this->assertRowColumns($this->rowContaining('Update found'), '', 'Update found');
+	}
+
+	public function testRsyncUpdateFoundHoldsBothColumns(): void
+	{
+		$this->assertNotFalse(file_put_contents("{$this->folder}/Rsync_v4.txt", "198.51.100.7\n"), 'failed to write the .txt');
+		$this->assertNotFalse(file_put_contents("{$this->orig}/Rsync_v4.orig", "198.51.100.7\n"), 'failed to write the .orig');
+
+		pfb_update_check('Rsync_v4', 'rsync://203.0.113.10/module', $this->folder, $this->orig, '', 'rsync', '_v4');
+
+		$this->assertRowColumns($this->rowContaining('( rsync )'), '( rsync )', 'Update found');
+	}
+
+	public function testMissingOriginalUpdateFoundHoldsTheVerdictColumn(): void
+	{
+		$this->assertNotFalse(file_put_contents("{$this->folder}/NoOrig_v4.txt", "198.51.100.7\n"), 'failed to write the .txt');
+
+		pfb_update_check('NoOrig_v4', 'http://203.0.113.10/list.txt', $this->folder, $this->orig, '', '', '_v4');
+
+		$this->assertRowColumns($this->rowContaining('Update found'), '', 'Update found');
+	}
+
+	/** @return list<array{string,string,string}> every parenthetical the detector can emit */
+	public static function detectorStatuses(): array
+	{
+		return [
+			'change-detection probe' => ['ISC_Block_v4', '( change check )', ''],
+			'rsync'                  => ['', '( rsync )', 'Update found'],
+			'local feed unchanged'   => ['ISC_Block_v4', '( local feed unchanged )', 'Update not required'],
+			'304 not modified'       => ['ISC_Block_v4', '( 304 not modified )', 'Update not required'],
+			'content changed'        => ['ISC_Block_v4', '( content changed )', 'Update found'],
+			'content unchanged'      => ['ISC_Block_v4', '( content unchanged )', 'Update not required'],
+		];
+	}
+
+	/**
+	 * The widest parenthetical the detector emits still leaves its verdict in column 80, so
+	 * no status the log can carry pushes the verdict column out of alignment.
+	 */
+	#[DataProvider('detectorStatuses')]
+	public function testEveryDetectorStatusHoldsBothColumns(string $header, string $status, string $verdict): void
+	{
+		// The probe row carries no verdict of its own: pfb_download() appends the cURL
+		// status to it, so stand in for that with the same '. 200 OK' the log shows.
+		$tail = $verdict === '' ? '. 200 OK' : '';
+
+		pfb_logger(pfb_log_status_line($header, $status, $verdict) . $tail . "\n", 1);
+
+		$this->assertRowColumns($this->rowContaining($status), $status, "{$verdict}{$tail}");
+	}
+}

--- a/tests/php/fixtures/function_inventory.json
+++ b/tests/php/fixtures/function_inventory.json
@@ -8358,6 +8358,19 @@
             }
         ]
     },
+    "pfb_log_header_pad": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": [
+            {
+                "name": "header",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            }
+        ]
+    },
     "pfb_log_iso_timestamp": {
         "returnsRef": false,
         "returnType": "string",
@@ -8413,6 +8426,33 @@
         "returnsRef": false,
         "returnType": null,
         "params": []
+    },
+    "pfb_log_status_line": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": [
+            {
+                "name": "header",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "status",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": null
+            },
+            {
+                "name": "verdict",
+                "byRef": false,
+                "variadic": false,
+                "type": null,
+                "default": "''"
+            }
+        ]
     },
     "pfb_log_tail_chunk": {
         "returnsRef": false,

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -4272,12 +4272,11 @@ def unbound_pid(vm: SmokeVM, *, timeout: float = 30.0) -> int:
 def detector_status_marker(header: str, status: str) -> str:
     """The scheduled detector's status row for ``header``, as one fixed string.
 
-    issue #3115: the detector pads ``[ header ]`` with spaces so its status text starts in
-    column 53 of the Update log, so the number of spaces before ``status`` depends on the
-    header's length. Mirrors ``pfb_log_status_line()`` (pfblockerng.inc) — the two must move
-    together. Fixed-string by design: :func:`count_log_marker` greps with ``-F``.
+    issue #3115: mirrors ``pfb_log_status_line()`` (pfblockerng.inc), which pads by BYTES —
+    the two must move together, pinned by ``test_detector_status_marker_parity.py``. Fixed
+    string by design: :func:`count_log_marker` greps with ``-F``.
     """
-    return f"[ {header} ]" + " " * max(1, 29 - len(header)) + status
+    return f"[ {header} ]" + " " * max(1, 29 - len(header.encode())) + status
 
 
 def count_log_marker(vm: SmokeVM, path: str, marker: str, *, timeout: float = 30.0) -> int:

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -4269,6 +4269,17 @@ def unbound_pid(vm: SmokeVM, *, timeout: float = 30.0) -> int:
         raise RuntimeError(f"unbound_pid: {UNBOUND_PID_FILE} not an integer: {text!r}") from exc
 
 
+def detector_status_marker(header: str, status: str) -> str:
+    """The scheduled detector's status row for ``header``, as one fixed string.
+
+    issue #3115: the detector pads ``[ header ]`` with spaces so its status text starts in
+    column 53 of the Update log, so the number of spaces before ``status`` depends on the
+    header's length. Mirrors ``pfb_log_status_line()`` (pfblockerng.inc) — the two must move
+    together. Fixed-string by design: :func:`count_log_marker` greps with ``-F``.
+    """
+    return f"[ {header} ]" + " " * max(1, 29 - len(header)) + status
+
+
 def count_log_marker(vm: SmokeVM, path: str, marker: str, *, timeout: float = 30.0) -> int:
     """Count occurrences in the file ``path`` of one fixed string ``marker``.
 

--- a/tests/smoke/test_smoke_feeds.py
+++ b/tests/smoke/test_smoke_feeds.py
@@ -1846,7 +1846,7 @@ def test_cron_304_skips_unchanged_remote_feed(
         # The cron detector prefixes the verdict with the feed header, so the marker
         # below is scoped by header and verdict.
         h.pin_cron_due(deployed_vm)
-        not_mod_marker = f"[ {header} ] ( 304 not modified )"
+        not_mod_marker = h.detector_status_marker(header, "( 304 not modified )")
         not_mod_before = h.count_log_marker(deployed_vm, h.PFB_LOG, not_mod_marker)
         dl_before = _feed_log_count(deployed_vm, header, "Downloading update")
 
@@ -1953,7 +1953,7 @@ def test_cron_200_reingest_changed_remote_feed(
         # premise (a status-only impl that skips the hash compare) would still log
         # "Downloading update" without ever logging this, and a header-scoped count also
         # proves THIS feed (not a sibling) was the one evaluated.
-        chg_marker = f"[ {header} ] ( content changed )"
+        chg_marker = h.detector_status_marker(header, "( content changed )")
         chg_before = h.count_log_marker(deployed_vm, h.PFB_LOG, chg_marker)
 
         h.reload(deployed_vm, "cron")
@@ -2043,7 +2043,7 @@ def test_cron_no_validator_download_hash_decides(
         # the "( content unchanged )" verdict line, so the marker below proves BOTH the
         # verdict and that THIS feed's header was evaluated.
         h.pin_cron_due(deployed_vm)
-        not_unch_marker = f"[ {header} ] ( content unchanged )"
+        not_unch_marker = h.detector_status_marker(header, "( content unchanged )")
         not_unch_before = h.count_log_marker(deployed_vm, h.PFB_LOG, not_unch_marker)
         dl_before = _feed_log_count(deployed_vm, header, "Downloading update")
 
@@ -2127,7 +2127,7 @@ def test_cron_spurious_200_same_bytes_no_reingest(
             # "( content unchanged )" verdict, so the marker below proves both the verdict
             # and that THIS feed's marker (aliasname_family) was the one evaluated.
             h.pin_cron_due(deployed_vm)
-            not_unch_marker = f"[ {feed_marker} ] ( content unchanged )"
+            not_unch_marker = h.detector_status_marker(feed_marker, "( content unchanged )")
             not_unch_before = h.count_log_marker(deployed_vm, h.PFB_LOG, not_unch_marker)
             dl_before = _feed_log_count(deployed_vm, feed_marker, "Downloading update")
 
@@ -2224,7 +2224,7 @@ def test_cron_lastmod_304_skips_unchanged_feed(
         # the "( 304 not modified )" verdict line itself, so the marker below is scoped by
         # header AND verdict — no separate global count + "fast guard" needed.
         h.pin_cron_due(deployed_vm)
-        not_mod_marker = f"[ {header} ] ( 304 not modified )"
+        not_mod_marker = h.detector_status_marker(header, "( 304 not modified )")
         not_mod_before = h.count_log_marker(deployed_vm, h.PFB_LOG, not_mod_marker)
         dl_before = _feed_log_count(deployed_vm, header, "Downloading update")
 

--- a/tests/test_detector_status_marker_parity.py
+++ b/tests/test_detector_status_marker_parity.py
@@ -1,0 +1,74 @@
+"""The smoke suite's detector marker must stay byte-identical to the PHP producer — issue #3115.
+
+``tests.smoke.helpers.detector_status_marker`` reimplements ``pfb_log_status_line()``'s header
+field in Python because ``count_log_marker`` matches the Update log with ``grep -F``: the marker
+has to carry the producer's exact padding. Two copies of one formula drift, and the drift is not
+obvious at the call site — the smoke assertions would just stop seeing their verdict.
+
+So this compares the two implementations by executing the shipped PHP, the same way
+``test_dnsbl_log_csv_quoting`` round-trips its rows through the real ``fgetcsv``.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from tests.smoke import helpers
+
+BOOTSTRAP = Path(__file__).resolve().parent / "php" / "bootstrap.php"
+
+# Header lengths that matter: inside the field, on both sides of its edge, and past it — plus
+# non-ASCII, where PHP's byte padding and a codepoint-based mirror diverge.
+HEADERS = [
+    "a",
+    "ISC_Block_v4",
+    "a" * 27,
+    "a" * 28,
+    "a" * 29,
+    "a" * 40,
+    "é" * 10,
+    "Ünïcode-Fêed",
+]
+
+STATUS = "( content changed )"
+
+
+def _php_status_lines(headers: list[str], status: str) -> dict[str, str]:
+    """Render ``pfb_log_status_line($header, $status, '')`` with the shipped PHP, per header."""
+    script = (
+        f"require {json.dumps(str(BOOTSTRAP))};"
+        f"$out = [];"
+        f"foreach (json_decode({json.dumps(json.dumps(headers))}) as $h) {{"
+        f"    $out[$h] = pfb_log_status_line($h, {json.dumps(status)}, '');"
+        f"}}"
+        f"echo json_encode($out, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);"
+    )
+    result = subprocess.run(
+        ["php", "-r", script],
+        capture_output=True,
+        check=True,
+        text=True,
+    )
+    rendered = json.loads(result.stdout)
+    assert isinstance(rendered, dict), f"PHP returned unexpected JSON: {result.stdout!r}"
+    return rendered
+
+
+@pytest.mark.skipif(shutil.which("php") is None, reason="php CLI not installed")
+def test_detector_status_marker_matches_the_php_producer() -> None:
+    """Every marker the smoke suite greps for is a prefix of the row PHP actually writes."""
+    rendered = _php_status_lines(HEADERS, STATUS)
+    assert set(rendered) == set(HEADERS), f"PHP skipped headers: {sorted(set(HEADERS) - set(rendered))}"
+
+    for header, php_row in rendered.items():
+        marker = helpers.detector_status_marker(header, STATUS)
+        assert php_row.startswith(marker), (
+            f"marker drifted from the producer for a {len(header.encode())}-byte header\n"
+            f"  marker: {marker!r}\n"
+            f"  PHP:    {php_row!r}"
+        )

--- a/tests/test_detector_status_marker_parity.py
+++ b/tests/test_detector_status_marker_parity.py
@@ -43,25 +43,27 @@ STATUS = "( content changed )"
 def _php_status_lines(headers: list[str], status: str) -> list[str]:
     """Render ``pfb_log_status_line($header, $status, '')`` with the shipped PHP, in order.
 
-    The payload rides `argv`, not the script text: a header carrying `$` would otherwise
-    interpolate PHP-side. It is read before the bootstrap require, which replaces `$argv` to
-    keep the package's daemon dispatch dormant. Ordered list, not a keyed map, because PHP
-    casts a numeric-string array key to an int.
+    Nothing rides the script text: a `$` in the payload, the status or the bootstrap path would
+    interpolate PHP-side. `argv` is read before the bootstrap require, which replaces it to keep
+    the package's daemon dispatch dormant. Ordered list, not a keyed map, because PHP casts a
+    numeric-string array key to an int. UTF-8 is explicit because `JSON_UNESCAPED_UNICODE` emits
+    raw bytes and `text=True` would otherwise decode them in the locale's encoding.
     """
     script = (
-        f"[, $payload, $status] = $argv;"
-        f"require {json.dumps(str(BOOTSTRAP))};"
-        f"$out = [];"
-        f"foreach (json_decode($payload) as $h) {{"
-        f"    $out[] = pfb_log_status_line($h, $status, '');"
-        f"}}"
-        f"echo json_encode($out, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);"
+        "[, $boot, $payload, $status] = $argv;"
+        "require $boot;"
+        "$out = [];"
+        "foreach (json_decode($payload) as $h) {"
+        "    $out[] = pfb_log_status_line($h, $status, '');"
+        "}"
+        "echo json_encode($out, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);"
     )
     result = subprocess.run(
-        ["php", "-r", script, "--", json.dumps(headers), status],
+        ["php", "-r", script, "--", str(BOOTSTRAP), json.dumps(headers), status],
         capture_output=True,
         check=True,
         text=True,
+        encoding="utf-8",
     )
     rendered = json.loads(result.stdout)
     assert isinstance(rendered, list) and len(rendered) == len(headers), (

--- a/tests/test_detector_status_marker_parity.py
+++ b/tests/test_detector_status_marker_parity.py
@@ -20,8 +20,9 @@ from tests.smoke import helpers
 BOOTSTRAP = Path(__file__).resolve().parent / "php" / "bootstrap.php"
 
 # Header lengths that matter: inside the field, on both sides of its edge, and past it — plus
-# non-ASCII, where PHP's byte padding and a codepoint-based mirror diverge, and the shapes that
-# would break a payload interpolated into the PHP script instead of passed to it.
+# non-ASCII, where PHP's byte padding and a codepoint-based mirror diverge; the two `$` shapes,
+# which corrupt a payload interpolated into the PHP script instead of passed to it; and a
+# numeric string, which PHP would cast to an int array key if the producer went back to a map.
 HEADERS = [
     "a",
     "ISC_Block_v4",

--- a/tests/test_detector_status_marker_parity.py
+++ b/tests/test_detector_status_marker_parity.py
@@ -12,18 +12,16 @@ So this compares the two implementations by executing the shipped PHP, the same 
 from __future__ import annotations
 
 import json
-import shutil
 import subprocess
 from pathlib import Path
-
-import pytest
 
 from tests.smoke import helpers
 
 BOOTSTRAP = Path(__file__).resolve().parent / "php" / "bootstrap.php"
 
 # Header lengths that matter: inside the field, on both sides of its edge, and past it — plus
-# non-ASCII, where PHP's byte padding and a codepoint-based mirror diverge.
+# non-ASCII, where PHP's byte padding and a codepoint-based mirror diverge, and the shapes that
+# would break a payload interpolated into the PHP script instead of passed to it.
 HEADERS = [
     "a",
     "ISC_Block_v4",
@@ -33,39 +31,48 @@ HEADERS = [
     "a" * 40,
     "é" * 10,
     "Ünïcode-Fêed",
+    "a$out",
+    '{$out}"\\',
+    "123",
 ]
 
 STATUS = "( content changed )"
 
 
-def _php_status_lines(headers: list[str], status: str) -> dict[str, str]:
-    """Render ``pfb_log_status_line($header, $status, '')`` with the shipped PHP, per header."""
+def _php_status_lines(headers: list[str], status: str) -> list[str]:
+    """Render ``pfb_log_status_line($header, $status, '')`` with the shipped PHP, in order.
+
+    The payload rides `argv`, not the script text: a header carrying `$` would otherwise
+    interpolate PHP-side. It is read before the bootstrap require, which replaces `$argv` to
+    keep the package's daemon dispatch dormant. Ordered list, not a keyed map, because PHP
+    casts a numeric-string array key to an int.
+    """
     script = (
+        f"[, $payload, $status] = $argv;"
         f"require {json.dumps(str(BOOTSTRAP))};"
         f"$out = [];"
-        f"foreach (json_decode({json.dumps(json.dumps(headers))}) as $h) {{"
-        f"    $out[$h] = pfb_log_status_line($h, {json.dumps(status)}, '');"
+        f"foreach (json_decode($payload) as $h) {{"
+        f"    $out[] = pfb_log_status_line($h, $status, '');"
         f"}}"
         f"echo json_encode($out, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);"
     )
     result = subprocess.run(
-        ["php", "-r", script],
+        ["php", "-r", script, "--", json.dumps(headers), status],
         capture_output=True,
         check=True,
         text=True,
     )
     rendered = json.loads(result.stdout)
-    assert isinstance(rendered, dict), f"PHP returned unexpected JSON: {result.stdout!r}"
+    assert isinstance(rendered, list) and len(rendered) == len(headers), (
+        f"PHP rendered {len(rendered) if isinstance(rendered, list) else type(rendered).__name__} "
+        f"rows for {len(headers)} headers: {result.stdout!r}"
+    )
     return rendered
 
 
-@pytest.mark.skipif(shutil.which("php") is None, reason="php CLI not installed")
 def test_detector_status_marker_matches_the_php_producer() -> None:
     """Every marker the smoke suite greps for is a prefix of the row PHP actually writes."""
-    rendered = _php_status_lines(HEADERS, STATUS)
-    assert set(rendered) == set(HEADERS), f"PHP skipped headers: {sorted(set(HEADERS) - set(rendered))}"
-
-    for header, php_row in rendered.items():
+    for header, php_row in zip(HEADERS, _php_status_lines(HEADERS, STATUS), strict=True):
         marker = helpers.detector_status_marker(header, STATUS)
         assert php_row.startswith(marker), (
             f"marker drifted from the producer for a {len(header.encode())}-byte header\n"


### PR DESCRIPTION
Fixes #3115

## What was wrong

Issue #2989 aligned the sync loop's status rows by padding `[ header ]` with spaces, which puts
their status text in column 53. The scheduled detector's own rows never got that treatment:

```
2026-09-02 17:23:22 [ ISC_Block_v4 ]
2026-09-02 17:23:22                                 ( change check )              . 200 OK
2026-09-02 17:23:22 [ ISC_Block_v4 ] ( content changed )      Update found
```

The verdict rows separate `[ header ]` from the status with one space and reach the verdict with a
single `\t`, so both of their columns move with the header's length; the change-detection probe row
pads with four tabs and lands in a third column again. Rendering the current producer strings with
the live 20-character stamp and 8-column tab stops:

```
ET_Comp_v4         status_col=35 verdict_col=56
ISC_Block_v4       status_col=37 verdict_col=64
Spamhaus_Drop_v4   status_col=41 verdict_col=64
BDS_Ban_v4         status_col=35 verdict_col=56
(change check)     status_col=48 verdict_col=80
(sync loop)        status_col=53
```

## The change

`pfb_log_status_line($header, $status, $verdict)` builds one status row and every detector row goes
through it. The two columns it pins are the ones already in the log, not new ones: **53** is issue
#2989's status column, and **80** is where the probe row's appended `. 200 OK` already sat. Padding
is spaces, never tabs — a tab's rendered width belongs to whatever displays the log, so the Update
viewer's textarea would place the columns somewhere else.

`$pfbarr['logtab']` now derives from the same `pfb_log_header_pad()` the builder uses, so the sync
loop's column and the detector's cannot drift apart. No log line is reworded; only its padding
changes.

An over-wide field keeps exactly one separating space and shifts what follows right — the rule
#2989 set for an over-long feed header, and it applies to two real rows, not just hypothetically:
the probe-failure sentence (42 characters) and the unexpected-status sentence (30) are wider than
the 27-column status field, so their verdicts land in columns 96 and 84 while their status text
still moves to 53.

`tests/smoke/test_smoke_feeds.py`'s five detector markers are fixed strings (`count_log_marker`
greps with `-F`), so they move to one `h.detector_status_marker()` helper. It pads on the header's
**byte** length, as PHP's `strlen` does, and `tests/test_detector_status_marker_parity.py` executes
the shipped PHP to keep the two copies honest.

**Escalation checked and cleared:** `tests/php/DownloadRejectValidatorClearTest.php:215,457` is the
only other fixed-string consumer of these lines tree-wide. It matches the bare parenthetical, which
is unchanged, and passes at this head.

## Evidence

**Red before, green after** — `tests/php/UpdateCheckLogAlignmentTest.php`, frozen byte-identical
between the two runs (`git hash-object` = `82340dc84f01fad13fa84c5c54831f7d91d5a0e0` at both), run
against an `origin/devel` extraction of the production files and then against this branch's:

```
# on unchanged production code
Tests: 19, Assertions: 116, Errors: 5, Failures: 13.

  a status row pads with spaces — a tab's width belongs to the renderer:
  '2026-09-02 16:19:16 \t\t\t\t( change check )\t\t'
  verdict text must start in column 80: '2026-09-02 16:19:16 Update found'
  Failed asserting that 20 is identical to 80.

# after the fix, same file, zero edits
OK (19 tests, 156 assertions)
```

The test drives `pfb_update_check()` itself for every detector row whose branch is decidable from
the filesystem — whois, previous-fail retry, missing `.txt`, rsync, missing `.orig`, and the
local-feed verdict across seven header lengths plus one over-long header — and the probe row through
`pfb_download()` on a local feed. The three conditional-GET parentheticals need a live origin
(`DownloadRejectValidatorClearTest` and the smoke feed suite exercise them end to end), so those are
pinned at the shared builder.

**Two targeted mutations**, both of which escaped the first revision of this PR:

```
# revert ONLY the probe row's call site to raw tabs
Tests: 19, Assertions: 154, Failures: 1.   testChangeDetectionProbeRowHoldsBothColumns

# drop the guaranteed separating space: str_pad("{$status} ", 27) -> str_pad($status, 27)
Tests: 19, Assertions: 154, Failures: 3.
  -'Unexpected probe status [418]! Update forced (fail-safe)'
  +'Unexpected probe status [418]!Update forced (fail-safe)'
```

**Column parity, PHP producer vs the Python smoke helper**, at every header length:

```
len= 1 status_col=53 verdict_col=80 py_marker_matches=True
len=12 status_col=53 verdict_col=80 py_marker_matches=True
len=27 status_col=53 verdict_col=80 py_marker_matches=True
len=28 status_col=53 verdict_col=80 py_marker_matches=True
len=29 status_col=54 verdict_col=81 py_marker_matches=True
len=40 status_col=65 verdict_col=92 py_marker_matches=True
```

and the parity test is not vacuous — against the shipped PHP rows, the codepoint-based mirror this
PR replaced mismatches 2 of 8 headers and a PHP-side field-width change mismatches 5 of 8:

```
shipped          mismatching headers: 0/8 []
codepoint drift  mismatching headers: 2/8 ['éééééééééé', 'Ünïcode-Fêed']
width drift      mismatching headers: 5/8 ['a', 'ISC_Block_v4', 'aaaaaaaaaaaa', 'éééééééééé', 'Ünïcode-Fêed']
```

**Gates**

| Gate | Result |
| --- | --- |
| `php -l` (both touched files) | pass |
| `vendor/bin/phpunit` | `Tests: 6485, Errors: 29, Failures: 14` — set-identical to `origin/devel`'s baseline on this host (tracked: #3103, #3083) |
| `composer phpstan` | `[OK] No errors` |
| `composer phpcs -- --standard=phpcs.xml.dist src/` | rc=0 |
| `uv run pytest -q` | `1 failed, 5886 passed` — the failure is the pre-existing Node-JUnit canary (#3081/#3083/#3117/#2983), red on `origin/devel` too |
| `uv run ruff check` / `ruff format --check` | pass |
| `uv run mypy tests/` | `no issues found in 380 source files` |

Baseline comparison was run against an `origin/devel` extraction; its only two extra failures
(`SrcPhpDeprecationLintTest`, `LogNowTokenRetiredTest`) are the two tests that read `git ls-files`
and so cannot run in a `.git`-less tree. Every other error and failure name is identical.

`tests/php/fixtures/function_inventory.json` is the regenerated parity golden for the two new
functions.

Note: `scripts/agent/run-gates.sh` reports `GATE FAIL` for `composer phpstan` / `composer phpcs` in
a root session because Composer refuses to load plugins as superuser; both gates were run directly
with `COMPOSER_ALLOW_SUPERUSER=1` and pass. That is a runner-environment gap, not a finding of this
change, and is out of scope here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Standardized update and change-detection log rows with consistently aligned status and verdict columns.
  * Improved readability of log headers and status messages, including long labels and varied status lengths.
  * Preserved existing update detection, validation, retry, and scheduling behavior.

* **Tests**
  * Added coverage for alignment across feed types, conditional responses, retries, missing files, and Unicode or numeric values.
  * Added cross-checks to ensure displayed status markers remain consistent across supported environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->