### PR TITLE
pfblockerng: append the IP parse accumulator in place

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
@@ -108,10 +108,8 @@ function pfb_ip_regex_matches(string $family, string $line, array $config): arra
 	return preg_match_all($pattern, $line, $matches) ? $matches[0] : [];
 }
 
-// #3121: $ip_data is appended IN PLACE and never returned. Passing it by value (and
-// handing a copy back) left the caller's string at refcount > 1 for the whole call, so
-// every append copied the entire accumulated buffer -- O(n²) over the feed, ~3 min for a
-// 300k-line feed on a live box where the direct append is under a second.
+// #3121: $ip_data is appended in place, never returned -- a by-value copy handed back
+// through the result made every append copy the whole buffer (O(n²) over the feed).
 /** @return array{line_number:int,raw_line:string,line:string,ip_suppressed:bool,parse_fail:int,messages:list<string>,detailed_parse_fail:bool} */
 function pfb_ip_parse_line_replay(string $raw_line, array $config, int $line_number,
     string &$ip_data, bool $ip_suppressed, int $parse_fail): array {
@@ -4007,7 +4005,6 @@ function sync_package_pfblockerng($cron='', ?string &$deferred_by = NULL): bool 
 
 								if (($fhandle = @fopen($pfb_parse_path, 'r')) !== FALSE) {
 									while (($line = @fgets($fhandle)) !== FALSE) {
-										$raw_line = $line;
 										$replayed_line = pfb_ip_parse_line_replay($line, [
 											'vtype'         => $list['vtype'],
 											'pftype'        => $pftype,

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
@@ -108,9 +108,13 @@ function pfb_ip_regex_matches(string $family, string $line, array $config): arra
 	return preg_match_all($pattern, $line, $matches) ? $matches[0] : [];
 }
 
-/** @return array{line_number:int,raw_line:string,line:string,ip_data:string,ip_suppressed:bool,parse_fail:int,messages:list<string>,detailed_parse_fail:bool} */
+// #3121: $ip_data is appended IN PLACE and never returned. Passing it by value (and
+// handing a copy back) left the caller's string at refcount > 1 for the whole call, so
+// every append copied the entire accumulated buffer -- O(n²) over the feed, ~3 min for a
+// 300k-line feed on a live box where the direct append is under a second.
+/** @return array{line_number:int,raw_line:string,line:string,ip_suppressed:bool,parse_fail:int,messages:list<string>,detailed_parse_fail:bool} */
 function pfb_ip_parse_line_replay(string $raw_line, array $config, int $line_number,
-    string $ip_data, bool $ip_suppressed, int $parse_fail): array {
+    string &$ip_data, bool $ip_suppressed, int $parse_fail): array {
 	$parsed = pfb_ip_parse_line($raw_line, $config);
 	foreach ($parsed['entries'] as $entry) {
 		$ip_data .= $entry . "\n";
@@ -119,7 +123,6 @@ function pfb_ip_parse_line_replay(string $raw_line, array $config, int $line_num
 		'line_number'       => $line_number + 1,
 		'raw_line'          => $raw_line,
 		'line'              => $parsed['line'],
-		'ip_data'           => $ip_data,
 		'ip_suppressed'     => $ip_suppressed || $parsed['suppressed'],
 		'parse_fail'        => $parse_fail + $parsed['parse_fail_delta'],
 		'messages'          => $parsed['messages'],
@@ -4018,7 +4021,6 @@ function sync_package_pfblockerng($cron='', ?string &$deferred_by = NULL): bool 
 										], $ip_lineno, $ip_data, $ip_suppressed, $parse_fail);
 										$ip_lineno    = $replayed_line['line_number'];
 										$line         = $replayed_line['line'];
-										$ip_data      = $replayed_line['ip_data'];
 										$ip_suppressed = $replayed_line['ip_suppressed'];
 										$parse_fail   = $replayed_line['parse_fail'];
 										foreach ($replayed_line['messages'] as $message) {

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
@@ -110,6 +110,7 @@ function pfb_ip_regex_matches(string $family, string $line, array $config): arra
 
 // #3121: $ip_data is appended in place, never returned -- a by-value copy handed back
 // through the result made every append copy the whole buffer (O(n²) over the feed).
+// A progress dot every 50 000 lines keeps the live tail moving on a large feed.
 /** @return array{line_number:int,raw_line:string,line:string,ip_suppressed:bool,parse_fail:int,messages:list<string>,detailed_parse_fail:bool} */
 function pfb_ip_parse_line_replay(string $raw_line, array $config, int $line_number,
     string &$ip_data, bool $ip_suppressed, int $parse_fail): array {
@@ -117,8 +118,12 @@ function pfb_ip_parse_line_replay(string $raw_line, array $config, int $line_num
 	foreach ($parsed['entries'] as $entry) {
 		$ip_data .= $entry . "\n";
 	}
+	$line_number++;
+	if ($line_number % 50000 === 0) {
+		$parsed['messages'][] = '.';
+	}
 	return [
-		'line_number'       => $line_number + 1,
+		'line_number'       => $line_number,
 		'raw_line'          => $raw_line,
 		'line'              => $parsed['line'],
 		'ip_suppressed'     => $ip_suppressed || $parsed['suppressed'],

--- a/tests/php/IpParseLineWiringTest.php
+++ b/tests/php/IpParseLineWiringTest.php
@@ -55,6 +55,28 @@ final class IpParseLineWiringTest extends TestCase
 		$this->assertSame("192.0.2.1\n192.0.2.2\n192.0.2.3\n", $ip_data);
 	}
 
+	/** #3121: a large feed keeps the live tail moving -- one progress dot every 50 000 lines. */
+	public function testReplayEmitsAProgressDotEveryFiftyThousandLines(): void
+	{
+		$ip_data = '';
+		$config  = $this->config('_v4', 'auto');
+
+		$before = pfb_ip_parse_line_replay("192.0.2.1\n", $config, 49998, $ip_data, FALSE, 0);
+		$this->assertSame(49999, $before['line_number']);
+		$this->assertSame([], $before['messages'], 'no dot short of the boundary');
+
+		$at = pfb_ip_parse_line_replay("192.0.2.2\n", $config, 49999, $ip_data, FALSE, 0);
+		$this->assertSame(50000, $at['line_number']);
+		$this->assertSame(['.'], $at['messages'], 'the 50 000th line emits exactly one dot');
+
+		$after = pfb_ip_parse_line_replay("192.0.2.3\n", $config, 50000, $ip_data, FALSE, 0);
+		$this->assertSame([], $after['messages'], 'no dot past the boundary');
+
+		$twice = pfb_ip_parse_line_replay("192.0.2.4\n", $config, 99999, $ip_data, FALSE, 0);
+		$this->assertSame(['.'], $twice['messages'], 'every multiple of 50 000');
+		$this->assertSame("192.0.2.1\n192.0.2.2\n192.0.2.3\n192.0.2.4\n", $ip_data);
+	}
+
 	public function testReplayCarriesV6SuppressionAndExistingState(): void
 	{
 		$ip_data = '';

--- a/tests/php/IpParseLineWiringTest.php
+++ b/tests/php/IpParseLineWiringTest.php
@@ -24,38 +24,57 @@ final class IpParseLineWiringTest extends TestCase
 
 	public function testReplayAppendsEntriesInParserOrderAndAdvancesLineNumber(): void
 	{
+		$ip_data = "10.0.0.1\n";
 		$state = pfb_ip_parse_line_replay(
 			"from 192.0.2.1 to 198.51.100.7\n",
 			$this->config('_v4'),
 			4,
-			"10.0.0.1\n",
+			$ip_data,
 			FALSE,
 			2
 		);
 
 		$this->assertSame(5, $state['line_number']);
 		$this->assertSame("from 192.0.2.1 to 198.51.100.7", $state['line']);
-		$this->assertSame("10.0.0.1\n192.0.2.1\n198.51.100.7\n", $state['ip_data']);
+		$this->assertSame("10.0.0.1\n192.0.2.1\n198.51.100.7\n", $ip_data);
 		$this->assertFalse($state['ip_suppressed']);
 		$this->assertSame(2, $state['parse_fail']);
 		$this->assertSame([], $state['messages']);
 		$this->assertFalse($state['detailed_parse_fail']);
 	}
 
+	/**
+	 * #3121: the accumulator is appended IN PLACE. A by-value copy returned through the
+	 * result array leaves the caller's string with refcount > 1 during the call, so every
+	 * append copies the whole buffer and a 300k-line feed takes minutes instead of seconds.
+	 * The caller's variable is the only accumulator: the result carries no copy of it.
+	 */
+	public function testReplayAppendsToTheCallerAccumulatorInPlace(): void
+	{
+		$ip_data = '';
+		foreach (["192.0.2.1\n", "192.0.2.2\n", "192.0.2.3\n"] as $line) {
+			$state = pfb_ip_parse_line_replay($line, $this->config('_v4', 'auto'), 0, $ip_data, FALSE, 0);
+			$this->assertArrayNotHasKey('ip_data', $state, 'result must not carry a second copy of the accumulator');
+		}
+
+		$this->assertSame("192.0.2.1\n192.0.2.2\n192.0.2.3\n", $ip_data);
+	}
+
 	public function testReplayCarriesV6SuppressionAndExistingState(): void
 	{
+		$ip_data = '';
 		$state = pfb_ip_parse_line_replay(
 			'fc00::1',
 			$this->config('_v6', 'auto', 'on'),
 			0,
-			'',
+			$ip_data,
 			TRUE,
 			1
 		);
 
 		$this->assertSame(1, $state['line_number']);
 		$this->assertSame('fc00::1', $state['line']);
-		$this->assertSame('', $state['ip_data']);
+		$this->assertSame('', $ip_data);
 		$this->assertTrue($state['ip_suppressed']);
 		$this->assertSame(1, $state['parse_fail']);
 		$this->assertSame([], $state['messages']);
@@ -63,11 +82,12 @@ final class IpParseLineWiringTest extends TestCase
 
 	public function testReplayReturnsDetailedFailureWithRawLineForDiagnostics(): void
 	{
+		$ip_data = '';
 		$state = pfb_ip_parse_line_replay(
 			" 999.999.999.999 \n",
 			$this->config('_v4', 'auto'),
 			9,
-			'',
+			$ip_data,
 			FALSE,
 			0
 		);

--- a/tests/php/IpParseLineWiringTest.php
+++ b/tests/php/IpParseLineWiringTest.php
@@ -43,12 +43,7 @@ final class IpParseLineWiringTest extends TestCase
 		$this->assertFalse($state['detailed_parse_fail']);
 	}
 
-	/**
-	 * #3121: the accumulator is appended IN PLACE. A by-value copy returned through the
-	 * result array leaves the caller's string with refcount > 1 during the call, so every
-	 * append copies the whole buffer and a 300k-line feed takes minutes instead of seconds.
-	 * The caller's variable is the only accumulator: the result carries no copy of it.
-	 */
+	/** #3121: the caller's variable is the only accumulator; the result carries no copy of it. */
 	public function testReplayAppendsToTheCallerAccumulatorInPlace(): void
 	{
 		$ip_data = '';

--- a/tests/php/fixtures/function_inventory.json
+++ b/tests/php/fixtures/function_inventory.json
@@ -6232,7 +6232,7 @@
             },
             {
                 "name": "ip_data",
-                "byRef": false,
+                "byRef": true,
                 "variadic": false,
                 "type": "string",
                 "default": null


### PR DESCRIPTION
Fixes #3121

## What

`pfb_ip_parse_line_replay()` took the accumulator `$ip_data` by value and handed a copy back through the result array. The caller's string stayed at refcount > 1 for the whole call, so every `.=` inside the wrapper copied the entire accumulated buffer: O(n²) over the feed. The accumulator is now taken by reference and appended in place; the `ip_data` key is gone from the result. The `function_inventory.json` golden pins the by-ref flag.

## Evidence

Live box (pfSense Plus 26.07, package `20260902132454.56eed0e`, `pfblockerng_apply.inc` byte-identical to `devel` at the time), real `qfeeds_ip_list_v4.norm` (306 755 lines), `/tmp/pfb_probe.php`:

| lines | direct `pfb_ip_parse_line` + local `.=` | replay wrapper as wired |
| --- | --- | --- |
| 50 000 | 0.29 s | 0.81 s |
| 100 000 | 0.43 s | 2.99 s |
| 200 000 | 0.57 s | 55.21 s |
| 306 755 (after fix) | 0.91 s | **0.95 s** |

Forced IP reparse through the Update page (scope=ip, force=parse) with the patched file hot-loaded on the box:

- before: `qfeeds_ip_list_v4` `17:23:46 … completed ..` → next line `17:27:08` (3 min 22 s in the parse loop)
- after: `18:22:42 … completed ..` → `18:22:43`; whole IP pass 44 s end to end; the live tail streamed continuously and ended on "Log viewer idle." — the "stream stops" report was the silent gap.

## Test-first

`tests/php/IpParseLineWiringTest.php` rewritten to the by-ref contract plus `testReplayAppendsToTheCallerAccumulatorInPlace`. Frozen at `git hash-object` `0123a8e0ada63018edba95edc49ce329ccb0e238`; red on untouched code (2 failures: caller accumulator not mutated, result still carries `ip_data`), green after the production edit with the same hash.

Local PHPUnit: 5/5 on the filter; full suite shows only the #3103 host-only `mwexec()` failures, reproduced identically on an `origin/devel` extraction.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved IP-feed parsing efficiency by reducing repeated data copying during processing.

* **User Experience**
  * Added periodic progress updates during large feed imports, displaying a dot every 50,000 lines.

* **Bug Fixes**
  * Improved accumulation of parsed IP data during feed processing to preserve results reliably.

* **Tests**
  * Added coverage for in-place data accumulation and progress update frequency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->