### PR TITLE
pfblockerng: revert the per-50k-line progress dot

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
@@ -110,7 +110,6 @@ function pfb_ip_regex_matches(string $family, string $line, array $config): arra
 
 // #3121: $ip_data is appended in place, never returned -- a by-value copy handed back
 // through the result made every append copy the whole buffer (O(n²) over the feed).
-// A progress dot every 50 000 lines keeps the live tail moving on a large feed.
 /** @return array{line_number:int,raw_line:string,line:string,ip_suppressed:bool,parse_fail:int,messages:list<string>,detailed_parse_fail:bool} */
 function pfb_ip_parse_line_replay(string $raw_line, array $config, int $line_number,
     string &$ip_data, bool $ip_suppressed, int $parse_fail): array {
@@ -118,12 +117,8 @@ function pfb_ip_parse_line_replay(string $raw_line, array $config, int $line_num
 	foreach ($parsed['entries'] as $entry) {
 		$ip_data .= $entry . "\n";
 	}
-	$line_number++;
-	if ($line_number % 50000 === 0) {
-		$parsed['messages'][] = '.';
-	}
 	return [
-		'line_number'       => $line_number,
+		'line_number'       => $line_number + 1,
 		'raw_line'          => $raw_line,
 		'line'              => $parsed['line'],
 		'ip_suppressed'     => $ip_suppressed || $parsed['suppressed'],

--- a/tests/php/IpParseLineWiringTest.php
+++ b/tests/php/IpParseLineWiringTest.php
@@ -55,26 +55,17 @@ final class IpParseLineWiringTest extends TestCase
 		$this->assertSame("192.0.2.1\n192.0.2.2\n192.0.2.3\n", $ip_data);
 	}
 
-	/** #3121: a large feed keeps the live tail moving -- one progress dot every 50 000 lines. */
-	public function testReplayEmitsAProgressDotEveryFiftyThousandLines(): void
+	/** #3123: the result's messages are the parser's own -- no synthetic progress output at any line count. */
+	public function testReplayReturnsOnlyParserMessages(): void
 	{
 		$ip_data = '';
 		$config  = $this->config('_v4', 'auto');
 
-		$before = pfb_ip_parse_line_replay("192.0.2.1\n", $config, 49998, $ip_data, FALSE, 0);
-		$this->assertSame(49999, $before['line_number']);
-		$this->assertSame([], $before['messages'], 'no dot short of the boundary');
-
-		$at = pfb_ip_parse_line_replay("192.0.2.2\n", $config, 49999, $ip_data, FALSE, 0);
-		$this->assertSame(50000, $at['line_number']);
-		$this->assertSame(['.'], $at['messages'], 'the 50 000th line emits exactly one dot');
-
-		$after = pfb_ip_parse_line_replay("192.0.2.3\n", $config, 50000, $ip_data, FALSE, 0);
-		$this->assertSame([], $after['messages'], 'no dot past the boundary');
-
-		$twice = pfb_ip_parse_line_replay("192.0.2.4\n", $config, 99999, $ip_data, FALSE, 0);
-		$this->assertSame(['.'], $twice['messages'], 'every multiple of 50 000');
-		$this->assertSame("192.0.2.1\n192.0.2.2\n192.0.2.3\n192.0.2.4\n", $ip_data);
+		foreach ([0, 49999, 99999] as $line_number) {
+			$state = pfb_ip_parse_line_replay("192.0.2.1\n", $config, $line_number, $ip_data, FALSE, 0);
+			$this->assertSame($line_number + 1, $state['line_number']);
+			$this->assertSame([], $state['messages'], "line {$state['line_number']} carries no synthetic message");
+		}
 	}
 
 	public function testReplayCarriesV6SuppressionAndExistingState(): void


### PR DESCRIPTION
Fixes #3123

Reverts the per-50 000-line progress dot added in #3122's follow-up commit; the accumulator fix stays exactly as landed (`pfblockerng_apply.inc` wrapper is byte-identical to `4853a7d4`, the pre-dot commit).

Test-first: `testReplayEmitsAProgressDotEveryFiftyThousandLines` replaced by `testReplayReturnsOnlyParserMessages`, which pins that the result's `messages` are the parser's own at lines 1, 50 000 and 100 000. Frozen at `git hash-object` `2a3fdc765095572d94399a076e7cf0e9871e2e78`: red on current `devel` ("line 50000 carries no synthetic message"), green after the revert with the same hash. `FunctionInventoryParityTest` unchanged (signature untouched).

Live: the reporting box runs the reverted file; a pass at 20:53 showed the remaining wait is the cross-list recompute after the last IPv6 feed (~20 s), outside this loop — tracked separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Replay processing no longer displays periodic progress-dot messages during large imports.
  - Line numbers continue advancing correctly while parser-generated messages remain available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->