### PR TITLE
pfblockerng: align the module fingerprint with ADR-42's md5

### DIFF
--- a/docs/misc/architecture-notes.md
+++ b/docs/misc/architecture-notes.md
@@ -515,7 +515,7 @@ live traffic on production hardware.
 
 Issue #3125 adds a package-upgrade restart signal alongside the feed passes: at init the
 python module fingerprints the staged shipped files (`pfb_unbound.py` + `pfb_dnsbl_regex_rules.py`,
-sha256 concat) into the `pfb_py_module.applied` marker, and `pfb_unbound_python('enabled')`
+md5 concat (ADR-42)) into the `pfb_py_module.applied` marker, and `pfb_unbound_python('enabled')`
 restarts the Resolver iff that marker drifts from the shipped files' fingerprint.
 
 ---

--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -646,13 +646,13 @@ PFB_MODULE_CODE_FILES = ("pfb_unbound.py", "pfb_dnsbl_regex_rules.py")
 
 
 def _module_fingerprint(paths: Sequence[str]) -> str | None:
-    """issue #3125: sha256(first) ++ sha256(second), lowercase hex, no separator -- must
+    """issue #3125: md5(first) ++ md5(second), lowercase hex, no separator -- must
     match PHP's pfb_unbound_py_module_fingerprint(). ``None`` if any file is unreadable."""
     parts = []
     for path in paths:
         try:
             with open(path, "rb") as fh:
-                parts.append(hashlib.sha256(fh.read()).hexdigest())
+                parts.append(hashlib.md5(fh.read()).hexdigest())
         except OSError:
             return None
     return "".join(parts)

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -11234,13 +11234,13 @@ function pfb_dnsbl_unlock_action($action) {
 }
 
 
-// issue #3125: mirror of python's _module_fingerprint() -- sha256 concat, pfb_unbound.py
-// first, no separator; sha256 not pfb_content_hash() because python has no xxh128.
+// issue #3125: mirror of python's _module_fingerprint() -- md5 concat, pfb_unbound.py
+// first, no separator. md5: ADR-42's Python-side algorithm, hashlib has no xxh128.
 // FALSE when any member is unreadable: nothing to compare, so no restart signal.
 function pfb_unbound_py_module_fingerprint(array $paths): string|false {
 	$fp = '';
 	foreach ($paths as $path) {
-		$digest = @hash_file('sha256', $path);
+		$digest = @md5_file($path);
 		if ($digest === FALSE) {
 			return FALSE;
 		}

--- a/tests/php/PythonModuleFingerprintTest.php
+++ b/tests/php/PythonModuleFingerprintTest.php
@@ -125,14 +125,14 @@ final class PythonModuleFingerprintTest extends TestCase
 
 	public function testFingerprintTwoFilesMatchesParityLiteral(): void
 	{
-		// H1: for file bytes "a" and "b" the digest is the cross-language constant.
+		// for file bytes "a" and "b" the digest is the cross-language constant.
 		$this->shipFiles();
 		$this->assertSame(self::PARITY_FP, pfb_unbound_py_module_fingerprint($GLOBALS['pfb']['unbound_py_module_src']));
 	}
 
 	public function testFingerprintUnreadableOrMissingPathIsFalse(): void
 	{
-		// H2: any unreadable member poisons the whole fingerprint -> FALSE, so an
+		// any unreadable member poisons the whole fingerprint -> FALSE, so an
 		// unreadable shipped file never fakes a restart signal. The missing-path
 		// shape runs under every uid; the chmod'd shape only when permissions bite.
 		$this->shipFiles();
@@ -158,7 +158,7 @@ final class PythonModuleFingerprintTest extends TestCase
 
 	public function testMarkerAbsentSignalsRestartAndLogs(): void
 	{
-		// H3: absent marker (fresh stage the running module never recorded) = drift.
+		// absent marker (fresh stage the running module never recorded) = drift.
 		$this->shipFiles();
 		$this->assertTrue(pfb_unbound_python('enabled'));
 		$log = (string) file_get_contents($GLOBALS['pfb']['log']);
@@ -167,7 +167,7 @@ final class PythonModuleFingerprintTest extends TestCase
 
 	public function testMarkerMatchingFingerprintConvergesToFalse(): void
 	{
-		// H4: call 1 writes the ini + whitelist (returns TRUE, before-state); with the
+		// call 1 writes the ini + whitelist (returns TRUE, before-state); with the
 		// marker already equal, call 2 has NOTHING left to signal -> FALSE.
 		$this->shipFiles();
 		file_put_contents($this->markerPath(), self::PARITY_FP . "\n");
@@ -177,7 +177,7 @@ final class PythonModuleFingerprintTest extends TestCase
 
 	public function testMarkerHoldingDifferentFingerprintKeepsSignaling(): void
 	{
-		// H5: a stale-but-wellformed marker (module changed since) = drift, again.
+		// a stale-but-wellformed marker (module changed since) = drift, again.
 		$this->shipFiles();
 		file_put_contents($this->markerPath(), str_repeat('f', 64) . "\n");
 		$this->assertTrue(pfb_unbound_python('enabled'));
@@ -186,7 +186,7 @@ final class PythonModuleFingerprintTest extends TestCase
 
 	public function testUnreadableShippedFileSuppressesSignal(): void
 	{
-		// H6: fingerprint FALSE = nothing to compare -> NO signal (second call FALSE),
+		// fingerprint FALSE = nothing to compare -> NO signal (second call FALSE),
 		// even though the marker is absent. False alarm beats restart, never the reverse.
 		$this->shipFiles();
 		$GLOBALS['pfb']['unbound_py_module_src'][0] = "{$this->tmp}/absent.py";
@@ -196,14 +196,14 @@ final class PythonModuleFingerprintTest extends TestCase
 
 	public function testDisabledModeNeverSignals(): void
 	{
-		// H7: the module compare lives ONLY in the enabled branch.
+		// the module compare lives ONLY in the enabled branch.
 		$this->shipFiles();
 		$this->assertFalse(pfb_unbound_python('disabled'));
 	}
 
 	public function testMarkerSurroundingWhitespaceStillMatches(): void
 	{
-		// H8: the marker is read trim()'d -- the writer's trailing newline (plus any
+		// the marker is read trim()'d -- the writer's trailing newline (plus any
 		// stray padding) must not fake a drift.
 		$this->shipFiles();
 		file_put_contents($this->markerPath(), '  ' . self::PARITY_FP . "  \n");
@@ -213,7 +213,7 @@ final class PythonModuleFingerprintTest extends TestCase
 
 	public function testMarkerJunkIsDifferentNeverCrashes(): void
 	{
-		// Hostile (brief S5): a junk marker -- 64 non-hex chars, or 10 MB of it --
+		// Hostile: a junk marker -- 64 non-hex chars, or 10 MB of it --
 		// is just "different" (restart signal); never parsed as anything else.
 		$this->shipFiles();
 		file_put_contents($this->markerPath(), str_repeat('z', 64));
@@ -225,7 +225,7 @@ final class PythonModuleFingerprintTest extends TestCase
 
 	public function testEmptiedShippedFilesStillFingerprintAsString(): void
 	{
-		// Hostile (brief S5): emptied shipped files fingerprint to the md5-of-empty
+		// Hostile: emptied shipped files fingerprint to the md5-of-empty
 		// pair -- still a string, still compares normally, no special case.
 		$this->shipFiles('', '');
 		$this->assertSame(self::EMPTY_FP, pfb_unbound_py_module_fingerprint($GLOBALS['pfb']['unbound_py_module_src']));

--- a/tests/php/PythonModuleFingerprintTest.php
+++ b/tests/php/PythonModuleFingerprintTest.php
@@ -8,7 +8,7 @@ use PHPUnit\Framework\TestCase;
  * issue #3125 -- the DNSBL module fingerprint drives a Resolver restart signal.
  *
  * pfb_unbound_py_module_fingerprint() digests the SHIPPED python module pair
- * (sha256 concat, pfb_unbound.py first, no separator); pfb_unbound_python('enabled')
+ * (md5 concat, pfb_unbound.py first, no separator); pfb_unbound_python('enabled')
  * signals a restart whenever the applied marker (pfb_py_module.applied, written by
  * the python module at init) trims to anything else -- and stays silent when the
  * marker matches. The PARITY_FP literal is pinned identically in
@@ -17,10 +17,10 @@ use PHPUnit\Framework\TestCase;
  */
 final class PythonModuleFingerprintTest extends TestCase
 {
-	private const PARITY_FP = 'ca978112ca1bbdcafac231b39a23dc4da786eff8147c4e72b9807785afee48bb'
-		. '3e23e8160039594a33894f6564e1b1348bbd7a0088d42c4acb73eeaed59c009d';
-	private const EMPTY_FP = 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
-		. 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855';
+	private const PARITY_FP = '0cc175b9c0f1b6a831c399e269772661'
+		. '92eb5ffee6ae2fec3ad71c777531578f';
+	private const EMPTY_FP = 'd41d8cd98f00b204e9800998ecf8427e'
+		. 'd41d8cd98f00b204e9800998ecf8427e';
 
 	private string $tmp;
 	private bool $hadPfb = FALSE;
@@ -179,7 +179,7 @@ final class PythonModuleFingerprintTest extends TestCase
 	{
 		// H5: a stale-but-wellformed marker (module changed since) = drift, again.
 		$this->shipFiles();
-		file_put_contents($this->markerPath(), str_repeat('f', 128) . "\n");
+		file_put_contents($this->markerPath(), str_repeat('f', 64) . "\n");
 		$this->assertTrue(pfb_unbound_python('enabled'));
 		$this->assertTrue(pfb_unbound_python('enabled'));
 	}
@@ -213,10 +213,10 @@ final class PythonModuleFingerprintTest extends TestCase
 
 	public function testMarkerJunkIsDifferentNeverCrashes(): void
 	{
-		// Hostile (brief S5): a junk marker -- 128 non-hex chars, or 10 MB of it --
+		// Hostile (brief S5): a junk marker -- 64 non-hex chars, or 10 MB of it --
 		// is just "different" (restart signal); never parsed as anything else.
 		$this->shipFiles();
-		file_put_contents($this->markerPath(), str_repeat('z', 128));
+		file_put_contents($this->markerPath(), str_repeat('z', 64));
 		$this->assertTrue(pfb_unbound_python('enabled'));
 
 		file_put_contents($this->markerPath(), str_repeat('x', 10 * 1024 * 1024));
@@ -225,7 +225,7 @@ final class PythonModuleFingerprintTest extends TestCase
 
 	public function testEmptiedShippedFilesStillFingerprintAsString(): void
 	{
-		// Hostile (brief S5): emptied shipped files fingerprint to the sha256-of-empty
+		// Hostile (brief S5): emptied shipped files fingerprint to the md5-of-empty
 		// pair -- still a string, still compares normally, no special case.
 		$this->shipFiles('', '');
 		$this->assertSame(self::EMPTY_FP, pfb_unbound_py_module_fingerprint($GLOBALS['pfb']['unbound_py_module_src']));

--- a/tests/test_module_fingerprint.py
+++ b/tests/test_module_fingerprint.py
@@ -33,7 +33,7 @@ def _write(tmp_path: Any, name: str, data: bytes) -> str:
 
 
 def test_fingerprint_two_files_is_concatenated_md5_in_order(tmp_path: Any) -> None:
-    """P1: digest is md5(first) ++ md5(second), 64 lowercase hex chars --
+    """digest is md5(first) ++ md5(second), 64 lowercase hex chars --
     and swapping the pair changes it (order is part of the contract)."""
     first = _write(tmp_path, "pfb_unbound.py", b"first")
     second = _write(tmp_path, "pfb_dnsbl_regex_rules.py", b"second")
@@ -45,7 +45,7 @@ def test_fingerprint_two_files_is_concatenated_md5_in_order(tmp_path: Any) -> No
 
 
 def test_fingerprint_missing_path_returns_none(tmp_path: Any) -> None:
-    """P2: any unreadable member poisons the whole fingerprint -> None."""
+    """any unreadable member poisons the whole fingerprint -> None."""
     present = _write(tmp_path, "pfb_unbound.py", b"x")
     missing = str(tmp_path / "absent.py")
 
@@ -54,7 +54,7 @@ def test_fingerprint_missing_path_returns_none(tmp_path: Any) -> None:
 
 
 def test_write_applied_happy_path_writes_marker_atomically(tmp_path: Any) -> None:
-    """P3: marker content is fingerprint + newline and no .tmp sidecar survives."""
+    """marker content is fingerprint + newline and no .tmp sidecar survives."""
     marker = str(tmp_path / "pfb_py_module.applied")
 
     assert P._module_write_applied(marker, PARITY_FP) is True
@@ -64,7 +64,7 @@ def test_write_applied_happy_path_writes_marker_atomically(tmp_path: Any) -> Non
 
 
 def test_write_applied_unwritable_dir_returns_false_without_raising(tmp_path: Any) -> None:
-    """P4: OSError from the temp write degrades to False -- never an exception.
+    """OSError from the temp write degrades to False -- never an exception.
 
     Permission-denied needs a non-root uid; the not-a-directory shape below is
     OSError (ENOTDIR) under EVERY uid, so the run stays meaningful as root too."""
@@ -85,7 +85,7 @@ def test_write_applied_unwritable_dir_returns_false_without_raising(tmp_path: An
 
 
 def test_fingerprint_matches_php_pinned_parity_literal(tmp_path: Any) -> None:
-    """P5: for bytes b"a", b"b" the digest equals the literal pinned in BOTH
+    """for bytes b"a", b"b" the digest equals the literal pinned in BOTH
     languages (see PythonModuleFingerprintTest.php)."""
     a = _write(tmp_path, "a", b"a")
     b = _write(tmp_path, "b", b"b")
@@ -94,7 +94,7 @@ def test_fingerprint_matches_php_pinned_parity_literal(tmp_path: Any) -> None:
 
 
 def test_fingerprint_empty_files_is_md5_of_empty_pair(tmp_path: Any) -> None:
-    """Hostile (brief S5): an emptied shipped file is still a STRING digest --
+    """Hostile: an emptied shipped file is still a STRING digest --
     the md5-of-empty pair -- so it compares normally, no special case."""
     a = _write(tmp_path, "a", b"")
     b = _write(tmp_path, "b", b"")

--- a/tests/test_module_fingerprint.py
+++ b/tests/test_module_fingerprint.py
@@ -4,7 +4,7 @@ WHY THIS FILE EXISTS
 --------------------
 PHP's ``pfb_unbound_python('enabled')`` restarts the Resolver iff the fingerprint
 marker (``pfb_py_module.applied``) disagrees with
-``sha256(pfb_unbound.py) ++ sha256(pfb_dnsbl_regex_rules.py)`` as staged in the
+``md5(pfb_unbound.py) ++ md5(pfb_dnsbl_regex_rules.py)`` as staged in the
 chroot. These two functions are the Python half of that cross-language contract:
 fixed file order (``pfb_unbound.py`` FIRST), no separator, lowercase hex; the
 marker write is atomic temp + ``os.replace`` and best-effort (``False`` on
@@ -18,15 +18,12 @@ from typing import Any
 
 import pfb_unbound as P
 
-# issue #3125: the cross-language parity constant -- sha256(b"a") ++ sha256(b"b").
+# issue #3125: the cross-language parity constant -- md5(b"a") ++ md5(b"b").
 # PythonModuleFingerprintTest.php pins the IDENTICAL literal; if either language
 # ever changes the digest recipe (order, separator, case, algorithm) one of the
 # two pins fails.
-PARITY_FP = (
-    "ca978112ca1bbdcafac231b39a23dc4da786eff8147c4e72b9807785afee48bb"
-    "3e23e8160039594a33894f6564e1b1348bbd7a0088d42c4acb73eeaed59c009d"
-)
-EMPTY_FP = hashlib.sha256(b"").hexdigest() * 2
+PARITY_FP = "0cc175b9c0f1b6a831c399e26977266192eb5ffee6ae2fec3ad71c777531578f"
+EMPTY_FP = hashlib.md5(b"").hexdigest() * 2
 
 
 def _write(tmp_path: Any, name: str, data: bytes) -> str:
@@ -35,14 +32,14 @@ def _write(tmp_path: Any, name: str, data: bytes) -> str:
     return str(path)
 
 
-def test_fingerprint_two_files_is_concatenated_sha256_in_order(tmp_path: Any) -> None:
-    """P1: digest is sha256(first) ++ sha256(second), 128 lowercase hex chars --
+def test_fingerprint_two_files_is_concatenated_md5_in_order(tmp_path: Any) -> None:
+    """P1: digest is md5(first) ++ md5(second), 64 lowercase hex chars --
     and swapping the pair changes it (order is part of the contract)."""
     first = _write(tmp_path, "pfb_unbound.py", b"first")
     second = _write(tmp_path, "pfb_dnsbl_regex_rules.py", b"second")
-    expected = hashlib.sha256(b"first").hexdigest() + hashlib.sha256(b"second").hexdigest()
+    expected = hashlib.md5(b"first").hexdigest() + hashlib.md5(b"second").hexdigest()
 
-    assert len(expected) == 128
+    assert len(expected) == 64
     assert P._module_fingerprint((first, second)) == expected
     assert P._module_fingerprint((second, first)) != expected
 
@@ -96,9 +93,9 @@ def test_fingerprint_matches_php_pinned_parity_literal(tmp_path: Any) -> None:
     assert P._module_fingerprint((a, b)) == PARITY_FP
 
 
-def test_fingerprint_empty_files_is_sha256_of_empty_pair(tmp_path: Any) -> None:
+def test_fingerprint_empty_files_is_md5_of_empty_pair(tmp_path: Any) -> None:
     """Hostile (brief S5): an emptied shipped file is still a STRING digest --
-    the sha256-of-empty pair -- so it compares normally, no special case."""
+    the md5-of-empty pair -- so it compares normally, no special case."""
     a = _write(tmp_path, "a", b"")
     b = _write(tmp_path, "b", b"")
 


### PR DESCRIPTION
Fixes #3127

Moves the #3125 DNSBL module-code fingerprint from sha256 to md5 on both sides, per ADR-42 (`legacy/ADRs/ADR_42_Hash_Based_Change_Detection/ADR.md:113`: xxh128 for PHP/shell, md5 for Python because `hashlib` has no xxhash — the same reason `pfb_dnsbl_loaded_fingerprint()` is md5). `hashlib.md5` in `_module_fingerprint()`, `md5_file()` in `pfb_unbound_py_module_fingerprint()`, marker now 64 hex chars; no new symbols, `function_inventory.json` untouched.

Test-first: parity literal in both test files becomes `md5(b"a") ++ md5(b"b")`, `EMPTY_FP` the md5-of-empty pair, fixtures 128 → 64. Red on the sha256 code (pytest `3 failed, 4 passed`; phpunit `Failures: 4`), frozen at `7d972de7…` (Python) / `5c6dc7ef…` (PHP), green after with identical hashes — re-executed by an independent verifier (gate record on the issue).

Deploy note: the first pass after this lands restarts Unbound once (md5 digest ≠ the sha256 marker), then converges as before.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected module fingerprint generation so Python and PHP implementations consistently use MD5-based file digests.
  - Updated fingerprint validation for empty and multi-file inputs.
- **Tests**
  - Updated parity checks and expected fingerprint values to reflect the corrected 64-character MD5 format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->