### PR TITLE
noopener: detect escaped quotes in PHP string HTML

### DIFF
--- a/scripts/check_noopener.py
+++ b/scripts/check_noopener.py
@@ -15,7 +15,8 @@ HEURISTIC (deliberately strict-adjacency, not an HTML parser)
 A `target … = … _blank…` occurrence (HTML ASCII case; double/single/no quotes;
 spaces/tabs around `=`; a `(?<![\\w-])` guard excludes `data-target="_blank"`)
 is a VIOLATION unless it is
-IMMEDIATELY followed — only whitespace between — by `rel=["']?noopener`.
+IMMEDIATELY followed — only whitespace between — by `rel=` then an optional
+backslash-escaped or bare quote and `noopener`.
 An unquoted `_blank/` prefix is deliberately treated as a flaggable near-miss:
 WHATWG includes the slash in the attribute value, but the likely typo must fail
 review rather than silently escape this checker.
@@ -72,7 +73,7 @@ _TARGET_BLANK_RE = re.compile(
 # `(?![\w-])` token-end guard (not `\b`) is required so `rel="noopener-evil"` -- a
 # DIFFERENT rel token that grants none of noopener's protection -- is NOT accepted
 # (a `\b` boundary treats the hyphen as a token end and would pass it).
-_REL_NOOPENER_ADJACENT_RE = re.compile(r'\s+rel=\\?(["\']?)noopener(?![\w-])')
+_REL_NOOPENER_ADJACENT_RE = re.compile(r'\s+rel=(?:\\?["\']|)noopener(?![\w-])')
 
 # Escape hatch, mirroring check_comment_narration.py's `narration-ok`.
 _ESCAPE_MARKER = "noopener-ok"

--- a/scripts/check_noopener.py
+++ b/scripts/check_noopener.py
@@ -58,8 +58,13 @@ from typing import NamedTuple
 # HTML ASCII case/whitespace only. The unquoted branch requires a value delimiter
 # or the deliberate slash near-miss and leaves it untouched for the adjacent-rel
 # matcher; quoted trailing spaces/tabs are included.
+#
+# issue #3085: the quote may be backslash-escaped -- HTML assembled inside a PHP
+# quoted string reads target=\"_blank\". Both delimiters take an optional escape,
+# and the `rel` matcher below must accept the same form or a correctly escaped
+# link would start reporting as a violation.
 _TARGET_BLANK_RE = re.compile(
-    r'(?<![\w-])(?ai:target)[ \t]*=[ \t]*(?:(?P<q>["\'])(?ai:_blank)[ \t]*(?P=q)|(?ai:_blank)(?=[ \t>/]|$))'
+    r'(?<![\w-])(?ai:target)[ \t]*=[ \t]*(?:\\?(?P<q>["\'])(?ai:_blank)[ \t]*\\?(?P=q)|(?ai:_blank)(?=[ \t>/]|$))'
 )
 
 # `rel="noopener…"` (or single-quoted / unquoted), immediately after `target=…`
@@ -67,7 +72,7 @@ _TARGET_BLANK_RE = re.compile(
 # `(?![\w-])` token-end guard (not `\b`) is required so `rel="noopener-evil"` -- a
 # DIFFERENT rel token that grants none of noopener's protection -- is NOT accepted
 # (a `\b` boundary treats the hyphen as a token end and would pass it).
-_REL_NOOPENER_ADJACENT_RE = re.compile(r'\s+rel=(["\']?)noopener(?![\w-])')
+_REL_NOOPENER_ADJACENT_RE = re.compile(r'\s+rel=\\?(["\']?)noopener(?![\w-])')
 
 # Escape hatch, mirroring check_comment_narration.py's `narration-ok`.
 _ESCAPE_MARKER = "noopener-ok"

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_geoip.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_geoip.inc
@@ -678,7 +678,7 @@ foreach (array( 'In' => 'Source', 'Out' => 'Destination') as $adv_mode => $adv_t
 		'Custom Port',
 		'text',
 		$pconfig["aliasports_{$advmode}"]
-	))->setHelp("<a target=\"_blank\" href=\"/firewall_aliases.php?tab=port\">Click Here to add/edit Aliases</a>
+	))->setHelp("<a target=\"_blank\" rel=\"noopener noreferrer\" href=\"/firewall_aliases.php?tab=port\">Click Here to add/edit Aliases</a>
 			Do not manually enter port numbers.<br />Do not use 'pfB_' in the Port Alias name."
 	)->setWidth(8);
 	$section->add($group);

--- a/src/usr/local/www/pfblockerng/pfblockerng_blacklist.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_blacklist.php
@@ -427,8 +427,8 @@ foreach ($blacklist_types as $type => $setting) {
 
 	$section->addInput(new Form_StaticText(
 		gettext('Links'),
-		"<a href=\"{$setting['WEBSITE']}\" target=\"_blank\"><i class=\"fa-solid fa-globe\"></i>&nbsp;{$setting['TITLE']} Summary</a>&emsp;"
-		. "<a href=\"{$setting['LICENSE']}\" target=\"_blank\"><i class=\"fa-solid fa-globe\"></i>&nbsp;{$setting['TITLE']} {$lic_txt}</a>"
+		"<a href=\"{$setting['WEBSITE']}\" target=\"_blank\" rel=\"noopener noreferrer\"><i class=\"fa-solid fa-globe\"></i>&nbsp;{$setting['TITLE']} Summary</a>&emsp;"
+		. "<a href=\"{$setting['LICENSE']}\" target=\"_blank\" rel=\"noopener noreferrer\"><i class=\"fa-solid fa-globe\"></i>&nbsp;{$setting['TITLE']} {$lic_txt}</a>"
 	));
 
 	// Add username/password fields if required

--- a/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
@@ -3690,7 +3690,7 @@ foreach (array( 'In' => 'Source', 'Out' => 'Destination') as $adv_mode => $adv_t
 		'Custom Port',
 		'text',
 		$pconfig["aliasports_{$advmode}"]
-	))->setHelp("<a target=\"_blank\" href=\"/firewall_aliases.php?tab=port\">Click Here to add/edit Aliases</a>
+	))->setHelp("<a target=\"_blank\" rel=\"noopener noreferrer\" href=\"/firewall_aliases.php?tab=port\">Click Here to add/edit Aliases</a>
 			Do not manually enter port numbers.<br />Do not use 'pfB_' in the Port Alias name."
 	)->setWidth(8)
 	 ->addClass('dnsbl_ip');

--- a/src/usr/local/www/pfblockerng/pfblockerng_feeds.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_feeds.php
@@ -586,13 +586,13 @@ function pfb_feeds_render_predefined_type($ftype, $info) {
 
 						// Add link to Donate/support link
 						if (isset($feed['donate'])) {
-							print ("&emsp;<a target=\"_blank\" href=\"{$feed['donate']}\" title=\"Click to donation/support page.\">
+							print ("&emsp;<a target=\"_blank\" rel=\"noopener noreferrer\" href=\"{$feed['donate']}\" title=\"Click to donation/support page.\">
 							<i class=\"fa-solid fa-cart-plus\"></i></a>");
 						}
 
 						// Add link to Feed registration
 						if ($feed['register']) {
-							print ("&emsp;<a target=\"_blank\" href=\"{$feed['register']}\" title=\"Click to register\">
+							print ("&emsp;<a target=\"_blank\" rel=\"noopener noreferrer\" href=\"{$feed['register']}\" title=\"Click to register\">
 								<i class=\"fa-solid fa-right-to-bracket\"></i></a>");
 						}
 					?>
@@ -918,7 +918,7 @@ print ($section);
 								// would render `javascript:...http...` as an executable link.
 								$url_hsc = htmlspecialchars($row['url'], ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
 								if (str_starts_with($row['url'], 'http://') || str_starts_with($row['url'], 'https://')) {
-									print ("<a target=\"_blank\" href=\"{$url_hsc}\">{$url_hsc}</a>");
+									print ("<a target=\"_blank\" rel=\"noopener noreferrer\" href=\"{$url_hsc}\">{$url_hsc}</a>");
 								} else {
 									print ("{$url_hsc}");
 								}

--- a/src/usr/local/www/widgets/widgets/pfblockerng.widget.php
+++ b/src/usr/local/www/widgets/widgets/pfblockerng.widget.php
@@ -517,7 +517,7 @@ function pfBlockerNG_get_failed() {
 			}
 
 			if ($pfb_found) {
-				$link   = "<a target=\"_blank\" href=\"/pfblockerng/pfblockerng_category_edit.php?type={$type}&act=edit&rowid={$key}\" ";
+				$link   = "<a target=\"_blank\" rel=\"noopener noreferrer\" href=\"/pfblockerng/pfblockerng_category_edit.php?type={$type}&act=edit&rowid={$key}\" ";
 				$link  .= "\"title=\"Click to view Alias\" >{$pfb_prefix}{$f_alias}</a>";
 				// Prepend, never splice into $text: the message is free-text and is not
 				// guaranteed to contain "{$pfb_prefix}{$f_alias}" verbatim -- a guaranteed
@@ -932,7 +932,7 @@ function pfBlockerNG_get_header($mode='') {
 					$d_type = ($data == 'Suppression') ? 'ip' : 'dnsbl';
 					$d_anchor = pfb_widget_anchor_layout_render($d_type)[$data === 'Suppression' ? 'suppression' : 'whitelist'];
 					print("{$tab5}<td {$tdl} title=\"{$titles[$key][$data]}\"><i class=\"{$faicon[$key][$col]}\"></i>&nbsp;&nbsp;"
-						. "<a target=\"_blank\" href=\"/pfblockerng/pfblockerng_{$d_type}.php#{$d_anchor}\" title=\"Link to {$data}\">"
+						. "<a target=\"_blank\" rel=\"noopener noreferrer\" href=\"/pfblockerng/pfblockerng_{$d_type}.php#{$d_anchor}\" title=\"Link to {$data}\">"
 						. "<small><span class=\"pfb_{$data}\">{$value}</span></small></a></td>\n");
 				}
 				else {
@@ -990,7 +990,7 @@ function pfBlockerNG_get_table($pfb_table, $mode='') {
 				// Packet column pivot to Alerts Tab
 				if ($values['packets'] > 0) {
 					$packets  = "<a href=\"/pfblockerng/pfblockerng_alerts.php?filterdnsbl={$pfb_alias}\" ";
-					$packets .= "target=\"_blank\" title=\"Click to view these packets in Alerts tab\" >{$values['packets']}</a>";
+					$packets .= "target=\"_blank\" rel=\"noopener noreferrer\" title=\"Click to view these packets in Alerts tab\" >{$values['packets']}</a>";
 				} else {
 					$packets = $values['packets'] ?: 0;
 				}
@@ -1008,7 +1008,7 @@ function pfBlockerNG_get_table($pfb_table, $mode='') {
 
 				// Packet column pivot to Alerts Tab
 				if ($values['packets'] > 0) {
-					$packets  = "<a target=\"_blank\" href=\"/pfblockerng/pfblockerng_alerts.php?filterip={$pfb_alias}\" ";
+					$packets  = "<a target=\"_blank\" rel=\"noopener noreferrer\" href=\"/pfblockerng/pfblockerng_alerts.php?filterip={$pfb_alias}\" ";
 					$packets .= "title=\"Click to view these packets in Alerts tab\" >{$values['packets']}</a>";
 				}
 				else {

--- a/tests/php/fixtures/geoip_pre_move_golden.json
+++ b/tests/php/fixtures/geoip_pre_move_golden.json
@@ -29,15 +29,15 @@
     "ZZ_v4.txt": "454debca5afcd37addd0dcca05094625dcde6402510f8fc664cd567893ec7096"
   },
   "continent_pages": {
-    "pfblockerng_Africa.php": "b15c8d777f2bb50a03e7ae14e0ffe47d8174824d353113bb05f9d5d96241e354",
-    "pfblockerng_Antarctica.php": "34a159e8d6df3cb763e1ec3eca544a7572fad6611d60bbb33b39123d9742ccea",
-    "pfblockerng_Asia.php": "3b167df2ea49435f9a9e41ea47a23cf5ac4f647df49c76ea5e0e9cc88ff66889",
-    "pfblockerng_Europe.php": "1b05fdfa9a82cdfc620141d79d6ca10e47633664a78eddb34cc82f7d19bb8594",
-    "pfblockerng_North_America.php": "7b7567a5f2f505c19001c5097170c2a000b28e0de05faa661a6e955ae70a849f",
-    "pfblockerng_Oceania.php": "0977c120be91c347e198241e5fa065f0be0c4f2a3efc68b764cdc2e0eb8146f8",
-    "pfblockerng_South_America.php": "765fc226e398169bd4f78e410e6e4781431e6eb0e5910ababfa1b2cd547fe3f2",
-    "pfblockerng_Proxy_and_Satellite.php": "6c76826113a514602e9d93f2dbf8312cba2807602170837da5839e105d3f2e57",
-    "pfblockerng_Top_Spammers.php": "1781c867e7acdf6f0f7f749286293f62a9c74acf6ddd5fb1a8d975234bb5b657"
+    "pfblockerng_Africa.php": "5c0506aa4be7308cac22555ea674e62ab4a61f8701e0bdc8dda019a60d0c4da9",
+    "pfblockerng_Antarctica.php": "eacc89adf27f50df67fcd29cb8cc0dc6d0d1e87d91241f5a3a1cb6a44824cc0f",
+    "pfblockerng_Asia.php": "2edb7f57a1fde62f244f373198f1816911c25d4176b28e58b864ddea1ed5f179",
+    "pfblockerng_Europe.php": "e5d729fe6b402ea024a2de010f90235dcd505b2532263a9114c50febb715cd0d",
+    "pfblockerng_North_America.php": "f67183803754dc167f428dbfac0e9a34440c62c0b18923a5562c9e4cdba7a4d2",
+    "pfblockerng_Oceania.php": "e38c477dcb24484675b7812f725e2722716ae967f95115902ad06c2adf3bb0e5",
+    "pfblockerng_South_America.php": "c0b9996d6960ade827784aa1d3f433860a11dea1d15bd5c65be2e1a2d965252f",
+    "pfblockerng_Proxy_and_Satellite.php": "3d5554e7d15f3b4bdd49da7cd64fde9ffcd37fe15cf9076e455718dd603dd8a6",
+    "pfblockerng_Top_Spammers.php": "a3ea116a9a213999d89e9b436907664d2d709b40aa2d10eb67fdd8602093c15c"
   },
   "reputation_empty": "db362e398b52d23dfdc8221b4dc0fb3f972d992ef7d37582c6c97ab0290b2f97",
   "reputation_populated": "ebca5913c83c5644f1bc95c07de3e8c1c0f63736dfe16c487865e63c4327b660",
@@ -45,5 +45,6 @@
   "reputation_hashes_amended": "issue #1896: the Reputation section's config_get_path/config_set_path calls now route through PfbConfig::readSection()/writeSection(); the pre-move template is otherwise unchanged",
   "continent_behavior_amended": "issue #2103: generated pages route anchor layout and MaxMind documentation rendering through behavior-tested helpers",
   "continent_copy_amended": "GUI reorg: generated country pages now name 'Force Global IP Logging' on the IP tab and point MaxMind credentials at the IP tab; the pre-move template is otherwise unchanged",
-  "reputation_markup_amended": "issue #2897: the embedded List-Action help and Reputation help in the generated pages now wrap bare-text <ul> indent wrappers in <li> children and declare overflow-wrap: anywhere on long-token fragments; the pre-move template is otherwise unchanged"
+  "reputation_markup_amended": "issue #2897: the embedded List-Action help and Reputation help in the generated pages now wrap bare-text <ul> indent wrappers in <li> children and declare overflow-wrap: anywhere on long-token fragments; the pre-move template is otherwise unchanged",
+  "continent_noopener_amended": "issue #3085: generated country pages now carry rel=noopener noreferrer on the Custom Port alias help link; the pre-move template is otherwise unchanged"
 }

--- a/tests/smoke/ui/test_render_smoke.py
+++ b/tests/smoke/ui/test_render_smoke.py
@@ -484,6 +484,16 @@ _NOOPENER_RENDER_CASES: tuple[tuple[str, str], ...] = (
     # GeoIP view (source guards it with `$gtype == 'geoip'`).
     ("/pfblockerng/pfblockerng_category.php?type=geoip", "https://www.maxmind.com"),
     ("/pfblockerng/pfblockerng_ip.php", "https://ipinfo.io"),
+    # issue #3085: escaped-quote PHP string form; target-first so the existing
+    # attribute-order assertion can match. href-first siblings (blacklist.php)
+    # stay unpinned until that assertion is order-tolerant.
+    ("/pfblockerng/pfblockerng_dnsbl.php", "/firewall_aliases.php?tab=port"),
+    ("/pfblockerng/pfblockerng_feeds.php", "https://botscout.com/donate.htm"),
+    ("/pfblockerng/pfblockerng_feeds.php", "https://pulsedive.com/premium/purchase.php"),
+    (
+        "/pfblockerng/pfblockerng_feeds.php",
+        "mailto:sales@bambenekconsulting.com?Subject=Access%20Request%20(pfBlockerNG)",
+    ),
 )
 
 

--- a/tests/test_noopener_check.py
+++ b/tests/test_noopener_check.py
@@ -291,6 +291,34 @@ def test_main_returns_0_on_clean_file(tmp_path: Path, capsys: pytest.CaptureFixt
     assert capsys.readouterr().err == ""
 
 
+def test_escaped_quote_target_blank_is_a_violation() -> None:
+    # issue #3085: HTML assembled inside a PHP double-quoted string reads
+    # target=\"_blank\". Bare-quote matching misses that form.
+    line = r'print ("<a target=\"_blank\" href=\"{$feed[\'donate\']}\">x</a>");'
+    violations = cno.find_violations(line, "feeds.php")
+    assert len(violations) == 1
+    assert violations[0].line == 1
+
+
+def test_escaped_quote_target_blank_with_adjacent_rel_is_clean() -> None:
+    # Paired clean form: a correctly escaped rel= must still count as adjacent.
+    line = r'print ("<a target=\"_blank\" rel=\"noopener noreferrer\" href=\"x\">y</a>");'
+    assert cno.find_violations(line, "feeds.php") == []
+
+
+def test_escaped_single_quote_target_blank_is_a_violation() -> None:
+    # Single-quoted sibling, escaped inside a PHP single-quoted string.
+    line = r"echo '<a target=\'_blank\' href=\'x\'>y</a>';"
+    assert len(cno.find_violations(line, "p.inc")) == 1
+
+
+def test_escaped_quote_rel_noopener_evil_is_still_rejected() -> None:
+    # Token-end guard must survive escaping: rel=\"noopener-evil\" grants none
+    # of noopener's protection.
+    line = r"<a target=\"_blank\" rel=\"noopener-evil\" href=\"x\">y</a>"
+    assert len(cno.find_violations(line, "p.inc")) == 1
+
+
 def test_default_scan_set_covers_both_ui_trees(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:

--- a/tests/test_noopener_check.py
+++ b/tests/test_noopener_check.py
@@ -312,10 +312,22 @@ def test_escaped_single_quote_target_blank_is_a_violation() -> None:
     assert len(cno.find_violations(line, "p.inc")) == 1
 
 
+def test_escaped_single_quote_target_blank_with_adjacent_rel_is_clean() -> None:
+    line = r"echo '<a target=\'_blank\' rel=\'noopener noreferrer\' href=\'x\'>y</a>';"
+    assert cno.find_violations(line, "p.inc") == []
+
+
 def test_escaped_quote_rel_noopener_evil_is_still_rejected() -> None:
     # Token-end guard must survive escaping: rel=\"noopener-evil\" grants none
     # of noopener's protection.
     line = r"<a target=\"_blank\" rel=\"noopener-evil\" href=\"x\">y</a>"
+    assert len(cno.find_violations(line, "p.inc")) == 1
+
+
+def test_backslash_without_quote_is_not_an_escaped_rel() -> None:
+    # Optional backslash on rel= is only the PHP-string quote escape. A lone
+    # `rel=\noopener` is not adjacent noopener.
+    line = r'<a target=_blank rel=\noopener href="x">'
     assert len(cno.find_violations(line, "p.inc")) == 1
 
 


### PR DESCRIPTION
Fixes #3085

`scripts/check_noopener.py` matched `target="_blank"` only with bare quotes. HTML assembled inside a PHP double-quoted string is `target=\"_blank\"`, so those links were invisible to the gate whether or not they carried `rel="noopener noreferrer"`.

Five of the live misses are external destinations (donate/register/feed URL, provider WEBSITE/LICENSE). Current browsers imply `noopener` for `target="_blank"`, so practical exploitability is low; the gate reporting those files clean is what was unambiguously broken.

## What changed

- Both quote delimiters in `_TARGET_BLANK_RE` take an optional backslash. `_REL_NOOPENER_ADJACENT_RE` accepts an optional backslash *with a quote* (`rel=\"noopener` / `rel="noopener` / unquoted `rel=noopener`); a lone `rel=\noopener` is not adjacent noopener.
- The eleven live sites the widened detector surfaces now carry `rel=\"noopener noreferrer\"` next to `target`, matching the escaped style.
- Unit rows per quoting form, plus four target-first Tier A render cases (dnsbl alias help, Botscout donate, Pulsedive register, Bambenek mailto). href-first siblings (blacklist.php) stay unpinned until that assertion is order-tolerant — pinning them would fail on a correct link.
- GeoIP continent-page golden hashes retargeted: those generated pages embed the Custom Port help from `pfblockerng_geoip.inc`.

Detector change and site fixes land together: widening detection alone turns `test_ui_trees_clean` red.

PR #3084 already widened the scan set into `pkg`, so `pfblockerng_geoip.inc` is in this patch rather than a follow-up.

## Test-first proof

Executed. Four new `find_violations()` cases, red before the detector change and green after. Round-1 review added the escaped-single clean twin and a `rel=\noopener` hole row (`ff882622`).

```
before the detector fix:  3 failed, 146 passed
after the detector fix:   149 passed
argless gate:             rc=0
php -l:                   clean on all five touched files
rel=\noopener hole:       1 failed, then 151 passed
GeoIP golden:             testPackageBytesMatchPreMoveGolden RED on continent_pages, then GREEN
```

| Frozen RED test | `git hash-object` | RED run tail |
| --- | --- | --- |
| `tests/test_noopener_check.py` | `a217f78da9ae596bebd3251aa4ab016bb54d8f9d` | `3 failed, 146 passed` then `FAILED test_backslash_without_quote_is_not_an_escaped_rel` |
| `tests/smoke/ui/test_render_smoke.py` | `e17d53f1b5e3adb15c6db6a76526bc92dc2828a0` | `FAILED test_pfblockerng_new_tab_link_renders_with_noopener_rel[/pfblockerng/pfblockerng_dnsbl.php-/firewall_aliases.php?tab=port]` (blob retargeted after rebase onto #3132, which also edited this file) |
| `tests/php/fixtures/geoip_pre_move_golden.json` | `edcde284233e9db39d9501fab10af9ef4198c005` | `GeoipPreMoveGoldenOracleTest::testPackageBytesMatchPreMoveGolden Failed asserting that two arrays are identical` |

## Live tiers (smoke host)

Ref `ff882622` (render proof; golden refresh is `ffeb7143`):

- `pfb-test unit` — PASSED — `/srv/Smoke/results/20260903T003853Z-unit`
- `pfb-test gates --diff origin/devel` — PASSED in 0s — `/srv/Smoke/results/20260903T004203Z-gates` (smoke checkout had no PR diff; GitHub CI is the gates run for this head)
- `pfb-test ui-render --ref ff882622 --filter test_pfblockerng_new_tab_link_renders_with_noopener_rel` — PASSED — `/srv/Smoke/results/20260903T004223Z-ui-render`
- `pfb-test smoke --ref ff882622 --filter test_pfblockerng_new_tab_link_renders_with_noopener_rel` — FAILED rc=5 — `/srv/Smoke/results/20260903T004436Z-smoke` (that filter is a `ui_render` test, not a smoke-marker test; empty collection)

## Not in this PR

Making `test_pfblockerng_new_tab_link_renders_with_noopener_rel` order-tolerant so href-first anchors can be pinned. That is a test defect that outlives this issue (166 target-first vs 20 href-first among rel-bearing anchors on the six pages).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Improvements**
  * External links that open in new tabs now use safer `noopener noreferrer` attributes across pfBlockerNG pages, widgets, feeds, blacklist providers, and GeoIP help links.
  * Link validation now correctly recognizes compliant links embedded in escaped PHP strings.

* **Tests**
  * Added coverage for escaped-quote link patterns and additional rendered links to help prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->