### PR TITLE
tests: skip five chmod-denial ShellSpec rows under uid 0

### DIFF
--- a/tests/shell/pfblockerng_processet_exit_spec.sh
+++ b/tests/shell/pfblockerng_processet_exit_spec.sh
@@ -116,6 +116,7 @@ RUNNER
 		Before 'plant_readonly_scratch'
 
 		It 'fails and keeps the live match publication byte-unchanged'
+			Skip if 'root bypasses directory permissions' [ "$(id -u)" -eq 0 ]
 			When run sh "${runner}"
 			The status should be failure
 			The output should include 'cannot create ET scratch file'
@@ -148,6 +149,7 @@ RUNNER
 		Before 'plant_readonly_etdir'
 
 		It 'fails and leaves both the feed and the live match publication untouched'
+			Skip if 'root bypasses directory permissions' [ "$(id -u)" -eq 0 ]
 			When run sh "${runner}"
 			The status should be failure
 			The output should include 'ET processing failed'
@@ -204,6 +206,7 @@ RUNNER
 		Before 'plant_readonly_origdir'
 
 		It 'fails and keeps the live match publication byte-unchanged'
+			Skip if 'root bypasses directory permissions' [ "$(id -u)" -eq 0 ]
 			When run sh "${runner}"
 			The status should be failure
 			The output should include 'ET processing failed'
@@ -222,6 +225,7 @@ RUNNER
 		Before 'plant_readonly_matchdir'
 
 		It 'fails and keeps the live match publication byte-unchanged'
+			Skip if 'root bypasses directory permissions' [ "$(id -u)" -eq 0 ]
 			When run sh "${runner}"
 			The status should be failure
 			The output should include 'ET processing failed'

--- a/tests/shell/precommit_identity_spec.sh
+++ b/tests/shell/precommit_identity_spec.sh
@@ -238,6 +238,7 @@ Describe '.githooks/check-commit-identity.sh + pre-commit wiring (issue #2982)'
   End
 
   It 'rejects an unreadable SSH signing key path'
+    Skip if 'root bypasses file permissions' [ "$(id -u)" -eq 0 ]
     true > "$repo/locked.pub"
     chmod 000 "$repo/locked.pub"
     gitc config user.signingkey "$repo/locked.pub"

--- a/tests/skip-allowlist.txt
+++ b/tests/skip-allowlist.txt
@@ -54,6 +54,13 @@ phpunit:DownloadGeoipStagePublishTest::testExtractionThatFailsPartWayLeavesTheSe
 
 # ShellSpec -- macOS/BSD host lacks the GNU stat/date/touch branch exercised in Linux CI.
 shellspec:tests/shell/pfblockerng_adr26_locale_spec.sh::ADR-26 — pfb_list_orig_by_mtime() diagnostic listing (Phase 3) lists *.orig oldest-first as "<YYYY-MM-DD> <HH:MM><TAB><name>" (ISO date, path + .orig stripped)  # GNU-only off-box branch; BSD branch is covered live by ADR-04 smoke
+# ShellSpec -- uid 0 bypasses chmod denial (issue #3116). CI is unprivileged, so these
+# skip only on a root-owned host; an unobserved allowlisted id is informational.
+shellspec:tests/shell/pfblockerng_processet_exit_spec.sh::processet() exit contract (issue #2683) when the ET scratch files cannot be created fails and keeps the live match publication byte-unchanged  # root bypasses directory permissions — denial cannot be simulated
+shellspec:tests/shell/pfblockerng_processet_exit_spec.sh::processet() exit contract (issue #2683) when a category split cannot be written fails and leaves both the feed and the live match publication untouched  # root bypasses directory permissions — denial cannot be simulated
+shellspec:tests/shell/pfblockerng_processet_exit_spec.sh::processet() exit contract (issue #2683) when the block publication cannot be moved into place fails and keeps the live match publication byte-unchanged  # root bypasses directory permissions — denial cannot be simulated
+shellspec:tests/shell/pfblockerng_processet_exit_spec.sh::processet() exit contract (issue #2683) when the match publication cannot be moved into place fails and keeps the live match publication byte-unchanged  # root bypasses directory permissions — denial cannot be simulated
+shellspec:tests/shell/precommit_identity_spec.sh::.githooks/check-commit-identity.sh + pre-commit wiring (issue #2982) rejects an unreadable SSH signing key path  # root bypasses file permissions — denial cannot be simulated
 
 # pytest -- 4 observed on the Linux CI runner.
 pytest:tests.test_build_pkg_origins::test_print_build_origins_includes_expected_dirs  # FreeBSD-ports checkout not present on the runner

--- a/tests/skip-allowlist.txt
+++ b/tests/skip-allowlist.txt
@@ -54,8 +54,7 @@ phpunit:DownloadGeoipStagePublishTest::testExtractionThatFailsPartWayLeavesTheSe
 
 # ShellSpec -- macOS/BSD host lacks the GNU stat/date/touch branch exercised in Linux CI.
 shellspec:tests/shell/pfblockerng_adr26_locale_spec.sh::ADR-26 — pfb_list_orig_by_mtime() diagnostic listing (Phase 3) lists *.orig oldest-first as "<YYYY-MM-DD> <HH:MM><TAB><name>" (ISO date, path + .orig stripped)  # GNU-only off-box branch; BSD branch is covered live by ADR-04 smoke
-# ShellSpec -- uid 0 bypasses chmod denial (issue #3116). CI is unprivileged, so these
-# skip only on a root-owned host; an unobserved allowlisted id is informational.
+# ShellSpec -- uid 0 bypasses chmod denial (issue #3116).
 shellspec:tests/shell/pfblockerng_processet_exit_spec.sh::processet() exit contract (issue #2683) when the ET scratch files cannot be created fails and keeps the live match publication byte-unchanged  # root bypasses directory permissions — denial cannot be simulated
 shellspec:tests/shell/pfblockerng_processet_exit_spec.sh::processet() exit contract (issue #2683) when a category split cannot be written fails and leaves both the feed and the live match publication untouched  # root bypasses directory permissions — denial cannot be simulated
 shellspec:tests/shell/pfblockerng_processet_exit_spec.sh::processet() exit contract (issue #2683) when the block publication cannot be moved into place fails and keeps the live match publication byte-unchanged  # root bypasses directory permissions — denial cannot be simulated


### PR DESCRIPTION
Fixes #3116

Five ShellSpec examples simulate permission denial with `chmod 555`/`chmod 000` and had no root-uid guard, so they are permanently red on a uid-0 host. CI is unprivileged and stays green. Same class as the #3052 sidecar row.

## What changed

Each of the five examples now starts with the existing skip shape (`Skip if 'root bypasses … permissions' [ "$(id -u)" -eq 0 ]`). The four processet rows chmod a directory; the identity-key row chmods a file. The resulting skip ids are recorded in `tests/skip-allowlist.txt` (unobserved allowlisted ids are informational).

Non-root behaviour is unchanged: the examples still run. Root skips instead of publishing through the denial.

## Test-first proof

The RED is the issue's root-uid ShellSpec run (5 failures). This host is uid 1001, so that red cannot be re-executed here. `tests/test_check_skip_allowlist.py` stays green (57 passed) and the new allowlist entries parse.

| Frozen RED test | `git hash-object` | RED run tail |
| --- | --- | --- |
| `tests/shell/pfblockerng_processet_exit_spec.sh` | `b4c6d130e7e6acd162554607bc100c5bfb3d5953` | root `shellspec`: 4 processet chmod-denial examples FAILED (issue #3116 evidence) |
| `tests/shell/precommit_identity_spec.sh` | `586f84727cee4cd42eaf900f752f18cf4ca7358e` | root `shellspec`: unreadable SSH signing key path FAILED |
| `tests/skip-allowlist.txt` | `4a802b71f7395e58fd063e984b9062414cfd8c49` | skip-id allowlist for the five new Skip if rows |

## Not asking the review bot yet

Adversarial legs first. The Fair Usage slot is in use nearby (PR #3129 / sibling PRs ~hourly). This PR will ask only after legs and CI are green, and only when that window is free.