### PR TITLE
tests: accept Node 24 and Node 26 JUnit skip classnames

### DIFF
--- a/tests/fixtures/skip-allowlist-node26-canary.xml
+++ b/tests/fixtures/skip-allowlist-node26-canary.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<testsuites>
+<testsuite name="nested # suite :: punctuation!" time="0.000000" disabled="0" errors="0" tests="1" failures="0" skipped="1" hostname="canary">
+<testcase name="skips # hash, punctuation: a::b!" time="0.000000" classname="nested # suite :: punctuation!">
+<skipped type="skipped" message="environment reason #42"/>
+</testcase>
+</testsuite>
+</testsuites>

--- a/tests/test_issue2369_skip_gate_coverage_hostile.py
+++ b/tests/test_issue2369_skip_gate_coverage_hostile.py
@@ -105,8 +105,37 @@ def test_native_node_canary_report_is_rejected_with_exact_skip_semantics(
         ]
     )
     assert rc == 1
+    err = capsys.readouterr().err
+    # issue #3117: Node 24's JUnit reporter uses classname="test"; Node 26 uses
+    # the enclosing describe name. The gate still rejects the skip; only the
+    # classname half of the id changes. Accept both so a host newer than CI's
+    # pin is not a false red.
+    node24 = "widget-js:test::skips # hash, punctuation: a::b!  reason: environment reason #42"
+    node26 = (
+        "widget-js:nested # suite :: punctuation!::skips # hash, punctuation: a::b!  reason: environment reason #42"
+    )
+    assert node24 in err or node26 in err, err
+
+
+def test_node26_junit_classname_canary_is_rejected_with_exact_skip_semantics(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    # Static Node-26 reporter shape so a CI pin bump to 26 cannot silently
+    # change every Node skip id without this row going red first.
+    root = Path(__file__).resolve().parents[1]
+    report = root / "tests/fixtures/skip-allowlist-node26-canary.xml"
+    rc = _checker.main(
+        [
+            "--suite",
+            "widget-js",
+            "--allowlist",
+            str(root / "tests/skip-allowlist.txt"),
+            str(report),
+        ]
+    )
+    assert rc == 1
     assert (
-        "widget-js:test::skips # hash, punctuation: a::b!  reason: environment reason #42"
+        "widget-js:nested # suite :: punctuation!::skips # hash, punctuation: a::b!  reason: environment reason #42"
     ) in capsys.readouterr().err
 
 

--- a/tests/test_issue2369_skip_gate_coverage_hostile.py
+++ b/tests/test_issue2369_skip_gate_coverage_hostile.py
@@ -15,6 +15,11 @@ _checker = _HELPERS["checker"]
 _checker_report = _HELPERS["_checker_report"]
 _shell_commands = _HELPERS["_shell_commands"]
 
+# issue #3117: Node 26 JUnit classname is the describe name, not "test".
+_NODE26_SKIP = (
+    "widget-js:nested # suite :: punctuation!::skips # hash, punctuation: a::b!  reason: environment reason #42"
+)
+
 
 def _mutate_widget_step(extra_command: str) -> dict[str, str]:
     texts = _workflow_texts()
@@ -106,22 +111,14 @@ def test_native_node_canary_report_is_rejected_with_exact_skip_semantics(
     )
     assert rc == 1
     err = capsys.readouterr().err
-    # issue #3117: Node 24's JUnit reporter uses classname="test"; Node 26 uses
-    # the enclosing describe name. The gate still rejects the skip; only the
-    # classname half of the id changes. Accept both so a host newer than CI's
-    # pin is not a false red.
+    # issue #3117: Node 24 classname is "test"; Node 26 uses the describe name.
     node24 = "widget-js:test::skips # hash, punctuation: a::b!  reason: environment reason #42"
-    node26 = (
-        "widget-js:nested # suite :: punctuation!::skips # hash, punctuation: a::b!  reason: environment reason #42"
-    )
-    assert node24 in err or node26 in err, err
+    assert node24 in err or _NODE26_SKIP in err, err
 
 
 def test_node26_junit_classname_canary_is_rejected_with_exact_skip_semantics(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    # Static Node-26 reporter shape so a CI pin bump to 26 cannot silently
-    # change every Node skip id without this row going red first.
     root = Path(__file__).resolve().parents[1]
     report = root / "tests/fixtures/skip-allowlist-node26-canary.xml"
     rc = _checker.main(
@@ -134,9 +131,7 @@ def test_node26_junit_classname_canary_is_rejected_with_exact_skip_semantics(
         ]
     )
     assert rc == 1
-    assert (
-        "widget-js:nested # suite :: punctuation!::skips # hash, punctuation: a::b!  reason: environment reason #42"
-    ) in capsys.readouterr().err
+    assert _NODE26_SKIP in capsys.readouterr().err
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fixes #3117

`test_native_node_canary_report_is_rejected_with_exact_skip_semantics` pinned Node 24's JUnit `classname="test"`. Node 26 emits the enclosing `describe` name instead, so the assertion fails on any host newer than CI's 24.19.0 pin. The skip *gate* still exits 1; only the classname half of the id changes.

## What changed

- The live Node canary accepts either skip id (Node 24 `widget-js:test::…` or Node 26 `widget-js:nested # suite :: punctuation!::…`).
- A static Node-26 JUnit fixture is checked on every host so a CI pin bump to 26 cannot silently rewrite Node skip ids without that row going red first.

The checker is unchanged. No `src/` change.

## Test-first proof

Issue RED on Node v26.8.1: the live canary asserted the Node-24 id and failed. This host is Node v20.19.2 (`classname="test"`), so that red cannot be re-run here. After the change: `22 passed` in `tests/test_issue2369_skip_gate_coverage_hostile.py`.

| Frozen RED test | `git hash-object` | RED run tail |
| --- | --- | --- |
| `tests/test_issue2369_skip_gate_coverage_hostile.py` | `c5cc34c8f45eebd312a0801f61a4c2871a180630` | Node 26: `AssertionError: assert 'widget-js:test::skips …' in '…widget-js:nested # suite :: punctuation!::skips …'` |
| `tests/fixtures/skip-allowlist-node26-canary.xml` | `9f8c0b718122a4c01a6bcfec358c5d0a5cc983a9` | static Node-26 reporter shape (new file) |

## Not asking the review bot yet

Adversarial legs first. Fair Usage is ~hourly on this account; do not collide with #3129 / #3130.