### PR TITLE
pfblockerng: hide the DNSBL TOP1M API Token field for keyless types

### DIFF
--- a/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
@@ -3890,10 +3890,9 @@ var pfb_top1m_token_providers = <?=$pfb_top1m_token_providers_json?>;
 
 function enable_top1m_token() {
 	var pfb_top1m_no_token = pfb_top1m_token_providers.indexOf($('#top1m_source').val()) === -1;
-	// ADR-59: the field renders blank on every GET, so a value here was typed this load.
-	// A hidden input is still submitted, and the save path writes any non-empty
-	// top1m_token -- so it must be cleared, or switching away from a token provider
-	// overwrites the stored token and invalidates the TOP1M baseline.
+	// ADR-59: the field renders blank on every GET, so a value here was typed this
+	// load. A hidden input is still submitted and the save path writes any non-empty
+	// top1m_token, so it must be cleared before hiding.
 	if (pfb_top1m_no_token) {
 		$('#top1m_token').val('');
 	}

--- a/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
@@ -3889,7 +3889,15 @@ function enable_idn_mode() {
 var pfb_top1m_token_providers = <?=$pfb_top1m_token_providers_json?>;
 
 function enable_top1m_token() {
-	disableInput('top1m_token', pfb_top1m_token_providers.indexOf($('#top1m_source').val()) === -1);
+	var pfb_top1m_no_token = pfb_top1m_token_providers.indexOf($('#top1m_source').val()) === -1;
+	// ADR-59: the field renders blank on every GET, so a value here was typed this load.
+	// A hidden input is still submitted, and the save path writes any non-empty
+	// top1m_token -- so it must be cleared, or switching away from a token provider
+	// overwrites the stored token and invalidates the TOP1M baseline.
+	if (pfb_top1m_no_token) {
+		$('#top1m_token').val('');
+	}
+	hideInput('top1m_token', pfb_top1m_no_token);
 }
 
 function enable_python_regex() {
@@ -3981,7 +3989,7 @@ events.push(function(){
 
 	var pfb_gated_ids = [
 		'pfb_psl_include_private', 'pfb_dnsport', 'pfb_dnsport_ssl',
-		'pfb_psl_allow_private', 'top1m_token', 'aliaslog'
+		'pfb_psl_allow_private', 'aliaslog'
 	];
 	$('form').submit(function() {
 		$.each(pfb_gated_ids, function(_, id) {

--- a/tests/php/GateDisableUiTest.php
+++ b/tests/php/GateDisableUiTest.php
@@ -6,6 +6,8 @@ use PHPUnit\Framework\TestCase;
 
 /**
  * Per-control gating: some single-row companions disable, others hide.
+ * A control that is temporarily unavailable greys out; one that does not APPLY
+ * to the current selection hides (issue #3060's top1m_token).
  * Whole sections still hide. Disabled controls re-enable on submit so POST
  * keeps the stored value (a disabled input is omitted from the form).
  */
@@ -37,7 +39,6 @@ final class GateDisableUiTest extends TestCase
 			'pfb_dnsport',
 			'pfb_dnsport_ssl',
 			'pfb_psl_allow_private',
-			'top1m_token',
 			'aliaslog',
 		] as $id) {
 			$this->assertStringContainsString("disableInput('{$id}'", $dnsbl, "{$id} must stay visible when inert");
@@ -52,6 +53,14 @@ final class GateDisableUiTest extends TestCase
 			$this->assertStringContainsString("hideCheckbox('{$id}'", $dnsbl, "{$id} hides while its parent is off");
 			$this->assertStringNotContainsString("disableInput('{$id}'", $dnsbl);
 		}
+
+		// issue #3060: the Cloudflare Radar API Token is not APPLICABLE for a keyless
+		// TOP1M type rather than temporarily unavailable, so it hides like the IP page's
+		// delta-batch input below instead of greying out. It is the one gated control on
+		// this page that moved out of the disable group, so it is pinned by name.
+		$this->assertStringContainsString("hideInput('top1m_token'", $dnsbl, 'top1m_token hides for a keyless TOP1M type');
+		$this->assertStringNotContainsString("disableInput('top1m_token'", $dnsbl, 'top1m_token must not grey out');
+		$this->assertStringNotContainsString("hideCheckbox('top1m_token'", $dnsbl, 'top1m_token is an input, not a checkbox row');
 
 		$ip = self::ip();
 		$this->assertStringContainsString("hideInput('pfb_alias_delta_batch'", $ip);

--- a/tests/smoke/ui/test_browser_dnsbl.py
+++ b/tests/smoke/ui/test_browser_dnsbl.py
@@ -1038,12 +1038,6 @@ def test_exception_fields_have_alias_autocomplete(
         )
 
 
-# A token string carrying the shapes a hostile paste would use -- an apostrophe, a double
-# quote, a shell/JS-interpolation sigil and enough length to rule out a truncating clear --
-# so the ``.val('')`` clear is proven against more than a tidy alphanumeric literal.
-_TYPED_TOKEN = "pfb'\"${IFS}<token>" + "z" * 256
-
-
 def test_top1m_token_hidden_and_cleared_for_keyless_providers(
     browser_page: Page,
     webui: WebUI,
@@ -1056,14 +1050,10 @@ def test_top1m_token_hidden_and_cleared_for_keyless_providers(
     type (Tranco) is keyless. ``cloudflare`` is the only provider whose ``auth``
     descriptor is non-``none`` (``pfblockerng_extra.inc``'s ``pfb_top1m_providers()``).
 
-    The clear is part of the contract, not decoration. A hidden input still POSTs,
-    and so does a disabled one on this page -- the submit handler re-enables every
-    id in ``pfb_gated_ids`` before submit -- while ``pfblockerng_dnsbl.php``'s save
-    path writes any NON-EMPTY ``top1m_token`` to config. So without the clear,
-    typing a token and then switching to a keyless provider overwrites the stored
-    token and flips the token half of ``$pfb_top1m_identity_changed``, invalidating
-    the TOP1M baseline. ADR-59 keeps the field blank on GET, so a value can only
-    have been typed this page load.
+    The clear is part of the contract, not decoration: ``hideInput()`` hides without
+    clearing, a hidden input is still submitted, and the save path writes any
+    non-empty ``top1m_token`` to config. ADR-59 keeps the field blank on GET, so a
+    value can only have been typed this page load.
 
     The TOP1M section is ``COLLAPSIBLE|SEC_CLOSED``, so it is expanded first --
     otherwise the field is already invisible and ``to_be_hidden()`` would pass for
@@ -1084,9 +1074,11 @@ def test_top1m_token_hidden_and_cleared_for_keyless_providers(
     expect(token).to_be_visible(timeout=JS_TIMEOUT_MS)
     _shot(page, screenshot_dir, "dnsbl_top1m_token_visible_cloudflare")
 
-    # A value typed while the field applied ...
-    token.fill(_TYPED_TOKEN)
-    expect(token).to_have_value(_TYPED_TOKEN, timeout=JS_TIMEOUT_MS)
+    # A value typed while the field applied -- an apostrophe, a double quote, an
+    # interpolation sigil and enough length to rule out a truncating clear.
+    typed = "pfb'\"${IFS}<token>" + "z" * 256
+    token.fill(typed)
+    expect(token).to_have_value(typed, timeout=JS_TIMEOUT_MS)
 
     # ... must be hidden AND cleared on the switch to a keyless provider.
     source.select_option("tranco")

--- a/tests/smoke/ui/test_browser_dnsbl.py
+++ b/tests/smoke/ui/test_browser_dnsbl.py
@@ -1036,3 +1036,67 @@ def test_exception_fields_have_alias_autocomplete(
             "write_config('pfBlockerNG smoke: PR660 autocomplete cleanup');\n"
             "echo 'OK';",
         )
+
+
+# A token string carrying the shapes a hostile paste would use -- an apostrophe, a double
+# quote, a shell/JS-interpolation sigil and enough length to rule out a truncating clear --
+# so the ``.val('')`` clear is proven against more than a tidy alphanumeric literal.
+_TYPED_TOKEN = "pfb'\"${IFS}<token>" + "z" * 256
+
+
+def test_top1m_token_hidden_and_cleared_for_keyless_providers(
+    browser_page: Page,
+    webui: WebUI,
+    screenshot_dir: Path,
+) -> None:
+    """``enable_top1m_token()`` HIDES the API Token field for keyless TOP1M types.
+
+    issue #3060: the handler used ``disableInput()``, which greys the field but
+    leaves it permanently visible -- dead UI on every install, since the default
+    type (Tranco) is keyless. ``cloudflare`` is the only provider whose ``auth``
+    descriptor is non-``none`` (``pfblockerng_extra.inc``'s ``pfb_top1m_providers()``).
+
+    The clear is part of the contract, not decoration. A hidden input still POSTs,
+    and so does a disabled one on this page -- the submit handler re-enables every
+    id in ``pfb_gated_ids`` before submit -- while ``pfblockerng_dnsbl.php``'s save
+    path writes any NON-EMPTY ``top1m_token`` to config. So without the clear,
+    typing a token and then switching to a keyless provider overwrites the stored
+    token and flips the token half of ``$pfb_top1m_identity_changed``, invalidating
+    the TOP1M baseline. ADR-59 keeps the field blank on GET, so a value can only
+    have been typed this page load.
+
+    The TOP1M section is ``COLLAPSIBLE|SEC_CLOSED``, so it is expanded first --
+    otherwise the field is already invisible and ``to_be_hidden()`` would pass for
+    the wrong reason. Before-state asserted, then both directions.
+    """
+    page = browser_page
+    _open(page, webui, DNSBL_PAGE)
+    _expand_section(page, "TOP1M_Whitelist")
+
+    source = page.locator("#top1m_source")
+    token = page.locator("#top1m_token")
+    expect(source).to_be_attached(timeout=JS_TIMEOUT_MS)
+    expect(token).to_be_attached(timeout=JS_TIMEOUT_MS)
+
+    # BEFORE: the one keyed provider shows the field.
+    source.select_option("cloudflare")
+    page.evaluate("$('#top1m_source').trigger('change')")
+    expect(token).to_be_visible(timeout=JS_TIMEOUT_MS)
+    _shot(page, screenshot_dir, "dnsbl_top1m_token_visible_cloudflare")
+
+    # A value typed while the field applied ...
+    token.fill(_TYPED_TOKEN)
+    expect(token).to_have_value(_TYPED_TOKEN, timeout=JS_TIMEOUT_MS)
+
+    # ... must be hidden AND cleared on the switch to a keyless provider.
+    source.select_option("tranco")
+    page.evaluate("$('#top1m_source').trigger('change')")
+    expect(token).to_be_hidden(timeout=JS_TIMEOUT_MS)
+    expect(token).to_have_value("", timeout=JS_TIMEOUT_MS)
+    _shot(page, screenshot_dir, "dnsbl_top1m_token_hidden_tranco")
+
+    # Both directions: back to the keyed provider re-shows it, still blank.
+    source.select_option("cloudflare")
+    page.evaluate("$('#top1m_source').trigger('change')")
+    expect(token).to_be_visible(timeout=JS_TIMEOUT_MS)
+    expect(token).to_have_value("", timeout=JS_TIMEOUT_MS)

--- a/tests/smoke/ui/test_render_smoke.py
+++ b/tests/smoke/ui/test_render_smoke.py
@@ -1461,6 +1461,11 @@ def test_dnsbl_top1m_source_options_exclude_alexa(webui: WebUI, php_error_log_gu
     labels, both attribution notes, and the masked token field are present, while
     the removed 'Alexa TOP1M' label and its ``value="alexa"`` option are absent
     from the body.
+
+    Also pins how the emitted JS gates that token field (issue #3060): it must
+    ``hideInput()`` it for a keyless TOP1M type rather than ``disableInput()`` it,
+    and with nothing left disabling the field its ``pfb_gated_ids`` entry -- the
+    submit handler's re-enable list -- must be gone with it.
     """
     path = "/pfblockerng/pfblockerng_dnsbl.php"
     resp = webui.get(path)
@@ -1487,6 +1492,38 @@ def test_dnsbl_top1m_source_options_exclude_alexa(webui: WebUI, php_error_log_gu
     assert "(CC BY-NC) 4.0" in body, "DNSBL page is missing the Cloudflare (CC BY-NC) 4.0 attribution note"
     assert 'name="top1m_token"' in body, "DNSBL page is missing the top1m_token field"
     assert 'type="password"' in body, "DNSBL page's top1m_token field must be masked (type=password)"
+    # issue #3060: the field must be HIDDEN for a keyless TOP1M type, not greyed out --
+    # disableInput() leaves permanently-visible dead UI on every default (Tranco) install,
+    # and the emitted handler is the render-tier evidence of which idiom the page uses.
+    # Once nothing disables the field, its 'top1m_token' entry in the submit handler's
+    # re-enable list (pfb_gated_ids) is dead code, so its absence is pinned here too.
+    # The three conditions are collected rather than asserted in sequence: asserted in a
+    # row, the first regression masks the other two, and each of these must stay
+    # individually visible in the failure message.
+    gated_match = re.search(r"var pfb_gated_ids = \[(.*?)\]", body, re.DOTALL)
+    assert gated_match, "DNSBL page is missing the pfb_gated_ids submit-handler list"
+    gated_ids = re.findall(r"'([^']+)'", gated_match.group(1))
+    assert gated_ids, f"pfb_gated_ids parsed empty -- the list shape changed: {gated_match.group(1)!r}"
+    top1m_token_failures = [
+        message
+        for satisfied, message in (
+            (
+                "hideInput('top1m_token'" in body,
+                "DNSBL page must hide the top1m_token field for keyless TOP1M types (issue #3060)",
+            ),
+            (
+                "disableInput('top1m_token'" not in body,
+                "DNSBL page still greys out top1m_token instead of hiding it (issue #3060)",
+            ),
+            (
+                "top1m_token" not in gated_ids,
+                "pfb_gated_ids still re-enables top1m_token on submit, but nothing disables it "
+                f"any more -- expected the entry dropped, got {gated_ids!r} (issue #3060)",
+            ),
+        )
+        if not satisfied
+    ]
+    assert not top1m_token_failures, "; ".join(top1m_token_failures)
     for absent in ("Alexa TOP1M", 'value="alexa"'):
         assert absent not in body, f"DNSBL page still renders the dropped Alexa TOP1M option ({absent!r})"
 


### PR DESCRIPTION
## Summary

On the DNSBL tab the Cloudflare Radar **API Token** field was greyed out, not hidden, for a TOP1M Type that needs no token. `cloudflare` is the only provider whose `auth` descriptor is non-`none` (`pfblockerng_extra.inc`'s `pfb_top1m_providers()`), and the default Type is the keyless `tranco`, so every default install rendered a permanently-visible dead control — while the field's own comment at `pfblockerng_dnsbl.php:3509` already said the intent was show/hide.

`enable_top1m_token()` now clears the field and calls `hideInput()`, the idiom already used at `pfblockerng_ip.php:731`.

Fixes #3060

## The clear is a bugfix, not preservation of existing behaviour

The issue's own analysis argued the clear was needed because "a hidden input still POSTs; a disabled one does not, so today's `disableInput()` prevents both". **That premise is false for this page.** `top1m_token` was listed in `pfb_gated_ids`, and the `$('form').submit` handler calls `disableInput(id, false)` on every gated id *before* the form is posted — precisely so a greyed control still submits its value. Verified in the tree before this change:

```
$ grep -n "top1m_token\|disableInput(id, false)" src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
3984:		'pfb_psl_allow_private', 'top1m_token', 'aliaslog'
3988:			disableInput(id, false);
```

So today — before this PR — typing a token under Cloudflare Radar, switching back to Tranco and saving already overwrites the stored token and flips `$pfb_top1m_identity_changed` (`pfblockerng_dnsbl.php:945-959`), invalidating the TOP1M baseline. The `.val('')` clear fixes that; it does not merely preserve what `disableInput()` was doing.

ADR-59 write-only semantics are untouched: the field is never populated from the stored value, so a value present can only have been typed in this page load, and a blank POST still means "keep the stored token" (`:957`).

## Dead code the diff creates, removed in the same diff

`:3892` was the only site that ever disabled `top1m_token`:

```
$ grep -c "disableInput('top1m_token'" src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php   # before
1
```

Once it hides instead, the `'top1m_token'` entry in `pfb_gated_ids` is a re-enable for a control nothing disables, so it is dropped. The other five ids are untouched.

## Tests

- `tests/smoke/ui/test_render_smoke.py` (Tier A, `ui_render`) — `test_dnsbl_top1m_source_options_exclude_alexa` now pins that the emitted JS calls `hideInput('top1m_token'`, never `disableInput('top1m_token'`, and that the parsed `pfb_gated_ids` array no longer carries `top1m_token`. The three conditions are collected and reported together so a regression in any one stays individually visible instead of being masked by the first failure.
- `tests/smoke/ui/test_browser_dnsbl.py` (Tier B, `ui_browser`) — `test_top1m_token_hidden_and_cleared_for_keyless_providers` expands the `COLLAPSIBLE|SEC_CLOSED` `TOP1M_Whitelist` section first (otherwise `to_be_hidden()` passes for the wrong reason), asserts the before-state under `cloudflare`, then hidden **and** blank under `tranco`, then visible and still blank on the way back. The typed value carries an apostrophe, a double quote, a `${...}` sigil and 256 filler characters, so the clear is proven against more than a tidy literal.
- `tests/php/GateDisableUiTest.php` — this hermetic test pinned the per-control gating contract with `top1m_token` in the *disable* group, which is the expectation this issue reverses. It moves to the hide group: a control that is temporarily unavailable greys out, one that does not apply to the current selection hides.

Both live tiers were re-run at the PR head `e9ad19c`: `ui-render` PASSED in 87s (`/srv/Smoke/results/20260903T020327Z-ui-render`), `ui-browser` PASSED in 115s (`/srv/Smoke/results/20260903T020122Z-ui-browser`).

### Frozen RED evidence

The two live-tier test files were committed and pushed as `6e1aefe` and run RED with `src/` byte-identical to `origin/devel` (`git diff origin/devel -- src/` empty), before the production change in `b9bfaac`. The PHPUnit expectation was run RED against `origin/devel`'s page restored into the worktree, frozen at that hash, then re-run green unchanged.

Review then changed `test_browser_dnsbl.py` (a docstring sentence this PR had made untrue, plus a single-use constant inlined). That voids the file's original freeze, so it was re-proven rather than re-labelled: the edited file was placed on the merge-base `d21a8ce` with `src/` untouched (`8bba133`, pushed as `red/3060-docstring` purely to give the harness a fetchable ref) and re-run RED, then re-run GREEN at the PR head with the file byte-identical. Its row below carries the NEW hash and the NEW red tail. The other two files were not touched and keep their original freeze.

The branch has since been rebased onto `c8f68b34`; commit contents are unchanged, and every `git hash-object` below is the shipped blob.

Note on enforcement, so this record is not read as stronger than it is: `check_coverage_pairing.py` only demands a frozen-RED table for release-plane diffs (`scripts/**`, `.github/**`). This is a `src/**` + `tests/**` diff, so CI checks test pairing but never parses the table below — the freeze rides on the discipline and on this record, which is the gap tracked as issue #3093.

| Frozen RED test | git hash-object | RED run tail |
| --- | --- | --- |
| `tests/smoke/ui/test_render_smoke.py` | ba3c6aebbe01f2f473de75aa01b9ecce37fdde31 | `pfb-test: FAILED (rc=1). Artifacts: /srv/Smoke/results/20260903T004222Z-ui-render` (ref 6e1aefe, filter `test_dnsbl_top1m_source_options_exclude_alexa`) |
| `tests/smoke/ui/test_browser_dnsbl.py` | 8a998773ebc64cba325898184a421374bc9ff354 | `pfb-test: FAILED (rc=1). Artifacts: /srv/Smoke/results/20260903T015827Z-ui-browser` (ref 8bba133 — edited file on merge-base `d21a8ce`, `src/` untouched; filter `test_top1m_token_hidden_and_cleared_for_keyless_providers`). The pre-edit freeze was `0ebb7548`, red at `/srv/Smoke/results/20260903T004717Z-ui-browser` |
| `tests/php/GateDisableUiTest.php` | 456dea531f8ea29812ae8a0afa70efd72a69d5d5 | `GateDisableUiTest::testSingleControlsUseDisableInputNotHide` failed at `GateDisableUiTest.php:61` — page source `contains "hideInput('top1m_token'"` asserted false against `origin/devel`; green after the fix (`OK (4 tests, 44 assertions)`) |

GREEN at `b9bfaac`, test files byte-identical (`git diff 6e1aefe b9bfaac -- tests/` empty): `ui-render` PASSED in 109s (`/srv/Smoke/results/20260903T005000Z-ui-render`), `ui-browser` PASSED in 121s (`/srv/Smoke/results/20260903T005159Z-ui-browser`). Each live leg selected exactly one test — `1/1084 tests collected (1083 deselected)` for both filters — so no leg is a zero-test green, and a zero-selection run would have exited rc=5 rather than rc=1.

## Coverage

| Axis | Rows | Covered by |
| --- | --- | --- |
| TOP1M provider × `auth` | `tranco`, `cisco`, `openpagerank`, `majestic` → `'none'`; `cloudflare` → `{header, scheme}` | data-driven: `pfb_top1m_token_providers` is derived from the descriptor table, so the JS has no per-provider branch. Tier B drives the `cloudflare` (shown) and `tranco` (hidden) arms; the other three keyless providers take the identical code path and are a stated deferral, not an omission |
| Callers of `enable_top1m_token()` | `#top1m_source` change (`:3966`), on-load (`:3968`) | Tier B: `_open()` runs the load pass, then each `select_option` + `trigger('change')` runs the change pass |
| `disableInput('top1m_token'` sites | one, `:3892` | removed; Tier A asserts the string is absent from the rendered page, `GateDisableUiTest` asserts it is absent from the source |
| `pfb_gated_ids` members | six before, five after | Tier A parses the emitted array and asserts only `top1m_token` is gone; `GateDisableUiTest::testSingleControlsUseDisableInputNotHide` still pins `disableInput()` for the other five |
| POST/save path | blank POST keeps the stored token (`:957`); `$pfb_top1m_identity_changed`'s token half needs a non-empty POST (`:945-948`) | unchanged by this diff — no save-path line is touched. Not exercised end to end in Tier B (a save round-trip is a live-config mutation the browser leg does not own), but it is **not** uncovered: `tests/smoke/ui/test_functional.py:565` (`test_dnsbl_top1m_token_masked_field_persists_and_is_never_echoed`) already POSTs a blank `top1m_token` and asserts the stored token survives, and `:957` does not branch on provider, so that is the same path a hidden-and-blank field takes |

Hostile-input rows: token typed under the keyed provider then switched away → hidden and cleared (Tier B); switched back → shown and blank, never the typed string (Tier B); quotes / `${...}` / long value → the same Tier B row uses exactly such a value; save with the field hidden and blank → covered server-side by `test_functional.py:565` as noted above.