### PR TITLE
tests: match routing-doc pins on collapsed whitespace

### DIFF
--- a/tests/test_cross_agent_tooling.py
+++ b/tests/test_cross_agent_tooling.py
@@ -273,15 +273,11 @@ def test_repository_intelligence_routing_is_canonical_for_every_client() -> None
     assert heading not in codex, "Codex must not own a second routing policy"
 
 
-def _collapsed_haystack(text: str) -> str:
-    # issue #3120: wrapping a Markdown paragraph must not drop a pin or hide a retired recipe.
-    return " ".join(text.split())
-
-
 def test_repository_intelligence_initializes_each_worktree_directly() -> None:
     routing = (ROOT / ".agents/context/repository-intelligence.md").read_text(encoding="utf-8")
     assert routing.strip(), "repository-intelligence routing must not be empty"
-    flat = _collapsed_haystack(routing)
+    # issue #3120: wrapping a Markdown paragraph must not drop a pin or hide a retired recipe.
+    flat = " ".join(routing.split())
     for contract in (
         "work-branch.sh --worktree",
         "scripts/agent/init-worktree-tools.sh",
@@ -370,17 +366,6 @@ def test_repository_intelligence_initializes_each_worktree_directly() -> None:
     )
     for obsolete_path in ("scripts/agent/graphify-store.py", "tests/test_graphify_store.py"):
         assert not (ROOT / obsolete_path).exists(), f"obsolete Graphify store path returned: {obsolete_path}"
-
-
-def test_repository_intelligence_pin_match_is_wrap_proof() -> None:
-    # issue #3120: the two probes that made the raw-text loops wrap-sensitive.
-    reflowed = "prints a notice\nand builds nothing"
-    assert "prints a notice and builds nothing" not in reflowed
-    assert "prints a notice and builds nothing" in _collapsed_haystack(reflowed)
-
-    wrapped_retired = "then runs\n  `graphify update <root>` when"
-    assert "then runs `graphify update <root>`" not in wrapped_retired.casefold()
-    assert "then runs `graphify update <root>`" in _collapsed_haystack(wrapped_retired).casefold()
 
 
 def test_markdownlint_excludes_generated_graphify_reports() -> None:

--- a/tests/test_cross_agent_tooling.py
+++ b/tests/test_cross_agent_tooling.py
@@ -273,9 +273,15 @@ def test_repository_intelligence_routing_is_canonical_for_every_client() -> None
     assert heading not in codex, "Codex must not own a second routing policy"
 
 
+def _collapsed_haystack(text: str) -> str:
+    # issue #3120: wrapping a Markdown paragraph must not drop a pin or hide a retired recipe.
+    return " ".join(text.split())
+
+
 def test_repository_intelligence_initializes_each_worktree_directly() -> None:
     routing = (ROOT / ".agents/context/repository-intelligence.md").read_text(encoding="utf-8")
     assert routing.strip(), "repository-intelligence routing must not be empty"
+    flat = _collapsed_haystack(routing)
     for contract in (
         "work-branch.sh --worktree",
         "scripts/agent/init-worktree-tools.sh",
@@ -316,9 +322,9 @@ def test_repository_intelligence_initializes_each_worktree_directly() -> None:
         "an exact `==` pin is never the answer",
         "installed the same way, never pinned",
     ):
-        assert contract in routing, f"direct worktree initialization routing lost {contract}"
+        assert contract in flat, f"direct worktree initialization routing lost {contract}"
 
-    folded_routing = routing.casefold()
+    folded_routing = flat.casefold()
     for obsolete in (
         "ignored and untracked",
         "graphify-refresh-required",
@@ -364,6 +370,17 @@ def test_repository_intelligence_initializes_each_worktree_directly() -> None:
     )
     for obsolete_path in ("scripts/agent/graphify-store.py", "tests/test_graphify_store.py"):
         assert not (ROOT / obsolete_path).exists(), f"obsolete Graphify store path returned: {obsolete_path}"
+
+
+def test_repository_intelligence_pin_match_is_wrap_proof() -> None:
+    # issue #3120: the two probes that made the raw-text loops wrap-sensitive.
+    reflowed = "prints a notice\nand builds nothing"
+    assert "prints a notice and builds nothing" not in reflowed
+    assert "prints a notice and builds nothing" in _collapsed_haystack(reflowed)
+
+    wrapped_retired = "then runs\n  `graphify update <root>` when"
+    assert "then runs `graphify update <root>`" not in wrapped_retired.casefold()
+    assert "then runs `graphify update <root>`" in _collapsed_haystack(wrapped_retired).casefold()
 
 
 def test_markdownlint_excludes_generated_graphify_reports() -> None:


### PR DESCRIPTION
Fixes #3120

`test_repository_intelligence_initializes_each_worktree_directly` pinned `.agents/context/repository-intelligence.md` by substring match against the raw file text. A harmless paragraph reflow dropped a pin (false red). A wrapped retired recipe was invisible to the obsolete-guard (false green).

## What changed

Both loops now match against `flat = " ".join(routing.split())` (and `flat.casefold()` for retired recipes).

Round-1 APPLY (`008e978c`) inlined that expression and dropped a helper plus a wrap-proof row that did not lock the live loops.

No `src/` change. The routing document is unchanged.

## Test-first proof

Session probes against the pre-change matcher (blob `4763ef8693015d9c3921d63456a57e38d396ac1d`) on a wrapped copy of the live routing text, not a commit:

- Reflow `prints a notice and builds nothing` across two lines → raw match False (false red).
- Append wrapped `then runs\n  \`graphify update <root>\`` → raw casefold match False (blind).
- Same inputs through `" ".join(text.split())` → both True.

After the change: `20 passed` in `tests/test_cross_agent_tooling.py`.

| Frozen RED test | `git hash-object` | RED run tail |
| --- | --- | --- |
| `tests/test_cross_agent_tooling.py` (pre-change matcher) | `4763ef8693015d9c3921d63456a57e38d396ac1d` | `PROBE1 raw match pin in reflowed: False`; `PROBE2 raw casefold obsolete in wrapped: False` |
| `tests/test_cross_agent_tooling.py` (shipped) | `3b395fe855b687ced2c03303b9b3c7b6df175bd6` | live loops GREEN on collapsed haystack |

## Not asking the review bot yet

Adversarial legs first. Fair Usage is ~hourly; Claude is using that slot and smoke. Grok will not ask and will not lease smoke.