### PR TITLE
pfblockerng: gate the toggle contract wherever a config mirror is declared

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -253,8 +253,10 @@ fi
 
 # --- Forbid an on/off toggle declaring its default in the page (issue #2123):
 #     a PFB_FILTER_ON_OFF save into a registered section must name a registry entry,
-#     and a registered toggle's default must not be restated by the page. Relevant to
-#     the settings pages and to the registry itself, so it runs on staged PHP/.inc. ---
+#     and a registered toggle's default must not be restated by the page. Scans tracked
+#     src/usr/local/www and src/usr/local/pkg .php/.inc/.xml (the checker's defaults;
+#     a mirror is declared wherever the contract applies, issue #3087), so it runs on
+#     staged PHP/.inc. ---
 if [ "$staged_php" = 1 ]; then
 	if exempted scripts/check_toggle_registry.py; then
 		exempt toggle-registry

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -254,10 +254,9 @@ fi
 # --- Forbid an on/off toggle declaring its default in the page (issue #2123):
 #     a PFB_FILTER_ON_OFF save into a registered section must name a registry entry,
 #     and a registered toggle's default must not be restated by the page. Scans tracked
-#     src/usr/local/www and src/usr/local/pkg .php/.inc/.xml (the checker's defaults;
-#     a mirror is declared wherever the contract applies, issue #3087), so it runs on
-#     staged PHP/.inc. ---
-if [ "$staged_php" = 1 ]; then
+#     src/usr/local/www and src/usr/local/pkg .php/.inc/.xml (the checker's defaults,
+#     issue #3087). ---
+if [ "$staged_php" = 1 ] || [ "$staged_xml" = 1 ]; then
 	if exempted scripts/check_toggle_registry.py; then
 		exempt toggle-registry
 	elif [ -n "$py_bin" ]; then

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -317,7 +317,9 @@ jobs:
       - name: Forbid an on/off toggle declaring its default in the page
         # issue #2123: a PFB_FILTER_ON_OFF save into a registered config section must
         # name a pfb_cfg_registry() entry, and a registered toggle's default must not be
-        # restated by the page. The --self-test run is this gate's red canary: it feeds a
+        # restated by the page. Scans tracked src/usr/local/www and src/usr/local/pkg
+        # .php/.inc/.xml (the checker's defaults; a section mirror is declared wherever
+        # the contract applies, issue #3087). The --self-test run is this gate's red canary: it feeds a
         # known-violating synthetic page through the same matchers and fails if either
         # rule stops firing, so a matcher that rots cannot green the real scan.
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -318,8 +318,8 @@ jobs:
         # issue #2123: a PFB_FILTER_ON_OFF save into a registered config section must
         # name a pfb_cfg_registry() entry, and a registered toggle's default must not be
         # restated by the page. Scans tracked src/usr/local/www and src/usr/local/pkg
-        # .php/.inc/.xml (the checker's defaults; a section mirror is declared wherever
-        # the contract applies, issue #3087). The --self-test run is this gate's red canary: it feeds a
+        # .php/.inc/.xml (the checker's defaults, issue #3087). The --self-test run is
+        # this gate's red canary: it feeds a
         # known-violating synthetic page through the same matchers and fails if either
         # rule stops firing, so a matcher that rots cannot green the real scan.
         run: |

--- a/docs/misc/config-gateway.md
+++ b/docs/misc/config-gateway.md
@@ -270,8 +270,13 @@ pages. Wired into `.github/workflows/test.yml`, `.githooks/pre-commit` and
 - **Scan set** (issue #3087): every tracked `.php`/`.inc`/`.xml` under `src/usr/local/www`
   and `src/usr/local/pkg` — the same roots `check_noopener.py` took after issue #3075. A
   mirror is declared wherever the contract applies (the dashboard widget, `pfblockerng.inc`,
-  `pfblockerng_geoip.inc`), so a root narrower than that reports clean for the wrong reason.
-  A mirror read quoted inside a heredoc is a known false positive; comments are skipped.
+  `pfblockerng_geoip.inc`).
+- **Matcher ceilings**, all recorded in the checker's docstring: the key group excludes the
+  hyphen, so a hyphenated key never reaches either rule (the widget's `widget-*` saves —
+  issue #3136); RULE 2's read matcher anchors on the assignment operator, so a read wrapped
+  in a call is not seen (issue #3137); comments are skipped by leading token only. A heredoc
+  body is matched as code, which is right for `pfblockerng_geoip.inc`'s generated-page
+  nowdocs.
 - Fails CLOSED: an unreadable registry, an unparseable `PFB_SECTIONS`, or fewer than 100
   parsed keys exits 2 rather than reporting clean.
 - `--self-test` is the red canary — a synthetic violating page must trip BOTH rules — and

--- a/docs/misc/config-gateway.md
+++ b/docs/misc/config-gateway.md
@@ -271,12 +271,8 @@ pages. Wired into `.github/workflows/test.yml`, `.githooks/pre-commit` and
   and `src/usr/local/pkg` — the same roots `check_noopener.py` took after issue #3075. A
   mirror is declared wherever the contract applies (the dashboard widget, `pfblockerng.inc`,
   `pfblockerng_geoip.inc`).
-- **Matcher ceilings**, all recorded in the checker's docstring: the key group excludes the
-  hyphen, so a hyphenated key never reaches either rule (the widget's `widget-*` saves —
-  issue #3136); RULE 2's read matcher anchors on the assignment operator, so a read wrapped
-  in a call is not seen (issue #3137); comments are skipped by leading token only. A heredoc
-  body is matched as code, which is right for `pfblockerng_geoip.inc`'s generated-page
-  nowdocs.
+- **Matcher ceilings** — recorded in the checker's docstring: hyphenated keys (issue #3136),
+  a call-wrapped RULE 2 read (issue #3137), comment/heredoc skip heuristics.
 - Fails CLOSED: an unreadable registry, an unparseable `PFB_SECTIONS`, or fewer than 100
   parsed keys exits 2 rather than reporting clean.
 - `--self-test` is the red canary — a synthetic violating page must trip BOTH rules — and

--- a/docs/misc/config-gateway.md
+++ b/docs/misc/config-gateway.md
@@ -267,6 +267,11 @@ pages. Wired into `.github/workflows/test.yml`, `.githooks/pre-commit` and
   clean scan of those sites.
 - The mirror → alias mapping is DERIVED from each page's own
   `$pfb['<mirror>'] = PfbConfig::readSection('<path>')`, so a new page needs no edit here.
+- **Scan set** (issue #3087): every tracked `.php`/`.inc`/`.xml` under `src/usr/local/www`
+  and `src/usr/local/pkg` — the same roots `check_noopener.py` took after issue #3075. A
+  mirror is declared wherever the contract applies (the dashboard widget, `pfblockerng.inc`,
+  `pfblockerng_geoip.inc`), so a root narrower than that reports clean for the wrong reason.
+  A mirror read quoted inside a heredoc is a known false positive; comments are skipped.
 - Fails CLOSED: an unreadable registry, an unparseable `PFB_SECTIONS`, or fewer than 100
   parsed keys exits 2 rather than reporting clean.
 - `--self-test` is the red canary — a synthetic violating page must trip BOTH rules — and

--- a/scripts/check_toggle_registry.py
+++ b/scripts/check_toggle_registry.py
@@ -36,9 +36,17 @@ Usage:
     check_toggle_registry.py [PATH ...]
     check_toggle_registry.py --self-test
 
-With no PATH, scans every tracked `src/usr/local/www/pfblockerng/*.php`. Exit 0 clean,
-1 on violations, 2 when the scan set or the registry could not be established (fail
-closed -- a gate that cannot read the registry must not report "clean").
+With no PATH, scans every tracked `.php`/`.inc`/`.xml` source under `src/usr/local/www`
+and `src/usr/local/pkg` -- issue #3087: a mirror is declared wherever the contract
+applies, so the dashboard widget and the pkg sources are in scope exactly as the
+settings pages are, and a root narrower than that surface reports clean for the wrong
+reason. Same root set as `check_noopener.py` after issue #3075. Exit 0 clean, 1 on
+violations, 2 when the scan set or the registry could not be established (fail closed --
+a gate that cannot read the registry must not report "clean").
+
+Ceiling: the matchers read source text, so a mirror read quoted inside a heredoc is a
+false positive. Comments are skipped by leading token; no heredoc in the scanned tree
+quotes one, and tracking heredoc state is more parser than this gate is worth.
 
 `--self-test` is the red canary the testing policy requires for a newly wired blocking
 gate: it feeds a known-violating synthetic page through the same matchers and exits 0
@@ -54,7 +62,11 @@ from pathlib import Path
 from typing import NamedTuple
 
 REGISTRY_FILE = "src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc"
-WWW_DIR = "src/usr/local/www/pfblockerng"
+
+# Every tree a `PfbConfig::readSection()` mirror is declared in: the Web UI pages and
+# widgets, and the pkg sources that share the same registry (issue #3087).
+SCAN_ROOTS = ("src/usr/local/www", "src/usr/local/pkg")
+SCAN_SUFFIXES = (".php", ".inc", ".xml")
 
 # A registry entry: its path key plus enough of the entry body to bound the match
 # to the entry's own closing `],`.
@@ -202,17 +214,17 @@ def find_violations(
 
 
 def _git_tracked_pages(root: Path) -> list[str]:
-    """Tracked `src/usr/local/www/pfblockerng/*.php` paths (sorted)."""
+    """Tracked `SCAN_ROOTS` sources with a `SCAN_SUFFIXES` extension (sorted)."""
     try:
         out = subprocess.run(
-            ["git", "-C", str(root), "ls-files", "-z", WWW_DIR],
+            ["git", "-C", str(root), "ls-files", "-z", *SCAN_ROOTS],
             capture_output=True,
             text=True,
             check=True,
         ).stdout
     except (OSError, subprocess.CalledProcessError):
         return []
-    return sorted(p for p in out.split("\0") if p.endswith(".php"))
+    return sorted(p for p in out.split("\0") if p.endswith(SCAN_SUFFIXES))
 
 
 _SELF_TEST_PAGE = """<?php
@@ -282,9 +294,9 @@ def main(argv: list[str] | None = None) -> int:
         paths = _git_tracked_pages(root)
         if not paths:
             print(
-                f"check_toggle_registry: `git ls-files {WWW_DIR}` returned nothing "
-                "(git unavailable or not a checkout) -- failing closed rather than "
-                "skipping the gate.",
+                f"check_toggle_registry: `git ls-files {' '.join(SCAN_ROOTS)}` returned "
+                "nothing (git unavailable or not a checkout) -- failing closed rather "
+                "than skipping the gate.",
                 file=sys.stderr,
             )
             return 2

--- a/scripts/check_toggle_registry.py
+++ b/scripts/check_toggle_registry.py
@@ -36,17 +36,24 @@ Usage:
     check_toggle_registry.py [PATH ...]
     check_toggle_registry.py --self-test
 
-With no PATH, scans every tracked `.php`/`.inc`/`.xml` source under `src/usr/local/www`
-and `src/usr/local/pkg` -- issue #3087: a mirror is declared wherever the contract
-applies, so the dashboard widget and the pkg sources are in scope exactly as the
-settings pages are, and a root narrower than that surface reports clean for the wrong
-reason. Same root set as `check_noopener.py` after issue #3075. Exit 0 clean, 1 on
-violations, 2 when the scan set or the registry could not be established (fail closed --
-a gate that cannot read the registry must not report "clean").
+With no PATH, scans every tracked `.php`/`.inc`/`.xml` under `SCAN_ROOTS` -- the root
+set `check_noopener.py` took after issue #3075. Exit 0 clean, 1 on violations, 2 when
+the scan set or the registry could not be established (fail closed -- a gate that
+cannot read the registry must not report "clean").
 
-Ceiling: the matchers read source text, so a mirror read quoted inside a heredoc is a
-false positive. Comments are skipped by leading token; no heredoc in the scanned tree
-quotes one, and tracking heredoc state is more parser than this gate is worth.
+Three matcher ceilings, none of them load-bearing on today's tree but all real:
+
+  * The key group excludes the hyphen, so a HYPHENATED key is invisible to both
+    rules. The dashboard widget's `$pfb['wglobal']['widget-popup']` saves are the live
+    instance: the file is scanned and its mirror resolves, but those three saves never
+    reach RULE 1. Registering them is a config-gateway change, so it is issue #3136,
+    not this gate's default set.
+  * RULE 2's read matcher anchors on the assignment operator, so a mirror read wrapped
+    in a call (`pfb_b64_text($pfb['dconfig']['k'] ?? NULL)`) is not seen -- issue #3137.
+  * Comments are skipped by LEADING token only, so a read quoted after code on the
+    same line, or inside a `/* */` block whose line lacks a `*`, is a false positive.
+    A heredoc body is matched as code, which is correct for the generated-page nowdocs
+    in `pfblockerng_geoip.inc` and wrong only for a heredoc carrying prose.
 
 `--self-test` is the red canary the testing policy requires for a newly wired blocking
 gate: it feeds a known-violating synthetic page through the same matchers and exits 0
@@ -60,6 +67,8 @@ import subprocess
 import sys
 from pathlib import Path
 from typing import NamedTuple
+
+from _git_paths import nul_listing
 
 REGISTRY_FILE = "src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc"
 
@@ -216,15 +225,10 @@ def find_violations(
 def _git_tracked_pages(root: Path) -> list[str]:
     """Tracked `SCAN_ROOTS` sources with a `SCAN_SUFFIXES` extension (sorted)."""
     try:
-        out = subprocess.run(
-            ["git", "-C", str(root), "ls-files", "-z", *SCAN_ROOTS],
-            capture_output=True,
-            text=True,
-            check=True,
-        ).stdout
+        paths = nul_listing(root, "ls-files", "-z", *SCAN_ROOTS)
     except (OSError, subprocess.CalledProcessError):
         return []
-    return sorted(p for p in out.split("\0") if p.endswith(SCAN_SUFFIXES))
+    return sorted(p for p in paths if p.endswith(SCAN_SUFFIXES))
 
 
 _SELF_TEST_PAGE = """<?php

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -3381,7 +3381,7 @@ function pfb_global() {
 	$pfb['dnsbl_idn_block_malicious']	= PfbConfig::read('dnsbl/pfb_idn_block_malicious');		// Confusable: block malicious homoglyphs (default 'on')
 	$pfb['dnsbl_idn_escalate_suspicious']	= PfbConfig::read('dnsbl/pfb_idn_escalate_suspicious');	// Confusable: escalate suspicious mixed-script to block (opt-in)
 	$pfb['dnsbl_regex']	= pfb_cfg_toggle_read($pfb['dnsblconfig']['pfb_regex'] ?? '');			// DNSBL Resolver python regex
-	$pfb['dnsbl_regex_list']= $pfb['dnsblconfig']['pfb_regex_list'] ?? '';	// DNSBL Resolver python regex list
+	$pfb['dnsbl_regex_list']= PfbConfig::read('dnsbl/pfb_regex_list');	// DNSBL Resolver python regex list
 	$pfb['dnsbl_regex_cap']	= PfbConfig::read('dnsbl/pfb_regex_cap');			// DNSBL Resolver Python opt-in regex length cap
 	$pfb['dnsbl_cname']	= pfb_cfg_toggle_read($pfb['dnsblconfig']['pfb_cname'] ?? '');			// DNSBL Resolver python CNAME Validation
 	$pfb['dnsbl_tld_allow']	= pfb_cfg_toggle_read($pfb['dnsblconfig']['tld_allow'] ?? '');			// DNSBL Resolver TLD Allow option
@@ -3391,10 +3391,10 @@ function pfb_global() {
 	$pfb['dnsbl_psl_feed_icann_policy'] = PfbConfig::read('dnsbl/pfb_psl_feed_icann_policy');		// issue #2371: feed-at-suffix PSL ICANN policy (PfbFeedSuffixPolicy enum; absent -> Honor)
 	$pfb['dnsbl_py_nolog']	= pfb_cfg_toggle_read($pfb['dnsblconfig']['pfb_py_nolog'] ?? '');			// DNSBL Resolver python - Log events via DNSBL Webserver vs python
 	$pfb['dnsbl_noaaaa']	= pfb_cfg_toggle_read($pfb['dnsblconfig']['pfb_noaaaa'] ?? '');			// DNSBL Resolver python no AAAA
-	$pfb['dnsbl_noaaaa_list']=$pfb['dnsblconfig']['pfb_noaaaa_list'] ?? '';	// DNSBL Resolver python no AAAA list
+	$pfb['dnsbl_noaaaa_list']=PfbConfig::read('dnsbl/pfb_noaaaa_list');	// DNSBL Resolver python no AAAA list
 
 	$pfb['dnsbl_gp']		= pfb_cfg_toggle_read($pfb['dnsblconfig']['pfb_gp'] ?? '');		// DNSBL Resolver python - DNSBL Bypass
-	$pfb['dnsbl_gp_bypass_list']	= $pfb['dnsblconfig']['pfb_gp_bypass_list'] ?? '';	// DNSBL Resolver python - List of Local IPs to bypass DNSBL
+	$pfb['dnsbl_gp_bypass_list']	= PfbConfig::read('dnsbl/pfb_gp_bypass_list');	// DNSBL Resolver python - List of Local IPs to bypass DNSBL
 
 	// SafeSearch — read via gateway (ADR-29).
 	$pfb['safesearch_enable']	= PfbConfig::read('ss/safesearch_enable');
@@ -4718,7 +4718,7 @@ function pfb_log_mgmt() {
 	// The RAW value, never a parsed one: the guards clamp it themselves (#1258), so no
 	// caller can hand them an out-of-range margin. Hoisting the read is fine; hoisting
 	// the parse is what let an unclamped margin reach the window arithmetic.
-	$margin_raw = $pfb['config']['pfb_log_trim_margin_pct'] ?? '';
+	$margin_raw = PfbConfig::read('gen/pfb_log_trim_margin_pct');
 
 	foreach (array(	'log', 'errlog', 'extraslog', 'ip_blocklog', 'ip_permitlog', 'ip_matchlog',
 			'ip_parse_err', 'dnslog', 'dnsbl_parse_err', 'dnsreplylog', 'unilog') as $logtype) {

--- a/tests/test_toggle_registry_check.py
+++ b/tests/test_toggle_registry_check.py
@@ -212,7 +212,8 @@ def test_every_exempt_row_still_names_a_live_site(monkeypatch: pytest.MonkeyPatc
     # Re-scan with the exemptions disabled: what fires is what genuinely needs a row.
     monkeypatch.setattr(ctr, "EXEMPT", {})
     live: set[tuple[str, str]] = set()
-    for page in sorted((_REPO_ROOT / ctr.WWW_DIR).glob("*.php")):
+    for rel in ctr._git_tracked_pages(_REPO_ROOT):
+        page = _REPO_ROOT / rel
         for v in ctr.find_violations(page.read_text(encoding="utf-8"), str(page), sections, keys):
             # detail's first quoted token is '<alias>/<key>'.
             live.add((page.name, v.detail.split("'")[1].split("/", 1)[1]))
@@ -221,8 +222,8 @@ def test_every_exempt_row_still_names_a_live_site(monkeypatch: pytest.MonkeyPatc
     assert not stale, f"EXEMPT rows no longer needed (delete them): {sorted(stale)}"
 
 
-def test_www_tree_is_clean() -> None:
-    """The real pages pass -- this gate blocks, it is not pre-broken."""
+def test_scanned_tree_is_clean() -> None:
+    """The real sources pass -- this gate blocks, it is not pre-broken."""
     result = subprocess.run(
         [sys.executable, str(_TOOL)],
         cwd=_REPO_ROOT,
@@ -230,7 +231,7 @@ def test_www_tree_is_clean() -> None:
         text=True,
         check=False,
     )
-    assert result.returncode == 0, f"src/usr/local/www/pfblockerng is not clean:\n{result.stderr}"
+    assert result.returncode == 0, f"the default scan set is not clean:\n{result.stderr}"
 
 
 def test_self_test_red_canary_passes() -> None:
@@ -315,10 +316,10 @@ def test_exempt_table_is_empty_after_the_2812_sweep() -> None:
     )
 
 
-def test_www_tree_is_clean_with_the_exempt_table_emptied(
+def test_scanned_tree_is_clean_with_the_exempt_table_emptied(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """The real pages carry no RULE 2 residue at all -- not one hidden by a row.
+    """The real sources carry no RULE 2 residue at all -- not one hidden by a row.
 
     Issue #2812's acceptance clause: with an empty EXEMPT table the gate still
     exits 0, so the sweep is proven against the live tree, not against the
@@ -326,7 +327,7 @@ def test_www_tree_is_clean_with_the_exempt_table_emptied(
     """
     monkeypatch.setattr(ctr, "EXEMPT", {})
     assert ctr.main([]) == 0, (
-        "src/usr/local/www/pfblockerng still carries page-level toggle defaults: issue #2812's sweep is incomplete"
+        "the scanned tree still carries page-level toggle defaults: issue #2812's sweep is incomplete"
     )
 
 
@@ -349,3 +350,119 @@ def test_widget_sentinel_after_a_gateway_read_is_not_a_page_default() -> None:
     """
     text = MIRROR + "$pconfig['maxmind_locale'] = PfbConfig::read('ip/maxmind_locale') ?: 'none';\n"
     assert _find(text) == []
+
+
+# --------------------------------------------------------------------------- #
+# Issue #3087 -- the scan set reaches every tree the contract applies to
+# --------------------------------------------------------------------------- #
+
+# The two files the review leg on PR #3084 named, plus the pkg source that turned out
+# to carry the residue: each declares a PfbConfig::readSection() mirror, and none of
+# them sat under the old `src/usr/local/www/pfblockerng` root.
+OUTSIDE_THE_OLD_ROOT = (
+    "src/usr/local/www/widgets/widgets/pfblockerng.widget.php",
+    "src/usr/local/pkg/pfblockerng/pfblockerng_geoip.inc",
+    "src/usr/local/pkg/pfblockerng/pfblockerng.inc",
+)
+
+
+def _tracked(*roots: str) -> set[str]:
+    """Tracked paths under `roots`, straight from git -- never a memorised list."""
+    out = subprocess.run(
+        ["git", "ls-files", "-z", *roots],
+        cwd=_REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+    return {p for p in out.split("\0") if p}
+
+
+def test_default_scan_set_reaches_outside_the_old_www_pfblockerng_root() -> None:
+    """The contract is not bounded by a directory, so the scan set must not be either.
+
+    A `PFB_FILTER_ON_OFF` save into a `PfbConfig::readSection()` mirror is written in
+    the dashboard widget and in the pkg `.inc` sources exactly as it is on the settings
+    pages. While the default root was `src/usr/local/www/pfblockerng`, a green run meant
+    "the pages I looked at were clean", not "the contract holds" (issue #3087, the same
+    defect #3075 fixed in check_noopener).
+    """
+    scanned = set(ctr._git_tracked_pages(_REPO_ROOT))
+    missing = [p for p in OUTSIDE_THE_OLD_ROOT if p not in scanned]
+    assert not missing, f"these do the gated shape but the gate never looks at them: {missing}"
+
+
+def test_widening_the_scan_set_keeps_every_page_the_old_root_held() -> None:
+    """Widening must be a superset: no settings page may drop out of the gate."""
+    scanned = set(ctr._git_tracked_pages(_REPO_ROOT))
+    old_root_pages = {p for p in _tracked("src/usr/local/www/pfblockerng") if p.endswith(".php")}
+    assert old_root_pages, "the old narrow root must still enumerate pages -- the fixture is wrong, not the gate"
+    assert old_root_pages <= scanned, f"pages lost from the scan set: {sorted(old_root_pages - scanned)}"
+
+
+def test_the_pkg_sources_read_registered_fields_through_the_gateway() -> None:
+    """RULE 2's subject is the registered field, not the page it is read on.
+
+    `dnsbl/pfb_regex_list`, `dnsbl/pfb_noaaaa_list`, `dnsbl/pfb_gp_bypass_list` and
+    `gen/pfb_log_trim_margin_pct` are all in `pfb_cfg_registry()`, and pfb_global() /
+    pfb_log_mgmt() read them off the section mirror with their own `?? ''` fallback --
+    a page-level default on a registered field, in a file the old root excluded.
+    """
+    pkg_sources = sorted(p for p in _tracked("src/usr/local/pkg") if p.endswith((".php", ".inc", ".xml")))
+    assert pkg_sources, "no pkg sources enumerated -- the fixture is wrong, not the gate"
+    result = subprocess.run(
+        [sys.executable, str(_TOOL), *pkg_sources],
+        cwd=_REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, f"src/usr/local/pkg restates a registered field's default:\n{result.stderr}"
+
+
+def test_empty_default_scan_set_fails_closed(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A scan set that enumerates nothing must exit 2, never 0.
+
+    This is the failure the widening exists to prevent, one level down: a gate that
+    reports clean because it silently looked at no files is the same lie as a gate
+    whose root is narrower than the surface it protects.
+    """
+    monkeypatch.setattr(ctr, "_git_tracked_pages", lambda _root: [])
+    assert ctr.main([]) == 2
+
+
+# --------------------------------------------------------------------------- #
+# Issue #3087 -- adversarial rows for the widened surface
+# --------------------------------------------------------------------------- #
+
+
+def test_read_wrapped_across_lines_is_still_flagged() -> None:
+    """Reformatting a read over two physical lines must not smuggle it past RULE 2."""
+    text = MIRROR + "$pconfig['enable_dup'] =\n\t$pfb['iconfig']['enable_dup'] ?? '';\n"
+    assert _rules(text) == ["page-level-default"]
+
+
+def test_read_inside_a_comment_is_not_flagged() -> None:
+    """A read quoted in prose is documentation, not code.
+
+    The pkg `.inc` sources the widened set now covers are heavily commented, including
+    docblock lines that quote the very shape RULE 2 forbids.
+    """
+    for comment in (
+        "// $pconfig['enable_dup'] = $pfb['iconfig']['enable_dup'] ?? '';\n",
+        "/* $pconfig['enable_dup'] = $pfb['iconfig']['enable_dup'] ?? ''; */\n",
+        " * $pconfig['enable_dup'] = $pfb['iconfig']['enable_dup'] ?? '';\n",
+    ):
+        assert _find(MIRROR + comment) == [], f"a commented read must not flag: {comment!r}"
+
+
+def test_a_key_sharing_a_registered_prefix_is_not_matched() -> None:
+    """The registry lookup is on the whole key, never a substring of one.
+
+    `enable_dup_extra` is unregistered and `enable_du` is not a key at all; matching
+    either against the registered `enable_dup` would flag a site the registry does not
+    own -- and, in the RULE 1 direction, would green one it does.
+    """
+    for key in ("enable_dup_extra", "enable_du"):
+        text = MIRROR + f"$pconfig['x'] = $pfb['iconfig']['{key}'] ?? '';\n"
+        assert _find(text) == [], f"{key} is not the registered enable_dup"


### PR DESCRIPTION
Fixes #3087

## What this changes

`scripts/check_toggle_registry.py` resolved its default scan root to
`src/usr/local/www/pfblockerng`, so a green run meant "the twenty pages I looked at
were clean", not "the toggle contract holds". Files that do exactly the gated shape —
a `PFB_FILTER_ON_OFF` save into a `PfbConfig::readSection()` mirror, or a page-level
default restated on a registered field — sat outside that root and were never gated.

Two changes, in one PR because the widened gate lands red without the second:

1. **The scan set widens** to every tracked `.php`/`.inc`/`.xml` under
   `src/usr/local/www` and `src/usr/local/pkg`. `WWW_DIR` becomes `SCAN_ROOTS` +
   `SCAN_SUFFIXES`, and the fail-closed message prints the roots it actually used.
2. **Four registered fields in `pfblockerng.inc` move onto the gateway** — the
   violations the widened set surfaces.

### Why these roots

The same root set `check_noopener.py` took after #3075 / PR #3084, for the same reason,
and both bounds are forced by evidence rather than chosen:

* `src/usr/local/www/widgets/widgets/pfblockerng.widget.php` declares a mirror at `:58`
  and does `PFB_FILTER_ON_OFF` saves at `:85-87`. It is under `www` but outside
  `www/pfblockerng`, so widening only to that directory's parent would still miss it —
  all of `www` is the floor.
* `src/usr/local/pkg/pfblockerng/pfblockerng_geoip.inc` declares a mirror at `:854` and
  saves through the filter at `:987-991`, so `pkg` must be in scope too. (The issue also
  cited `:433-446`; that half is wrong and the review caught it — `$pfb['geoipconfig']`
  comes from `config_get_path("installedpackages/{$conf_type}/config/0", [])` at `:290`,
  a dynamic per-continent path and never a `readSection()` mirror, so all eight of those
  saves resolve to no alias and are skipped by design. `:987-991` alone carries the root.)

`.xml` is included because `check_noopener` includes it over the identical roots; one
root-and-suffix policy across the two whole-UI-tree checkers is one thing to reason
about instead of two. It adds `src/usr/local/pkg/pfblockerng.xml` and
`src/usr/local/www/wizards/pfblockerng_wizard.xml`, and no violations.

### Scan-set evidence

| | files the argless run scans |
| --- | --- |
| before | 20 |
| after | 35 |

Nothing is dropped — the old root's pages are a strict subset, pinned by
`test_widening_the_scan_set_keeps_every_page_the_old_root_held` — and the widened run is
clean rather than empty:

```
$ python3 scripts/check_toggle_registry.py ; echo rc=$?
rc=0
$ python3 scripts/check_toggle_registry.py --self-test
check_toggle_registry --self-test: both rules fired on the violating page (2 finding(s)) -- gate wiring proven.
```

A gate that reports clean because it silently scanned nothing is the defect this issue is
about, one level down, so `test_empty_default_scan_set_fails_closed` pins the exit-2 path
as well.

### The four migrations

All four keys were **already** in `pfb_cfg_registry()`. These are RULE 2 findings, not
RULE 1: the registry already owned the default and `pfblockerng.inc` restated it with its
own `?? ''`. No registry entry is added or altered here, so no registered default moves
and no grandfathering question arises.

| Site | Key | Registered type / default | Was | Effective default today |
| --- | --- | --- | --- | --- |
| `pfblockerng.inc:3384` | `dnsbl/pfb_regex_list` | plain string, `''`, no adapters | `$pfb['dnsblconfig'][…] ?? ''` | `''` — identical |
| `pfblockerng.inc:3394` | `dnsbl/pfb_noaaaa_list` | plain string, `''`, no adapters | `$pfb['dnsblconfig'][…] ?? ''` | `''` — identical |
| `pfblockerng.inc:3397` | `dnsbl/pfb_gp_bypass_list` | plain string, `''`, no adapters | `$pfb['dnsblconfig'][…] ?? ''` | `''` — identical |
| `pfblockerng.inc:4721` | `gen/pfb_log_trim_margin_pct` | plain string, `'0'`, no adapters | `$pfb['config'][…] ?? ''` | `0` either way — see below |

For the three list fields the registered default is `''`, and `notConfigured()` maps both
absence and a stored `''` to it, so the migration is byte-identical for every input.

`gen/pfb_log_trim_margin_pct` is the one where the two literals differ, and it is still
behaviour-preserving: the value is handed raw to `pfb_log_trim_margin_pct()`, whose own
`is_scalar(...) && preg_match('/^[0-9]+$/', ...)` guard resolves `''` and `'0'` alike to
`0` (`LogTrimMarginPctTest` pins both). The General page already read this key through
`PfbConfig::read()` at `pfblockerng_general.php:102`; this makes `pfb_log_mgmt()` agree
with it.

**One observable side effect, on corrupt config only.** A non-scalar stored value reaches
`PfbConfig::read()`'s `(string) $stored` cast (`pfblockerng_extra.inc:2096`) and emits an
`Array to string conversion` warning where the old mirror read passed the array straight
into the `is_scalar`-guarded parser. The resolved margin is `0` either way, nothing
crashes, and the suite still passes; measured, the change takes those classes from 29 PHP
warnings to 30, triggered by
`LogMgmtAgeCutoffTest::testMarginConfigValueAsArrayDoesNotCrash` and its chroot sibling.
The identical cast is already reached for this same key by the General page, so the
warning class predates this PR — it now has a second reach. Tightening
`PfbConfig::read()` to treat a non-scalar as absent would fix it for all ~100 registered
fields at once, which is a gateway change with its own red→green and does not belong in
this PR.

### Callers

All three are argless, so no invocation changes: `.githooks/pre-commit:265`,
`.github/workflows/test.yml:325`, `scripts/agent/run-gates.sh:91`. Their prose did name a
narrower surface than the gate now covers, which was a blocking review finding on #3084 —
the pre-commit and workflow comments and `docs/misc/config-gateway.md`'s toggle-gate
section now state the real scan set.

### EXEMPT

Still empty. None of the four is exempted; all four are fixed.

## Known ceilings

The review surfaced three matcher ceilings. None is load-bearing on today's tree — the
widened run is genuinely clean, not clean-by-blindness — but all three are real, all
three are now named in the checker docstring and in `docs/misc/config-gateway.md`, and
two have follow-up tickets.

1. **Hyphenated keys are invisible to both rules** — the key group excludes `-`. The live
   instance is the dashboard widget: it is in the scan set and its `wglobal` mirror
   resolves, but its three `PFB_FILTER_ON_OFF` saves of `widget-popup` / `widget-sortmix`
   / `widget-show_agg` never reach RULE 1. Enumerated repo-wide: exactly 3 sites, all in
   the widget, and **zero in the old narrow root** — which is why the limitation only
   becomes visible once the set widens. Not fixed here because `EXEMPT` is a RULE 2
   record by explicit design, so landing `[\w-]+` green requires *registering* the three
   widget keys — registry entries, grandfather classification, `CfgGatewayTest` rows,
   `$inventory`, the sniff's `$registeredPaths`. That is a config-gateway change with its
   own behaviour question, so it is **#3136**.
2. **RULE 2's read matcher anchors on the assignment operator**, so a mirror read wrapped
   in a call is not seen — 32 such reads exist in the widened set, 10 in `pfblockerng.inc`.
   All are benign today (those registered defaults equal what the wrapped fallback already
   produced), and the blind spot is pre-existing and orthogonal to the root widening. It
   is **#3137**, which also absorbs `pfblockerng_dnsbl.php:106-108` once PR #3132 lands.
3. **Comments are skipped by leading token only**, so a read quoted after code on the same
   line, or inside a `/* */` block whose line lacks a `*`, is a false positive. No live
   instance. A heredoc body is matched as *code* — which is correct: the `repconfig`
   mirror and the RULE 1 saves in `pfblockerng_geoip.inc` live inside a generated-page
   nowdoc, so gating it is a feature, and it is a false positive only for a heredoc
   carrying prose.

## Frozen RED

| Frozen RED test | git hash-object | RED run tail |
| --- | --- | --- |
| `tests/test_toggle_registry_check.py` | `41723f348fdb9369d1c87b121e300f575de4e4c0` | `FAILED tests/test_toggle_registry_check.py::test_default_scan_set_reaches_outside_the_old_www_pfblockerng_root - AssertionError: these do the gated shape but the gate never looks at them: ...` — `FAILED tests/test_toggle_registry_check.py::test_the_pkg_sources_read_registered_fields_through_the_gateway - AssertionError: src/usr/local/pkg restates a registered field's default:` — `2 failed, 31 passed in 0.30s` |

RED was executed at the tests-only commit (`bc12a255` after the rebase), in a detached
worktree at that exact commit so the production tree could not leak in. GREEN is the same
file, unchanged (`git hash-object` re-checked identical at every head since), giving
`33 passed`. Neither review round touched a test file, so the freeze still holds at the
current head. The rebase rewrote the commit graph, so the original RED commit is no
longer an ancestor — the record rests on content-hash identity, not SHA ancestry, and the
byte-identical tests-only commit `bc12a255` IS an ancestor of the head.

## Test rows

* `test_default_scan_set_reaches_outside_the_old_www_pfblockerng_root` — the widget,
  `pfblockerng_geoip.inc` and `pfblockerng.inc` are in the default scan set (RED).
* `test_the_pkg_sources_read_registered_fields_through_the_gateway` — `src/usr/local/pkg`
  restates no registered field's default (RED).
* `test_widening_the_scan_set_keeps_every_page_the_old_root_held` — the widening is a
  superset; no settings page silently drops out.
* `test_empty_default_scan_set_fails_closed` — an empty enumeration exits 2, never 0.
* `test_read_wrapped_across_lines_is_still_flagged` — reformatting a read over two
  physical lines does not evade RULE 2.
* `test_read_inside_a_comment_is_not_flagged` — `//`, `/* */` and docblock ` * ` lines
  quoting the forbidden shape stay clean.
* `test_a_key_sharing_a_registered_prefix_is_not_matched` — the lookup is on the whole
  key, so neither `enable_dup_extra` nor `enable_du` matches `enable_dup`.
* `test_every_exempt_row_still_names_a_live_site` and the two tree-clean rows now follow
  the checker's own scan set instead of globbing the old directory.

## Gate run

`scripts/agent/run-gates.sh --diff origin/devel`: `composer phpstan`, `composer phpcs`,
`markdownlint`, `ruff`, `pytest` and the checker gates all PASS. `vendor/bin/phpunit`
reports 7 failures, all of them the documented GNU-tar-versus-bsdtar host divergence in
`DownloadExtractedPayloadSanityTest` / `DownloadRejectValidatorClearTest`
(`/usr/bin/tar cannot read ZIP on this host; the appliance uses bsdtar`). The same 7 fail
identically at `origin/devel` in a detached baseline worktree, so they are pre-existing
and environmental, not this change. CI grades on Linux with the pinned toolchain and is
the authoritative answer.

## Review round 1

Four independent legs, all against `cdb1f209`; audit comments on the timeline. One
blocking finding (the widget ceiling, now #3136 + disclosure), no other blocking.
Applied in `f5d40843`: the scan-set enumeration now reuses `scripts/_git_paths.nul_listing`
— the helper `check_agent_roles.py` and `check_context_budget.py` already use, whose
`os.fsdecode` is exactly why issue #3073 exists — which also closes the reported
`UnicodeDecodeError` on a non-UTF-8 tracked path that exited 1 with a traceback instead
of the exit-2 contract; the pre-commit gate now fires on staged `.xml` as well as
`.php`/`.inc`, matching the noopener step over the same roots; and the ceilings above are
recorded.

## Review round 2

All four legs re-run on small tier against `5e72cf72`; audit comments on the timeline.
**Zero blocking findings** — the round closes under the convergence rule. Round 1's
blocking finding was verified closed by the contract leg against source, including
independent confirmation that `EXEMPT` is consulted only in RULE 2, so registration
really is a prerequisite for widening the key group. The correctness leg proved the new
`_git_paths` import resolves in all four invocation paths and that the non-UTF-8
filename case now scans the file correctly rather than merely failing closed. The test
honesty leg re-ran every mutation through the new plumbing and ruled the frozen-file
declines sound under `testing.md` principle 1. One nitpick applied in `f855783a`: the
`config-gateway.md` ceilings bullet is now a pointer at the docstring instead of a
restatement of it.
