### PR TITLE
pfblockerng: see hyphenated config keys, classify widget-* as foreign (#3136)

### DIFF
--- a/docs/misc/config-gateway.md
+++ b/docs/misc/config-gateway.md
@@ -271,8 +271,11 @@ pages. Wired into `.github/workflows/test.yml`, `.githooks/pre-commit` and
   and `src/usr/local/pkg` — the same roots `check_noopener.py` took after issue #3075. A
   mirror is declared wherever the contract applies (the dashboard widget, `pfblockerng.inc`,
   `pfblockerng_geoip.inc`).
-- **Matcher ceilings** — recorded in the checker's docstring: hyphenated keys (issue #3136),
-  a call-wrapped RULE 2 read (issue #3137), comment/heredoc skip heuristics.
+- **Hyphenated keys** (issue #3136): the key group now includes `-`, so the widget's
+  `global/widget-*` saves reach the rules; they are classified foreign via
+  `FOREIGN_KEY_PREFIXES` (the `rep` arrangement above), not registered.
+- **Matcher ceilings** — recorded in the checker's docstring: a call-wrapped RULE 2 read
+  (issue #3137), comment/heredoc skip heuristics.
 - Fails CLOSED: an unreadable registry, an unparseable `PFB_SECTIONS`, or fewer than 100
   parsed keys exits 2 rather than reporting clean.
 - `--self-test` is the red canary — a synthetic violating page must trip BOTH rules — and

--- a/scripts/check_toggle_registry.py
+++ b/scripts/check_toggle_registry.py
@@ -41,13 +41,15 @@ set `check_noopener.py` took after issue #3075. Exit 0 clean, 1 on violations, 2
 the scan set or the registry could not be established (fail closed -- a gate that
 cannot read the registry must not report "clean").
 
-Three matcher ceilings, none of them load-bearing on today's tree but all real:
+The key group includes the hyphen (issue #3136), so a HYPHENATED key reaches all three
+matchers. The dashboard widget's `$pfb['wglobal']['widget-*']` saves are the live
+instance: those keys are a deliberately-foreign namespace inside the registered `global`
+section (the widget marks each foreign in-code), so RULE 1 classifies them foreign via
+`FOREIGN_KEY_PREFIXES` -- the owner decided (2026-09-03) to recognise them, not register
+them -- while a hyphenated key ANYWHERE ELSE still fires normally.
 
-  * The key group excludes the hyphen, so a HYPHENATED key is invisible to both
-    rules. The dashboard widget's `$pfb['wglobal']['widget-popup']` saves are the live
-    instance: the file is scanned and its mirror resolves, but those three saves never
-    reach RULE 1. Registering them is a config-gateway change, so it is issue #3136,
-    not this gate's default set.
+Two matcher ceilings remain, neither load-bearing on today's tree but both real:
+
   * RULE 2's read matcher anchors on the assignment operator, so a mirror read wrapped
     in a call (`pfb_b64_text($pfb['dconfig']['k'] ?? NULL)`) is not seen -- issue #3137.
   * Comments are skipped by LEADING token only, so a read quoted after code on the
@@ -96,15 +98,15 @@ _MIRROR_RE = re.compile(r"\$pfb\s*\[\s*'(\w+)'\s*\]\s*=\s*PfbConfig::readSection
 # wrapped across lines is still one match and cannot slip past the gate by being
 # reformatted.
 _SAVE_RE = re.compile(
-    r"\$pfb\s*\[\s*'(\w+)'\s*\]\s*\[\s*'(\w+)'\s*\]\s*=[^;]*?\bPFB_FILTER_ON_OFF\b",
+    r"\$pfb\s*\[\s*'(\w+)'\s*\]\s*\[\s*'([\w-]+)'\s*\]\s*=[^;]*?\bPFB_FILTER_ON_OFF\b",
     re.DOTALL,
 )
 
 # A read of a section mirror carrying its own default. Two spellings:
 #   $x = $pfb['iconfig']['enable_dup'] ?: '';
 #   $x = isset($pfb['aglobal']['alertrefresh']) ? $pfb['aglobal']['alertrefresh'] : 'on';
-_READ_COALESCE_RE = re.compile(r"=\s*\$pfb\s*\[\s*'(\w+)'\s*\]\s*\[\s*'(\w+)'\s*\]\s*\?[:?]")
-_READ_ISSET_RE = re.compile(r"isset\(\s*\$pfb\s*\[\s*'(\w+)'\s*\]\s*\[\s*'(\w+)'\s*\]\s*\)\s*\?[^?:]*:")
+_READ_COALESCE_RE = re.compile(r"=\s*\$pfb\s*\[\s*'(\w+)'\s*\]\s*\[\s*'([\w-]+)'\s*\]\s*\?[:?]")
+_READ_ISSET_RE = re.compile(r"isset\(\s*\$pfb\s*\[\s*'(\w+)'\s*\]\s*\[\s*'([\w-]+)'\s*\]\s*\)\s*\?[^?:]*:")
 
 # Sanity floor: the registry has had >100 entries since issue #1920's audit. A parse
 # that finds fewer has broken, and a broken parse must fail the gate rather than
@@ -118,6 +120,17 @@ _MIN_REGISTRY_KEYS = 100
 # DELIBERATE exemption -- a future row must name the decision that makes the duplication
 # acceptable, and a row whose site is gone is dead weight -- delete it.
 EXEMPT: dict[tuple[str, str], str] = {}
+
+# alias -> foreign key-prefixes: a key that lives in a REGISTERED section but outside
+# the registry's scope -- a foreign namespace, not an unregistered save. This is the
+# key-prefix sibling of RULE 1's foreign-section escape, and the `rep` arrangement
+# docs/misc/config-gateway.md describes (a registered section with foreign siblings).
+# `global/widget-*` are the dashboard widget's keys, marked foreign in-code eleven
+# times in src/usr/local/www/widgets/widgets/pfblockerng.widget.php
+# ("foreign key: pfblockerngglobal/widget-* ... not in registry"), so they are display
+# preferences, not filter/security config. Issue #3136 (owner decision 2026-09-03):
+# recognise them, do not register them.
+FOREIGN_KEY_PREFIXES: dict[str, tuple[str, ...]] = {"global": ("widget-",)}
 
 
 class Violation(NamedTuple):
@@ -173,6 +186,11 @@ def find_violations(
         if alias is None:
             # The mirror is not a registered section at all (no PFB_SECTIONS alias):
             # a foreign section, outside the registry's scope.
+            continue
+        if key.startswith(FOREIGN_KEY_PREFIXES.get(alias, ())):
+            # A deliberately-foreign key namespace inside a registered section -- the
+            # same out-of-scope disposition as a foreign section, keyed on the prefix.
+            # Not an EXEMPT row: that is a RULE 2 backlog record, not a classification.
             continue
         # EXEMPT is a RULE 2 record only: one backlog row must never license an
         # unregistered save of that key name forever.

--- a/scripts/check_toggle_registry.py
+++ b/scripts/check_toggle_registry.py
@@ -121,15 +121,9 @@ _MIN_REGISTRY_KEYS = 100
 # acceptable, and a row whose site is gone is dead weight -- delete it.
 EXEMPT: dict[tuple[str, str], str] = {}
 
-# alias -> foreign key-prefixes: a key that lives in a REGISTERED section but outside
-# the registry's scope -- a foreign namespace, not an unregistered save. This is the
-# key-prefix sibling of RULE 1's foreign-section escape, and the `rep` arrangement
-# docs/misc/config-gateway.md describes (a registered section with foreign siblings).
-# `global/widget-*` are the dashboard widget's keys, marked foreign in-code eleven
-# times in src/usr/local/www/widgets/widgets/pfblockerng.widget.php
-# ("foreign key: pfblockerngglobal/widget-* ... not in registry"), so they are display
-# preferences, not filter/security config. Issue #3136 (owner decision 2026-09-03):
-# recognise them, do not register them.
+# alias -> foreign key-prefixes: display-pref keys in a REGISTERED section but outside
+# the registry's scope (issue #3136 owner decision: recognise, do not register). See
+# docs/misc/config-gateway.md's `rep`-arrangement note.
 FOREIGN_KEY_PREFIXES: dict[str, tuple[str, ...]] = {"global": ("widget-",)}
 
 

--- a/tests/test_toggle_registry_check.py
+++ b/tests/test_toggle_registry_check.py
@@ -466,3 +466,64 @@ def test_a_key_sharing_a_registered_prefix_is_not_matched() -> None:
     for key in ("enable_dup_extra", "enable_du"):
         text = MIRROR + f"$pconfig['x'] = $pfb['iconfig']['{key}'] ?? '';\n"
         assert _find(text) == [], f"{key} is not the registered enable_dup"
+
+
+# --------------------------------------------------------------------------- #
+# Issue #3136 -- hyphenated keys are seen; the widget-* namespace is foreign
+# --------------------------------------------------------------------------- #
+
+# The dashboard widget's own mirror: `wglobal` resolves to the registered `global`
+# section, but its `widget-*` keys are a deliberately-foreign namespace (the widget
+# marks each in-code: "foreign key: ... not in registry").
+WGLOBAL_MIRROR = f"$pfb['wglobal'] = PfbConfig::readSection('{GLOBAL_SECTION}');\n"
+
+
+def test_foreign_widget_prefix_save_is_not_flagged() -> None:
+    """The widget's real shape: a `global/widget-*` PFB_FILTER_ON_OFF save is a
+    foreign key-namespace inside a registered section, so RULE 1 must not flag it --
+    the same out-of-scope disposition a foreign section already gets. This is red at
+    the 4a-only intermediate (the widened matcher would flag it) and green once the
+    foreign-prefix classification lands.
+    """
+    text = (
+        WGLOBAL_MIRROR
+        + "$pfb['wglobal']['widget-popup'] = pfb_filter($_POST['pfb_popup'] ?? '', PFB_FILTER_ON_OFF, 'widget');\n"
+    )
+    assert _find(text, "pfblockerng.widget.php") == []
+
+
+def test_hyphenated_key_outside_the_foreign_namespace_is_still_flagged() -> None:
+    """Anti-vacuity: widening the key group so hyphens are seen must NOT blanket-
+    silence every hyphenated key. A hyphenated key doing the registry-governed save
+    shape, in a registered section outside any foreign namespace, still fires RULE 1.
+    Red until the key group is widened (the current `\\w+` group cannot see it).
+    """
+    text = MIRROR + "$pfb['iconfig']['pfb-new-flag'] = pfb_filter($_POST['x'] ?? '', PFB_FILTER_ON_OFF, 'ip') ?: '';\n"
+    violations = _find(text)
+    assert [v.rule for v in violations] == ["unregistered-toggle"]
+    assert "ip/pfb-new-flag" in violations[0].detail
+
+
+def test_foreign_prefix_is_a_boundary_not_a_substring() -> None:
+    """`widgetx-foo` shares the letters but not the `widget-` prefix boundary, so the
+    exemption is a prefix match, not a loose substring: it still fires RULE 1.
+    """
+    text = (
+        WGLOBAL_MIRROR
+        + "$pfb['wglobal']['widgetx-foo'] = pfb_filter($_POST['x'] ?? '', PFB_FILTER_ON_OFF, 'widget');\n"
+    )
+    violations = _find(text, "pfblockerng.widget.php")
+    assert [v.rule for v in violations] == ["unregistered-toggle"]
+    assert "global/widgetx-foo" in violations[0].detail
+
+
+def test_widget_prefix_in_an_unregistered_section_is_foreign_via_missing_alias() -> None:
+    """A `widget-` key in a section with no PFB_SECTIONS alias is already foreign
+    through the missing-alias branch -- the prefix rule is not what saves it, so the
+    two foreign dispositions do not overlap or mask each other.
+    """
+    text = (
+        "$pfb['bconfig'] = PfbConfig::readSection('installedpackages/pfblockerngblacklist');\n"
+        "$pfb['bconfig']['widget-popup'] = pfb_filter($_POST['x'] ?? '', PFB_FILTER_ON_OFF, 'b') ?: '';\n"
+    )
+    assert _find(text, "pfblockerng.widget.php") == []

--- a/tests/test_toggle_registry_check.py
+++ b/tests/test_toggle_registry_check.py
@@ -527,3 +527,15 @@ def test_widget_prefix_in_an_unregistered_section_is_foreign_via_missing_alias()
         "$pfb['bconfig']['widget-popup'] = pfb_filter($_POST['x'] ?? '', PFB_FILTER_ON_OFF, 'b') ?: '';\n"
     )
     assert _find(text, "pfblockerng.widget.php") == []
+
+
+def test_foreign_prefix_is_keyed_to_its_section_not_applied_globally() -> None:
+    """The exemption is keyed on the section ALIAS, not the prefix alone: a `widget-`
+    key in a DIFFERENT registered section (here `ip`) is not the widget's namespace and
+    still fires RULE 1. This pins FOREIGN_KEY_PREFIXES to `dict[alias, ...]` -- a bare
+    global `("widget-",)` prefix set, ignoring the alias, would wrongly exempt it.
+    """
+    text = MIRROR + "$pfb['iconfig']['widget-popup'] = pfb_filter($_POST['x'] ?? '', PFB_FILTER_ON_OFF, 'ip') ?: '';\n"
+    violations = _find(text)
+    assert [v.rule for v in violations] == ["unregistered-toggle"]
+    assert "ip/widget-popup" in violations[0].detail


### PR DESCRIPTION
Fixes #3136

## What and why

`check_toggle_registry.py` bound the config key as `(\w+)`, so a **hyphenated** key was invisible to all three matchers (`_SAVE_RE`, `_READ_COALESCE_RE`, `_READ_ISSET_RE`). The dashboard widget's `global/widget-*` `PFB_FILTER_ON_OFF` saves were scanned (since #3134/#3087) but never reached RULE 1.

This implements the **owner's teach-the-checker decision (2026-09-03)**, which supersedes the issue body's "register the three keys": the `widget-*` keys are a deliberately-foreign namespace (marked foreign in-code eleven times in `pfblockerng.widget.php`), display preferences rather than filter/security config. Registering 3 of ~11 would reverse that decision for part of one namespace. So:

1. **4a** — widen the key group to `[\w-]+` in all three matchers so hyphenated keys are seen.
2. **4b** — recognise the foreign namespace via a narrow `FOREIGN_KEY_PREFIXES = {"global": ("widget-",)}`, keyed on section alias + prefix. This is the key-prefix sibling of RULE 1's existing foreign-*section* escape (`alias is None`), NOT an `EXEMPT` row (that stays a RULE-2-only backlog record) and NOT a registry change. Mirrors the `rep` arrangement in `docs/misc/config-gateway.md`.
3. **4c** — the docstring hyphen ceiling and `config-gateway.md`'s ceiling note are rewritten to state the closed behaviour.

No `pfb_cfg_registry()`, sniff, `CfgGatewayTest`, or widget `.php` change.

## Frozen RED proof

| Frozen RED test | git hash-object | RED run tail |
| --- | --- | --- |
| `tests/test_toggle_registry_check.py` | `95c1287c8033a8665a85d33b50446d4b278c741c` | `FAILED test_hyphenated_key_outside_the_foreign_namespace_is_still_flagged` / `FAILED test_foreign_prefix_is_a_boundary_not_a_substring` / `FAILED test_foreign_prefix_is_keyed_to_its_section_not_applied_globally` — `3 failed, 35 passed` (current test file run against pre-fix production) |

At GREEN (production applied) all 38 tests pass. An intermediate 4a-only run (key group widened, `FOREIGN_KEY_PREFIXES` removed) additionally reddens `test_foreign_widget_prefix_save_is_not_flagged` and `test_scanned_tree_is_clean`, proving the 4b foreign classification is load-bearing rather than a blanket hyphen silence.

## Coverage

- **Anti-vacuity (load-bearing):** a hyphenated key in a registered section *outside* the foreign namespace still fires RULE 1 (`test_hyphenated_key_outside_the_foreign_namespace_is_still_flagged`).
- **Section-narrowing (added in review):** a `widget-` key under a *different registered* alias (`ip`) still fires — pinning `FOREIGN_KEY_PREFIXES` to `dict[alias, …]`; a bare global prefix set would wrongly exempt it. Proven RED under that exact mutation.
- **Foreign save clean:** the widget's real `global/widget-popup` on/off save is not flagged.
- **Prefix boundary:** `widgetx-foo` (shares letters, not the `widget-` boundary) still fires; a `widget-` key in an unregistered section is foreign via the missing-alias branch.
- All three matchers widened; argless run clean; `--self-test` still fires both rules.

## Review

Four independent adversarial legs (correctness+hostile, over-engineering, contract, test-honesty) reviewed the whole PR against the issue + owner-decision spec — all non-blocking; audit comments recorded on the PR. The section-narrowing row above was added in response to the over-engineering leg's coverage note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
