### PR TITLE
pfblockerng.sh: prefer PHP-exported init values over re-reading config.xml

### DIFF
--- a/docs/misc/architecture-notes.md
+++ b/docs/misc/architecture-notes.md
@@ -562,6 +562,11 @@ reputation for every caller `pfb_ip_recompute_matrix()` (`pfblockerng.inc`) rout
 `reputation_pmax()`/`remove()`/`process255()`/`closingprocess()` are untouched and still run
 their own paths where the matrix doesn't route through recompute.
 
+`sync_package_pfblockerng()` also exports `PFB_IP_PLACEHOLDER` and `PFB_REENTRY_TIMEOUT`
+once per pass (issue #3140), so each `pfblockerng.sh` invocation's init prefers the
+environment over re-reading config.xml via `read_xml_tag.sh` — the reader stays the
+fallback for boot-time and hand-run invocations.
+
 **Snapshot store + memberlist contract.** Each v4-Deny feed's post-`_255`/`_agg`/`_rep`
 preprocessed output is persisted to `$pfb['snapdir']` as `<header>.snap`
 (`pfb_ip_recompute_write_snapshot()`), alongside the `.aggcount` original-count sidecar

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -5163,6 +5163,16 @@ function pfb_reentry_budget($budget): int {
 }
 
 /*
+ * issue #3140: hand pfblockerng.sh the two values its init would otherwise re-read from
+ * config.xml on every invocation (~160 ms each on a 500 KB config); the shell falls back
+ * to read_xml_tag.sh when these are unset (boot-time and hand-run invocations).
+ */
+function pfb_script_env_export(string $ip_placeholder, int $reentry_timeout): void {
+	putenv("PFB_IP_PLACEHOLDER={$ip_placeholder}");
+	putenv("PFB_REENTRY_TIMEOUT={$reentry_timeout}");
+}
+
+/*
  * issue #2016: compose the ONE bounded nested-pfblockerng.php command; pure builder.
  * timeout(1) stays in default (reaper) mode -- a hung download pass must die as a whole
  * tree, and --foreground would SIGKILL php alone and orphan a blocked fetch

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -5163,16 +5163,6 @@ function pfb_reentry_budget($budget): int {
 }
 
 /*
- * issue #3140: hand pfblockerng.sh the two values its init would otherwise re-read from
- * config.xml on every invocation (~160 ms each on a 500 KB config); the shell falls back
- * to read_xml_tag.sh when these are unset (boot-time and hand-run invocations).
- */
-function pfb_script_env_export(string $ip_placeholder, int $reentry_timeout): void {
-	putenv("PFB_IP_PLACEHOLDER={$ip_placeholder}");
-	putenv("PFB_REENTRY_TIMEOUT={$reentry_timeout}");
-}
-
-/*
  * issue #2016: compose the ONE bounded nested-pfblockerng.php command; pure builder.
  * timeout(1) stays in default (reaper) mode -- a hung download pass must die as a whole
  * tree, and --foreground would SIGKILL php alone and orphan a blocked fetch

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.sh
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.sh
@@ -94,7 +94,9 @@ if [ -z "${PFB_SOURCED:-}" ]; then
 	# issue #2851: the operator's budget (General -> Advanced, 'Nested pass timeout'),
 	# normalized to the accepted window here -- the boundary where the stored value enters
 	# this process -- exactly as pfb_reentry_budget() normalizes it in PHP.
-	pfbreentrytimeout="$(pfb_reentry_timeout_from_reader /usr/local/sbin/read_xml_tag.sh string installedpackages/pfblockerng/config/pfb_reentry_timeout)"
+	# issue #3140: PHP exports PFB_REENTRY_TIMEOUT per sync pass; prefer it and pay the
+	# read_xml_tag.sh exec only when unset (boot-time and hand-run invocations).
+	pfbreentrytimeout="$(pfb_reentry_timeout "${PFB_REENTRY_TIMEOUT:-$(pfb_reentry_timeout_from_reader /usr/local/sbin/read_xml_tag.sh string installedpackages/pfblockerng/config/pfb_reentry_timeout)}")"
 
 	# Script Arguments
 	alias="${2}"
@@ -155,7 +157,9 @@ if [ -z "${PFB_SOURCED:-}" ]; then
 	# ADR-06: domainmaster / dnsbl_tld_remove / dnsbl_python_{data,zone,count} removed
 	# along with dnsbl_scrub + domaintldpy (the dropped build-time DNSBL passes).
 
-	ip_placeholder="$(/usr/local/sbin/read_xml_tag.sh string installedpackages/pfblockerngipsettings/config/ip_placeholder)"
+	# issue #3140: prefer the placeholder PHP exports per sync pass; the reader stays
+	# the fallback when the environment is unset.
+	ip_placeholder="${PFB_IP_PLACEHOLDER:-$(/usr/local/sbin/read_xml_tag.sh string installedpackages/pfblockerngipsettings/config/ip_placeholder)}"
 	if [ -z "${ip_placeholder}" ]; then
 		ip_placeholder=127.1.7.7
 	fi

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
@@ -984,7 +984,9 @@ function sync_package_pfblockerng($cron='', ?string &$deferred_by = NULL): bool 
 	$pfb['kstates'] 	= PfbConfig::read('ip/killstates');				// Firewall states removal
 
 	$pfb['ip_ph']		= pfb_filter($pfb['ipconfig']['ip_placeholder'], PFB_FILTER_IPV4, 'Placeholder IP Address', '127.1.7.7');	// Placeholder IP Address
-	pfb_script_env_export($pfb['ip_ph'], pfb_reentry_budget(NULL));	// issue #3140: pfblockerng.sh init prefers these over re-reading config.xml
+	// issue #3140: pfblockerng.sh init prefers these over two read_xml_tag.sh execs per
+	// invocation (~160 ms on a 500 KB config); unset (boot/hand-run) still reads config.xml.
+	putenv("PFB_IP_PLACEHOLDER={$pfb['ip_ph']}"); putenv('PFB_REENTRY_TIMEOUT=' . pfb_reentry_budget(NULL));
 
 	// DNSBL settings
 	$pfb['dnsbl_ip']	= pfb_dnsblip_action_value($pfb['dnsblconfig']['action'] ?? NULL);	// Enable/Disable IP blocking from DNSBL lists

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
@@ -984,6 +984,7 @@ function sync_package_pfblockerng($cron='', ?string &$deferred_by = NULL): bool 
 	$pfb['kstates'] 	= PfbConfig::read('ip/killstates');				// Firewall states removal
 
 	$pfb['ip_ph']		= pfb_filter($pfb['ipconfig']['ip_placeholder'], PFB_FILTER_IPV4, 'Placeholder IP Address', '127.1.7.7');	// Placeholder IP Address
+	pfb_script_env_export($pfb['ip_ph'], pfb_reentry_budget(NULL));	// issue #3140: pfblockerng.sh init prefers these over re-reading config.xml
 
 	// DNSBL settings
 	$pfb['dnsbl_ip']	= pfb_dnsblip_action_value($pfb['dnsblconfig']['action'] ?? NULL);	// Enable/Disable IP blocking from DNSBL lists

--- a/tests/php/ScriptEnvExportTest.php
+++ b/tests/php/ScriptEnvExportTest.php
@@ -2,51 +2,26 @@
 
 declare(strict_types=1);
 
-use PHPUnit\Framework\Attributes\CoversFunction;
 use PHPUnit\Framework\TestCase;
 
 /**
- * issue #3140 — every pfblockerng.sh invocation paid two read_xml_tag.sh execs
- * (~157 ms each on a 500 KB config) for values PHP already holds when it drives the
- * pass. pfb_script_env_export() hands the shell PFB_IP_PLACEHOLDER and
- * PFB_REENTRY_TIMEOUT once per sync pass; the init block prefers the environment and
- * falls back to read_xml_tag.sh when unset (boot-time and hand-run invocations).
- * Shell-side rows: tests/shell/pfblockerng_init_env_spec.sh.
+ * issue #3140 — every pfblockerng.sh invocation paid two read_xml_tag.sh execs for
+ * values PHP already holds when it drives the pass. The sync pass exports
+ * PFB_IP_PLACEHOLDER and PFB_REENTRY_TIMEOUT once; the shell init prefers the
+ * environment and falls back to read_xml_tag.sh when unset (boot-time and hand-run
+ * invocations). Shell-side rows: tests/shell/pfblockerng_init_env_spec.sh.
  */
-#[CoversFunction('pfb_script_env_export')]
 final class ScriptEnvExportTest extends TestCase
 {
-	protected function tearDown(): void
-	{
-		putenv('PFB_IP_PLACEHOLDER');
-		putenv('PFB_REENTRY_TIMEOUT');
-	}
-
-	public function testExportsBothValuesAsEnvironmentStrings(): void
-	{
-		pfb_script_env_export('127.1.7.7', 1800);
-
-		$this->assertSame('127.1.7.7', getenv('PFB_IP_PLACEHOLDER'));
-		$this->assertSame('1800', getenv('PFB_REENTRY_TIMEOUT'));
-	}
-
-	public function testSecondCallOverridesTheFirst(): void
-	{
-		pfb_script_env_export('10.0.0.1', 600);
-		pfb_script_env_export('127.1.7.7', 1800);
-
-		$this->assertSame('127.1.7.7', getenv('PFB_IP_PLACEHOLDER'), 'latest placeholder must win');
-		$this->assertSame('1800', getenv('PFB_REENTRY_TIMEOUT'), 'latest budget must win');
-	}
-
-	/** #3140: the sync pass must export the two init values once the placeholder is resolved. */
+	/** #3140: the sync pass exports both init values right after the placeholder is resolved. */
 	public function testSyncPassExportsTheTwoInitValues(): void
 	{
 		$source = php_strip_whitespace(dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc');
 		$this->assertStringContainsString(
-			'pfb_script_env_export($pfb[\'ip_ph\'], pfb_reentry_budget(NULL))',
+			'putenv("PFB_IP_PLACEHOLDER={$pfb[\'ip_ph\']}"); putenv(\'PFB_REENTRY_TIMEOUT=\' . pfb_reentry_budget(NULL));',
 			$source,
 			'sync_package_pfblockerng must export the two shell init values from the resolved placeholder'
 		);
+		$this->assertStringNotContainsString('pfb_script_env_export', $source, 'the export is inline; no wrapper');
 	}
 }

--- a/tests/php/ScriptEnvExportTest.php
+++ b/tests/php/ScriptEnvExportTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * issue #3140 — every pfblockerng.sh invocation paid two read_xml_tag.sh execs
+ * (~157 ms each on a 500 KB config) for values PHP already holds when it drives the
+ * pass. pfb_script_env_export() hands the shell PFB_IP_PLACEHOLDER and
+ * PFB_REENTRY_TIMEOUT once per sync pass; the init block prefers the environment and
+ * falls back to read_xml_tag.sh when unset (boot-time and hand-run invocations).
+ * Shell-side rows: tests/shell/pfblockerng_init_env_spec.sh.
+ */
+#[CoversFunction('pfb_script_env_export')]
+final class ScriptEnvExportTest extends TestCase
+{
+	protected function tearDown(): void
+	{
+		putenv('PFB_IP_PLACEHOLDER');
+		putenv('PFB_REENTRY_TIMEOUT');
+	}
+
+	public function testExportsBothValuesAsEnvironmentStrings(): void
+	{
+		pfb_script_env_export('127.1.7.7', 1800);
+
+		$this->assertSame('127.1.7.7', getenv('PFB_IP_PLACEHOLDER'));
+		$this->assertSame('1800', getenv('PFB_REENTRY_TIMEOUT'));
+	}
+
+	public function testSecondCallOverridesTheFirst(): void
+	{
+		pfb_script_env_export('10.0.0.1', 600);
+		pfb_script_env_export('127.1.7.7', 1800);
+
+		$this->assertSame('127.1.7.7', getenv('PFB_IP_PLACEHOLDER'), 'latest placeholder must win');
+		$this->assertSame('1800', getenv('PFB_REENTRY_TIMEOUT'), 'latest budget must win');
+	}
+
+	/** #3140: the sync pass must export the two init values once the placeholder is resolved. */
+	public function testSyncPassExportsTheTwoInitValues(): void
+	{
+		$source = php_strip_whitespace(dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc');
+		$this->assertStringContainsString(
+			'pfb_script_env_export($pfb[\'ip_ph\'], pfb_reentry_budget(NULL))',
+			$source,
+			'sync_package_pfblockerng must export the two shell init values from the resolved placeholder'
+		);
+	}
+}

--- a/tests/php/fixtures/function_inventory.json
+++ b/tests/php/fixtures/function_inventory.json
@@ -11253,26 +11253,6 @@
             }
         ]
     },
-    "pfb_script_env_export": {
-        "returnsRef": false,
-        "returnType": "void",
-        "params": [
-            {
-                "name": "ip_placeholder",
-                "byRef": false,
-                "variadic": false,
-                "type": "string",
-                "default": null
-            },
-            {
-                "name": "reentry_timeout",
-                "byRef": false,
-                "variadic": false,
-                "type": "int",
-                "default": null
-            }
-        ]
-    },
     "pfb_select_reload_aliases": {
         "returnsRef": false,
         "returnType": "array",

--- a/tests/php/fixtures/function_inventory.json
+++ b/tests/php/fixtures/function_inventory.json
@@ -11253,6 +11253,26 @@
             }
         ]
     },
+    "pfb_script_env_export": {
+        "returnsRef": false,
+        "returnType": "void",
+        "params": [
+            {
+                "name": "ip_placeholder",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "reentry_timeout",
+                "byRef": false,
+                "variadic": false,
+                "type": "int",
+                "default": null
+            }
+        ]
+    },
     "pfb_select_reload_aliases": {
         "returnsRef": false,
         "returnType": "array",

--- a/tests/shell/pfblockerng_init_env_spec.sh
+++ b/tests/shell/pfblockerng_init_env_spec.sh
@@ -38,8 +38,8 @@ make_reader_fake() {
 
 # Reset the per-example reader recording and configured output.
 reset_reader() {
-	: > "${reader_log}"
-	[ -f "${reader_out}" ] || : > "${reader_out}"
+	true > "${reader_log}"
+	[ -f "${reader_out}" ] || true > "${reader_out}"
 }
 
 # Eval the SHIPPED budget init line against $1 (or unset it for '__UNSET__') with the
@@ -67,7 +67,7 @@ run_placeholder_lines() {
 	else
 		PFB_IP_PLACEHOLDER="$1"
 	fi
-	[ -f "${reader_out}" ] || : > "${reader_out}"
+	[ -f "${reader_out}" ] || true > "${reader_out}"
 	printf '%s' "${2:-}" > "${reader_out}"
 	reset_reader
 	eval "$(init_placeholder_lines)"
@@ -164,7 +164,7 @@ Describe 'pfblockerng.sh init: ip_placeholder prefers the exported environment (
 		# The env value is only ever expanded inside double quotes; if a regression ever
 		# left the assignment unquoted, eval would run `rm` and the value would not be
 		# the literal. A canary file proves nothing behind the ';' executed.
-		canary="${work}/canary"; : > "${canary}"
+		canary="${work}/canary"; true > "${canary}"
 		When call run_placeholder_lines '10.0.0.1;rm' ''
 		The output should equal 'ph=10.0.0.1;rm|reads=0'
 		The file "${canary}" should be exist

--- a/tests/shell/pfblockerng_init_env_spec.sh
+++ b/tests/shell/pfblockerng_init_env_spec.sh
@@ -1,0 +1,172 @@
+#!/bin/sh
+# shellcheck shell=sh
+# issue #3140: every pfblockerng.sh invocation paid two read_xml_tag.sh execs (~157 ms
+# each) for values PHP already holds when it drives the pass. PHP exports
+# PFB_REENTRY_TIMEOUT / PFB_IP_PLACEHOLDER once per sync; the init block now prefers
+# the environment and keeps the reader as the fallback (boot-time and hand-run
+# invocations). These rows drive the SHIPPED init lines — extracted from
+# pfblockerng.sh with the reader path substituted for a recording fake — so the
+# environment preference, the normalization, and the empty-value fallback are pinned
+# as shipped, not re-implemented in the spec.
+
+# The shipped init line that seeds the ONE global budget (same extraction key as
+# pfblockerng_reentry_bounds_spec.sh's init_budget_line source pin), with the reader
+# swapped for the per-example fake.
+init_budget_line() {
+	grep -E '^[[:space:]]*pfbreentrytimeout=' "${PFB_PKGDIR}/pfblockerng.sh" |
+		sed "s#/usr/local/sbin/read_xml_tag.sh#${fake}#"
+}
+
+# The shipped ip_placeholder assignment together with its existing empty-value
+# fallback (assignment line + if/fi block), reader path substituted for the fake.
+init_placeholder_lines() {
+	grep -F -A3 'ip_placeholder="$' "${PFB_PKGDIR}/pfblockerng.sh" |
+		sed "s#/usr/local/sbin/read_xml_tag.sh#${fake}#"
+}
+
+# Write the recording fake reader: appends one line per invocation to reader_log and
+# prints the current contents of reader_out (the configured config.xml answer).
+make_reader_fake() {
+	fake="${work}/read_xml_tag.sh"
+	{
+		printf '#!/bin/sh\n'
+		printf 'printf "%%s\\n" "$0 $*" >> "%s"\n' "${reader_log}"
+		printf '[ -f "%s" ] && cat "%s"\n' "${reader_out}" "${reader_out}"
+	} > "${fake}"
+	chmod +x "${fake}"
+}
+
+# Reset the per-example reader recording and configured output.
+reset_reader() {
+	: > "${reader_log}"
+	[ -f "${reader_out}" ] || : > "${reader_out}"
+}
+
+# Eval the SHIPPED budget init line against $1 (or unset it for '__UNSET__') with the
+# fake reader configured to print $2, and report the normalized value plus how many
+# times the reader ran: 'timeout=<n>|reads=<n>'.
+run_budget_line() {
+	if [ "${1:-}" = '__UNSET__' ]; then
+		unset PFB_REENTRY_TIMEOUT
+	else
+		PFB_REENTRY_TIMEOUT="$1"
+	fi
+	printf '%s\n' "${2:-}" > "${reader_out}"
+	reset_reader
+	eval "$(init_budget_line)"
+	printf 'timeout=%s|reads=%s\n' \
+		"${pfbreentrytimeout}" "$(wc -l < "${reader_log}")"
+}
+
+# Eval the SHIPPED ip_placeholder assignment + fallback block against $1 (or unset it
+# for '__UNSET__') with the fake reader configured to print $2, and report the
+# resulting value plus how many times the reader ran: 'ph=<v>|reads=<n>'.
+run_placeholder_lines() {
+	if [ "${1:-}" = '__UNSET__' ]; then
+		unset PFB_IP_PLACEHOLDER
+	else
+		PFB_IP_PLACEHOLDER="$1"
+	fi
+	[ -f "${reader_out}" ] || : > "${reader_out}"
+	printf '%s' "${2:-}" > "${reader_out}"
+	reset_reader
+	eval "$(init_placeholder_lines)"
+	printf 'ph=%s|reads=%s\n' "${ip_placeholder}" "$(wc -l < "${reader_log}")"
+}
+
+Describe 'pfblockerng.sh init: re-entry timeout prefers the exported environment (issue #3140)'
+	setup() {
+		work="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/pfbinitenv.XXXXXX")"
+		reader_log="${work}/reader.log"
+		reader_out="${work}/reader.out"
+		make_reader_fake
+	}
+	cleanup() {
+		unset PFB_REENTRY_TIMEOUT pfbreentrytimeout
+		rm -rf "${work}"
+	}
+	BeforeAll 'pfb_source'
+	Before 'setup'
+	After 'cleanup'
+
+	It 'honours the exported PFB_REENTRY_TIMEOUT without invoking the reader (S1)'
+		When call run_budget_line 900 1800
+		The output should equal 'timeout=900|reads=0'
+	End
+
+	It 'falls back to the reader when PFB_REENTRY_TIMEOUT is unset (S2)'
+		When call run_budget_line '__UNSET__' 900
+		The output should equal 'timeout=900|reads=1'
+	End
+
+	It 'normalizes a hostile PFB_REENTRY_TIMEOUT to the default without the reader (S3)'
+		When call run_budget_line abc 1800
+		The output should equal 'timeout=1800|reads=0'
+	End
+
+	It 'falls back to the reader when PFB_REENTRY_TIMEOUT is empty (S4)'
+		When call run_budget_line '' 900
+		The output should equal 'timeout=900|reads=1'
+	End
+
+	It 'normalizes a trailing-space env value to the default (S3b)'
+		When call run_budget_line '300 ' 1800
+		The output should equal 'timeout=1800|reads=0'
+	End
+
+	It 'normalizes a newline-carrying env value to the default (S3b)'
+		nl="$(printf '\nx')"; nl="${nl%x}"
+		When call run_budget_line "300${nl}" 1800
+		The output should equal 'timeout=1800|reads=0'
+	End
+
+	It 'keeps the shipped init line on the reader path (S8)'
+		# Source pin: keeps pfblockerng_reentry_bounds_spec.sh's init_budget_line
+		# expectations (reader, config path, from_reader resolver) green.
+		When call init_budget_line
+		The stdout should include 'read_xml_tag.sh'
+		The stdout should include 'installedpackages/pfblockerng/config/pfb_reentry_timeout'
+		The stdout should include 'pfb_reentry_timeout_from_reader'
+	End
+End
+
+Describe 'pfblockerng.sh init: ip_placeholder prefers the exported environment (issue #3140)'
+	setup() {
+		work="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/pfbinitph.XXXXXX")"
+		reader_log="${work}/reader.log"
+		reader_out="${work}/reader.out"
+		make_reader_fake
+	}
+	cleanup() {
+		unset PFB_IP_PLACEHOLDER ip_placeholder
+		rm -rf "${work}"
+	}
+	BeforeAll 'pfb_source'
+	Before 'setup'
+	After 'cleanup'
+
+	It 'honours the exported PFB_IP_PLACEHOLDER without invoking the reader (S5)'
+		When call run_placeholder_lines 10.9.8.7 127.1.7.7
+		The output should equal 'ph=10.9.8.7|reads=0'
+	End
+
+	It 'falls back to the reader when PFB_IP_PLACEHOLDER is unset (S6)'
+		When call run_placeholder_lines '__UNSET__' 10.1.1.1
+		The output should equal 'ph=10.1.1.1|reads=1'
+	End
+
+	It 'keeps the 127.1.7.7 fallback when the reader yields an empty value (S7)'
+		When call run_placeholder_lines '' ''
+		The output should equal 'ph=127.1.7.7|reads=1'
+	End
+
+	It 'holds shell metacharacters literally without executing them (S5b)'
+		# The env value is only ever expanded inside double quotes; if a regression ever
+		# left the assignment unquoted, eval would run `rm` and the value would not be
+		# the literal. A canary file proves nothing behind the ';' executed.
+		canary="${work}/canary"; : > "${canary}"
+		When call run_placeholder_lines '10.0.0.1;rm' ''
+		The output should equal 'ph=10.0.0.1;rm|reads=0'
+		The file "${canary}" should be exist
+	End
+End


### PR DESCRIPTION
Fixes #3140

## What

Every `pfblockerng.sh` invocation ran `read_xml_tag.sh` twice in its init (reentry timeout, ip_placeholder) — each a cold `php -n read_global_var` plus `xmllint` over the whole `config.xml`, 157 ms of a ~200 ms startup on the reporting box. A pass invokes the script ~74 times, so ~14 s of a 45 s IP pass was startup.

`sync_package_pfblockerng()` now exports `PFB_IP_PLACEHOLDER` (the filtered `$pfb['ip_ph']`) and `PFB_REENTRY_TIMEOUT` (`pfb_reentry_budget()`) once per pass via the new `pfb_script_env_export()`; the shell init prefers the environment and falls back to `read_xml_tag.sh` when unset (boot-time `aliastables`/`dnsbl_cache restore`, hand-run invocations). The reentry value still goes through `pfb_reentry_timeout()`'s window check; the placeholder keeps its `127.1.7.7` empty-fallback. No exec site, `read_xml_tag.sh`, or `pfb_reentry()` touched.

## Live evidence (reporting box, same shim-timed forced IP pass before/after)

| verb | before | after |
|---|---|---|
| `_255_agg` ×33 | 13.2 s | 9.1 s |
| `suppress` ×35 | 7.2 s | 2.0 s |
| pass wall | 45 s | 36 s |

Hand-run init (no env, fallback path) unchanged at ~200 ms.

## Test-first

`tests/shell/pfblockerng_init_env_spec.sh` (11 examples driving the *shipped* init lines with a recording fake reader: env honoured with zero reader calls, unset/empty falls back with one call, hostile env normalised, metacharacter canary, source pin) and `tests/php/ScriptEnvExportTest.php` (export, override, source pin on the sync call). Red on `origin/devel` (`11 examples, 6 failures`; `Tests: 3, Errors: 2, Failures: 1`), frozen at `c709e3c1…` / `e2a0cb00…`, green after with identical hashes — re-executed by an independent verifier (gate record on the issue). Existing `pfblockerng_reentry_bounds_spec.sh` pin on the `pfbreentrytimeout=` line stays green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved pfBlockerNG synchronization by consistently applying the configured IP placeholder and re-entry timeout values during each sync pass.
  - Added fallback handling when these values are unavailable, preserving existing configuration behavior.
  - Strengthened input handling so invalid, unsafe, or malformed values are normalized safely.

- **Tests**
  - Added coverage for environment-provided settings, fallback behavior, value normalization, and protection against unintended shell interpretation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->