### PR TITLE
alerts: bound wildcard-delete resolver flush wait (#2880)

### DIFF
--- a/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
@@ -1433,7 +1433,32 @@ if (isset($_POST) && !empty($_POST)) {
 				$swapped = pfb_reload_unbound('enabled', FALSE, FALSE, TRUE);
 				if ($swapped) {
 					if ($_POST['entry_delete'] == 'delete_domainwildcard') {
-						exec("{$pfb['chroot_cmd']} flush_zone +c . 2>&1");
+						// issue #2880: this flush rides resolver-control IPC inside the
+						// page request, and raw exec() waits unboundedly -- a hung
+						// unbound-control left the HTTP request without any terminal
+						// state. Reuse the CNAME lookup seam above (issue #2083):
+						// timeout(1) default reaper mode, 30s TERM budget + 5s kill
+						// grace matching the established Alerts DNS ceiling, output
+						// to a regular file with stdin on /dev/null so no descendant
+						// can hold the capture pipe, and an explicit status. Expiry
+						// (124) and nonzero control status must never read as an
+						// ordinary success: the wildcard removal is already persisted
+						// above, so both name the saved state and the next manual
+						// recovery action instead of rolling it back silently.
+						$flush_zone_file = "{$g['tmp_path']}/pfb_alerts_flush_zone_" . getmypid() . '_' . bin2hex(random_bytes(8));
+						$flush_zone_status = 0;
+						exec(escapeshellarg($pfb['timeout'] ?? '/usr/bin/timeout') .
+							" -s TERM -k 5 30 {$pfb['chroot_cmd']} flush_zone +c . > " .
+							escapeshellarg($flush_zone_file) . " 2>&1 < /dev/null",
+							$flush_zone_output, $flush_zone_status);
+						@unlink($flush_zone_file);
+						if ($flush_zone_status === 124) {
+							pfb_logger("\npfblockerng_alerts: wildcard-delete flush_zone TIMED OUT (killed); the whitelist edit was saved and stale cached subdomains may persist until the next resolver reload\n", 2);
+							$savemsg .= " The wildcard removal was saved, but the resolver cache flush TIMED OUT (killed after 30s) -- stale cached subdomains may persist until the next resolver reload; use a DNSBL Force Reload or run 'unbound-control flush_zone' to clear them.";
+						} elseif ($flush_zone_status !== 0) {
+							pfb_logger("\npfblockerng_alerts: wildcard-delete flush_zone FAILED (exit {$flush_zone_status}); the whitelist edit was saved and stale cached subdomains may persist until the next resolver reload\n", 2);
+							$savemsg .= " The wildcard removal was saved, but the resolver cache flush FAILED (exit {$flush_zone_status}) -- stale cached subdomains may persist until the next resolver reload; use a DNSBL Force Reload or run 'unbound-control flush_zone' to clear them.";
+						}
 					} else {
 						pfb_unbound_py_ccache_flush(array($entry));
 					}

--- a/tests/php/AlertsUnboundCachePolicyTest.php
+++ b/tests/php/AlertsUnboundCachePolicyTest.php
@@ -69,7 +69,7 @@ final class AlertsUnboundCachePolicyTest extends TestCase
 		$this->assertOrdered(
 			$delete,
 			'$swapped = pfb_reload_unbound(\'enabled\', FALSE, FALSE, TRUE);',
-			'exec("{$pfb[\'chroot_cmd\']} flush_zone +c . 2>&1");'
+			'exec(escapeshellarg($pfb[\'timeout\'] ?? \'/usr/bin/timeout\') . " -s TERM -k 5 30 {$pfb[\'chroot_cmd\']} flush_zone +c . > "'
 		);
 		$this->assertStringContainsString('if ($swapped)', $delete,
 			'cache work must be skipped when reload falls back to a full restart');

--- a/tests/php/AlertsWildcardFlushTimeoutTest.php
+++ b/tests/php/AlertsWildcardFlushTimeoutTest.php
@@ -1,0 +1,420 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Issue #2880: the Alerts wildcard-delete resolver flush is bounded and its
+ * expiry/failure is never reported as an ordinary success.
+ *
+ * The delete_domainwildcard POST path runs `unbound-control flush_zone +c .`
+ * synchronously inside the page request. Unbounded, a resolver-control IPC
+ * stall leaves the HTTP request without any terminal state; and a control
+ * failure was silently swallowed. This test drives the SHIPPED POST-path block
+ * (carved verbatim from pfblockerng_alerts.php, located from its unique reload
+ * anchor) in a worker process with a deterministic `$pfb['chroot_cmd']`
+ * double, so the same byte-identical test is red against the unbounded shape
+ * and green once the established bounded-wait seam lands.
+ */
+final class AlertsWildcardFlushTimeoutTest extends TestCase
+{
+	private const ALERTS_PHP = __DIR__ . '/../../src/usr/local/www/pfblockerng/pfblockerng_alerts.php';
+
+	/** The success message the delete_domainwildcard case seeds before the flush. */
+	private const SUCCESS_MSG = 'The Wildcard Domain [ .example.com ] has been deleted from the DNSBL Whitelist customlist!';
+
+	/**
+	 * Salvage cap for the worker's end-of-run signal. It exists only to reap a
+	 * stuck run. On the unbounded pre-#2880 path the hanging flush never
+	 * returns, so the RED run fails HERE by design: the worker cannot reach
+	 * its signal within the cap, which is exactly the defect being fixed.
+	 */
+	private const FLUSH_SALVAGE_SECONDS = 30;
+
+	private string $tmp;
+
+	protected function setUp(): void
+	{
+		$this->tmp = sys_get_temp_dir() . '/pfb_alerts_flush_test_' . getmypid() . '_' . bin2hex(random_bytes(4));
+		$this->assertTrue(mkdir($this->tmp, 0777, TRUE), 'could not create the test sandbox');
+	}
+
+	protected function tearDown(): void
+	{
+		rmdir_recursive($this->tmp);
+	}
+
+	/**
+	 * A hung resolver control must not block the request forever: the flush
+	 * runs under the bounded wrapper (exact established limits), the request
+	 * terminates, and the page distinguishes expiry from success while naming
+	 * the persisted mutation state and the next recovery action.
+	 */
+	public function testHungResolverFlushIsBoundedAndNeverReportsOrdinarySuccess(): void
+	{
+		$r = $this->runFlush('stall');
+
+		$this->assertTrue(
+			$r['completed'],
+			"the flush worker never terminated within the salvage cap, i.e. the POST path still blocks on resolver-control IPC\n"
+			. "child log: {$r['child_log']}"
+		);
+		$this->assertBoundedFlushCall($r['timeout_calls'], $r['chroot']);
+		$this->assertStringContainsString('TIMED OUT', $r['savemsg'], 'expiry must be user-visible');
+		$this->assertStringContainsString('saved', $r['savemsg'], 'persisted mutation state must be explicit after expiry');
+		$this->assertStringContainsString('unbound-control flush_zone', $r['savemsg'], 'next recovery action must be explicit after expiry');
+		$this->assertNotSame(self::SUCCESS_MSG, $r['savemsg'], 'expiry must not be reported as an ordinary success');
+		$this->assertStringContainsString('TIMED OUT', $r['log'], 'expiry must be logged');
+		$this->assertNoOrphan($r['marker'], 'hung row');
+	}
+
+	/** An immediate nonzero control status must be distinguishable from success. */
+	public function testImmediateNonzeroFlushIsDistinguishedFromSuccess(): void
+	{
+		$r = $this->runFlush('fail');
+
+		$this->assertTrue($r['completed'], "worker did not terminate\nchild log: {$r['child_log']}");
+		$this->assertBoundedFlushCall($r['timeout_calls'], $r['chroot']);
+		$this->assertStringContainsString('FAILED (exit 3)', $r['savemsg'], 'control failure must be user-visible with its status');
+		$this->assertStringContainsString('saved', $r['savemsg'], 'persisted mutation state must be explicit after failure');
+		$this->assertNotSame(self::SUCCESS_MSG, $r['savemsg'], 'control failure must not be reported as an ordinary success');
+		$this->assertStringContainsString('FAILED', $r['log'], 'control failure must be logged');
+	}
+
+	/** A control binary that cannot even launch must be distinguishable from success. */
+	public function testMissingControlBinaryIsDistinguishedFromSuccess(): void
+	{
+		$r = $this->runFlush('missing');
+
+		$this->assertTrue($r['completed'], "worker did not terminate\nchild log: {$r['child_log']}");
+		$this->assertBoundedFlushCall($r['timeout_calls'], $r['chroot']);
+		$this->assertStringContainsString('FAILED (exit 127)', $r['savemsg'], 'launch failure must be user-visible with its status');
+		$this->assertNotSame(self::SUCCESS_MSG, $r['savemsg'], 'launch failure must not be reported as an ordinary success');
+	}
+
+	/** A healthy flush just below the budget preserves the existing success UI. */
+	public function testHealthyFlushPreservesExistingSuccessBehavior(): void
+	{
+		$r = $this->runFlush('ok');
+
+		$this->assertTrue($r['completed'], "worker did not terminate\nchild log: {$r['child_log']}");
+		$this->assertBoundedFlushCall($r['timeout_calls'], $r['chroot']);
+		$this->assertSame(self::SUCCESS_MSG, $r['savemsg'], 'a successful flush must not alter the existing success message');
+		$this->assertStringNotContainsString('TIMED OUT', $r['savemsg']);
+		$this->assertStringNotContainsString('FAILED', $r['savemsg']);
+		$this->assertStringNotContainsString('TIMED OUT', $r['log']);
+		$this->assertStringNotContainsString('FAILED', $r['log']);
+	}
+
+	/**
+	 * Concurrent-reload row: when the resolver reload did not swap, no flush
+	 * runs and the page makes no cache-flush claim at all.
+	 */
+	public function testReloadSwapFailureRunsNoFlushAndMakesNoCacheClaim(): void
+	{
+		$r = $this->runFlush('ok', FALSE);
+
+		$this->assertTrue($r['completed'], "worker did not terminate\nchild log: {$r['child_log']}");
+		$this->assertSame(array(), $r['timeout_calls'], 'no flush may run when the reload did not swap');
+		$this->assertSame(self::SUCCESS_MSG, $r['savemsg'], 'no cache-flush outcome may be claimed without a flush');
+		$this->assertStringNotContainsString('TIMED OUT', $r['savemsg']);
+		$this->assertStringNotContainsString('FAILED', $r['savemsg']);
+	}
+
+	/**
+	 * The bounded wrapper must carry the established Alerts DNS limits:
+	 * timeout(1) default reaper mode, 30s TERM budget, 5s kill grace — the
+	 * exact configured limits of the in-file CNAME lookup seam (issue #2083).
+	 *
+	 * @param list<list<string>> $calls
+	 */
+	private function assertBoundedFlushCall(array $calls, string $chroot): void
+	{
+		$this->assertNotEmpty($calls, 'the flush ran without the bounded timeout(1) wrapper');
+		$this->assertSame(
+			array('-s', 'TERM', '-k', '5', '30', $chroot, 'flush_zone', '+c', '.'),
+			$calls[0],
+			'the wildcard flush wrapper does not use the established 30s TERM + 5s kill-grace limits'
+		);
+	}
+
+	/** The hanging double must be reaped by the flush itself, never orphaned. */
+	private function assertNoOrphan(string $marker, string $context): void
+	{
+		$pid = $this->markerPid($marker);
+		if ($pid === NULL) {
+			$this->fail("flush double never announced its pid ({$context})");
+		}
+		$deadline = microtime(TRUE) + 10;
+		while (microtime(TRUE) < $deadline) {
+			if (!@posix_kill($pid, 0)) {
+				return;
+			}
+			usleep(50000);
+		}
+		$this->fail("orphan: the hanging flush double (pid {$pid}) outlived the bounded flush ({$context})");
+	}
+
+	/**
+	 * Run one flush scenario in a worker process against the SHIPPED POST-path
+	 * block. $mode: 'stall' (double hangs forever), 'fail' (double exits 3),
+	 * 'missing' (control binary does not exist -> 127), 'ok' (double exits 0
+	 * quickly). The timeout(1) seam is a shim that logs its exact invocation
+	 * and emulates the wrapper deterministically (kill + 124 on the hung row)
+	 * so no wall-clock budget can make a verdict flake.
+	 *
+	 * @return array{completed:bool,savemsg:string,log:string,timeout_calls:list<list<string>>,child_log:string,marker:string,chroot:string}
+	 */
+	private function runFlush(string $mode, bool $swapped = TRUE): array
+	{
+		$marker = "{$this->tmp}/flush marker.log";
+		$timeout_log = "{$this->tmp}/timeout args.log";
+		$timeout_flag = "{$this->tmp}/timeout fired";
+		$result = "{$this->tmp}/flush result.json";
+		$child_log = "{$this->tmp}/child output.log";
+		$done_signal = "{$this->tmp}/done signal";
+		$this->assertTrue(posix_mkfifo($done_signal, 0600), 'could not create the end-of-run signal');
+
+		$double = $this->fixture('flush_double.sh',
+			"printf '%s\\n' \"--START-- \$\$\" >> " . escapeshellarg($marker) . "\n"
+			. match ($mode) {
+				'stall' => "while true; do :; done\n",
+				'fail' => "exit 3\n",
+				default => "sleep 0.2\n",
+			}
+		);
+		$chroot = $mode === 'missing' ? "{$this->tmp}/missing-unbound-control" : $double;
+
+		$timeout = $this->fixture('timeout_shim.sh',
+			"printf '%s\\n' --CALL-- >> " . escapeshellarg($timeout_log) . "\n"
+			. "printf '%s\\n' \"\$@\" >> " . escapeshellarg($timeout_log) . "\n"
+			. "shift 5\n"
+			. "\"\$@\" & child=\$!\n"
+			. ($mode === 'stall' ?
+				// Kill only after the double announced its pid, so the reaped-pid
+				// assertion is deterministic rather than a race.
+				"i=0\n"
+				. "while [ ! -s " . escapeshellarg($marker) . " ] && [ \$i -lt 400 ]; do sleep 0.05; i=\$((i + 1)); done\n"
+				. "touch " . escapeshellarg($timeout_flag) . "\n"
+				. "kill -TERM \$child 2>/dev/null\n"
+				: '')
+			. "wait \$child; rc=\$?\n"
+			. "[ -f " . escapeshellarg($timeout_flag) . " ] && exit 124\n"
+			. "exit \$rc\n"
+		);
+
+		$block = $this->flushBlock();
+		$function = 'function pfb_alerts_test_wildcard_flush(bool $swapped): void { '
+			. 'global $pfb, $g, $savemsg, $entry; '
+			. "\$entry = 'example.com'; "
+			. '$savemsg = ' . var_export(self::SUCCESS_MSG, TRUE) . '; '
+			. $block
+			. ' }';
+
+		$worker = "{$this->tmp}/flush worker.php";
+		$bootstrap = realpath(__DIR__ . '/bootstrap.php');
+		if ($bootstrap === FALSE) {
+			throw new RuntimeException('test bootstrap path unavailable');
+		}
+		$worker_code = "<?php\n"
+			. 'require_once ' . var_export($bootstrap, TRUE) . ";\n"
+			. "if (function_exists('posix_setsid')) { posix_setsid(); }\n"
+			// Announce end of run from a shutdown handler, so a worker that dies
+			// before writing its result still reports in and is graded by the
+			// salvage logic rather than hanging the whole suite.
+			. 'register_shutdown_function(static function (): void { $signal = fopen('
+				. var_export($done_signal, TRUE) . ", 'r+'); fwrite(\$signal, \"done\\n\"); fclose(\$signal); });\n"
+			. 'eval(' . var_export($function, TRUE) . ");\n"
+			. '$GLOBALS[\'g\'][\'tmp_path\'] = ' . var_export($this->tmp, TRUE) . ";\n"
+			. '$GLOBALS[\'pfb\'][\'log\'] = ' . var_export("{$this->tmp}/pfblockerng.log", TRUE) . ";\n"
+			. '$GLOBALS[\'pfb\'][\'errlog\'] = ' . var_export("{$this->tmp}/pfblockerng.errlog", TRUE) . ";\n"
+			. '$GLOBALS[\'pfb\'][\'chroot_cmd\'] = ' . var_export($chroot, TRUE) . ";\n"
+			. '$GLOBALS[\'pfb\'][\'timeout\'] = ' . var_export($timeout, TRUE) . ";\n"
+			. '$_POST[\'entry_delete\'] = \'delete_domainwildcard\';' . "\n"
+			. 'pfb_alerts_test_wildcard_flush(' . var_export($swapped, TRUE) . ');' . "\n"
+			. 'file_put_contents(' . var_export($result, TRUE) . ', json_encode(['
+				. "'savemsg' => \$savemsg, "
+				. "'log' => (is_file(\$GLOBALS['pfb']['log']) ? file_get_contents(\$GLOBALS['pfb']['log']) : '')"
+				. ' . (is_file($GLOBALS[\'pfb\'][\'errlog\']) ? file_get_contents($GLOBALS[\'pfb\'][\'errlog\']) : \'\'),'
+			. ' ]));' . "\n";
+		file_put_contents($worker, $worker_code);
+
+		$descriptors = array(
+			0 => array('file', '/dev/null', 'r'),
+			1 => array('file', $child_log, 'ab'),
+			2 => array('file', $child_log, 'ab'),
+		);
+		// Hold the signal open BEFORE the worker starts: a worker that finishes
+		// at once must not report into a pipe this side has not attached to yet.
+		$done = fopen($done_signal, 'r+');
+		$this->assertIsResource($done, 'could not open the end-of-run signal');
+		$process = proc_open(array(PHP_BINARY, $worker), $descriptors, $pipes);
+		if (!is_resource($process)) {
+			throw new RuntimeException('could not start flush worker');
+		}
+		$worker_status = proc_get_status($process);
+		$worker_pid = (int) ($worker_status['pid'] ?? 0);
+
+		$reported = FALSE;
+		try {
+			$read = array($done);
+			$write = NULL;
+			$except = NULL;
+			$reported = stream_select($read, $write, $except, self::FLUSH_SALVAGE_SECONDS) === 1
+				&& fgets($done) === "done\n";
+		} finally {
+			if (!$reported) {
+				// The worker sits in exec() on the hung double; only SIGKILL of
+				// its whole session gets it back.
+				$killed = $worker_pid > 0 && function_exists('posix_kill') && @posix_kill(-$worker_pid, 9);
+				if (!$killed) {
+					proc_terminate($process, 9);
+				}
+			}
+			proc_close($process);
+			fclose($done);
+			// Never leak the flush double, whatever happened above.
+			$leftover = $this->markerPid($marker);
+			if ($leftover !== NULL && function_exists('posix_kill')) {
+				@posix_kill($leftover, 9);
+			}
+		}
+		if (!$reported) {
+			$this->fail(sprintf(
+				'STUCK/ENVIRONMENT: the flush worker never reached its end-of-run signal within %ds. '
+				. 'Against the unbounded pre-#2880 POST path this IS the expected red (the request blocks on resolver-control IPC); '
+				. 'otherwise the run is stuck or its host starved the worker (child output: %s)',
+				self::FLUSH_SALVAGE_SECONDS,
+				is_file($child_log) ? (string) file_get_contents($child_log) : '(none)'
+			));
+		}
+
+		$payload = is_file($result) ? json_decode((string) file_get_contents($result), TRUE) : array();
+		return array(
+			'completed' => is_file($result),
+			'savemsg' => (string) ($payload['savemsg'] ?? ''),
+			'log' => (string) ($payload['log'] ?? ''),
+			'timeout_calls' => $this->timeoutCalls($timeout_log),
+			'child_log' => is_file($child_log) ? (string) file_get_contents($child_log) : '',
+			'marker' => $marker,
+			'chroot' => $chroot,
+		);
+	}
+
+	/**
+	 * Carve the shipped `if ($swapped) { ... }` wildcard-flush block from the
+	 * page's delete_domainwildcard POST tail. It is located from the block's
+	 * unique `pfb_reload_unbound('enabled', FALSE, FALSE, TRUE)` anchor (the
+	 * page has two other `if ($swapped)` sites) and brace-matched through the
+	 * tokenizer, so string-interpolated braces (`{$pfb['chroot_cmd']}`) can
+	 * never truncate it and the same extraction drives the pre-#2880
+	 * unbounded shape and the bounded rewrite alike. The anchor assignment
+	 * itself is deliberately NOT carved: the harness supplies $swapped so no
+	 * row depends on the real reload's off-appliance verdict.
+	 */
+	private function flushBlock(): string
+	{
+		$source = file_get_contents(self::ALERTS_PHP);
+		if ($source === FALSE) {
+			throw new RuntimeException('test oracle: failed to read pfblockerng_alerts.php');
+		}
+		$anchor = "\$swapped = pfb_reload_unbound('enabled', FALSE, FALSE, TRUE);";
+		$anchor_pos = strpos($source, $anchor);
+		if ($anchor_pos === FALSE) {
+			throw new RuntimeException('test oracle: wildcard flush anchor not found');
+		}
+		$block_head = 'if ($swapped) {';
+		$pos = strpos($source, $block_head, $anchor_pos + strlen($anchor));
+		if ($pos === FALSE) {
+			throw new RuntimeException('test oracle: wildcard flush block head not found after anchor');
+		}
+		$tokens = token_get_all($source);
+		$offset = 0;
+		$head_idx = NULL;
+		foreach ($tokens as $idx => $tok) {
+			if ($head_idx === NULL && $offset === $pos) {
+				$head_idx = $idx;
+			}
+			$offset += strlen(is_array($tok) ? $tok[1] : $tok);
+		}
+		if ($head_idx === NULL) {
+			throw new RuntimeException('test oracle: block head does not align with a token boundary');
+		}
+		$offset = $pos;
+		// `if ($swapped)` carries no braces of its own, so the first opening
+		// brace after the head token opens the block. Bare '{'/'}' tokens and
+		// the interpolation openers are tracked; quoted strings arrive as
+		// single tokens, so shell braces inside them cannot skew the depth.
+		$depth = 0;
+		$end_offset = NULL;
+		$seen_open = FALSE;
+		for ($i = $head_idx, $n = count($tokens); $i < $n; $i++) {
+			$tok = $tokens[$i];
+			$len = strlen(is_array($tok) ? $tok[1] : $tok);
+			if ($seen_open) {
+				if ($tok === '{' || (is_array($tok) && in_array($tok[0], array(T_CURLY_OPEN, T_DOLLAR_OPEN_CURLY_BRACES), TRUE))) {
+					$depth++;
+				} elseif ($tok === '}') {
+					$depth--;
+					if ($depth === 0) {
+						$end_offset = $offset + $len - 1;
+						break;
+					}
+				}
+			} elseif ($tok === '{') {
+				$seen_open = TRUE;
+				$depth = 1;
+			}
+			$offset += $len;
+		}
+		if ($end_offset === NULL) {
+			throw new RuntimeException('test oracle: wildcard flush block braces do not close');
+		}
+		return substr($source, $pos, $end_offset + 1 - $pos);
+	}
+
+	private function fixture(string $name, string $body): string
+	{
+		$path = "{$this->tmp}/{$name}";
+		file_put_contents($path, "#!/bin/sh\n{$body}\n");
+		chmod($path, 0755);
+		return $path;
+	}
+
+	private function markerPid(string $marker): ?int
+	{
+		$lines = @file($marker, FILE_IGNORE_NEW_LINES);
+		foreach ($lines ?: array() as $line) {
+			if (str_starts_with($line, '--START--')) {
+				$pid = (int) substr($line, strlen('--START--'));
+				if ($pid > 0) {
+					return $pid;
+				}
+			}
+		}
+		return NULL;
+	}
+
+	/** @return list<list<string>> */
+	private function timeoutCalls(string $path): array
+	{
+		$lines = @file($path, FILE_IGNORE_NEW_LINES);
+		$calls = array();
+		$call = array();
+		foreach ($lines ?: array() as $line) {
+			if ($line === '--CALL--') {
+				if ($call !== array()) {
+					$calls[] = $call;
+					$call = array();
+				}
+				continue;
+			}
+			$call[] = $line;
+		}
+		if ($call !== array()) {
+			$calls[] = $call;
+		}
+		return $calls;
+	}
+}


### PR DESCRIPTION
## What this is

A **port** of pre-resign commit `6abb064cc` ("alerts: bound wildcard-delete resolver flush wait (#2880)") onto current `devel`. The **production diff is byte-identical** to the source commit's. Two test-side deviations were required and are itemised at the bottom.

**Why not a rebase or cherry-pick:** this repository's history was re-signed. The original lane branch `issue-2880-alerts-wildcard-flush-bound` has **no merge-base** with current `devel`, so `git rebase` and `git cherry-pick` are the wrong tools. A blob checkout was also wrong: `devel` had moved `pfblockerng_alerts.php` in unrelated hunks (the `pfb_feed_pass_acquire($pfb_contended)` work around lines 1314/1372), so checking out the source blob would have silently reverted that landed change. The port used `git show 6abb064cc -- <prod path> | git apply -3`, which reproduces the source hunk exactly and preserves everything `devel` landed since. Verified content-for-content, with only the hunk's line offset differing (1427 -> 1433, from devel's +6 lines above the call site):

```
=== production hunk still byte-identical to source commit? ===
PRODUCTION HUNK BODY IDENTICAL to 6abb064cc
```

## What it does

The `delete_domainwildcard` POST path ran `unbound-control flush_zone +c .` through raw `exec()`: a hung resolver-control socket blocked the HTTP request forever and any control failure was silently swallowed. The change wraps the call in the bounded-wait seam the Alerts CNAME lookup already uses (`timeout(1)` default reaper mode, 30s TERM budget, 5s kill grace, output to a regular file, stdin `/dev/null`) and captures the status. Expiry (124) and non-zero control exits log and surface a distinct user-visible message naming the already-persisted removal and the manual recovery action; a healthy flush preserves existing success behaviour byte-for-byte.

## Red -> green proof (executed, test-first)

Test file checked out and run RED **before** any production change, with the production path verified untouched at red time (`git diff --stat` against the base empty, call site still `exec("{$pfb['chroot_cmd']} flush_zone +c . 2>&1");` at line 1436).

**RED** — `vendor/bin/phpunit tests/php/AlertsWildcardFlushTimeoutTest.php`, production at base:

```
1) AlertsWildcardFlushTimeoutTest::testHungResolverFlushIsBoundedAndNeverReportsOrdinarySuccess
STUCK/ENVIRONMENT: the flush worker never reached its end-of-run signal within 30s.
Against the unbounded pre-#2880 POST path this IS the expected red (the request
blocks on resolver-control IPC); otherwise the run is stuck or its host starved the worker

2) AlertsWildcardFlushTimeoutTest::testImmediateNonzeroFlushIsDistinguishedFromSuccess
the flush ran without the bounded timeout(1) wrapper
3) AlertsWildcardFlushTimeoutTest::testMissingControlBinaryIsDistinguishedFromSuccess
the flush ran without the bounded timeout(1) wrapper
4) AlertsWildcardFlushTimeoutTest::testHealthyFlushPreservesExistingSuccessBehavior
the flush ran without the bounded timeout(1) wrapper

FAILURES!
Tests: 5, Assertions: 27, Failures: 4.

real	0m30.798s
```

**GREEN** — same file, zero edits, after `git apply -3` of the production hunk:

```
.....                                                               5 / 5 (100%)

Time: 00:00.686, Memory: 30.00 MB

OK (5 tests, 48 assertions)

real	0m0.911s
```

The 30.8s -> 0.69s wall-clock drop is the bound taking effect.

**Freeze** — `git hash-object tests/php/AlertsWildcardFlushTimeoutTest.php`:
- red time: `759d2712d3466b2dacc2bd3d8bedc57d1641f918`
- after the green run: `759d2712d3466b2dacc2bd3d8bedc57d1641f918`
- committed blob (`git rev-parse HEAD:<test>`): `759d2712d3466b2dacc2bd3d8bedc57d1641f918`

An earlier cycle in this lane banked hash `4c558e4919c1227f1178eaa0b53ddf5f07d9e178` — that is the source commit's untouched test blob, and it matches the frozen RED hash recorded independently in issue #2880's own BLOCKED comment. It is **superseded** because deviation 2 below required a one-token change to the test, so the whole red->green cycle was re-executed from scratch against a reverted production file rather than quietly re-frozen.

## Coverage matrix — all 5 tests from the source commit's test file

| # | Test | Red | Green |
| - | ---- | --- | ----- |
| 1 | `testHungResolverFlushIsBoundedAndNeverReportsOrdinarySuccess` | FAIL (30s salvage cap consumed on the unbounded path) | PASS |
| 2 | `testImmediateNonzeroFlushIsDistinguishedFromSuccess` | FAIL (no bounded wrapper) | PASS |
| 3 | `testMissingControlBinaryIsDistinguishedFromSuccess` | FAIL (no bounded wrapper) | PASS |
| 4 | `testHealthyFlushPreservesExistingSuccessBehavior` | FAIL (no bounded wrapper) | PASS |
| 5 | `testReloadSwapFailureRunsNoFlushAndMakesNoCacheClaim` | **PASS in both runs** — no flush is expected on that row, so it has no red to claim | PASS |

## Two defects found in the source commit

Both were found by running the **full** suites. Neither is drift: both files are byte-identical between `6abb064cc` and current `devel`.

### 1. A stale source-text pin (PHPUnit)

`AlertsUnboundCachePolicyTest::testWildcardWhitelistRemovalFlushesFullCacheAfterSuccessfulSwap` is a source-*text* wiring pin (it reads `php_strip_whitespace()` output) that quoted the literal `exec("{$pfb['chroot_cmd']} flush_zone +c . 2>&1");`. The change rewrites exactly that call, so the literal vanished and the pin failed with "missing targeted flush". **Source commit `6abb064cc` itself shipped this red**, having touched only two files and never re-derived the pin — consistent with the issue's own BLOCKED comment, which flagged the staleness and admitted "Full-suite RED was not reproduced against the reviewer's baseline".

This PR re-derives that one expected literal. The pinned *intent* is unchanged; the reload-before-flush ordering assertion, the `if ($swapped)` gate check and the `assertSame(1, substr_count($source, 'flush_zone +c .'))` uniqueness count are untouched. **Mutation proof it is not vacuous** (deleted the bounded flush call from the ported production file, then restored):

```
=== [1] GREEN baseline with re-derived pin ===        OK (3 tests, 29 assertions)
=== [2] MUTATE: delete the bounded flush exec ===     flush_zone +c . occurrences: 0
=== [3] PIN MUST BE RED ===
missing targeted flush: exec(escapeshellarg($pfb['timeout'] ?? '/usr/bin/timeout') . " -s TERM -k 5 30 {$pfb['chroot_cmd']} flush_zone +c . > "
Tests: 3, Assertions: 26, Failures: 1.
=== [4] RESTORE ===  RESTORE EXACT (hash 71137c7e before == after)
=== [5] MUST BE GREEN AGAIN ===                       OK (3 tests, 29 assertions)
```

### 2. A retired-idiom violation in the test file (ShellSpec)

`tests/shell/pfblockerng_truncate_survival_spec.sh:387` is a repo-wide structural retirement guard (issues #1172, #1850) that runs `git grep -nE '(while|until)[[:space:]]+:' -- src scripts tests` and requires zero hits. The ported test file's hung-resolver double was `'stall' => "while :; do :; done\n"` — a hit. Probed both directions: the spec **passes** on the pristine base and **fails** with the ported file present, and the shellspec job is `success` on `devel`'s own CI at that base and every run before it. The original lane never saw this because a PHP-only diff does not make `run-gates.sh` select shellspec; only CI's full-suite shellspec catches it.

Fixed by the guard's own retirement target, one token: `while :` -> `while true`. Both guards now return empty from this repository, and the spec is fully green:

```
=== GUARD 1: colon-loop (expected empty) ===   (empty -> clean)
=== GUARD 2: legacy ': >' truncate  ===        (empty -> clean)
=== the guard spec alone ===                   12 examples, 0 failures
```

**The double still genuinely hangs after the swap** — the bounded row must pass because the bound reaped a real stall, not because the stall stopped stalling. Removing only the `timeout(1)` bound from the ported production hunk (keeping the flush, the file capture and the status):

```
=== the hung row MUST be RED (bound gone, double still stalls) ===
STUCK/ENVIRONMENT: the flush worker never reached its end-of-run signal within 30s
Tests: 1, Assertions: 4, Failures: 1.
real	0m31.401s
=== RESTORE ===  RESTORE EXACT (71137c7e)
=== the hung row MUST be GREEN again ===       OK (1 test, 11 assertions)   Time: 00:00.594
```

### Why this matters beyond this PR

Both defects, plus a dash-only stderr warning found independently on the #2877 port, share one cause: a PHP-only or shell-only diff never selects the other language's suite in `run-gates.sh`, and none of these source commits ever reached CI. That is the actual reason these branches sat un-landed, and it is a stronger argument for porting them through the full gate than anything in the original commit messages.

## Gates

`scripts/agent/run-gates.sh --diff origin/devel`, plus the PHP gates re-run individually. Note: `composer phpstan`/`composer phpcs` need `COMPOSER_ALLOW_SUPERUSER=1` on a root-running host, and `check_composer_vendor.py` rejects a symlinked `vendor` — neither `run-gates.sh` nor the pre-commit hook exports the former.

| Gate | Command | Result |
| ---- | ------- | ------ |
| `php -l` | per touched file (3) | `No syntax errors detected` x3 |
| phpstan | `composer phpstan` | `[OK] No errors` |
| phpcs | `composer phpcs -- --standard=phpcs.xml.dist src/` | exit 0, no output |
| composer vendor | `check_composer_vendor.py` | PASS |
| coverage pairing | `check_coverage_pairing.py --name-status-z` | PASS |
| shellspec (guard spec) | `shellspec --shell dash <spec>` | 12 examples, 0 failures |
| focused PHPUnit | both Alerts test files | `OK (8 tests, 77 assertions)` |
| pre-commit hooks | full chain, **no `--no-verify`** | all steps passed |

**Full `vendor/bin/phpunit` is red on this host, and identically red without this change.** Measured against a pristine base worktree:

| | Tests | Assertions | Errors | Failures |
| - | - | - | - | - |
| pristine base | 6497 | 40550 | 29 | 14 |
| this branch | 6502 | 40600 | 29 | 14 |

`+5` tests are exactly the five added here. Diffing both runs' failing/erroring rows **by name** with the worktree path prefix normalised gives **139 identical entries on both sides — zero new failing names**. Those 29 errors + 14 failures = **43 cases**, precisely the already-tracked host defect **#3103** ("43 PHPUnit cases fail locally on a Debian/PHP 8.4 host but pass in CI (mwexec() undoubled)"); this host is PHP 8.4.24. Per `testing.md`, CI is authoritative where host and CI disagree — and CI's PHPUnit passes on **8.3, 8.4 and 8.5**.

`FunctionInventoryParityTest` was confirmed by run, not inspection: `OK (1 test, 6 assertions)`. The diff adds no function declarations, so the golden needed no regeneration.

## UI tier (test mandate #4)

no-test-needed: this change adds no UI surface — it bounds a POST handler's wait on resolver-control IPC. The page's existing Tier A row already covers its render, and the new failure-path message cannot be reached from any hermetic tier, so it is pinned hermetically in AlertsWildcardFlushTimeoutTest instead.

- **No new UI surface.** Existing page, no new route, no new element, no structural or visual change. The only user-visible addition is text appended to the existing `$savemsg` channel on a failure path.
- **Tier A status of `pfblockerng_alerts.php` on current `devel`: already covered.** `tests/smoke/ui/test_render_smoke.py` has `Page("alerts", "/pfblockerng/pfblockerng_alerts.php", ("Alert Settings",))` at line 178, plus view rows `alerts_ip_block_stat` and `alerts_dnsbl_stat` at lines 186-187. It is **not** in `EXCLUDED_FROM_TIER_A`; that tuple's only remaining entry is `dnsbl_vip_sinkhole_pages`, asserted as the sole exclusion at lines 3538-3541. The page is Tier-A reachable and structurally unchanged, so the existing Tier A row covers this change and no new UI test is warranted.
- **Why the new message needs no new hermetic row:** it is reachable only when resolver control hangs or exits non-zero, which no hermetic tier can trigger. Its contract is pinned in `AlertsWildcardFlushTimeoutTest` across expiry, immediate non-zero, missing-binary, healthy and reload-swap-failure rows.
- **Smoke-seat item for the landing seat:** the live failure-path behaviour — a supported wildcard delete against a non-responsive resolver-control endpoint, observing the finite page state and subsequent DNS behaviour — is a **smoke-seat** row per `testing.md` "Runtime claims need a smoke seat". It has **not** been run here and **no runtime result is claimed** in this PR.

## Deviations from a strict byte-identical port

1. `tests/php/AlertsUnboundCachePolicyTest.php` — one expected literal re-derived (oracle reconciliation for defect 1). Not part of the source commit.
2. `tests/php/AlertsWildcardFlushTimeoutTest.php:182` — one token, `while :` -> `while true` (defect 2). The shipped test is therefore **not** byte-identical to `6abb064cc`.

The **production diff remains byte-identical** to `6abb064cc`. No bound was widened or narrowed, and no mechanism was invented.

## Landing notes

- **Do not land from this PR as-is.** This lane's assignment was port + publish only: no squash, no merge, no fast-forward.
- Issue #2880 is still `ready-for-human` and its **reserved decisions remain open**: the budget policy (fixed 30s TERM + 5s grace vs a dedicated setting), the post-expiry state semantics (this change keeps the persisted removal and reports manual recovery), and whether expiry should persist a durable retry marker instead of only an inline message. This PR ports the original behaviour unchanged; it does not settle those choices.

Fixes #2880


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented resolver cache flush operations from waiting indefinitely by enforcing a timeout.
  * Added clear warnings when cache flushing times out or fails, including recovery guidance.
  * Preserved successful whitelist updates while informing users that stale cached subdomains may remain temporarily.

* **Tests**
  * Added coverage for timeout, failure, success, cleanup, and reload-swap scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->