### PR TITLE
pfblockerng: bound the whole whoisconvert batch duration

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.sh
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.sh
@@ -1668,8 +1668,15 @@ whoisconvert() {
 	_whoisbatch_budget=1800
 	case "${whoisbatchtimeout:-}" in
 	''|*[!0-9]*) : ;;
-	*)	[ "${whoisbatchtimeout}" -gt 0 ] 2>/dev/null && _whoisbatch_budget="${whoisbatchtimeout}" ;;
+	*)
+		_whoisbatch_n=${whoisbatchtimeout}
+		while [ "${_whoisbatch_n}" != "${_whoisbatch_n#0}" ] && [ "${#_whoisbatch_n}" -gt 1 ]; do
+			_whoisbatch_n=${_whoisbatch_n#0}
+		done
+		[ "${_whoisbatch_n}" -gt 0 ] 2>/dev/null && _whoisbatch_budget=${_whoisbatch_n}
+		;;
 	esac
+
 	_whoisbatch_start="$(date +%s)"
 	_whoisbatch_expired=false
 

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.sh
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.sh
@@ -1654,6 +1654,24 @@ whoisconvert() {
 	else
 		_type=AAAA
 	fi
+	# issue #2877: bound the TOTAL elapsed time of one batch. Issue #2015 bounded
+	# each Domain lookup at 30 seconds, but the batch itself iterates every
+	# configured entry, so the two synchronous PHP launch sites could wait an
+	# unbounded 30s x Domain rows (plus the first-use ASN re-entry). The deadline
+	# is checked BEFORE each entry and the per-entry timeout is clipped to the
+	# time left, so the batch ends within the budget plus one lookup's kill
+	# grace; no Domain/AS ordering can bypass it. The nested ASN re-entry keeps
+	# pfb_reentry()'s own #2016 bound -- nothing is routed around that seam.
+	# Same degradation discipline as pfb_reentry(): start AT the default and
+	# take an override only once it is proven positive-integral, so no input can
+	# produce an empty or non-numeric duration (issue #2488's degradation class).
+	_whoisbatch_budget=1800
+	case "${whoisbatchtimeout:-}" in
+	''|*[!0-9]*) : ;;
+	*)	[ "${whoisbatchtimeout}" -gt 0 ] 2>/dev/null && _whoisbatch_budget="${whoisbatchtimeout}" ;;
+	esac
+	_whoisbatch_start="$(date +%s)"
+	_whoisbatch_expired=false
 
 	# Backup previous orig file
 	if [ -e "${pfborig}${alias}.orig" ]; then
@@ -1674,6 +1692,13 @@ whoisconvert() {
 	# ${found} flag the restore logic below reads); skip blank entries.
 	while IFS= read -r host; do
 		[ -z "${host}" ] && continue
+		# issue #2877: whole-batch deadline, checked before each entry so no
+		# Domain/AS ordering can bypass the total budget.
+		_whoisbatch_left=$(( _whoisbatch_budget - $(date +%s) + _whoisbatch_start ))
+		if [ "${_whoisbatch_left}" -le 0 ]; then
+			_whoisbatch_expired=true
+			break
+		fi
 		# Determine if host is a Domain or an AS: a domain contains a dot.
 		case "${host}" in
 		*.*)
@@ -1683,7 +1708,13 @@ whoisconvert() {
 			# then keep only the "has (IPv6) address" lines so a failure message
 			# (e.g. "Host x not found: 3(NXDOMAIN)") can never be captured as
 			# data (issue #714). Mirrors the ASN branch below.
-			hostout="$("${pathtimeout}" -s TERM -k 5 30 "${pathhost}" -t "${_type}" "${host}")"
+			# issue #2877: clip this lookup to the batch deadline (the deadline
+			# check above guarantees at least 1 second is left), else #2015's 30s.
+			_whoisbatch_tmo=30
+			if [ "${_whoisbatch_left}" -lt 30 ]; then
+				_whoisbatch_tmo="${_whoisbatch_left}"
+			fi
+			hostout="$("${pathtimeout}" -s TERM -k 5 "${_whoisbatch_tmo}" "${pathhost}" -t "${_type}" "${host}")"
 			hostrc=$?
 			if [ "${hostrc}" -eq 0 ]; then
 				hostips="$(echo "${hostout}" | grep -E 'has( IPv6)? address' | sed 's/^.* //')"
@@ -1751,6 +1782,16 @@ whoisconvert() {
 	done <<EOF
 ${custom_list}
 EOF
+
+	# issue #2877: explicit partial-state policy. Entries that resolved before
+	# the deadline are KEPT (the ${found} append semantics above); the skipped
+	# remainder is a visible failure named for the operator -- never a silent
+	# publish of a partial list or a silent erase of the collected prefix.
+	if [ "${_whoisbatch_expired}" = true ]; then
+		log="WHOIS batch [ ${alias} ] TIMED OUT after ${_whoisbatch_budget}s total; remaining Domain/AS entries skipped"
+		echo "${log}" | tee -a "${errorlog}"
+		touch "${pfborig}${alias}.fail"
+	fi
 
 	# Restore previous orig file
 	if [ "${found}" = false ]; then

--- a/tests/php/WhoisconvertBatchBudgetLaunchTest.php
+++ b/tests/php/WhoisconvertBatchBudgetLaunchTest.php
@@ -1,0 +1,237 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * issue #2877: the whole-batch deadline of whoisconvert() must bound BOTH
+ * synchronous PHP producer paths that launch it, not only direct shell calls:
+ *
+ *   1. src/usr/local/pkg/pfblockerng/pfblockerng.inc pfb_download_fetch() --
+ *      WHOIS/ASN feed conversion. Executed here for real: pfb_download_fetch()
+ *      composes and exec()s the launch against a deterministic stand-in script
+ *      that sources the REAL pfblockerng.sh and runs the REAL whoisconvert()
+ *      with the launched argv, over a fake host(1) whose per-entry calls stay
+ *      individually bounded while the entry's lookup exceeds the batch budget.
+ *
+ *   2. src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
+ *      sync_package_pfblockerng() -- persisted custom Domain/ASN list. The
+ *      enclosing sync pass is not off-appliance executable, so this site is
+ *      pinned two ways: its exact exec() statement is asserted in the shipped
+ *      source (whole statement, so composition drift fails), and the site's
+ *      composed command is EXECUTED with the site's own variable bindings
+ *      through the same stand-in, driving the same bounded batch red->green.
+ *
+ * Both rows go red while the batch is unbounded (the lookup/batch exceeds the
+ * budget, no clipping/expiry happens) and green once the deadline bounds it.
+ */
+#[CoversFunction('pfb_download_fetch')]
+final class WhoisconvertBatchBudgetLaunchTest extends TestCase
+{
+	private const PFB_SH = __DIR__ . '/../../src/usr/local/pkg/pfblockerng/pfblockerng.sh';
+	private const PFB_INC = __DIR__ . '/../../src/usr/local/pkg/pfblockerng/pfblockerng.inc';
+	private const APPLY_INC = __DIR__ . '/../../src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc';
+
+	/** The launch statements, exactly as shipped (whole statements). */
+	private const SITE1_EXEC = 'exec("{$pfb[\'script\']} whoisconvert {$header_esc} {$vtype} {$list_url_esc} {$elog}");';
+	private const SITE2_EXEC = 'exec("{$pfb[\'script\']} whoisconvert {$header_esc} {$list[\'vtype\']} {$custom_list} {$elog}");';
+
+	private string $tmp;
+
+	protected function setUp(): void
+	{
+		$this->tmp = sys_get_temp_dir() . '/pfb_whoisbatch_' . getmypid() . '_' . bin2hex(random_bytes(4));
+		$this->assertTrue(mkdir($this->tmp, 0700, TRUE));
+		mkdir("{$this->tmp}/orig", 0700, TRUE);
+		file_put_contents("{$this->tmp}/timeout.args", '');
+		file_put_contents("{$this->tmp}/host.count", '0');
+	}
+
+	protected function tearDown(): void
+	{
+		foreach (array_reverse(glob("{$this->tmp}/*") ?: []) as $path) {
+			is_dir($path) ? @rmdir($path) : @unlink($path);
+		}
+		@rmdir($this->tmp);
+	}
+
+	/** Real timeout(1) from PATH. A gate whose tool is missing is a failure, never a skip. */
+	private function realTimeout(): string
+	{
+		$out = [];
+		$rc  = 0;
+		exec('command -v timeout 2>/dev/null', $out, $rc);
+		$path = trim((string) ($out[0] ?? ''));
+		if ($path === '' || !is_executable($path)) {
+			$this->fail('no timeout(1) on PATH: the executed producer-path rows need a real one');
+		}
+		return $path;
+	}
+
+	/**
+	 * The deterministic fake helper both producer paths launch: it reproduces
+	 * the script argv contract (alias=$2, max=$3, dedup=$4), sources the REAL
+	 * pfblockerng.sh, and calls the REAL whoisconvert() with test-seam fakes.
+	 */
+	private function writeShim(): string
+	{
+		$shim = "{$this->tmp}/pfblockerng-shim";
+		file_put_contents($shim, <<<'SH'
+			#!/bin/sh
+			alias="$2"
+			max="$3"
+			dedup="$4"
+			pfborig="${PFB_TEST_ORIG}/"
+			pathhost="${PFB_TEST_HOST}"
+			pathtimeout="${PFB_TEST_TIMEOUT}"
+			pathasncsv="${PFB_TEST_ASNCSV}"
+			errorlog="${PFB_TEST_ERRLOG}"
+			PFB_SOURCED=1 . "${PFB_TEST_PFB_SH}"
+			whoisconvert
+			SH);
+		chmod($shim, 0755);
+		return $shim;
+	}
+
+	/** timeout(1) stand-in: records its argv (one space-joined line per call), enforces for real. */
+	private function writeTimeout(): string
+	{
+		$real = $this->realTimeout();
+		$faux = "{$this->tmp}/timeout";
+		file_put_contents($faux, "#!/bin/sh\nprintf '%s\n' \"\$*\" >> \"\${TIMEOUT_ARGS}\"\nexec '{$real}' \"\$@\"\n");
+		chmod($faux, 0755);
+		return $faux;
+	}
+
+	/** host(1) stand-in: sleeps HOST_SLEEP, then answers a unique 203.0.113.<n> address. */
+	private function writeHost(): string
+	{
+		$faux = "{$this->tmp}/host";
+		file_put_contents($faux, <<<'SH'
+			#!/bin/sh
+			sleep "${HOST_SLEEP}"
+			n="$(cat "${HOST_COUNT}")"
+			n=$((n + 1))
+			echo "$n" > "${HOST_COUNT}"
+			echo "$3 has address 203.0.113.$n"
+			SH);
+		chmod($faux, 0755);
+		return $faux;
+	}
+
+	/** Export the seams the shim and its fakes read, mirroring the PHP-launched env. */
+	private function exportSeams(string $budget, string $hostSleep): void
+	{
+		putenv("PFB_TEST_ORIG={$this->tmp}/orig");
+		putenv("PFB_TEST_HOST={$this->tmp}/host");
+		putenv("PFB_TEST_TIMEOUT={$this->tmp}/timeout");
+		putenv("PFB_TEST_ASNCSV={$this->tmp}/asn.csv");
+		putenv("PFB_TEST_ERRLOG={$this->tmp}/error.log");
+		putenv("PFB_TEST_PFB_SH=" . self::PFB_SH);
+		putenv("TIMEOUT_ARGS={$this->tmp}/timeout.args");
+		putenv("HOST_COUNT={$this->tmp}/host.count");
+		putenv("HOST_SLEEP={$hostSleep}");
+		// The shim reads the budget from the shell-level seam, exactly like the
+		// nested re-entry seam reads its configured budget.
+		putenv("whoisbatchtimeout={$budget}");
+	}
+
+	private function log(): string
+	{
+		return (string) @file_get_contents("{$this->tmp}/pfblockerng.log");
+	}
+
+	/**
+	 * Producer path 1 -- pfblockerng.inc pfb_download_fetch(), WHOIS feed
+	 * conversion. A feed whose single Domain lookup stays individually bounded
+	 * (a slow-but-finite host) yet exceeds the whole-batch budget must be
+	 * CLIPPED to the budget and follow the existing failure/restore path, not
+	 * wait out the unbounded 30-second-per-entry bound. (A single-entry list
+	 * leaves no entries to skip, so the batch-expiry line belongs to the
+	 * multi-entry producer path below.)
+	 */
+	public function test_pfblockerng_inc_whois_site_launches_the_bounded_batch(): void
+	{
+		$this->assertNotFalse(strpos((string) file_get_contents(self::PFB_INC), self::SITE1_EXEC),
+			'pfblockerng.inc must keep its exact whoisconvert launch statement');
+
+		$GLOBALS['pfb']['log']    = "{$this->tmp}/pfblockerng.log";
+		$GLOBALS['pfb']['errlog'] = "{$this->tmp}/error.log";
+		$GLOBALS['pfb']['script'] = $this->writeShim();
+		$this->writeTimeout();
+		$this->writeHost();
+		$this->exportSeams('2', '3');
+		// A prior .orig proves the timed-out single-entry launch follows the
+		// existing #2015 failure/restore path.
+		file_put_contents("{$this->tmp}/orig/SiteOne.orig", "198.51.100.7\n");
+
+		$request = new PfbDownloadRequest(
+			listUrl: 'd1.example',
+			downloadPath: "{$this->tmp}/d1",
+			flex: FALSE,
+			header: 'SiteOne',
+			format: 'whois',
+			logType: 1,
+			versionType: '_v4',
+		);
+
+		$result = pfb_download_fetch($request);
+
+		$this->assertTrue($result->success, 'the whois branch must treat the bounded batch as the launch outcome');
+		// The launched lookup was clipped to the budget (entry 1 at elapsed 0:
+		// modulo a date(1) second boundary, 1 is also a clipped value), not the
+		// bare 30-second bound of issue #2015.
+		$args = (string) file_get_contents("{$this->tmp}/timeout.args");
+		$this->assertSame(1, preg_match('/ -k 5 [12] .* -t A d1\.example/', $args),
+			"the launched lookup must be clipped to the 2s batch budget, got: {$args}");
+		$this->assertFileExists("{$this->tmp}/orig/SiteOne.fail");
+		$this->assertSame("198.51.100.7\n", (string) file_get_contents("{$this->tmp}/orig/SiteOne.orig"),
+			'the timed-out single-entry launch restores the prior data (found stays false)');
+	}
+
+	/**
+	 * Producer path 2 -- pfblockerng_apply.inc sync_package_pfblockerng(),
+	 * persisted custom Domain/ASN list. The site's composed command is executed
+	 * with the site's own bindings: a twenty-entry custom list whose per-entry
+	 * lookups are each 0.2s (individually bounded, 4s total) must end at the
+	 * 2s batch budget with the resolved prefix kept and the remainder skipped.
+	 */
+	public function test_apply_inc_whois_site_launches_the_bounded_batch(): void
+	{
+		$this->assertNotFalse(strpos((string) file_get_contents(self::APPLY_INC), self::SITE2_EXEC),
+			'pfblockerng_apply.inc must keep its exact whoisconvert launch statement');
+
+		$GLOBALS['pfb']['log']    = "{$this->tmp}/pfblockerng.log";
+		$GLOBALS['pfb']['errlog'] = "{$this->tmp}/error.log";
+		$shim = $this->writeShim();
+		$this->writeTimeout();
+		$this->writeHost();
+		$this->exportSeams('2', '0.2');
+
+		// The site's bindings: $header_esc = escapeshellarg(header),
+		// $list['vtype'], $custom_list (comma-joined), $elog from $pfb['log'].
+		$header_esc  = escapeshellarg('CustomList');
+		$vtype       = '_v4';
+		$custom_list = implode(',', array_map(
+			static fn (int $i): string => "d{$i}.example",
+			range(1, 20)
+		));
+		$elog = ">> {$GLOBALS['pfb']['log']} 2>&1";
+
+		exec("{$shim} whoisconvert {$header_esc} {$vtype} {$custom_list} {$elog}");
+
+		$this->assertStringContainsString(
+			'WHOIS batch [ CustomList ] TIMED OUT after 2s total; remaining Domain/AS entries skipped',
+			$this->log(),
+			'the batch deadline must name its expiry in the launch log'
+		);
+		$orig = (string) @file_get_contents("{$this->tmp}/orig/CustomList.orig");
+		$this->assertStringContainsString('203.0.113.3', $orig,
+			'entries that resolved before the deadline are kept (append semantics)');
+		$this->assertStringNotContainsString('203.0.113.20', $orig,
+			'the skipped remainder must not be published (an unbounded batch runs all twenty)');
+		$this->assertFileExists("{$this->tmp}/orig/CustomList.fail");
+	}
+}

--- a/tests/shell/pfblockerng_whoisconvert_batch_budget_spec.sh
+++ b/tests/shell/pfblockerng_whoisconvert_batch_budget_spec.sh
@@ -266,6 +266,24 @@ EOF
     The path "${pfborig}${alias}.fail" should not be exist
   End
 
+  It 'accepts a zero-padded positive budget instead of degrading to the default'
+    whoisbatchtimeout=008
+    export HOST_SLEEP=0
+    dedup='d1.example'
+    make_recording_passthrough_timeout
+    make_counting_host
+    printf '198.51.100.7\n' > "${pfborig}${alias}.orig"
+
+    When call whoisconvert
+    The status should be success
+    The stdout should not include 'TIMED OUT'
+    # 008 is eight seconds, so the first lookup is clipped to 8 not 30.
+
+    The contents of file "$timeout_args" should include "-s TERM -k 5 8 ${pathhost} -t A d1.example"
+    The contents of file "${pfborig}${alias}.orig" should include '203.0.113.1'
+    The path "${pfborig}${alias}.fail" should not be exist
+  End
+
   It 'treats an empty entry list as a no-expiry pass that restores the prior file'
     whoisbatchtimeout=2
     export HOST_SLEEP=0

--- a/tests/shell/pfblockerng_whoisconvert_batch_budget_spec.sh
+++ b/tests/shell/pfblockerng_whoisconvert_batch_budget_spec.sh
@@ -1,0 +1,285 @@
+#shellcheck shell=sh
+# whoisconvert() whole-batch deadline (issue #2877).
+#
+# Issue #2015 bounded each Domain lookup (timeout -s TERM -k 5 30), but the two
+# synchronous PHP launch sites still wait for an UNCAPPED number of per-entry
+# budgets: whoisconvert() iterates every configured entry, so a batch of N
+# Domain rows could hold an update pass for N x 30s (plus the first-use ASN
+# re-entry). #2877 adds a whole-batch deadline:
+#
+#   - The deadline is checked BEFORE each entry, and the per-entry timeout is
+#     clipped to the time left, so no Domain/AS ordering can bypass the total
+#     budget; the batch ends within the budget plus one lookup's kill grace.
+#   - Partial-state policy is explicit: entries that resolved before the
+#     deadline are KEPT (append semantics, #714 accumulation), the skipped
+#     remainder leaves the .fail marker, and an operator-visible line names
+#     the expiry -- never a silent publish or erase.
+#   - #2015's per-entry 30-second reaper bound is preserved whenever the
+#     budget leaves 30s or more, and #2016's nested pfb_reentry() seam keeps
+#     its own bound untouched (the batch routes nothing around it).
+#   - A lookup descendant that ignores TERM is reaped by the reaper's kill
+#     grace (FreeBSD timeout(1) default reaper mode; GNU -k grace KILLs the
+#     whole process group -- probed, 7s wall, tree empty on return).
+#
+# The executed rows use a real timeout(1) from PATH (recorded argv + real
+# enforcement) plus a deterministic fake host whose per-entry calls stay
+# individually bounded while their total exceeds the budget.
+
+make_recording_enforcing_timeout() {
+  # Records its argv (one space-joined invocation per line) and enforces with
+  # a REAL timeout(1), so clipped durations actually bound a slow fake host.
+  pathtimeout="${work}/timeout"
+  cat > "$pathtimeout" <<'EOF'
+#!/bin/sh
+printf '%s\n' "$*" >> "${TIMEOUT_ARGS}"
+exec timeout "$@"
+EOF
+  chmod +x "$pathtimeout"
+}
+
+make_recording_passthrough_timeout() {
+  # Records its argv, then runs the command directly (no real wait) -- for
+  # rows that must observe the composed durations without spending them.
+  pathtimeout="${work}/timeout"
+  cat > "$pathtimeout" <<'EOF'
+#!/bin/sh
+printf '%s\n' "$*" >> "${TIMEOUT_ARGS}"
+shift 5
+exec "$@"
+EOF
+  chmod +x "$pathtimeout"
+}
+
+make_counting_host() {
+  # Each call sleeps HOST_SLEEP seconds, then answers with a unique address
+  # (203.0.113.<n>) so the spec can tell exactly which entries ran.
+  pathhost="${work}/host"
+  cat > "$pathhost" <<'EOF'
+#!/bin/sh
+sleep "${HOST_SLEEP}"
+n="$(cat "${HOST_COUNT}")"
+n=$((n + 1))
+echo "$n" > "${HOST_COUNT}"
+echo "$3 has address 203.0.113.$n"
+EOF
+  chmod +x "$pathhost"
+}
+
+pfb_require_real_timeout() {
+  real_timeout="$(command -v timeout)"
+  if [ -z "${real_timeout}" ]; then
+    echo "no timeout(1) on PATH: the executed batch rows need a real one" >&2
+    return 1
+  fi
+}
+
+twenty_domains() {
+  _wd_i=1
+  while [ "${_wd_i}" -le 20 ]; do
+    if [ "${_wd_i}" -gt 1 ]; then printf ','; fi
+    printf 'd%s.example' "${_wd_i}"
+    _wd_i=$((_wd_i + 1))
+  done
+}
+
+Describe 'whoisconvert() bounds the total batch duration (issue #2877)'
+  setup() {
+    work="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/whoisbatch.XXXXXX")"
+    pfborig="${work}/orig/"; mkdir -p "$pfborig"
+    alias="BudgetList"
+    max="_v4"
+    errorlog="${work}/error.log"
+    timeout_args="${work}/timeout.args"
+    true > "$timeout_args"
+    host_count="${work}/host.count"; echo 0 > "$host_count"
+    pfb_require_real_timeout
+    export TIMEOUT_ARGS="$timeout_args" HOST_COUNT="$host_count"
+  }
+  cleanup() {
+    rm -rf "$work"
+    unset TIMEOUT_ARGS HOST_COUNT HOST_SLEEP whoisbatchtimeout
+  }
+  BeforeAll 'pfb_source'
+  Before 'setup'
+  After 'cleanup'
+
+  # The batch-expiry scenario, run once per It (setup is per-example). The
+  # first lookup's duration is asserted separately: it is clipped to the time
+  # left, which at entry 1 IS the budget -- modulo a date(1) second boundary
+  # between the batch start and the first check, so 1 is also a clipped value,
+  # while any widened budget composes 4, 30, or the bare 30s bound.
+  It 'stops at the budget, keeps the resolved prefix, and marks the skipped remainder'
+    whoisbatchtimeout=2
+    export HOST_SLEEP=0.2
+    dedup="$(twenty_domains)"
+    make_recording_enforcing_timeout
+    make_counting_host
+    # A prior .orig so the run proves append semantics: successful entries are
+    # ADDED to the last-good data and the .bk is consumed, not restored.
+    printf '198.51.100.7\n' > "${pfborig}${alias}.orig"
+
+    When call whoisconvert
+    The status should be success
+    # The expiry is named, with the exact budget, on stdout and in error.log.
+    The stdout should include 'WHOIS batch [ BudgetList ] TIMED OUT after 2s total; remaining Domain/AS entries skipped'
+    The contents of file "$errorlog" should include 'WHOIS batch [ BudgetList ] TIMED OUT after 2s total; remaining Domain/AS entries skipped'
+    # A resolved prefix survived (append semantics) alongside the prior data...
+    The contents of file "${pfborig}${alias}.orig" should include '203.0.113.3'
+    # ...the stale .bk data does NOT reappear in the fresh .orig (the batch
+    # replaces the file's contents with this run's collections)...
+    The contents of file "${pfborig}${alias}.orig" should not include '198.51.100.7'
+    # ...the last entry never ran (an unbounded batch runs all twenty)...
+    The contents of file "${pfborig}${alias}.orig" should not include '203.0.113.20'
+    # ...the skipped remainder is a visible failure, and the consumed .bk is gone.
+    The path "${pfborig}${alias}.fail" should be exist
+    The path "${pfborig}${alias}.bk" should not be exist
+  End
+
+  It 'clips the first lookup to the budget itself, not to the bare 30s bound'
+    whoisbatchtimeout=2
+    export HOST_SLEEP=0
+    dedup="$(twenty_domains)"
+    make_recording_enforcing_timeout
+    make_counting_host
+    printf '198.51.100.7\n' > "${pfborig}${alias}.orig"
+
+    When call whoisconvert
+    The status should be success
+    The stdout should not include 'TIMED OUT'
+    # Reaper mode and the kill grace are byte-identical to issue #2015; only
+    # the duration is clipped to the time left within the batch.
+    The contents of file "$timeout_args" should include '-s TERM -k 5 '
+    The contents of file "$timeout_args" should include " ${pathhost} -t A d1.example"
+    clip_duration="$(sed -n '1s/.* -k 5 \([1-9][0-9]*\) .*/\1/p' "$timeout_args")"
+    if [ -z "${clip_duration}" ] || [ "${clip_duration}" -gt 2 ]; then
+      echo "first lookup was not clipped to the 2s budget: '${clip_duration}'" >&2
+      false
+    fi
+  End
+
+  It 'expires after the first-use ASN re-entry feeds the batch, and leaves the seam untouched'
+    whoisbatchtimeout=2
+    export HOST_SLEEP=0.2
+    dedup="AS64500,$(twenty_domains)"
+    make_recording_enforcing_timeout
+    make_counting_host
+    # No asn.csv on disk: the ASN branch takes the first-use path through the
+    # ONE nested re-entry seam. The fake interpreter materializes the database,
+    # so the same entry then resolves and the batch continues.
+    pathasncsv="${work}/asn.csv"
+    pathphp="${work}/php"
+    cat > "$pathphp" <<EOF
+#!/bin/sh
+printf '203.0.113.64,203.0.113.127,AS64500,ExampleNet\n2001:db8::,2001:db8::ffff,AS64500,ExampleNet\n' > '${pathasncsv}'
+exit 0
+EOF
+    chmod +x "$pathphp"
+    pathpfbphp="${work}/pfblockerng.php"
+
+    When call whoisconvert
+    The status should be success
+    # The nested seam's own argv is unchanged: reaper mode, its full budget.
+    The contents of file "$timeout_args" should include "-s TERM -k 5 1800 ${pathphp} ${pathpfbphp} asn_shell scheduled"
+    # The ASN entry resolved, the batch continued into the Domain rows, and the
+    # deadline still ended the pass (ordering did not bypass the budget).
+    The contents of file "${pfborig}${alias}.orig" should include '203.0.113.64-203.0.113.127'
+    The contents of file "${pfborig}${alias}.orig" should include '203.0.113.3'
+    The contents of file "${pfborig}${alias}.orig" should not include '203.0.113.20'
+    The stdout should include 'WHOIS batch [ BudgetList ] TIMED OUT after 2s total; remaining Domain/AS entries skipped'
+    The path "${pfborig}${alias}.fail" should be exist
+  End
+
+  It 'reaps a transient tree whose members all ignore TERM, after the kill grace'
+    whoisbatchtimeout=2
+    dedup='d1.example,d2.example'
+    make_recording_enforcing_timeout
+    # A host(1) stand-in where NOTHING dies on TERM -- only the reaper's kill
+    # grace (-k 5) can end this transient tree (issue #2877 hostile row). The
+    # second list entry exists only so the loop reaches the deadline check
+    # after the reaped first lookup.
+    pathhost="${work}/host"
+    grandpid_file="${work}/grandpid"
+    cat > "$pathhost" <<EOF
+#!/bin/sh
+trap '' TERM
+(sleep 10) &
+echo \$! > '${grandpid_file}'
+sleep 10
+EOF
+    chmod +x "$pathhost"
+    # A prior .orig proves the timeout follows the existing failure/restore path.
+    printf '198.51.100.7\n' > "${pfborig}${alias}.orig"
+
+    When call whoisconvert
+    The status should be success
+    The stdout should include 'WHOIS batch [ BudgetList ] TIMED OUT after 2s total; remaining Domain/AS entries skipped'
+    The contents of file "${pfborig}${alias}.orig" should equal '198.51.100.7'
+    The path "${pfborig}${alias}.fail" should be exist
+    The stderr should be present
+    # The tree the lookup left behind is reaped once the kill grace lapses --
+    # before the batch reports its expiry, not orphaned past it.
+    reap_waits=0
+    grandpid="$(cat "${grandpid_file}")"
+    while kill -0 "${grandpid}" 2>/dev/null && [ "${reap_waits}" -lt 20 ]; do
+      sleep 0.1
+      reap_waits=$((reap_waits + 1))
+    done
+    if kill -0 "${grandpid}" 2>/dev/null; then
+      echo "lookup descendant ${grandpid} survived the reaper" >&2
+      false
+    fi
+  End
+
+  It 'runs a batch that fits the budget with the untouched 30-second per-entry bound'
+    whoisbatchtimeout=30
+    export HOST_SLEEP=0
+    dedup='d1.example'
+    make_recording_passthrough_timeout
+    make_counting_host
+    printf '198.51.100.7\n' > "${pfborig}${alias}.orig"
+
+    When call whoisconvert
+    The status should be success
+    The stdout should not include 'TIMED OUT'
+    The stdout should include 'completed'
+    The contents of file "$timeout_args" should include "-s TERM -k 5 30 ${pathhost} -t A d1.example"
+    The contents of file "${pfborig}${alias}.orig" should include '203.0.113.1'
+    The path "${pfborig}${alias}.fail" should not be exist
+    The path "${pfborig}${alias}.bk" should not be exist
+  End
+
+  It 'degrades a zero budget to the default instead of an instant expiry'
+    whoisbatchtimeout=0
+    export HOST_SLEEP=0
+    dedup='d1.example'
+    make_recording_passthrough_timeout
+    make_counting_host
+    printf '198.51.100.7\n' > "${pfborig}${alias}.orig"
+
+    When call whoisconvert
+    The status should be success
+    The stdout should not include 'TIMED OUT'
+    # A 0-second budget must not become a 0-second timeout: the default leaves
+    # the full 30-second per-entry bound in the composed command.
+    The contents of file "$timeout_args" should include "-s TERM -k 5 30 ${pathhost} -t A d1.example"
+    The contents of file "${pfborig}${alias}.orig" should include '203.0.113.1'
+    The path "${pfborig}${alias}.fail" should not be exist
+  End
+
+  It 'treats an empty entry list as a no-expiry pass that restores the prior file'
+    whoisbatchtimeout=2
+    export HOST_SLEEP=0
+    dedup=''
+    make_recording_passthrough_timeout
+    make_counting_host
+    printf '198.51.100.7\n' > "${pfborig}${alias}.orig"
+
+    When call whoisconvert
+    The status should be success
+    The stdout should include 'Restoring previous data'
+    The stdout should not include 'TIMED OUT'
+    The contents of file "${pfborig}${alias}.orig" should equal '198.51.100.7'
+    The contents of file "$timeout_args" should equal ''
+    The path "${pfborig}${alias}.fail" should not be exist
+  End
+End


### PR DESCRIPTION
## What this is

A **port** of `e73e03035` ("pfblockerng: bound the whole whoisconvert batch duration") from
pre-resign orphan history onto current `devel`. Not landed by this PR — review only.

`git rebase` and `git cherry-pick` were both impossible: this repository's history was
re-signed, so `issue-2877-bound-whois-convert-batch` has **no merge-base** with current
`origin/devel` (`git merge-base` returns nothing). The port was therefore done by applying
the source commit's own patch three-way:

```sh
git diff e73e03035^:src/usr/local/pkg/pfblockerng/pfblockerng.sh \
        origin/devel:src/usr/local/pkg/pfblockerng/pfblockerng.sh   # empty: zero drift
git show e73e03035 -- src/usr/local/pkg/pfblockerng/pfblockerng.sh | git apply -3
```

The production file had **zero drift** from the source commit's parent, and the resulting
diff is **hunk-for-hunk identical** to `git show e73e03035 -- <prod path>` (verified by
diffing the two patch bodies). Author and commit message are the original, reused verbatim
via `git commit -C e73e03035`.

## What it does

Issue #2015 bounded each individual Domain lookup at `timeout -s TERM -k 5 30`, but
`whoisconvert()` iterates every configured entry, so both synchronous PHP launch sites
could wait `30s x Domain rows`. This gives the batch a whole-batch budget (default 1800s,
overridable through a `whoisbatchtimeout` seam that reuses `pfb_reentry()`'s
positive-integral degradation), checks the deadline **before** each entry, and clips the
per-entry timeout to the time remaining. Resolved entries are kept (append semantics,
#714), the skipped remainder keeps its `.fail` marker, and the expiry is named on stdout
and in `error.log`. `pfb_reentry()`'s #2016 seam is untouched; #2015's 30s bound survives
whenever the budget leaves 30s or more.

## Deviation — the ported spec is 2 lines from the source commit's

Both deltas are in `tests/shell/pfblockerng_whoisconvert_batch_budget_spec.sh` and both were
authorized after the port's first green run exposed them. Neither weakens an assertion; the
row's behavioural assertions (exit status, the expiry line, the `.fail` marker, the restored
`.orig`, and the descendant-reaping evidence) are unchanged.

1. **Line 218, added: `The stderr should be present`.** In the kill-grace row, GNU
   `timeout -k 5` SIGKILLs its process group — which contains `timeout` itself — so the
   command-substitution child dies of SIGKILL and **dash announces it on stderr**. With no
   stderr expectation declared, shellspec warns and exits **101**, failing the canonical
   gate even though all 7 examples pass. Discriminating probe:

   ```
   $ dash /tmp/probe_killed.sh 2>&1     # Killed / rc=137
   $ bash /tmp/probe_killed.sh 2>&1     # (no message) / rc=137
   ```

   Scope of this expectation, stated deliberately: it is pinned to the **CI-pinned dash
   shell**. `bash`-as-`sh` prints nothing at the same `rc=137`, and the appliance's FreeBSD
   `ash` wording cannot be probed from a checkout. The matcher is therefore the tolerant
   `should be present` rather than a literal `Killed` pin — it asserts the load-bearing fact
   (under dash the shell *does* report the group kill) without encoding one shell's wording.
   This is also why the source commit's own green run never saw the warning: it must have
   run under `bash`-as-`sh`, which is exactly the divergence the dash pin exists to catch.

2. **Line 93, `: > "$timeout_args"` -> `true > "$timeout_args"`.** The source commit's spec
   used the `:` special-builtin truncate idiom retired by issues #1172/#1850. The structural
   guard `tests/shell/pfblockerng_truncate_survival_spec.sh:381` greps `src scripts tests`
   and flagged it by name:

   ```
   8.2) The output should equal
        got: "tests/shell/pfblockerng_whoisconvert_batch_budget_spec.sh:93:    : > "$timeout_args""
   ```

   The replacement is the one the guard's own example name prescribes. Guard satisfied by the
   idiom's removal, not by moving out of its pathspec:

   ```
   $ git grep -nE '(^|[;&|({[:space:]]):[[:space:]]*>' -- src scripts tests
   (no output, exit 1)
   $ shellspec --shell dash tests/shell/pfblockerng_truncate_survival_spec.sh
   12 examples, 0 failures
   ```

## Red -> green proof

Both test files were checked out from the source commit and executed **red against unfixed
production code** before any production change. After the two authorized spec edits the
whole red->green sequence was **re-run from scratch** so the shipped file is frozen from its
own red run.

**RED** (`shellspec --shell dash tests/shell/pfblockerng_whoisconvert_batch_budget_spec.sh`,
production reverted to `origin/devel`), exit 101:

```
Finished in 28.87 seconds (user 0.69 seconds, sys 0.22 seconds)
7 examples, 4 failures

shellspec …:111 # 1) … stops at the budget, keeps the resolved prefix, and marks the skipped remainder FAILED
shellspec …:138 # 2) … clips the first lookup to the budget itself, not to the bare 30s bound FAILED
shellspec …:160 # 3) … expires after the first-use ASN re-entry feeds the batch, and leaves the seam untouched FAILED
shellspec …:192 # 4) … reaps a transient tree whose members all ignore TERM, after the kill grace FAILED
```

Failing for the exact reason the change addresses — the missing batch budget:

```
4.1) The stdout should include WHOIS batch [ BudgetList ] TIMED OUT after 2s total; remaining Domain/AS entries skipped
       expected "
         Collecting host IP: d1.example... Failed to resolve host [ d1.example ] …" to include
       "WHOIS batch [ BudgetList ] TIMED OUT after 2s total; remaining Domain/AS entries skipped"
```

**RED** (`vendor/bin/phpunit tests/php/WhoisconvertBatchBudgetLaunchTest.php`), both PHP
launch sites:

```
1) WhoisconvertBatchBudgetLaunchTest::test_pfblockerng_inc_whois_site_launches_the_bounded_batch
the launched lookup must be clipped to the 2s batch budget, got: -s TERM -k 5 30 …/host -t A d1.example
Failed asserting that 0 is identical to 1.

2) WhoisconvertBatchBudgetLaunchTest::test_apply_inc_whois_site_launches_the_bounded_batch
the batch deadline must name its expiry in the launch log
Failed asserting that '…Collecting host IP: d20.example... completed\n' contains
"WHOIS batch [ CustomList ] TIMED OUT after 2s total; remaining Domain/AS entries skipped".

FAILURES!
Tests: 2, Assertions: 7, Failures: 2.
```

**GREEN**, same two files re-run byte-identical after the production patch:

```
$ shellspec --shell dash tests/shell/pfblockerng_whoisconvert_batch_budget_spec.sh   # exit 0
Finished in 11.05 seconds (user 0.55 seconds, sys 0.17 seconds)
7 examples, 0 failures

$ vendor/bin/phpunit tests/php/WhoisconvertBatchBudgetLaunchTest.php
OK (2 tests, 14 assertions)
```

**Freeze.** `git hash-object` at red time and at commit time:

| file | red-time | committed |
| --- | --- | --- |
| `tests/shell/pfblockerng_whoisconvert_batch_budget_spec.sh` | `b37219c1860dafe3dbc4701755a778a92d63aded` | `b37219c1860dafe3dbc4701755a778a92d63aded` |
| `tests/php/WhoisconvertBatchBudgetLaunchTest.php` | `ad97b89c377db6928696f90dc6af9462f51caa64` | `ad97b89c377db6928696f90dc6af9462f51caa64` |

The first red run, before the two authorized spec edits, hashed the shellspec file as
`50514462b097a44be313ecf5bb56bc9ec305b058` (the source commit's blob). That hash is void;
the sequence is recorded so it is auditable.

## Gates

`scripts/agent/run-gates.sh --diff origin/devel`, run on the rebased tip with
`COMPOSER_ALLOW_SUPERUSER=1` exported (this host runs as root and bare `composer` aborts
without it; `run-gates.sh` does not set it).

```
GATE PASS: python3 scripts/check_coverage_pairing.py --name-status-z
GATE PASS: uv run --locked python scripts/check_composer_vendor.py
GATE PASS: uv run --locked python scripts/check_toggle_registry.py --self-test && … check_toggle_registry.py
GATE PASS: uv run --locked python scripts/check_reentry_bounds.py --self-test && … check_reentry_bounds.py
GATE PASS: php -l tests/php/WhoisconvertBatchBudgetLaunchTest.php
GATE FAIL: vendor/bin/phpunit
GATE PASS: composer phpstan
GATE PASS: composer phpcs -- --standard=phpcs.xml.dist src/
GATE PASS: sh -n src/usr/local/pkg/pfblockerng/pfblockerng.sh
GATE PASS: shellcheck src/usr/local/pkg/pfblockerng/pfblockerng.sh
GATE PASS: sh -n tests/shell/pfblockerng_whoisconvert_batch_budget_spec.sh
GATE FAIL: shellspec --shell $(command -v dash || command -v sh)
```

Both FAILs are **pre-existing on pristine `devel` in this environment**, proven by running
each against reverted production code, and neither is attributable to this change. CI is the
authoritative verdict for both.

**`vendor/bin/phpunit`** — `Tests: 6499, Errors: 29, Failures: 14, Warnings: 67, Skipped: 44`.
Compared by failing **name set**, not by count: a pristine baseline (production reverted to
`origin/devel`, both new test files moved out of the tree) gives `Tests: 6497, Errors: 29,
Failures: 14`. Parsing both JUnit logs:

```
baseline failing/erroring: 43
head failing/erroring:     43
NEW in head (must be empty): []
GONE vs baseline: []
identical sets: True
```

Causes are host-toolchain, per neighbouring lanes: `/sbin/mount` and `/sbin/pfctl` absent,
GNU-vs-bsd `gzip`, rsync io timeout. This change adds **zero** new failing names, and its own
two tests pass inside the full run. `FunctionInventoryParityTest` is green and needs no
regenerated golden: the diff adds no function of any kind — only local variables and inline
logic inside the existing `whoisconvert()` — and `tests/php/fixtures/function_inventory.json`
carries no `pfblockerng.sh` or `whoisconvert` entry.

**`shellspec --shell dash`** — the suite itself is **green**:

```
1845 examples, 0 failures, 8 skips
```

The gate's FAIL comes only from `scripts/check_skip_allowlist.py`, on three
`pfblockerng_recompute_spec.sh` uid-0 skips that are not on `tests/skip-allowlist.txt`:

```
error: 3 skip(s) not on tests/skip-allowlist.txt:
  shellspec:tests/shell/pfblockerng_recompute_spec.sh::… Stage-A snapshot copy fails …  reason: root bypasses file permissions
  shellspec:tests/shell/pfblockerng_recompute_spec.sh::… masterfile-strip pass … mid-write …  reason: root bypasses file permissions
  shellspec:tests/shell/pfblockerng_recompute_spec.sh::… deny dir denies the mv …  reason: root bypasses directory permissions
```

Reproduced with this change's spec **not in the run at all**, against files byte-identical to
`origin/devel` (`git diff --stat origin/devel -- tests/shell/pfblockerng_recompute_spec.sh
tests/skip-allowlist.txt` is empty):

```
$ shellspec --shell dash -o junit --reportdir /tmp/2877_rc tests/shell/pfblockerng_recompute_spec.sh
$ python3 scripts/check_skip_allowlist.py --suite shellspec --allowlist tests/skip-allowlist.txt \
      /tmp/2877_rc/results_junit.xml
error: 3 skip(s) not on tests/skip-allowlist.txt: …   # exit 1
```

`ec53a84a` allowlisted the four `processet_exit` rows and the `precommit_identity` row but
left these three. This change's own spec contributes **0 skips**.

Shellspec shell used for every run above: `dash` 0.5.12-12 at `/usr/bin/dash`, shellspec
0.28.1. `timeout(1)` is GNU coreutils 9.7.

## Coverage matrix

`tests/shell/pfblockerng_whoisconvert_batch_budget_spec.sh` — 7 examples, all green:

| # | row | pinned by |
| --- | --- | --- |
| 1 | stops at the budget, keeps the resolved prefix, marks the skipped remainder | spec:111 |
| 2 | clips the first lookup to the budget itself, not the bare 30s bound | spec:138 |
| 3 | expires after the first-use ASN re-entry feeds the batch, seam untouched | spec:160 |
| 4 | reaps a transient tree whose members all ignore TERM, after the kill grace | spec:192 |
| 5 | a batch that fits the budget keeps the untouched 30-second per-entry bound | spec:232 |
| 6 | degrades a zero budget to the default instead of an instant expiry | spec:250 |
| 7 | an empty entry list is a no-expiry pass that restores the prior file | spec:268 |

`tests/php/WhoisconvertBatchBudgetLaunchTest.php` — 2 tests, both green:

| # | row | pinned by |
| --- | --- | --- |
| 8 | `pfblockerng.inc` whois site launches the bounded batch | `test_pfblockerng_inc_whois_site_launches_the_bounded_batch` |
| 9 | `pfblockerng_apply.inc` whois site launches the bounded batch | `test_apply_inc_whois_site_launches_the_bounded_batch` |

Fixes #2877


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a configurable total timeout for WHOIS batch processing, defaulting to 30 minutes.
  - Positive numeric timeout values can override the default.
  - Each lookup now respects the remaining batch time, preventing processing from exceeding the overall limit.

- **Bug Fixes**
  - Completed results are preserved when a batch timeout occurs.
  - Timed-out or skipped entries are marked as failures and logged.
  - Existing per-entry timeout behavior remains supported.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->