### PR TITLE
pfblockerng: decide an aggregate alias changed on its content

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -7988,13 +7988,18 @@ function pfb_pfctl_tables_parse(array $lines): array {
 
 // ADR-11: build + register the opt-in per-type aggregate ("Uber") Native aliases. ONE generic
 // loop over type->dir {Deny,Permit,Match,Native} x family {v4,v6}: each SELECTED type
-// ($pfb['agg_types']) gets a memberlist, an mtime-gated `pfblockerng.sh aggregate` run, and a
-// standard pfB urltable alias pfB_<Type>_Aggregated_<fam> (NEVER a firewall rule). A rebuilt
-// aggregate's name merges into $pfb['changed_ip_aliases']/$pfb_alias_lists (reload gating); a
-// non-selected type is torn down (files + pf table removed, omitted from $new_aliases_list so
-// the caller's orphan-prune unlinks it). Additive: nothing selected => byte-identical pass.
-// Array args are by-reference (caller's alias-registration arrays).
-function pfb_build_aggregate_aliases(array &$new_aliases, array &$new_aliases_list, array &$pfb_alias_lists) {
+// ($pfb['agg_types']) gets a memberlist, a `pfblockerng.sh aggregate` run, and a standard pfB
+// urltable alias pfB_<Type>_Aggregated_<fam> (NEVER a firewall rule). A non-selected type is torn
+// down (files + pf table removed, omitted from $new_aliases_list so the caller's orphan-prune
+// unlinks it). Additive: nothing selected => byte-identical pass. Array args are by-reference
+// (caller's alias-registration arrays).
+//
+// issue #3156: the action's rebuild gate is an mtime gate, and a member rewritten with identical
+// bytes still trips it, so a rebuild is NOT a change. What counts as changed -- the name entering
+// $pfb['changed_ip_aliases']/$pfb_alias_lists, and the pf table being pushed -- is decided on the
+// aggregate's canonical CONTENT, the way every member alias decides it (ADR-40), plus a
+// file-vs-kernel emptiness mismatch so an empty table still repopulates.
+function pfb_build_aggregate_aliases(array &$new_aliases, array &$new_aliases_list, array &$pfb_alias_lists, array &$pfb_alias_prev_sets) {
 	global $pfb;
 
 	$all_types	= array('Deny', 'Permit', 'Match', 'Native');
@@ -8004,6 +8009,10 @@ function pfb_build_aggregate_aliases(array &$new_aliases, array &$new_aliases_li
 	if ($pfb['enable'] !== PfbToggle::On) {
 		$selected = array();
 	}
+
+	// ONE `pfctl -vvsTables` for every aggregate's address count (pfb_pfctl_table_count() would
+	// dump every member of every table). Skipped entirely when nothing is selected.
+	$table_stats = empty($selected) ? array() : pfb_pfctl_tables_parse(pfb_pfctl_tables_raw());
 
 	foreach ($all_types as $type) {
 		foreach (array('v4', 'v6') as $family) {
@@ -8033,8 +8042,11 @@ function pfb_build_aggregate_aliases(array &$new_aliases, array &$new_aliases_li
 			$memberlist	= "{$pfb['dbdir']}/{$aliasname}.members";
 			@file_put_contents($memberlist, $members ? (implode("\n", $members) . "\n") : '', LOCK_EX);
 
-			// mtime BEFORE the build, to detect whether the action actually rebuilt.
-			$mtime_before = file_exists($aggout) ? pfb_file_mtime($aggout) : 0;
+			// Canonical set BEFORE the build: the baseline the rebuild is judged against, and
+			// the previous set the apply site deltas from.
+			$prev_set = file_exists($aggout)
+				? pfb_canonical_alias_set((string) (@file_get_contents($aggout) ?: ''))
+				: array();
 
 			$family_esc	= escapeshellarg($family);
 			$memberlist_esc	= escapeshellarg($memberlist);
@@ -8045,7 +8057,15 @@ function pfb_build_aggregate_aliases(array &$new_aliases, array &$new_aliases_li
 			$agg_esc	= escapeshellarg((($pfb['agg'] ?? PfbToggle::Off) === PfbToggle::On) ? 'on' : 'off');
 			exec("{$pfb['script']} aggregate {$family_esc} {$memberlist_esc} {$aggout_esc} {$consumer_esc} {$agg_esc} 2>&1");
 
-			$rebuilt = file_exists($aggout) && (pfb_file_mtime($aggout) > $mtime_before);
+			$new_set = file_exists($aggout)
+				? pfb_canonical_alias_set((string) (@file_get_contents($aggout) ?: ''))
+				: array();
+
+			// Changed = the union's membership moved, or the file and the kernel table disagree
+			// about being empty (boot, a stray kill, or a stale table under an emptied union).
+			$want_empty  = empty($new_set);
+			$table_empty = ((int) ($table_stats[$aliasname]['addresses'] ?? 0)) === 0;
+			$changed     = ($new_set !== $prev_set) || ($want_empty !== $table_empty);
 
 			// Register the Native urltable alias (mirror the member-alias shape).
 			// NEVER pfb_firewall_rule() -- Native means no firewall rule.
@@ -8059,21 +8079,24 @@ function pfb_build_aggregate_aliases(array &$new_aliases, array &$new_aliases_li
 							'detail'	=> 'DO NOT EDIT THIS ALIAS'
 							);
 
-			// Load the table now (well before the ADR-12 post-hook), so a hook consumer
-			// (e.g. an HAProxy graceful reload) always sees the FRESH aggregate. A 0-byte
-			// aggout (empty union) is pruned to an empty table, matching pfB member aliases.
-			if (file_exists($aggout) && filesize($aggout) > 0) {
-				pfb_pfctl_table_op($aliasname, 'replace', "-f {$aggout_esc}");
-			} else {
-				pfb_pfctl_table_op($aliasname, 'kill');
-			}
+			// Push the table only on a change: an unchanged aggregate's table already holds this
+			// set. Done here, well before the ADR-12 post-hook, so a hook consumer (e.g. an
+			// HAProxy graceful reload) always sees the FRESH aggregate. An empty union is pruned
+			// to an empty table, matching pfB member aliases.
+			if ($changed) {
+				if ($want_empty) {
+					pfb_pfctl_table_op($aliasname, 'kill');
+				} else {
+					pfb_pfctl_table_op($aliasname, 'replace', "-f {$aggout_esc}");
+				}
 
-			// Merge a (re)built aggregate's name into the changed-alias set so the ADR-12
-			// post-hook's PFB_CHANGED_IP_ALIASES reflects it; additive -- an unchanged
-			// (mtime-gated, skipped) aggregate adds nothing.
-			if ($rebuilt) {
-				$pfb['changed_ip_aliases'][]	= $aliasname;
-				$pfb_alias_lists[]		= $aliasname;
+				// ADR-12: PFB_CHANGED_IP_ALIASES reflects it; $pfb_alias_lists carries it into the
+				// reload set (which also gates the ramdisk archive). The previous set is stashed
+				// the way the member-alias write loop stashes -- an empty kernel table stashes an
+				// empty set, so the apply site full-replaces instead of deltaing onto nothing.
+				$pfb['changed_ip_aliases'][]		= $aliasname;
+				$pfb_alias_lists[]			= $aliasname;
+				$pfb_alias_prev_sets[$aliasname]	= $table_empty ? array() : $prev_set;
 			}
 
 			// Member list is transient scratch; the never-empty consumer + the alias file

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -7986,6 +7986,17 @@ function pfb_pfctl_tables_parse(array $lines): array {
 }
 
 
+// issue #3156: read an aggregate output file in the three states its change gate needs. Absent is
+// '' -- a real empty union. Present but not a readable regular file is FALSE -- an I/O error,
+// never emptiness, since inferring emptiness there would kill a populated table. is_file()
+// separates the middle case because a directory returns '' from file_get_contents(), and it also
+// keeps a FIFO at that path from blocking the pass on a read that never completes.
+// @return string|false
+function pfb_aggregate_read(string $path) {
+	return is_file($path) ? @file_get_contents($path) : (file_exists($path) ? FALSE : '');
+}
+
+
 // ADR-11: build + register the opt-in per-type aggregate ("Uber") Native aliases. ONE generic
 // loop over type->dir {Deny,Permit,Match,Native} x family {v4,v6}: each SELECTED type
 // ($pfb['agg_types']) gets a memberlist, a `pfblockerng.sh aggregate` run, and a standard pfB
@@ -8046,9 +8057,11 @@ function pfb_build_aggregate_aliases(array &$new_aliases, array &$new_aliases_li
 			@file_put_contents($memberlist, $members ? (implode("\n", $members) . "\n") : '', LOCK_EX);
 
 			// Canonical set BEFORE the build: the baseline the rebuild is judged against, and the
-			// previous set the apply site deltas from. is_file() for the same reason as the
-			// post-build read below, plus it keeps a FIFO at that path from blocking the pass.
-			$prev_set = pfb_canonical_alias_set(is_file($aggout) ? (string) (@file_get_contents($aggout) ?: '') : '');
+			// previous set the apply site deltas from. An unreadable baseline leaves nothing to
+			// compare, so it reads as [] and the gate below over-reports -- only the post-build
+			// read is allowed to conclude the union is EMPTY.
+			$prev_raw = pfb_aggregate_read($aggout);
+			$prev_set = pfb_canonical_alias_set($prev_raw === FALSE ? '' : $prev_raw);
 
 			$family_esc	= escapeshellarg($family);
 			$memberlist_esc	= escapeshellarg($memberlist);
@@ -8071,11 +8084,10 @@ function pfb_build_aggregate_aliases(array &$new_aliases, array &$new_aliases_li
 							'detail'	=> 'DO NOT EDIT THIS ALIAS'
 							);
 
-			// Only an absent aggregate is a real empty union. A path that is present but not a
-			// readable regular file is an I/O error, and inferring emptiness would kill a populated
-			// table -- pfb_alias_set_different() refuses the same inference. is_file() carries it:
-			// a directory there reads as '' rather than FALSE.
-			$new_raw = is_file($aggout) ? @file_get_contents($aggout) : (file_exists($aggout) ? FALSE : '');
+			// Only an absent aggregate is a real empty union; anything present that pfb_aggregate_read()
+			// cannot read is an I/O error, and inferring emptiness would kill a populated table --
+			// pfb_alias_set_different() refuses the same inference.
+			$new_raw = pfb_aggregate_read($aggout);
 			if ($new_raw === FALSE) {
 				pfb_logger(" Updating [ {$aliasname} ]: aggregate unreadable, leaving its table alone\n", 2);
 				unlink_if_exists($memberlist);

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -7995,10 +7995,11 @@ function pfb_pfctl_tables_parse(array $lines): array {
 // (caller's alias-registration arrays).
 //
 // issue #3156: the action's rebuild gate is an mtime gate, and a member rewritten with identical
-// bytes still trips it, so a rebuild is NOT a change. What counts as changed -- the name entering
+// bytes still trips it, so a rebuild is NOT a change. Changed -- the name entering
 // $pfb['changed_ip_aliases']/$pfb_alias_lists, and the pf table being pushed -- is decided on the
-// aggregate's canonical CONTENT, the way every member alias decides it (ADR-40), plus a
-// file-vs-kernel emptiness mismatch so an empty table still repopulates.
+// aggregate's canonical CONTENT (ADR-40's signal), plus a file-vs-kernel EMPTINESS mismatch. Only
+// emptiness, so nonzero kernel drift heals on the next content change or the ADR-61 tick, not
+// every pass -- the same trade the member-alias write loop makes.
 function pfb_build_aggregate_aliases(array &$new_aliases, array &$new_aliases_list, array &$pfb_alias_lists, array &$pfb_alias_prev_sets) {
 	global $pfb;
 
@@ -8011,7 +8012,9 @@ function pfb_build_aggregate_aliases(array &$new_aliases, array &$new_aliases_li
 	}
 
 	// ONE `pfctl -vvsTables` for every aggregate's address count (pfb_pfctl_table_count() would
-	// dump every member of every table). Skipped entirely when nothing is selected.
+	// dump every member of every table). Skipped entirely when nothing is selected. An absent or
+	// failing pfctl yields [], so every table reads empty and every aggregate re-pushes: the
+	// over-report direction, the same one pfb_pfctl_table_count()'s callers take.
 	$table_stats = empty($selected) ? array() : pfb_pfctl_tables_parse(pfb_pfctl_tables_raw());
 
 	foreach ($all_types as $type) {
@@ -8042,11 +8045,9 @@ function pfb_build_aggregate_aliases(array &$new_aliases, array &$new_aliases_li
 			$memberlist	= "{$pfb['dbdir']}/{$aliasname}.members";
 			@file_put_contents($memberlist, $members ? (implode("\n", $members) . "\n") : '', LOCK_EX);
 
-			// Canonical set BEFORE the build: the baseline the rebuild is judged against, and
-			// the previous set the apply site deltas from.
-			$prev_set = file_exists($aggout)
-				? pfb_canonical_alias_set((string) (@file_get_contents($aggout) ?: ''))
-				: array();
+			// Canonical set BEFORE the build: the baseline the rebuild is judged against, and the
+			// previous set the apply site deltas from.
+			$prev_set = pfb_canonical_alias_set((string) (@file_get_contents($aggout) ?: ''));
 
 			$family_esc	= escapeshellarg($family);
 			$memberlist_esc	= escapeshellarg($memberlist);
@@ -8056,16 +8057,6 @@ function pfb_build_aggregate_aliases(array &$new_aliases, array &$new_aliases_li
 			// the shell skips the union's redundant iprange for v4 and just sort -u's it (like v6).
 			$agg_esc	= escapeshellarg((($pfb['agg'] ?? PfbToggle::Off) === PfbToggle::On) ? 'on' : 'off');
 			exec("{$pfb['script']} aggregate {$family_esc} {$memberlist_esc} {$aggout_esc} {$consumer_esc} {$agg_esc} 2>&1");
-
-			$new_set = file_exists($aggout)
-				? pfb_canonical_alias_set((string) (@file_get_contents($aggout) ?: ''))
-				: array();
-
-			// Changed = the union's membership moved, or the file and the kernel table disagree
-			// about being empty (boot, a stray kill, or a stale table under an emptied union).
-			$want_empty  = empty($new_set);
-			$table_empty = ((int) ($table_stats[$aliasname]['addresses'] ?? 0)) === 0;
-			$changed     = ($new_set !== $prev_set) || ($want_empty !== $table_empty);
 
 			// Register the Native urltable alias (mirror the member-alias shape).
 			// NEVER pfb_firewall_rule() -- Native means no firewall rule.
@@ -8079,24 +8070,38 @@ function pfb_build_aggregate_aliases(array &$new_aliases, array &$new_aliases_li
 							'detail'	=> 'DO NOT EDIT THIS ALIAS'
 							);
 
-			// Push the table only on a change: an unchanged aggregate's table already holds this
-			// set. Done here, well before the ADR-12 post-hook, so a hook consumer (e.g. an
-			// HAProxy graceful reload) always sees the FRESH aggregate. An empty union is pruned
-			// to an empty table, matching pfB member aliases.
-			if ($changed) {
+			// Only an ABSENT aggregate is a real empty union. Anything present that is not a
+			// readable regular file is an I/O error, and inferring emptiness from it would kill a
+			// populated table -- pfb_alias_set_different() refuses the same inference. Note a
+			// directory at that path reads as '' rather than FALSE, so is_file() carries the test.
+			$new_raw = is_file($aggout) ? @file_get_contents($aggout) : (file_exists($aggout) ? FALSE : '');
+			if ($new_raw === FALSE) {
+				pfb_logger(" Updating [ {$aliasname} ]: aggregate unreadable, leaving its table alone\n", 2);
+				unlink_if_exists($memberlist);
+				continue;
+			}
+
+			// Changed = the union's membership moved, or the file and the kernel table disagree
+			// about being empty (boot, a stray kill, or a stale table under an emptied union).
+			$new_set     = pfb_canonical_alias_set($new_raw);
+			$want_empty  = empty($new_set);
+			$table_empty = ((int) ($table_stats[$aliasname]['addresses'] ?? 0)) === 0;
+
+			if (($new_set !== $prev_set) || ($want_empty !== $table_empty)) {
+				// Pushed here, well before the ADR-12 post-hook, so a hook consumer (e.g. an
+				// HAProxy graceful reload) sees the fresh aggregate.
 				if ($want_empty) {
 					pfb_pfctl_table_op($aliasname, 'kill');
 				} else {
 					pfb_pfctl_table_op($aliasname, 'replace', "-f {$aggout_esc}");
 				}
 
-				// ADR-12: PFB_CHANGED_IP_ALIASES reflects it; $pfb_alias_lists carries it into the
-				// reload set (which also gates the ramdisk archive). The previous set is stashed
-				// the way the member-alias write loop stashes -- an empty kernel table stashes an
-				// empty set, so the apply site full-replaces instead of deltaing onto nothing.
-				$pfb['changed_ip_aliases'][]		= $aliasname;
-				$pfb_alias_lists[]			= $aliasname;
-				$pfb_alias_prev_sets[$aliasname]	= $table_empty ? array() : $prev_set;
+				$pfb['changed_ip_aliases'][]	= $aliasname;
+				$pfb_alias_lists[]		= $aliasname;
+				// Stash the previous set for the apply site's delta, EXCEPT where deltaing is
+				// impossible: an empty kernel table has nothing to delta from, and a killed table
+				// no longer exists, so both stash [] and take that site's full-replace branch.
+				$pfb_alias_prev_sets[$aliasname] = ($table_empty || $want_empty) ? array() : $prev_set;
 			}
 
 			// Member list is transient scratch; the never-empty consumer + the alias file

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -7997,9 +7997,9 @@ function pfb_pfctl_tables_parse(array $lines): array {
 // issue #3156: the action's rebuild gate is an mtime gate, and a member rewritten with identical
 // bytes still trips it, so a rebuild is NOT a change. Changed -- the name entering
 // $pfb['changed_ip_aliases']/$pfb_alias_lists, and the pf table being pushed -- is decided on the
-// aggregate's canonical CONTENT (ADR-40's signal), plus a file-vs-kernel EMPTINESS mismatch. Only
-// emptiness, so nonzero kernel drift heals on the next content change or the ADR-61 tick, not
-// every pass -- the same trade the member-alias write loop makes.
+// aggregate's canonical CONTENT (ADR-40's signal), plus a file-vs-kernel EMPTINESS mismatch. So
+// nonzero kernel drift waits for the next content change (sooner via the ADR-61 tick only when a
+// failed apply ledgered it) -- the same trade the member-alias write loop makes.
 function pfb_build_aggregate_aliases(array &$new_aliases, array &$new_aliases_list, array &$pfb_alias_lists, array &$pfb_alias_prev_sets) {
 	global $pfb;
 
@@ -8012,9 +8012,9 @@ function pfb_build_aggregate_aliases(array &$new_aliases, array &$new_aliases_li
 	}
 
 	// ONE `pfctl -vvsTables` for every aggregate's address count (pfb_pfctl_table_count() would
-	// dump every member of every table). Skipped entirely when nothing is selected. An absent or
-	// failing pfctl yields [], so every table reads empty and every aggregate re-pushes: the
-	// over-report direction, the same one pfb_pfctl_table_count()'s callers take.
+	// dump every member of every table); skipped entirely when nothing is selected. An absent or
+	// failing pfctl yields [], so every table reads empty and re-pushes: the over-report
+	// direction pfb_pfctl_table_count()'s callers also take.
 	$table_stats = empty($selected) ? array() : pfb_pfctl_tables_parse(pfb_pfctl_tables_raw());
 
 	foreach ($all_types as $type) {
@@ -8046,8 +8046,9 @@ function pfb_build_aggregate_aliases(array &$new_aliases, array &$new_aliases_li
 			@file_put_contents($memberlist, $members ? (implode("\n", $members) . "\n") : '', LOCK_EX);
 
 			// Canonical set BEFORE the build: the baseline the rebuild is judged against, and the
-			// previous set the apply site deltas from.
-			$prev_set = pfb_canonical_alias_set((string) (@file_get_contents($aggout) ?: ''));
+			// previous set the apply site deltas from. is_file() for the same reason as the
+			// post-build read below, plus it keeps a FIFO at that path from blocking the pass.
+			$prev_set = pfb_canonical_alias_set(is_file($aggout) ? (string) (@file_get_contents($aggout) ?: '') : '');
 
 			$family_esc	= escapeshellarg($family);
 			$memberlist_esc	= escapeshellarg($memberlist);
@@ -8070,10 +8071,10 @@ function pfb_build_aggregate_aliases(array &$new_aliases, array &$new_aliases_li
 							'detail'	=> 'DO NOT EDIT THIS ALIAS'
 							);
 
-			// Only an ABSENT aggregate is a real empty union. Anything present that is not a
-			// readable regular file is an I/O error, and inferring emptiness from it would kill a
-			// populated table -- pfb_alias_set_different() refuses the same inference. Note a
-			// directory at that path reads as '' rather than FALSE, so is_file() carries the test.
+			// Only an absent aggregate is a real empty union. A path that is present but not a
+			// readable regular file is an I/O error, and inferring emptiness would kill a populated
+			// table -- pfb_alias_set_different() refuses the same inference. is_file() carries it:
+			// a directory there reads as '' rather than FALSE.
 			$new_raw = is_file($aggout) ? @file_get_contents($aggout) : (file_exists($aggout) ? FALSE : '');
 			if ($new_raw === FALSE) {
 				pfb_logger(" Updating [ {$aliasname} ]: aggregate unreadable, leaving its table alone\n", 2);

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
@@ -4572,7 +4572,7 @@ function sync_package_pfblockerng($cron='', ?string &$deferred_by = NULL): bool 
 	#  which themselves precede the ADR-12 post-update hook (closing tail).	#
 	#  Native => registered urltable but NEVER pfb_firewall_rule (no rule).	#
 	#########################################################################
-	pfb_build_aggregate_aliases($new_aliases, $new_aliases_list, $pfb_alias_lists);
+	pfb_build_aggregate_aliases($new_aliases, $new_aliases_list, $pfb_alias_lists, $pfb_alias_prev_sets);
 
 	#########################################
 	#	UPDATE pfSense ALIAS TABLES	#

--- a/tests/php/AggregateAliasChangeGateTest.php
+++ b/tests/php/AggregateAliasChangeGateTest.php
@@ -341,15 +341,17 @@ final class AggregateAliasChangeGateTest extends TestCase
 	}
 
 	/**
-	 * Given the aggregate file exists but cannot be read
+	 * Given something other than a readable file stands at the aggregate's path
 	 * When the builder evaluates it
 	 * Then it leaves the alias alone: an I/O error is not an empty union, and inferring one
 	 *      would kill a populated table.
 	 *
-	 * A directory standing at the aggregate's path is how this is forced here — `chmod 000` does
-	 * not stop root, and the suite runs as root on some hosts.
+	 * A directory is what this forces, and it is the case `is_file()` exists for — a directory
+	 * reads as `''`, not `FALSE`, so a `=== FALSE` test alone would infer an empty union from it.
+	 * A permission-denied regular file is the other half of the guard and cannot be built here:
+	 * `chmod 000` does not stop root, and the suite runs as root on some hosts.
 	 */
-	public function testUnreadableAggregateLeavesTheTableAlone(): void
+	public function testWrongTypeAtTheAggregatePathLeavesTheTableAlone(): void
 	{
 		$this->writeMember('Feed', ['198.51.100.7']);
 		$this->runBuilder();
@@ -364,6 +366,8 @@ final class AggregateAliasChangeGateTest extends TestCase
 		$this->assertSame([], $second['ops'], 'an unreadable aggregate must not touch the kernel table');
 		$this->assertNotContains(self::ALIAS, $second['lists'], 'an unreadable aggregate must not be reported');
 		$this->assertNotContains(self::ALIAS, $second['changed'], 'an unreadable aggregate must not be reported');
+		$this->assertStringContainsString('unreadable', (string) @file_get_contents($GLOBALS['pfb']['log']),
+			'the pass says why it left the alias alone');
 		$this->assertContains(self::ALIAS, $second['registered'],
 			'the alias stays registered — dropping it would make the caller prune it as an orphan');
 	}

--- a/tests/php/AggregateAliasChangeGateTest.php
+++ b/tests/php/AggregateAliasChangeGateTest.php
@@ -32,6 +32,7 @@ final class AggregateAliasChangeGateTest extends TestCase
 	private string $dbdir;
 	private string $pfctl_call_log;
 	private string $tables_fixture;
+	private string $shell_log;
 
 	private const ALIAS = 'pfB_Deny_Aggregated_v4';
 
@@ -50,6 +51,9 @@ final class AggregateAliasChangeGateTest extends TestCase
 		}
 
 		$this->pfctl_call_log = "{$this->tmp}/pfctl_calls.txt";
+		// What the shipped pfb_aggregate() printed, so a test can tell a real rebuild apart from
+		// the action's own skip.
+		$this->shell_log      = "{$this->tmp}/shell_output.txt";
 		// What the mock pfctl reports for `-vvsTables`; the tests rewrite it to say whether the
 		// aggregate's kernel table currently holds addresses.
 		$this->tables_fixture = "{$this->tmp}/pfctl_tables.txt";
@@ -141,7 +145,7 @@ final class AggregateAliasChangeGateTest extends TestCase
 			. "errorlog=\"\${tmpdir}/error.log\"\n"
 			. "pathaggregate=/nonexistent/iprange\n"
 			. "case \"\$1\" in\n"
-			. "  aggregate) pfb_aggregate \"\$@\" ;;\n"
+			. '  aggregate) pfb_aggregate "$@" >> ' . escapeshellarg($this->shell_log) . " 2>&1 ;;\n"
 			. "  *) exit 0 ;;\n"
 			. "esac\n";
 		$this->assertNotFalse(file_put_contents($path, $body), 'failed to write the script wrapper');
@@ -181,15 +185,29 @@ final class AggregateAliasChangeGateTest extends TestCase
 	}
 
 	/**
+	 * What the shipped `pfb_aggregate()` printed for the alias under test during the last pass.
+	 * Scoped by alias name because selecting a type builds both families, and the memberless v6
+	 * sibling prints its own verdict into the same log.
+	 */
+	private function shellOutput(): string
+	{
+		$raw   = is_file($this->shell_log) ? (string) file_get_contents($this->shell_log) : '';
+		$mine  = array_filter(explode("\n", $raw), static fn (string $l): bool => str_contains($l, self::ALIAS . '.txt'));
+		return implode("\n", $mine);
+	}
+
+	/**
 	 * One builder pass. Returns what it reported: the reload set, the ADR-12 changed set, the
-	 * previous-set stash, and the pfctl calls it made.
+	 * previous-set stash, the pfctl operations aimed at the alias under test, the aliases it
+	 * registered, and what the shell printed.
 	 *
-	 * @return array{lists:list<string>,changed:list<string>,prev:array<string,array<int,string>>,ops:list<string>}
+	 * @return array{lists:list<string>,changed:list<string>,prev:array<string,array<int,string>>,ops:list<string>,registered:list<string>,shell:string}
 	 */
 	private function runBuilder(): array
 	{
 		global $pfb;
 		@unlink($this->pfctl_call_log);
+		@unlink($this->shell_log);
 		$pfb['changed_ip_aliases'] = [];
 		$new_aliases      = [];
 		$new_aliases_list = [];
@@ -199,10 +217,12 @@ final class AggregateAliasChangeGateTest extends TestCase
 		pfb_build_aggregate_aliases($new_aliases, $new_aliases_list, $alias_lists, $prev_sets);
 
 		return [
-			'lists'   => $alias_lists,
-			'changed' => $pfb['changed_ip_aliases'],
-			'prev'    => $prev_sets,
-			'ops'     => $this->pfctlOps(),
+			'lists'      => $alias_lists,
+			'changed'    => $pfb['changed_ip_aliases'],
+			'prev'       => $prev_sets,
+			'ops'        => $this->pfctlOps(),
+			'registered' => $new_aliases_list,
+			'shell'      => $this->shellOutput(),
 		];
 	}
 
@@ -239,6 +259,10 @@ final class AggregateAliasChangeGateTest extends TestCase
 
 		$second = $this->runBuilder();
 
+		// Without this the case would pass vacuously if the action ever started SKIPPING here:
+		// a skip leaves the file untouched, so "byte-identical" would prove nothing.
+		$this->assertStringNotContainsString('skipping rebuild', $second['shell'],
+			"the action must really rebuild for this case to mean anything: {$second['shell']}");
 		$this->assertSame($before, (string) file_get_contents($aggregate),
 			'the rebuilt aggregate must be byte-identical — otherwise this test proves nothing');
 		$this->assertNotContains(self::ALIAS, $second['lists'],
@@ -291,6 +315,57 @@ final class AggregateAliasChangeGateTest extends TestCase
 		$this->assertSame(['replace'], $third['ops'], 'an empty kernel table must be repopulated');
 		$this->assertSame([], $third['prev'][self::ALIAS] ?? NULL,
 			'an empty kernel table stashes an empty previous set, so the apply site full-replaces');
+	}
+
+	/**
+	 * Given every member of a live aggregate is removed
+	 * When the union comes back empty while the kernel table still holds addresses
+	 * Then the table is killed and an EMPTY previous set is stashed, so the apply site
+	 *      full-replaces rather than issuing `-T delete` against a table that no longer exists —
+	 *      which under the user-selectable `Delta` mode is a logged failure and a sync-status
+	 *      ledger entry.
+	 */
+	public function testEmptiedUnionKillsTheTableAndStashesAnEmptyPreviousSet(): void
+	{
+		$member = $this->writeMember('Feed', ['198.51.100.7']);
+		$this->runBuilder();
+		$this->setKernelTable(1);
+
+		$this->assertTrue(unlink($member), 'failed to remove the last member');
+		$second = $this->runBuilder();
+
+		$this->assertContains(self::ALIAS, $second['lists'], 'an emptied union must be reported');
+		$this->assertSame(['kill'], $second['ops'], 'an emptied union prunes the table');
+		$this->assertSame([], $second['prev'][self::ALIAS] ?? NULL,
+			'a killed table stashes an empty previous set, so no delta is computed against it');
+	}
+
+	/**
+	 * Given the aggregate file exists but cannot be read
+	 * When the builder evaluates it
+	 * Then it leaves the alias alone: an I/O error is not an empty union, and inferring one
+	 *      would kill a populated table.
+	 *
+	 * A directory standing at the aggregate's path is how this is forced here — `chmod 000` does
+	 * not stop root, and the suite runs as root on some hosts.
+	 */
+	public function testUnreadableAggregateLeavesTheTableAlone(): void
+	{
+		$this->writeMember('Feed', ['198.51.100.7']);
+		$this->runBuilder();
+		$this->setKernelTable(1);
+
+		$aggregate = "{$this->aliasdir}/" . self::ALIAS . '.txt';
+		$this->assertTrue(unlink($aggregate), 'failed to remove the aggregate file');
+		$this->assertTrue(mkdir($aggregate), 'failed to put a directory in the aggregate path');
+
+		$second = $this->runBuilder();
+
+		$this->assertSame([], $second['ops'], 'an unreadable aggregate must not touch the kernel table');
+		$this->assertNotContains(self::ALIAS, $second['lists'], 'an unreadable aggregate must not be reported');
+		$this->assertNotContains(self::ALIAS, $second['changed'], 'an unreadable aggregate must not be reported');
+		$this->assertContains(self::ALIAS, $second['registered'],
+			'the alias stays registered — dropping it would make the caller prune it as an orphan');
 	}
 
 	/** A box that selects no aggregate type pays nothing: no build, no pfctl call, no report. */

--- a/tests/php/AggregateAliasChangeGateTest.php
+++ b/tests/php/AggregateAliasChangeGateTest.php
@@ -1,0 +1,310 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * issue #3156 — an aggregate ("Uber") alias is reported changed only when its content changed.
+ *
+ * `pfb_aggregate()`'s rebuild gate is an mtime gate: a member file rewritten with byte-identical
+ * content still bumps its mtime, so the union is rebuilt. That is a cheap heuristic and it is
+ * allowed to over-trigger. What may NOT over-trigger is what the rebuild is taken to MEAN — the
+ * aggregate's name entering `$pfb['changed_ip_aliases']` and `$pfb_alias_lists`, and its pf table
+ * being re-pushed. Every member alias already decides that on content (ADR-40); the aggregate
+ * decided it on the output file's mtime, so a content-identical rebuild read as a change and the
+ * kernel table was replaced on every pass.
+ *
+ * The shell side is the SHIPPED `pfb_aggregate()`, sourced through a wrapper — the mtime gate under
+ * test is the real one, not a stand-in. CIDR Aggregation is on, so the union takes the sort -u path
+ * and needs no `iprange`.
+ */
+#[CoversFunction('pfb_build_aggregate_aliases')]
+final class AggregateAliasChangeGateTest extends TestCase
+{
+	/** @var array<string,array{bool,mixed}> */
+	private array $saved = [];
+
+	private string $tmp;
+	private string $denydir;
+	private string $aliasdir;
+	private string $dbdir;
+	private string $pfctl_call_log;
+	private string $tables_fixture;
+
+	private const ALIAS = 'pfB_Deny_Aggregated_v4';
+
+	protected function setUp(): void
+	{
+		foreach (['pfb', 'g', 'config'] as $name) {
+			$this->saved[$name] = [array_key_exists($name, $GLOBALS), $GLOBALS[$name] ?? NULL];
+		}
+
+		$this->tmp      = sys_get_temp_dir() . '/pfb_agg_gate_' . getmypid() . '_' . uniqid();
+		$this->denydir  = "{$this->tmp}/deny";
+		$this->aliasdir = "{$this->tmp}/alias";
+		$this->dbdir    = "{$this->tmp}/db";
+		foreach ([$this->tmp, $this->denydir, $this->aliasdir, $this->dbdir] as $dir) {
+			$this->assertTrue(mkdir($dir, 0777, TRUE), "failed to create {$dir}");
+		}
+
+		$this->pfctl_call_log = "{$this->tmp}/pfctl_calls.txt";
+		// What the mock pfctl reports for `-vvsTables`; the tests rewrite it to say whether the
+		// aggregate's kernel table currently holds addresses.
+		$this->tables_fixture = "{$this->tmp}/pfctl_tables.txt";
+		$this->setKernelTable(0);
+
+		global $pfb;
+		$pfb['denydir']       = $this->denydir;
+		$pfb['permitdir']     = "{$this->tmp}/permit";
+		$pfb['matchdir']      = "{$this->tmp}/match";
+		$pfb['nativedir']     = "{$this->tmp}/native";
+		$pfb['aliasdir']      = $this->aliasdir;
+		$pfb['dbdir']         = $this->dbdir;
+		$pfb['weblocal']      = 'http://127.0.0.1/pfblockerng/www/index.php';
+		$pfb['ip_ph']         = '127.1.7.7';
+		$pfb['enable']        = PfbToggle::On;
+		$pfb['agg']           = PfbToggle::On;
+		$pfb['agg_types']     = ['Deny'];
+		$pfb['pfctl']         = $this->writePfctlMock();
+		$pfb['script']        = $this->writeAggregateWrapper();
+		$pfb['changed_ip_aliases'] = [];
+		$pfb['log']           = "{$this->tmp}/pfblockerng.log";
+		$pfb['errlog']        = "{$this->tmp}/error.log";
+		$pfb['runlog']        = '';
+		$pfb['runlog_active'] = FALSE;
+	}
+
+	protected function tearDown(): void
+	{
+		rmdir_recursive($this->tmp);
+		foreach ($this->saved as $name => [$existed, $value]) {
+			if ($existed) {
+				$GLOBALS[$name] = $value;
+			} else {
+				unset($GLOBALS[$name]);
+			}
+		}
+	}
+
+	/**
+	 * A mock pfctl: records `-T <op>` calls, and answers `-vvsTables` from the fixture file.
+	 *
+	 * Its paths are baked into the script rather than passed as arguments, because
+	 * pfb_pfctl_tables_raw() escapeshellarg()s $pfb['pfctl'] as a single binary path — a
+	 * "binary plus args" value would be quoted whole and fail to execute.
+	 */
+	private function writePfctlMock(): string
+	{
+		$path = "{$this->tmp}/pfctl_mock.sh";
+		$mock = "#!/bin/sh\n"
+			. 'LOG=' . escapeshellarg($this->pfctl_call_log) . "\n"
+			. 'TABLES=' . escapeshellarg($this->tables_fixture) . "\n"
+			. <<<'SH'
+			if [ "$1" = '-vvsTables' ]; then
+			    cat "$TABLES"
+			    exit 0
+			fi
+			table=''
+			action=''
+			while [ "$#" -gt 0 ]; do
+			    case "$1" in
+			        -t) table="$2"; shift 2 ;;
+			        -T) action="$2"; shift 2 ;;
+			        *)  shift ;;
+			    esac
+			done
+			printf '%s\t%s\n' "$action" "$table" >> "$LOG"
+			SH;
+		$this->assertNotFalse(file_put_contents($path, $mock), 'failed to write the pfctl mock');
+		$this->assertTrue(chmod($path, 0755), 'failed to make the pfctl mock executable');
+		return $path;
+	}
+
+	/**
+	 * A `$pfb['script']` stand-in that runs the SHIPPED pfb_aggregate() — sourced with
+	 * PFB_SOURCED=1, given the temp paths the executable path would have set, and no appliance
+	 * path anywhere.
+	 */
+	private function writeAggregateWrapper(): string
+	{
+		$sh   = dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng.sh';
+		$path = "{$this->tmp}/script_wrapper.sh";
+		$body = "#!/bin/sh\n"
+			. "PFB_SOURCED=1\n"
+			. ". " . escapeshellarg($sh) . "\n"
+			. "tmpdir=" . escapeshellarg("{$this->tmp}/shell") . "\n"
+			. "mkdir -p \"\${tmpdir}\"\n"
+			. "tempfile=\"\${tmpdir}/t1\"\n"
+			. "dedupfile=\"\${tmpdir}/dedup\"\n"
+			. "errorlog=\"\${tmpdir}/error.log\"\n"
+			. "pathaggregate=/nonexistent/iprange\n"
+			. "case \"\$1\" in\n"
+			. "  aggregate) pfb_aggregate \"\$@\" ;;\n"
+			. "  *) exit 0 ;;\n"
+			. "esac\n";
+		$this->assertNotFalse(file_put_contents($path, $body), 'failed to write the script wrapper');
+		$this->assertTrue(chmod($path, 0755), 'failed to make the script wrapper executable');
+		return $path;
+	}
+
+	/** Make the mock pfctl report $addresses entries for the aggregate's kernel table. */
+	private function setKernelTable(int $addresses): void
+	{
+		$alias = self::ALIAS;
+		$this->assertNotFalse(
+			file_put_contents($this->tables_fixture, "--a-r-\t{$alias}\n\tAddresses:   {$addresses}\n"),
+			'failed to write the pfctl tables fixture'
+		);
+	}
+
+	/**
+	 * The pfctl operations aimed at the alias under test. Scoped by table because selecting a
+	 * type builds BOTH families, and the memberless v6 sibling has its own (empty) verdict.
+	 *
+	 * @return list<string>
+	 */
+	private function pfctlOps(): array
+	{
+		if (!file_exists($this->pfctl_call_log)) {
+			return [];
+		}
+		$ops = [];
+		foreach (array_filter(explode("\n", file_get_contents($this->pfctl_call_log) ?: '')) as $line) {
+			[$action, $table] = explode("\t", $line, 2);
+			if ($table === self::ALIAS) {
+				$ops[] = $action;
+			}
+		}
+		return $ops;
+	}
+
+	/**
+	 * One builder pass. Returns what it reported: the reload set, the ADR-12 changed set, the
+	 * previous-set stash, and the pfctl calls it made.
+	 *
+	 * @return array{lists:list<string>,changed:list<string>,prev:array<string,array<int,string>>,ops:list<string>}
+	 */
+	private function runBuilder(): array
+	{
+		global $pfb;
+		@unlink($this->pfctl_call_log);
+		$pfb['changed_ip_aliases'] = [];
+		$new_aliases      = [];
+		$new_aliases_list = [];
+		$alias_lists      = [];
+		$prev_sets        = [];
+
+		pfb_build_aggregate_aliases($new_aliases, $new_aliases_list, $alias_lists, $prev_sets);
+
+		return [
+			'lists'   => $alias_lists,
+			'changed' => $pfb['changed_ip_aliases'],
+			'prev'    => $prev_sets,
+			'ops'     => $this->pfctlOps(),
+		];
+	}
+
+	private function writeMember(string $header, array $entries): string
+	{
+		$path = "{$this->denydir}/{$header}_v4.txt";
+		$this->assertNotFalse(file_put_contents($path, implode("\n", $entries) . "\n"), "failed to write {$path}");
+		return $path;
+	}
+
+	/**
+	 * Scenario: the reported defect.
+	 *
+	 * Given an aggregate already built from its members, and its kernel table loaded
+	 * When a member is rewritten with byte-identical content, moving only its mtime
+	 * Then the aggregate is not reported changed and its kernel table is not touched,
+	 *      even though the union was rebuilt.
+	 */
+	public function testMemberRewrittenWithIdenticalContentReportsNoChange(): void
+	{
+		$member = $this->writeMember('Feed', ['198.51.100.7', '203.0.113.0/24']);
+
+		$first = $this->runBuilder();
+		$this->assertContains(self::ALIAS, $first['lists'], 'the initial build must report a change');
+		$aggregate = "{$this->aliasdir}/" . self::ALIAS . '.txt';
+		$this->assertFileExists($aggregate, 'the initial build must write the aggregate');
+		$before = (string) file_get_contents($aggregate);
+
+		// The table now holds what the first pass loaded, and the member's mtime moves without
+		// its content changing — the recompute swap and the suppression republish both do this
+		// (issue #3158).
+		$this->setKernelTable(2);
+		$this->assertTrue(touch($member, time() + 5), 'failed to bump the member mtime');
+
+		$second = $this->runBuilder();
+
+		$this->assertSame($before, (string) file_get_contents($aggregate),
+			'the rebuilt aggregate must be byte-identical — otherwise this test proves nothing');
+		$this->assertNotContains(self::ALIAS, $second['lists'],
+			'an unchanged aggregate must not enter the alias reload set');
+		$this->assertNotContains(self::ALIAS, $second['changed'],
+			'an unchanged aggregate must not enter PFB_CHANGED_IP_ALIASES');
+		$this->assertSame([], $second['ops'],
+			'an unchanged aggregate must not be re-pushed to the kernel: ' . implode(',', $second['ops']));
+	}
+
+	/**
+	 * Given an aggregate whose kernel table is loaded
+	 * When a member's content actually changes
+	 * Then the aggregate is reported changed, its table is replaced, and its PREVIOUS canonical
+	 *      set is stashed so the apply site can take the ADR-40 delta path instead of a full
+	 *      replace.
+	 */
+	public function testMemberContentChangeReportsChangeAndStashesThePreviousSet(): void
+	{
+		$this->writeMember('Feed', ['198.51.100.7']);
+		$this->runBuilder();
+		$this->setKernelTable(1);
+
+		$this->writeMember('Feed', ['198.51.100.7', '192.0.2.9']);
+		$second = $this->runBuilder();
+
+		$this->assertContains(self::ALIAS, $second['lists'], 'a changed aggregate must enter the reload set');
+		$this->assertContains(self::ALIAS, $second['changed'], 'a changed aggregate must enter PFB_CHANGED_IP_ALIASES');
+		$this->assertSame(['replace'], $second['ops'], 'a changed aggregate is loaded into the kernel');
+		$this->assertSame(['198.51.100.7'], $second['prev'][self::ALIAS] ?? NULL,
+			'the previous canonical set must be stashed so the apply site deltas instead of replacing');
+	}
+
+	/**
+	 * The empty-kernel-table repopulation path: an aggregate whose file did not change but whose
+	 * table holds nothing must still be loaded. This is the same signal the member-alias write
+	 * loop uses, and without it a boot or a stray `pfctl -T kill` would leave the table empty
+	 * until a member's content happened to change.
+	 */
+	public function testUnchangedAggregateWithAnEmptyKernelTableIsStillLoaded(): void
+	{
+		$this->writeMember('Feed', ['198.51.100.7']);
+		$this->runBuilder();
+
+		// Table emptied out from under us; the aggregate file is untouched.
+		$this->setKernelTable(0);
+		$third = $this->runBuilder();
+
+		$this->assertContains(self::ALIAS, $third['lists'], 'an empty kernel table must force a reload');
+		$this->assertSame(['replace'], $third['ops'], 'an empty kernel table must be repopulated');
+		$this->assertSame([], $third['prev'][self::ALIAS] ?? NULL,
+			'an empty kernel table stashes an empty previous set, so the apply site full-replaces');
+	}
+
+	/** A box that selects no aggregate type pays nothing: no build, no pfctl call, no report. */
+	public function testNoSelectedTypeTouchesNothing(): void
+	{
+		global $pfb;
+		$pfb['agg_types'] = [];
+		$this->writeMember('Feed', ['198.51.100.7']);
+
+		$result = $this->runBuilder();
+
+		$this->assertSame([], $result['lists'], 'nothing selected must report no change');
+		$this->assertSame([], $result['changed'], 'nothing selected must report no change');
+		$this->assertSame([], $result['ops'], 'nothing selected must not call pfctl');
+		$this->assertFileDoesNotExist("{$this->aliasdir}/" . self::ALIAS . '.txt');
+	}
+}

--- a/tests/php/fixtures/function_inventory.json
+++ b/tests/php/fixtures/function_inventory.json
@@ -160,6 +160,19 @@
             }
         ]
     },
+    "pfb_aggregate_read": {
+        "returnsRef": false,
+        "returnType": null,
+        "params": [
+            {
+                "name": "path",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
     "pfb_alerts_default_page": {
         "returnsRef": false,
         "returnType": null,

--- a/tests/php/fixtures/function_inventory.json
+++ b/tests/php/fixtures/function_inventory.json
@@ -805,6 +805,13 @@
                 "variadic": false,
                 "type": "array",
                 "default": null
+            },
+            {
+                "name": "pfb_alias_prev_sets",
+                "byRef": true,
+                "variadic": false,
+                "type": "array",
+                "default": null
             }
         ]
     },

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -2812,10 +2812,11 @@ def read_hook_env(vm: SmokeVM, path: str, *, timeout: float = 30.0) -> dict[str,
 # see pfblockerng.inc:1174). For each selected Type x family, the update pass
 # (sync_package_pfblockerng -> pfb_build_aggregate_aliases, inc:2144) builds the Native
 # urltable alias ``pfB_<Type>_Aggregated_<family>`` (Type in {Deny,Permit,Match,Native},
-# family in {v4,v6}) = the deduped/iprange'd union of that type's dir, loads it inline
-# (``pfctl -T replace``), and writes a never-empty ``.lst`` consumer file under
-# PFB_DBDIR. NO firewall rule (Native). Deselect/disable tears the aggregate down. A
-# rebuilt aggregate's name merges into the post-hook PFB_CHANGED_IP_ALIASES.
+# family in {v4,v6}) = the deduped/iprange'd union of that type's dir, and writes a
+# never-empty ``.lst`` consumer file under PFB_DBDIR. NO firewall rule (Native).
+# Deselect/disable tears the aggregate down. A CHANGED aggregate — content, not a mere
+# rebuild (issue #3156) — is loaded inline (``pfctl -T replace``) and merges into the
+# post-hook PFB_CHANGED_IP_ALIASES.
 
 AGG_TYPES = ("Deny", "Permit", "Match", "Native")
 CFG_AGG_TYPES = CFG_GLOBAL + "/pfb_agg_types"

--- a/tests/smoke/test_smoke_aggregate.py
+++ b/tests/smoke/test_smoke_aggregate.py
@@ -6,11 +6,12 @@ pfBlockerNG can build, per SELECTED action type x family, a Native ``urltable`` 
 ``pfb_agg_types`` (IP settings, opt-in, default ``""`` = none) gates it. The build
 runs IN the update pass (``sync_package_pfblockerng`` -> ``pfb_build_aggregate_aliases``,
 ``inc:2144``, called ``inc:11116``): for each selected type it writes the member union,
-runs ``pfblockerng.sh aggregate`` (cat | sort -u | iprange, mtime-gated), registers the
-Native alias (NEVER ``pfb_firewall_rule`` -- no rule), loads the pf table INLINE
-(``pfctl -T replace``), and writes a never-empty ``.lst`` consumer file. A deselected /
-disabled type is torn down (alias/table/files removed). A genuinely (re)built aggregate's
-name is merged into ``$pfb['changed_ip_aliases']`` -> the ADR-12 ``post`` hook's
+runs ``pfblockerng.sh aggregate`` (cat | sort -u | iprange, rebuilt on a member's mtime),
+registers the Native alias (NEVER ``pfb_firewall_rule`` -- no rule), and writes a never-empty
+``.lst`` consumer file. A deselected / disabled type is torn down (alias/table/files removed).
+Whether that rebuild counts as a CHANGE is decided on the aggregate's canonical content, not on
+its mtime (issue #3156): only a changed aggregate is loaded INLINE (``pfctl -T replace``) and
+merged into ``$pfb['changed_ip_aliases']`` -> the ADR-12 ``post`` hook's
 ``PFB_CHANGED_IP_ALIASES`` -- and the build/load completes BEFORE the ``post`` hook fires.
 
 These tests drive the REAL production path: ``helpers.reload(vm, scope)`` runs the same


### PR DESCRIPTION
Fixes #3156

## What was wrong

Reported from a live box: every feed logs `exists.`, the only feed event is a permanently-404 feed
whose *previous contents are restored*, and both aggregates are still fully replaced — every pass.

```
2026-09-03 07:56:39 No changes to Firewall rules, skipping Filter Reload
2026-09-03 07:56:39 Alias table changes detected, updating:
2026-09-03 07:56:40  Updating [ pfB_Deny_Aggregated_v4 ]: replace
2026-09-03 07:56:41  Updating [ pfB_Deny_Aggregated_v6 ]: replace
```

The aggregate's change detection was mtime-based end to end, while ADR-40 made every other alias
content-based:

1. `pfb_aggregate()` skips its rebuild only when no member file is *newer* than the aggregate
   output. A member rewritten with byte-identical content still bumps its mtime, so the union is
   rebuilt. Executed against the shipped shell function:

   ```
   --- run 2 (members untouched) ---
   aggregate [ v4 ]: member set unchanged, no member newer than […/agg.txt], skipping rebuild.
   --- run 3 (member mtime bumped, content identical) ---
   aggregate [ v4 ]: union 3 -> 3 CIDRs -> …/agg.txt
   ```

2. `pfb_build_aggregate_aliases()` then derived its change signal from the aggregate's *own* mtime,
   so a content-identical rebuild read as a change and the name entered
   `$pfb['changed_ip_aliases']` and `$pfb_alias_lists`.
3. Aggregates were never stashed in `$pfb_alias_prev_sets`, so the apply site computed
   `force_rpl = empty(NULL) = TRUE` and took the full `-T replace` branch rather than a delta.
4. The builder's own inline `pfctl -T replace` was not gated on the rebuild signal at all, so the
   kernel table was re-pushed even on the passes where the shell *did* skip.

And the churn that keeps tripping step 1 is not the 404 feed alone. One event fans out to every
member of both families: the restore path rewrites its own member with identical bytes and flips the
box-wide `$pfb['repcheck']`; `pfb_ip_recompute_matrix()` turns that single flag into `invoke_v4`
**and** `invoke_v6` when Dedup is on; and `pfb_recompute_finish()` then `mv -f`s every member alias
of both families with no content diff — as does the suppression republish. Those unconditional
rewrites are tracked separately in #3158; this PR fixes the aggregate's own detection, which must be
content-based however often a member's mtime moves.

## The change

`pfb_build_aggregate_aliases()` decides "changed" from the aggregate's canonical set — captured
before the build and compared after — plus a file-vs-kernel emptiness mismatch:

```php
$changed = ($new_set !== $prev_set) || ($want_empty !== $table_empty);
```

The mismatch term is what keeps the boot / stray-`kill` path working: a non-empty file over an empty
table still loads, and an emptied union over a populated table still kills. Only a changed aggregate
is pushed to the kernel, merged into `$pfb['changed_ip_aliases']` and `$pfb_alias_lists`, and its
previous set is now stashed in `$pfb_alias_prev_sets` so the apply site takes the ADR-40 delta path
instead of always force-replacing — stashing `[]` when the kernel table is empty, exactly as the
member-alias write loop does.

The emptiness probe is one `pfctl -vvsTables` for every table
(`pfb_pfctl_tables_parse(pfb_pfctl_tables_raw())`), skipped entirely when no aggregate type is
selected. `pfb_pfctl_table_count()` was not reused: it dumps every member of the table it counts,
which for a Deny aggregate is the whole union, up to eight times a pass.

This also fixes an under-sensitivity in the old signal: `pfb_file_mtime($aggout) > $mtime_before`
compares equal for two passes inside the same second, so a genuine change went unreported. The
regression test's content-change case fails on unchanged production code for exactly that reason.

## Evidence

**Red before, green after** — `tests/php/AggregateAliasChangeGateTest.php`, frozen byte-identical
between the runs (`git hash-object` = `318c400f1da6669a31efb38a5bb2b1d9d302849c` at both), against
`origin/devel`'s production files and then this branch's:

```
# on unchanged production code
Tests: 6, Assertions: 85, Failures: 5.     # every behavioural case

# after the fix, same file, zero edits
OK (6 tests, 96 assertions)
```

The test drives the real `pfb_build_aggregate_aliases()`, and its `$pfb['script']` runs the
**shipped** `pfb_aggregate()` through a wrapper that sources `pfblockerng.sh` with `PFB_SOURCED=1` —
so the mtime gate under test is the real one, not a stand-in. CIDR Aggregation is on, so the union
takes the `sort -u` path and needs no `iprange`. Cases:

- a member rewritten with identical content and a bumped mtime → no change reported, no `pfctl`
  call. The case asserts the rebuilt aggregate is byte-identical **and** that the action's own
  output does not say `skipping rebuild`, so it cannot pass because nothing happened;
- a real content change → reported, replaced, previous set stashed for the delta;
- an unchanged aggregate over an emptied kernel table → still loaded, empty previous set stashed;
- an emptied union over a live table → killed, and an **empty** previous set stashed, so the apply
  site force-replaces instead of issuing `-T delete` against a dead table (which under the
  user-selectable `Delta` mode is a logged failure plus a sync-status ledger entry);
- something other than a readable file at the aggregate's path → the alias is left alone, still
  registered, and the pass says why. An I/O error is not an empty union;
- no type selected → nothing built, no `pfctl`, no report.

Review re-executed seven mutations against the gate in round 1 and five more in round 2 — dropping
either term, inverting it, either direction of the stash ternary, moving the `pfctl` call back
outside the guard, capturing the baseline after the build instead of before, dropping `is_file()`
from the I/O guard, dropping the early `continue`, and moving the alias registration back below it.
All twelve were caught.

**Gates**

| Gate | Result |
| --- | --- |
| `php -l` (both touched files) | pass |
| `vendor/bin/phpunit` | `Tests: 6504, Errors: 29, Failures: 14` — name-for-name the pre-existing set on this host (tracked: #3103, #3083); none of them touches aggregates |
| `composer phpstan` | `[OK] No errors` |
| `composer phpcs -- --standard=phpcs.xml.dist src/` | rc=0 |
| `uv run pytest -q` | `5913 passed, 7 skipped` |
| `uv run ruff check` / `ruff format --check` | pass |
| `uv run mypy tests/` | `no issues found in 381 source files` |

`tests/php/fixtures/function_inventory.json` is the regenerated parity golden for the builder's new
fourth parameter.

## Not in this PR

- **#3158** — the recompute swap and the suppression republish rewrite member files whose content
  did not change. That is what keeps triggering the union rebuild (the 15-second gap in the reported
  log); this PR only stops the rebuild from being *mistaken for a change*.
- **#3159** — the rule-change path kills the aggregate tables it has no rule for, because
  `$pfb_tables` is a live `pfctl -s Tables` listing and aggregates are never in
  `$pfb_active_aliases`. `filter_configure()` restores them, so it is currently masked.
- **#3161** — the regenerated `graphify-out/graph.json` adds ~76,000 changed lines beside this
  48-line change, which makes the PR diff unreadable through the GitHub UI or an API reader. Two
  review legs hit it independently.

Note: `scripts/agent/run-gates.sh` reports `GATE FAIL` for `composer phpstan` / `composer phpcs` in a
root session because Composer refuses to load plugins as superuser; both were run directly with
`COMPOSER_ALLOW_SUPERUSER=1` and pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Aggregate aliases now reload only when their canonical content changes, preventing unnecessary updates caused by rebuild timestamps alone.
  * Empty kernel tables and transitions to empty aggregates are handled correctly during synchronization.
  * Unreadable aggregate outputs are skipped safely without modifying the existing table.
  * Changed aggregates correctly preserve prior contents for accurate update processing.

* **Documentation**
  * Updated aggregate alias behavior documentation to reflect content-based change detection and selective loading.

* **Tests**
  * Added coverage for unchanged, changed, empty, invalid, and unselected aggregate scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->