### PR TITLE
pfblockerng.sh: sort each closing sanity side once

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.sh
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.sh
@@ -2234,14 +2234,15 @@ closingprocess() {
 		# issue #1084 review: mastercat (s1/s3) carries BOTH families' rows (v6 Deny joined
 		# cross-list dedup), so the shared deny concatenation (s2/s4) must include v6 too.
 		# issue #1263: awk 1 -- an unterminated deny file no longer welds into its neighbour.
-		# issue #3154: one concat+sort feeds s2 and s4; a short write (exhausted tmpdir) only
-		# ever LOWERS s2, so an unchecked one could print PASSED over a real mismatch.
+		# issue #3154: one concat+sort feeds s2 and s4; a short write (exhausted tmpdir) makes
+		# the count unreliable either way, so an unchecked one could print PASSED over a real
+		# mismatch -- a truncation inside a placeholder row even RAISES it.
 		if find "${pfbdeny}"*.txt -type f 2>/dev/null | xargs awk 1 | LC_ALL=C sort > "${tempfile}"; then
 			s2="$(grep -cv "^${ip_placeholder2}$" "${tempfile}")"
 			s4="$(LC_ALL=C uniq -d "${tempfile}" | tail -30 | grep -v "^${ip_placeholder2}$")"
 		else
 			s2='incomplete'
-			s4=''
+			s4='incomplete'
 			log="closing: deny folder concatenation into [ ${tempfile} ] failed; sanity counts unreliable."
 			echo "${log}" | tee -a "${errorlog}"
 		fi

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.sh
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.sh
@@ -2223,7 +2223,11 @@ closingprocess() {
 	# Execute when 'de-duplication' is enabled
 	if [ "${alias}" = 'on' ]; then
 		LC_ALL=C sort -o "${masterfile}" "${masterfile}"
-		sort -t . -k 1,1n -k 2,2n -k 3,3n -k 4,4n "${mastercat}" > "${tempfile}"; mv -f "${tempfile}" "${mastercat}"
+		# issue #3154: one byte-order sort of mastercat, in place. The octet-numeric
+		# ordering this used to produce was read by nothing (every consumer is a
+		# grep/awk set operation, and the file is re-cut from masterfile next pass),
+		# while s3 below re-sorted it anyway to feed uniq -d.
+		LC_ALL=C sort -o "${mastercat}" "${mastercat}"
 
 		echo "   [ Original IP count   ]  [ ${counto} ]"
 		countm="$(grep -c ^ "${masterfile}")"
@@ -2232,11 +2236,14 @@ closingprocess() {
 		# issue #1084 review: mastercat (s1/s3) now carries BOTH families' rows
 		# (v6 Deny joined cross-list dedup) -- the deny-folder re-scan (s2/s4) must
 		# include v6 Deny files too, else the family mismatch alone fails sanity.
-		s1="$(grep -cv "^${ip_placeholder2}$" "${mastercat}")"
 		# issue #1263: awk 1 -- an unterminated deny file no longer welds into its neighbour.
-		s2="$(find "${pfbdeny}"*.txt -type f 2>/dev/null | xargs awk 1 | grep -cv "^${ip_placeholder2}$")"
-		s3="$(LC_ALL=C sort "${mastercat}" | LC_ALL=C uniq -d | tail -30)"
-		s4="$(find "${pfbdeny}"*.txt -type f 2>/dev/null | xargs awk 1 | LC_ALL=C sort | LC_ALL=C uniq -d | tail -30 | grep -v "^${ip_placeholder2}$")"
+		# issue #3154: concatenate and sort the deny folder once; s2 counts that file
+		# and s4 lists its duplicates, instead of each walking the folder itself.
+		find "${pfbdeny}"*.txt -type f 2>/dev/null | xargs awk 1 | LC_ALL=C sort > "${tempfile}"
+		s1="$(grep -cv "^${ip_placeholder2}$" "${mastercat}")"
+		s2="$(grep -cv "^${ip_placeholder2}$" "${tempfile}")"
+		s3="$(LC_ALL=C uniq -d "${mastercat}" | tail -30)"
+		s4="$(LC_ALL=C uniq -d "${tempfile}" | tail -30 | grep -v "^${ip_placeholder2}$")"
 	else
 		echo "   [ Original IP count   ]  [ ${counto} ]"
 	fi

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.sh
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.sh
@@ -2223,27 +2223,30 @@ closingprocess() {
 	# Execute when 'de-duplication' is enabled
 	if [ "${alias}" = 'on' ]; then
 		LC_ALL=C sort -o "${masterfile}" "${masterfile}"
-		# issue #3154: one byte-order sort of mastercat, in place. The octet-numeric
-		# ordering this used to produce was read by nothing (every consumer is a
-		# grep/awk set operation, and the file is re-cut from masterfile next pass),
-		# while s3 below re-sorted it anyway to feed uniq -d.
+		# issue #3154: byte order, in place -- no consumer computes on the old octet ordering
+		# (the Masterfiles log view is its only reader) and s3 re-sorted it anyway.
 		LC_ALL=C sort -o "${mastercat}" "${mastercat}"
 
 		echo "   [ Original IP count   ]  [ ${counto} ]"
 		countm="$(grep -c ^ "${masterfile}")"
 		echo; echo "   [ Final IP Count  ]  [ ${countm} ]"; echo
 
-		# issue #1084 review: mastercat (s1/s3) now carries BOTH families' rows
-		# (v6 Deny joined cross-list dedup) -- the deny-folder re-scan (s2/s4) must
-		# include v6 Deny files too, else the family mismatch alone fails sanity.
+		# issue #1084 review: mastercat (s1/s3) carries BOTH families' rows (v6 Deny joined
+		# cross-list dedup), so the shared deny concatenation (s2/s4) must include v6 too.
 		# issue #1263: awk 1 -- an unterminated deny file no longer welds into its neighbour.
-		# issue #3154: concatenate and sort the deny folder once; s2 counts that file
-		# and s4 lists its duplicates, instead of each walking the folder itself.
-		find "${pfbdeny}"*.txt -type f 2>/dev/null | xargs awk 1 | LC_ALL=C sort > "${tempfile}"
+		# issue #3154: one concat+sort feeds s2 and s4; a short write (exhausted tmpdir) only
+		# ever LOWERS s2, so an unchecked one could print PASSED over a real mismatch.
+		if find "${pfbdeny}"*.txt -type f 2>/dev/null | xargs awk 1 | LC_ALL=C sort > "${tempfile}"; then
+			s2="$(grep -cv "^${ip_placeholder2}$" "${tempfile}")"
+			s4="$(LC_ALL=C uniq -d "${tempfile}" | tail -30 | grep -v "^${ip_placeholder2}$")"
+		else
+			s2='incomplete'
+			s4=''
+			log="closing: deny folder concatenation into [ ${tempfile} ] failed; sanity counts unreliable."
+			echo "${log}" | tee -a "${errorlog}"
+		fi
 		s1="$(grep -cv "^${ip_placeholder2}$" "${mastercat}")"
-		s2="$(grep -cv "^${ip_placeholder2}$" "${tempfile}")"
 		s3="$(LC_ALL=C uniq -d "${mastercat}" | tail -30)"
-		s4="$(LC_ALL=C uniq -d "${tempfile}" | tail -30 | grep -v "^${ip_placeholder2}$")"
 	else
 		echo "   [ Original IP count   ]  [ ${counto} ]"
 	fi

--- a/tests/shell/pfblockerng_adr26_locale_spec.sh
+++ b/tests/shell/pfblockerng_adr26_locale_spec.sh
@@ -107,12 +107,23 @@ Describe 'ADR-26 — pfblockerng.sh locale/portability source invariants (Phases
     When call has "LC_ALL=C sort -t ' ' -k2,2 -s \"\${rec_new_stream}\""
     The status should be success
   End
-  It 'prefixes both commands in the s3 mastercat duplicate probe with LC_ALL=C'
-    When call has 's3="$(LC_ALL=C sort "${mastercat}" | LC_ALL=C uniq -d | tail -30)"'
+  # issue #3154 sorted each side once: mastercat in place and the deny folder into
+  # tempfile, so the duplicate probes are a bare `uniq -d` over an already-C-sorted
+  # file. Every sort and uniq in the pair still carries LC_ALL=C.
+  It 'prefixes the mastercat order (sort -o) with LC_ALL=C'
+    When call has 'LC_ALL=C sort -o "${mastercat}" "${mastercat}"'
     The status should be success
   End
-  It 'prefixes both commands in the s4 deny-folder duplicate probe with LC_ALL=C'
-    When call has 's4="$(find "${pfbdeny}"*.txt -type f 2>/dev/null | xargs awk 1 | LC_ALL=C sort | LC_ALL=C uniq -d | tail -30 | grep -v "^${ip_placeholder2}$")"'
+  It 'prefixes the s3 mastercat duplicate probe with LC_ALL=C'
+    When call has 's3="$(LC_ALL=C uniq -d "${mastercat}" | tail -30)"'
+    The status should be success
+  End
+  It 'prefixes the deny-folder concatenation sink with LC_ALL=C'
+    When call has 'find "${pfbdeny}"*.txt -type f 2>/dev/null | xargs awk 1 | LC_ALL=C sort > "${tempfile}"'
+    The status should be success
+  End
+  It 'prefixes the s4 deny-folder duplicate probe with LC_ALL=C'
+    When call has 's4="$(LC_ALL=C uniq -d "${tempfile}" | tail -30 | grep -v "^${ip_placeholder2}$")"'
     The status should be success
   End
 

--- a/tests/shell/pfblockerng_closing_sort_spec.sh
+++ b/tests/shell/pfblockerng_closing_sort_spec.sh
@@ -123,21 +123,22 @@ Describe 'closingprocess() dedup-mode sort trim (#3154)'
   End
 
   It 'never reports PASSED when the deny concatenation cannot be written (C6)'
-    # Given the same real mismatch, plus a `sort` that writes part of its output and
-    # exits nonzero -- what an exhausted tmpdir does (partial write, exit 2). Truncation
-    # only ever LOWERS the deny count, so it can drag s2 down onto s1 and print PASSED
-    # over a genuine mismatch; the sanity verdict is mirrored into the GUI dedup ledger
-    # by pfb_sync_status_dedup_check(), so a false PASSED closes a key that must stay open.
-    printf 'A 1.2.3.4\n'  > "$masterfile"
-    printf '1.2.3.4\n'    > "$mastercat"
-    printf '1.2.3.4\n'    > "${pfbdeny}A.txt"
-    printf '5.6.7.8\n'    > "${pfbdeny}B.txt"
+    # Given a deny folder twice the size of mastercat, holding a cross-file duplicate that
+    # survives truncation, plus a `sort` that writes part of its output and exits nonzero --
+    # what an exhausted tmpdir does (partial write, exit 2). Truncation only ever LOWERS the
+    # deny count, so it can drag s2 down onto s1 and print PASSED over a genuine mismatch;
+    # the verdict is mirrored into the GUI dedup ledger by pfb_sync_status_dedup_check(), so
+    # a false PASSED closes a key that must stay open.
+    printf 'A 1.2.3.4\nB 5.6.7.8\n'      > "$masterfile"
+    printf '1.2.3.4\n5.6.7.8\n'          > "$mastercat"
+    printf '1.2.3.4\n'                   > "${pfbdeny}A.txt"
+    printf '1.2.3.4\n5.6.7.8\n9.9.9.9\n' > "${pfbdeny}B.txt"
     mkdir -p "${work}/bin"
     real_sort="$(command -v sort)"
     {
       printf '#!/bin/sh\n'
       printf 'case " $* " in *" -o "*) exec %s "$@" ;; esac\n' "$real_sort"
-      printf '%s "$@" | head -1\nexit 2\n' "$real_sort"
+      printf '%s "$@" | head -2\nexit 2\n' "$real_sort"
     } > "${work}/bin/sort"
     chmod +x "${work}/bin/sort"
     PATH="${work}/bin:${PATH}"
@@ -145,11 +146,13 @@ Describe 'closingprocess() dedup-mode sort trim (#3154)'
     # When the final report runs.
     When call closingprocess
 
-    # Then no count is reported from the short write, the verdict stays FAILED, and the
-    # failure is logged instead of being papered over.
+    # Then the count is refused rather than reported low, the duplicate listing the partial
+    # file would have yielded is withheld, the verdict stays FAILED, and it is logged.
     The status should be success
     The stdout should not include 'PASSED'
     The stdout should include 'Database Sanity check [  FAILED  ]'
+    The stdout should include 'Deny folder Count   [ incomplete ]'
+    The stdout should include "$(printf 'Deny folder/Masterfile uniq check\n\nSync check')"
     The stdout should include 'deny folder concatenation'
     The contents of the file "$errorlog" should include 'sanity counts unreliable'
   End

--- a/tests/shell/pfblockerng_closing_sort_spec.sh
+++ b/tests/shell/pfblockerng_closing_sort_spec.sh
@@ -1,13 +1,8 @@
 #shellcheck shell=sh
-# issue #3154: closingprocess()'s dedup-mode probes re-sorted what they had just
-# sorted. mastercat got a numeric octet sort (sort -t . -k1,1n ...) whose ordering
-# no consumer reads -- every reader is a grep/awk set operation and the file is
-# re-cut from masterfile next pass -- and s3 then sorted it AGAIN to feed uniq -d;
-# the deny folder was concatenated and walked twice, once for the count (s2) and
-# once sorted for the duplicate listing (s4). One C sort per side now feeds both
-# probes. What the sanity check REPORTS -- the PASSED/FAILED line and the two
-# duplicate listings, placeholder rows included in the masterfile listing and
-# excluded from the deny listing -- must be unchanged.
+# issue #3154: closingprocess()'s dedup probes now sort each side once -- mastercat in
+# place, the deny folder into tempfile -- and read those files. What the sanity check
+# REPORTS must not move: the PASSED/FAILED line with both counts, and the two duplicate
+# listings, placeholder rows kept in the masterfile listing and dropped from the deny one.
 
 Describe 'closingprocess() dedup-mode sort trim (#3154)'
   setup() {
@@ -33,9 +28,12 @@ Describe 'closingprocess() dedup-mode sort trim (#3154)'
     cat "$mastercat"
   }
 
+  closing_body() {
+    sed -n '/^closingprocess()/,/^}/p' "${PFB_PKGDIR}/pfblockerng.sh"
+  }
+
   deny_concat_count() {
-    sed -n '/^closingprocess()/,/^}/p' "${PFB_PKGDIR}/pfblockerng.sh" |
-      grep -c 'find "${pfbdeny}"'
+    closing_body | grep -c 'find "${pfbdeny}"'
   }
 
   It 'leaves mastercat in byte order, not octet-numeric order (C1)'
@@ -96,7 +94,7 @@ Describe 'closingprocess() dedup-mode sort trim (#3154)'
 
   It 'sorts each side once: no numeric octet sort, one deny concatenation (C4)'
     # Given the sourced script's closingprocess() body.
-    When run sh -c 'sed -n "/^closingprocess()/,/^}/p" "${PFB_PKGDIR}/pfblockerng.sh"'
+    When call closing_body
 
     # Then the extraction was real, the octet sort is gone, and the deny folder is
     # concatenated once for both probes.
@@ -105,5 +103,54 @@ Describe 'closingprocess() dedup-mode sort trim (#3154)'
     The output should not include 'sort -t .'
     The output should include 'uniq -d'
     The result of function deny_concat_count should equal 1
+  End
+
+  It 'reports FAILED with both counts when the two sides disagree (C5)'
+    # Given a deny folder holding one row more than mastercat -- the mismatch the check
+    # exists to catch, and the only branch that prints s2 as a number.
+    printf 'A 1.2.3.4\n'         > "$masterfile"
+    printf '1.2.3.4\n'           > "$mastercat"
+    printf '1.2.3.4\n5.6.7.8\n'  > "${pfbdeny}A.txt"
+
+    # When the final report runs.
+    When call closingprocess
+
+    # Then the verdict flips and each side's count is named.
+    The status should be success
+    The stdout should include 'Database Sanity check [  FAILED  ]'
+    The stdout should include 'Masterfile Count    [ 1 ]'
+    The stdout should include 'Deny folder Count   [ 2 ]'
+  End
+
+  It 'never reports PASSED when the deny concatenation cannot be written (C6)'
+    # Given the same real mismatch, plus a `sort` that writes part of its output and
+    # exits nonzero -- what an exhausted tmpdir does (partial write, exit 2). Truncation
+    # only ever LOWERS the deny count, so it can drag s2 down onto s1 and print PASSED
+    # over a genuine mismatch; the sanity verdict is mirrored into the GUI dedup ledger
+    # by pfb_sync_status_dedup_check(), so a false PASSED closes a key that must stay open.
+    printf 'A 1.2.3.4\n'  > "$masterfile"
+    printf '1.2.3.4\n'    > "$mastercat"
+    printf '1.2.3.4\n'    > "${pfbdeny}A.txt"
+    printf '5.6.7.8\n'    > "${pfbdeny}B.txt"
+    mkdir -p "${work}/bin"
+    real_sort="$(command -v sort)"
+    {
+      printf '#!/bin/sh\n'
+      printf 'case " $* " in *" -o "*) exec %s "$@" ;; esac\n' "$real_sort"
+      printf '%s "$@" | head -1\nexit 2\n' "$real_sort"
+    } > "${work}/bin/sort"
+    chmod +x "${work}/bin/sort"
+    PATH="${work}/bin:${PATH}"
+
+    # When the final report runs.
+    When call closingprocess
+
+    # Then no count is reported from the short write, the verdict stays FAILED, and the
+    # failure is logged instead of being papered over.
+    The status should be success
+    The stdout should not include 'PASSED'
+    The stdout should include 'Database Sanity check [  FAILED  ]'
+    The stdout should include 'deny folder concatenation'
+    The contents of the file "$errorlog" should include 'sanity counts unreliable'
   End
 End

--- a/tests/shell/pfblockerng_closing_sort_spec.sh
+++ b/tests/shell/pfblockerng_closing_sort_spec.sh
@@ -146,13 +146,14 @@ Describe 'closingprocess() dedup-mode sort trim (#3154)'
     # When the final report runs.
     When call closingprocess
 
-    # Then the count is refused rather than reported low, the duplicate listing the partial
-    # file would have yielded is withheld, the verdict stays FAILED, and it is logged.
+    # Then both the count and the duplicate listing say so rather than reporting the
+    # partial file's contents -- an empty listing under that heading reads as "no
+    # duplicates" -- the verdict stays FAILED, and the failure is logged.
     The status should be success
     The stdout should not include 'PASSED'
     The stdout should include 'Database Sanity check [  FAILED  ]'
     The stdout should include 'Deny folder Count   [ incomplete ]'
-    The stdout should include "$(printf 'Deny folder/Masterfile uniq check\n\nSync check')"
+    The stdout should include "$(printf 'Deny folder/Masterfile uniq check\nincomplete')"
     The stdout should include 'deny folder concatenation'
     The contents of the file "$errorlog" should include 'sanity counts unreliable'
   End

--- a/tests/shell/pfblockerng_closing_sort_spec.sh
+++ b/tests/shell/pfblockerng_closing_sort_spec.sh
@@ -1,0 +1,109 @@
+#shellcheck shell=sh
+# issue #3154: closingprocess()'s dedup-mode probes re-sorted what they had just
+# sorted. mastercat got a numeric octet sort (sort -t . -k1,1n ...) whose ordering
+# no consumer reads -- every reader is a grep/awk set operation and the file is
+# re-cut from masterfile next pass -- and s3 then sorted it AGAIN to feed uniq -d;
+# the deny folder was concatenated and walked twice, once for the count (s2) and
+# once sorted for the duplicate listing (s4). One C sort per side now feeds both
+# probes. What the sanity check REPORTS -- the PASSED/FAILED line and the two
+# duplicate listings, placeholder rows included in the masterfile listing and
+# excluded from the deny listing -- must be unchanged.
+
+Describe 'closingprocess() dedup-mode sort trim (#3154)'
+  setup() {
+    work="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/closingsort.XXXXXX")"
+    pfborig="${work}/orig/"; pfbdeny="${work}/deny/"
+    pfbpermit="${work}/permit/"; pfbmatch="${work}/match/"; pfbnative="${work}/native/"
+    pfbmatchgen="${pfbmatch}generated/"
+    mkdir -p "$pfborig" "$pfbdeny" "$pfbpermit" "$pfbmatch" "$pfbnative" "$pfbmatchgen"
+    pfsensealias="${work}/alias/"; mkdir -p "$pfsensealias"
+    masterfile="${work}/masterfile"; mastercat="${work}/mastercat"
+    tempfile="${work}/t1"; errorlog="${work}/err.log"; now="now"
+    ip_placeholder2="127.0.0.1"
+    alias="on"
+    pathpfctl="${work}/pfctl"; printf '#!/bin/sh\n' > "$pathpfctl"; chmod +x "$pathpfctl"
+  }
+  cleanup() { rm -rf "$work"; }
+  BeforeAll 'pfb_source'
+  Before 'setup'
+  After 'cleanup'
+
+  closing_then_mastercat() {
+    closingprocess > /dev/null
+    cat "$mastercat"
+  }
+
+  deny_concat_count() {
+    sed -n '/^closingprocess()/,/^}/p' "${PFB_PKGDIR}/pfblockerng.sh" |
+      grep -c 'find "${pfbdeny}"'
+  }
+
+  It 'leaves mastercat in byte order, not octet-numeric order (C1)'
+    # Given a mastercat whose rows sort differently by byte than by octet value
+    # (9. before 10. numerically; 10. before 9. by byte).
+    printf 'A 9.0.0.0\nB 10.0.0.1\nC 192.0.2.1\n' > "$masterfile"
+    printf '192.0.2.1\n9.0.0.0\n10.0.0.1\n'       > "$mastercat"
+
+    # When the final report runs.
+    When call closing_then_mastercat
+
+    # Then the file is left sorted the one way the duplicate probe reads it --
+    # LC_ALL=C -- with no row lost.
+    The status should be success
+    The lines of stdout should equal 3
+    The line 1 of stdout should equal '10.0.0.1'
+    The line 2 of stdout should equal '192.0.2.1'
+    The line 3 of stdout should equal '9.0.0.0'
+  End
+
+  It 'reports both duplicate listings and PASSED when the counts match (C2)'
+    # Given a duplicate inside mastercat and the same row in two different deny
+    # files, with the masterfile and deny-folder counts still equal.
+    printf 'A 1.2.3.4\nA 1.2.3.4\nB 5.6.7.8\n' > "$masterfile"
+    printf '1.2.3.4\n1.2.3.4\n5.6.7.8\n'       > "$mastercat"
+    printf '1.2.3.4\n5.6.7.8\n' > "${pfbdeny}A.txt"
+    printf '1.2.3.4\n'          > "${pfbdeny}B.txt"
+
+    # When the final report runs.
+    When call closingprocess
+
+    # Then the sanity check passes and each listing names the duplicate directly
+    # under its own heading.
+    The status should be success
+    The stdout should include 'Database Sanity check [  PASSED  ]'
+    The stdout should include "$(printf 'Masterfile/Deny folder uniq check\n1.2.3.4')"
+    The stdout should include "$(printf 'Deny folder/Masterfile uniq check\n1.2.3.4')"
+  End
+
+  It 'keeps the placeholder out of the deny listing but not the masterfile one (C3)'
+    # Given the empty-list placeholder duplicated on both sides: s3 reports it,
+    # s4 filters it out -- an asymmetry the rewrite must not level.
+    printf 'A 127.0.0.1\nA 127.0.0.1\nB 1.2.3.4\n' > "$masterfile"
+    printf '127.0.0.1\n127.0.0.1\n1.2.3.4\n'       > "$mastercat"
+    printf '127.0.0.1\n1.2.3.4\n' > "${pfbdeny}A.txt"
+    printf '127.0.0.1\n'          > "${pfbdeny}B.txt"
+
+    # When the final report runs.
+    When call closingprocess
+
+    # Then only the masterfile listing names it; the deny listing is empty and the
+    # placeholder-free counts still match.
+    The status should be success
+    The stdout should include 'Database Sanity check [  PASSED  ]'
+    The stdout should include "$(printf 'Masterfile/Deny folder uniq check\n127.0.0.1')"
+    The stdout should include "$(printf 'Deny folder/Masterfile uniq check\n\nSync check')"
+  End
+
+  It 'sorts each side once: no numeric octet sort, one deny concatenation (C4)'
+    # Given the sourced script's closingprocess() body.
+    When run sh -c 'sed -n "/^closingprocess()/,/^}/p" "${PFB_PKGDIR}/pfblockerng.sh"'
+
+    # Then the extraction was real, the octet sort is gone, and the deny folder is
+    # concatenated once for both probes.
+    The status should be success
+    The output should include 'closingprocess()'
+    The output should not include 'sort -t .'
+    The output should include 'uniq -d'
+    The result of function deny_concat_count should equal 1
+  End
+End


### PR DESCRIPTION
## What

`closingprocess()`'s dedup-mode sanity block sorted each side twice.

- `mastercat` got an octet-numeric sort (`sort -t . -k1,1n -k2,2n -k3,3n -k4,4n`) whose ordering nothing computes on — every code reader in the tree is a `grep`/`awk` set operation, and the file is re-cut with `cut -d ' ' -f2 masterfile` on the next pass — and the `s3` duplicate probe then sorted it *again* to feed `uniq -d`.
- The deny folder was concatenated and walked twice: unsorted for the count (`s2`), then concatenated and sorted again for the duplicate listing (`s4`).

Now each side is sorted exactly once — `mastercat` in place with `LC_ALL=C sort -o`, the deny concatenation into `${tempfile}` — and `s1`–`s4` read those files. The check itself (`s1 == s2`, both duplicate listings, `tail -30`, the placeholder filter on the deny listing only) is unchanged.

The deny concatenation is written under a guard: the shell reports a failed create, and `sort` reports the write errors it detects, so a short write no longer yields a count. Truncation usually *lowers* `s2` (and, when it lands inside a placeholder row, can raise it) — either way an unchecked write could drag the deny count onto the masterfile count and print `PASSED` over exactly the mismatch the check exists to catch. On a failed write both the count and the duplicate listing read `incomplete`, the failure is logged to `errorlog`, and the verdict stays `FAILED`. That verdict is not display-only: `pfblockerng_apply.inc:5088` → `pfb_sync_status_dedup_check()` greps the last `Sanity check` line and closes the ip/dedup ledger key on `PASSED`.

Dropping the old `sort … > "${tempfile}"; mv -f "${tempfile}" "${mastercat}"` also removes a latent data-loss path: that `mv` ran unconditionally, so a failed sort published a partial or empty `mastercat` into `/var/db` (reproduced during review — 2000 rows corrupted to 1552 under an exhausted `tmpdir`). `sort -o` renames only on success.

**User-visible change:** `mastercat` is left in byte order rather than octet order. The only surface where that shows is the *Masterfiles* log view (`pfblockerng_log.php:84`, last 10 000 lines), so an operator opening it right after a pass sees rows starting `10.` before `9.`. No code path depends on the order, and the next pass re-cuts the file unsorted anyway.

## Measured

Synthetic 423 624-row masterfile with a 34-file deny folder, 5 iterations per row, input restored *outside* the timed body, GNU coreutils 9.7 (`PATH=/usr/bin:/bin` — this box also has a uutils `sort` shim that shadows it). Method: `/var/tmp/agents/3154-bench/bench2.sh`.

| step | before | after |
|---|---|---|
| `mastercat` sort | 199 ms (`sort -t .`) | 110 ms (`LC_ALL=C sort -o`) |
| `s1` | 1 ms | 1 ms |
| `s2` | 31 ms (concat + `grep -cv`) | 1 ms (`grep -cv` on the sorted file) |
| `s3` | 79 ms (`sort \| uniq -d`) | 19 ms (`uniq -d`) |
| `s4` | 191 ms (concat + `sort \| uniq -d`) | 19 ms (`uniq -d`) |
| deny concatenation + sort | — | 193 ms |
| **total** | **501 ms** | **343 ms** |

The win is the `mastercat` side (278 ms → 129 ms here): four numeric key comparisons per row cost ~1.8× a plain byte sort on GNU coreutils, and the second sort disappears entirely. The deny side is roughly flat on this box (222 ms → 213 ms) — it trades a second full folder walk for a materialised sorted file, so the gain there depends on storage, not CPU. Scaled against #3154's own FreeBSD measurements on the reporting box, the `mastercat` side alone is a ~1.2 s trim of the ~3.7 s `closing` costs there: it measured the octet sort at 1153 ms and `s3` at 548 ms (1701 ms together), against a new cost of one byte sort plus `uniq -d` on presorted input — 227 ms measured there, and at most the 284 ms that box measured for `sort -o` over the (larger) masterfile, so 1701 − 284 − 227 ≈ 1190 ms.

Equivalence on the same fixture, with a duplicated placeholder row and a duplicated ordinary row added on both sides: `s1`, `s2`, `s3` and `s4` are byte-identical between the old shape and the final guarded shape (`s1`/`s2` = 423 625; `s3`/`s4` = the same 28-row `tail -30` window).

## Tests

`tests/shell/pfblockerng_closing_sort_spec.sh` (new, 6 rows):

- **C1** `mastercat` is left in byte order, not octet-numeric order — the one observable behaviour change. RED on `devel` (`9.0.0.0` first), green after.
- **C2** dedup on, duplicate inside `mastercat` and the same row in two deny files: `PASSED` plus both duplicate listings naming the row directly under their headings.
- **C3** the placeholder duplicated on both sides: reported by the masterfile listing, filtered out of the deny listing.
- **C4** source pin: no `sort -t .` left in `closingprocess()`, `uniq -d` present, exactly one `find "${pfbdeny}"` concatenation. RED on `devel` on both clauses (`sort -t .` present; count 2).
- **C5** the sides disagree → `FAILED` with `Masterfile Count    [ 1 ]` and `Deny folder Count   [ 2 ]` — the only branch that prints `s2` as a number.
- **C6** a `sort` that writes part of its output and exits 2 (what a real ENOSPC does) over a genuine 2-vs-4 mismatch → `Deny folder Count   [ incomplete ]` rather than a low count, `incomplete` under the deny duplicate heading rather than the partial file's listing (the truncated prefix holds a duplicate pair, so a leak would show it), verdict stays `FAILED`, failure logged. RED on the pre-guard head, which printed `PASSED`.

`tests/shell/pfblockerng_adr26_locale_spec.sh`: the two ADR-26 pins that quoted the old `s3`/`s4` pipelines now pin the new shapes — four rows instead of two, so every `sort` and `uniq` in the pair still has to carry `LC_ALL=C`.

Red proofs, both with the spec file frozen byte-identical across the pair:

- `af269bd744b8c7955a32d5a93bcd1bbca81922ce` — untouched production script → `4 examples, 2 failures` (C1, C4); after the trim → `4 examples, 0 failures`.
- `465813eb29e078f16a3b45d595cc62fb49e751d8` — pre-guard production script (`4a6337a4`) with this exact committed spec → `6 examples, 1 failure` (C6, the report printed `Database Sanity check [  PASSED  ]` over a real 2-vs-4 mismatch); with the guard → `26 examples, 0 failures` alongside the ADR-26 spec. Both escaping mutations found in review are now caught: `s2=0` instead of the sentinel → `6 examples, 1 failure`; `s4` read from the truncated file → `6 examples, 1 failure`.

`52 examples, 0 failures` across every spec that drives `closingprocess()`; full shellspec suite `1865 examples, 0 failures, 8 skips`.

Fixes #3154

## Review

Four independent read-only legs, two rounds, plus a verification pass; every leg's audit comment and every finding's outcome are in the PR comments. Round 1 found one blocking defect — the write guard above — and it was reproduced against a real 16 KiB tmpfs, not only the test shim. Round 2 found two escaped mutations in the guard's own coverage (a numeric sentinel and an unsuppressed `s4`), both now pinned. One deferred finding, confirmed real and pre-existing on `devel`: #3165.
