### PR TITLE
tests: allowlist the three uid-0 recompute skips (#3148)

### DIFF
--- a/tests/skip-allowlist.txt
+++ b/tests/skip-allowlist.txt
@@ -54,12 +54,15 @@ phpunit:DownloadGeoipStagePublishTest::testExtractionThatFailsPartWayLeavesTheSe
 
 # ShellSpec -- macOS/BSD host lacks the GNU stat/date/touch branch exercised in Linux CI.
 shellspec:tests/shell/pfblockerng_adr26_locale_spec.sh::ADR-26 — pfb_list_orig_by_mtime() diagnostic listing (Phase 3) lists *.orig oldest-first as "<YYYY-MM-DD> <HH:MM><TAB><name>" (ISO date, path + .orig stripped)  # GNU-only off-box branch; BSD branch is covered live by ADR-04 smoke
-# ShellSpec -- uid 0 bypasses chmod denial (issue #3116).
+# ShellSpec -- uid 0 bypasses chmod denial (issues #3116, #3148).
 shellspec:tests/shell/pfblockerng_processet_exit_spec.sh::processet() exit contract (issue #2683) when the ET scratch files cannot be created fails and keeps the live match publication byte-unchanged  # root bypasses directory permissions — denial cannot be simulated
 shellspec:tests/shell/pfblockerng_processet_exit_spec.sh::processet() exit contract (issue #2683) when a category split cannot be written fails and leaves both the feed and the live match publication untouched  # root bypasses directory permissions — denial cannot be simulated
 shellspec:tests/shell/pfblockerng_processet_exit_spec.sh::processet() exit contract (issue #2683) when the block publication cannot be moved into place fails and keeps the live match publication byte-unchanged  # root bypasses directory permissions — denial cannot be simulated
 shellspec:tests/shell/pfblockerng_processet_exit_spec.sh::processet() exit contract (issue #2683) when the match publication cannot be moved into place fails and keeps the live match publication byte-unchanged  # root bypasses directory permissions — denial cannot be simulated
 shellspec:tests/shell/precommit_identity_spec.sh::.githooks/check-commit-identity.sh + pre-commit wiring (issue #2982) rejects an unreadable SSH signing key path  # root bypasses file permissions — denial cannot be simulated
+shellspec:tests/shell/pfblockerng_recompute_spec.sh::pfb_recompute() hostile inputs aborts cleanly (log + .new cleanup, live files untouched) when a Stage-A snapshot copy fails (source unreadable, issue #1084 review)  # root bypasses file permissions — denial cannot be simulated
+shellspec:tests/shell/pfblockerng_recompute_spec.sh::pfb_recompute() hostile inputs aborts the masterfile-strip pass cleanly (no masterfile.new debris) when it fails mid-write (issue #1084 review)  # root bypasses file permissions — denial cannot be simulated
+shellspec:tests/shell/pfblockerng_recompute_spec.sh::pfb_recompute() hostile inputs stops the swap and logs the failing artifact -- without rolling anything back -- when the deny dir denies the mv (EACCES mid-swap, issue #1084 review)  # root bypasses directory permissions — denial cannot be simulated
 
 # pytest -- 4 observed on the Linux CI runner.
 pytest:tests.test_build_pkg_origins::test_print_build_origins_includes_expected_dirs  # FreeBSD-ports checkout not present on the runner


### PR DESCRIPTION
Fixes #3148.

`tests/shell/pfblockerng_recompute_spec.sh` carries three chmod-denial cases guarded by `Skip if ... [ "$(id -u)" -eq 0 ]`, and none of them were recorded in `tests/skip-allowlist.txt`. On any root-owned host the suite is green but `scripts/check_skip_allowlist.py` rejects the three skips, so the shellspec canonical gate can never reach green there — every lane has to record it as RUN-WITH-PREEXISTING-FAILURE, exactly the folklore `.agents/policy/testing.md` forbids.

ec53a84a (#3116) recorded the same uid-0 class for `pfblockerng_processet_exit_spec.sh` and `precommit_identity_spec.sh` but missed this trio. This adds the three ids to the same group, each with its own `# <reason>` line, copied verbatim from the JUnit report rather than from the spec source.

## Evidence (root host, uid 0; shellspec 0.28.1, `--shell dash`)

RED — at the parent commit, files byte-identical to `origin/devel`:

```
$ shellspec --shell dash -o junit --reportdir /tmp/rc3148 tests/shell/pfblockerng_recompute_spec.sh
$ python3 scripts/check_skip_allowlist.py --suite shellspec --allowlist tests/skip-allowlist.txt /tmp/rc3148/results_junit.xml
error: 3 skip(s) not on tests/skip-allowlist.txt:
  shellspec:tests/shell/pfblockerng_recompute_spec.sh::pfb_recompute() hostile inputs aborts cleanly (log + .new cleanup, live files untouched) when a Stage-A snapshot copy fails (source unreadable, issue #1084 review)  reason: root bypasses file permissions
  shellspec:tests/shell/pfblockerng_recompute_spec.sh::pfb_recompute() hostile inputs aborts the masterfile-strip pass cleanly (no masterfile.new debris) when it fails mid-write (issue #1084 review)  reason: root bypasses file permissions
  shellspec:tests/shell/pfblockerng_recompute_spec.sh::pfb_recompute() hostile inputs stops the swap and logs the failing artifact -- without rolling anything back -- when the deny dir denies the mv (EACCES mid-swap, issue #1084 review)  reason: root bypasses directory permissions
exit=1
```

GREEN — same unmodified JUnit report, allowlist changed:

```
$ python3 scripts/check_skip_allowlist.py --suite shellspec --allowlist tests/skip-allowlist.txt /tmp/rc3148/results_junit.xml
exit=0
```

GREEN — full shellspec suite plus the gate check at this head:

```
$ shellspec --shell dash -o junit --reportdir /tmp/rcall3148
<testsuites tests="1859" time="445.91" errors="0" failures="0" ...>
$ python3 scripts/check_skip_allowlist.py --suite shellspec --allowlist tests/skip-allowlist.txt /tmp/rcall3148/results_junit.xml
exit=0   # 1 informational line: the ADR-26 locale row, not observed on this host
```

`scripts/agent/run-gates.sh`: `GATES: PASS` — weak evidence here, and not what this PR rests on. `gates_for()` selects gates by file extension, so a `.txt`-only diff selects nothing but the coverage-pairing gate; the shellspec + checker runs above are the load-bearing evidence. That gap is now tracked as #3166.

## Notes

- Data-only change; no production or spec file is touched, so the gate command itself is the red→green artifact.
- The group header now reads `(issues #3116, #3148)` so the rows are not misread as all originating in #3116; per-row reasons carry the WHY the file mandates.
- CI runs as a non-root user and therefore does not observe these three skips; an allowlisted id absent from a run is informational only, so this cannot turn CI red.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated ShellSpec coverage handling for three permission-related recomputation scenarios, including snapshot-copy, masterfile-update, and directory-swap failures.
  - Documented that these cases are skipped when elevated permissions bypass the expected filesystem restrictions.
  - Updated references to the related issue tracking items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->