### PR TITLE
pfblockerng: skip empty-list suppress spawns

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -8351,6 +8351,11 @@ function pfb_ip_suppress_body_for_vtype(bool $supp_on, string $vtype, bool $supp
 	    $adv, $feed_changed, pfb_ip_recompute_ran_for_vtype($vtype, $ran_v4, $ran_v6));
 }
 
+// issue #3150: same predicate the v4 suppress verb evaluates (`[ -e ] && [ -s ]`).
+function pfb_ip_suppress_list_present(string $path): bool {
+	return is_readable($path) && filesize($path) > 0;
+}
+
 // ---------------------------------------------------------------------------
 // ADR-40 — forward-delta alias-table apply
 // ---------------------------------------------------------------------------

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
@@ -4411,14 +4411,16 @@ function sync_package_pfblockerng($cron='', ?string &$deferred_by = NULL): bool 
 								if (file_exists("{$pfbfolder}/{$header}.txt") && $member_eligible) {
 									$suppression_body_active = pfb_ip_suppress_body_for_vtype($pfb['supp'] === PfbToggle::On, $vtype, $pfb['supp_update'], $pfbadv, in_array($alias, $final_alias_old), $pfb_recompute_ran_v4, $pfb_recompute_ran_v6);
 									// Script to run suppression process (print header only)
-									if ($pfbrunonce && $pfb['supp'] === PfbToggle::On && $vtype == '_v4' && $pfb['supp_update']) {
+									if ($pfbrunonce && $pfb['supp'] === PfbToggle::On && $vtype == '_v4' && $pfb['supp_update']
+									    && pfb_ip_suppress_list_present($pfb['supptxt'])) {
 										exec("{$pfb['script']} suppress suppressheader {$elog}");
 										$pfbrunonce = FALSE;
 									}
 									// Script to run suppression process (body) — feed-changed aliases, OR any
 									// alias recompute rewrote this pass (issue #1084 review: recompute rewrites
 									// every family alias on any trigger, not just feed-changed ones).
-									if ($suppression_body_active && $vtype == '_v4') {
+									if ($suppression_body_active && $vtype == '_v4'
+									    && pfb_ip_suppress_list_present($pfb['supptxt'])) {
 										if ($pfb['dup'] === PfbToggle::On) {
 											exec("{$pfb['script']} suppress {$header_esc} {$pfbfolder} on {$elog}");
 										} else {
@@ -4441,7 +4443,7 @@ function sync_package_pfblockerng($cron='', ?string &$deferred_by = NULL): bool 
 										$pfbrunonce = FALSE;
 									}
 									if ($suppression_body_active && $vtype == '_v6'
-									    && is_readable("{$pfb['supptxt_v6']}") && filesize("{$pfb['supptxt_v6']}") > 0) {
+									    && pfb_ip_suppress_list_present($pfb['supptxt_v6'])) {
 										$member_file = "{$pfbfolder}/{$header}.txt";
 										$pre_count   = count(@file($member_file, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES) ?: []);
 										if (pfb_suppress_file_v6($member_file, "{$pfb['supptxt_v6']}")) {

--- a/tests/php/IpSuppressListPresentTest.php
+++ b/tests/php/IpSuppressListPresentTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * issue #3150 — the v4 shell `suppress` verb no-ops when pfbsuppression.txt is
+ * absent or empty, but PHP still spawned it once per v4 alias (and once for
+ * suppressheader) whenever the Suppression toggle was on. v6 already gated on
+ * a nonempty customlist file; v4 did not.
+ *
+ * Feature: suppress-list presence gate
+ *   Scenario: missing or empty customlist file is inactive (toggle alone must
+ *     not buy a process spawn)
+ *   Scenario: a nonempty customlist file is present
+ *   Scenario: live v4 header/body execs and the v6 sibling all dispatch through
+ *     this predicate — firewall orchestration has no safe off-box driver
+ */
+#[CoversFunction('pfb_ip_suppress_list_present')]
+final class IpSuppressListPresentTest extends TestCase
+{
+	private string $dir;
+
+	protected function setUp(): void
+	{
+		$this->dir = sys_get_temp_dir() . '/pfb_supplist_' . getmypid() . '_' . uniqid();
+		$this->assertTrue(mkdir($this->dir, 0777, TRUE));
+	}
+
+	protected function tearDown(): void
+	{
+		rmdir_recursive($this->dir);
+		$this->assertDirectoryDoesNotExist($this->dir);
+	}
+
+	public function testMissingFileIsInactive(): void
+	{
+		$this->assertFalse(
+			pfb_ip_suppress_list_present("{$this->dir}/pfbsuppression.txt"),
+			'absent customlist must not unlock the suppress spawn'
+		);
+	}
+
+	public function testEmptyFileIsInactive(): void
+	{
+		$path = "{$this->dir}/pfbsuppression.txt";
+		$this->assertNotFalse(file_put_contents($path, ''));
+
+		$this->assertFalse(
+			pfb_ip_suppress_list_present($path),
+			'empty customlist must not unlock the suppress spawn'
+		);
+	}
+
+	public function testNonemptyFileIsPresent(): void
+	{
+		$path = "{$this->dir}/pfbsuppression.txt";
+		$this->assertNotFalse(file_put_contents($path, "10.0.0.1/32\n"));
+
+		$this->assertTrue(
+			pfb_ip_suppress_list_present($path),
+			'nonempty customlist must unlock the suppress spawn'
+		);
+	}
+
+	public function testLiveV4SuppressExecsRequireTheNonemptyCustomlist(): void
+	{
+		$source = php_strip_whitespace(dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc');
+		$this->assertStringContainsString(
+			'if ($pfbrunonce && $pfb[\'supp\'] === PfbToggle::On && $vtype == \'_v4\' && $pfb[\'supp_update\'] && pfb_ip_suppress_list_present($pfb[\'supptxt\'])) {',
+			$source,
+			'issue #3150: suppressheader spawn must not run when the customlist file is empty or absent'
+		);
+		$this->assertStringContainsString(
+			'if ($suppression_body_active && $vtype == \'_v4\' && pfb_ip_suppress_list_present($pfb[\'supptxt\'])) {',
+			$source,
+			'issue #3150: per-alias suppress exec must not run when the customlist file is empty or absent'
+		);
+	}
+
+	public function testLiveV6SuppressBodyUsesTheSameListPresencePredicate(): void
+	{
+		$source = php_strip_whitespace(dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc');
+		$this->assertStringContainsString(
+			'if ($suppression_body_active && $vtype == \'_v6\' && pfb_ip_suppress_list_present($pfb[\'supptxt_v6\'])) {',
+			$source,
+			'issue #3150: v6 sibling must share the nonempty-list predicate'
+		);
+	}
+}

--- a/tests/php/fixtures/function_inventory.json
+++ b/tests/php/fixtures/function_inventory.json
@@ -7098,6 +7098,19 @@
             }
         ]
     },
+    "pfb_ip_suppress_list_present": {
+        "returnsRef": false,
+        "returnType": "bool",
+        "params": [
+            {
+                "name": "path",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            }
+        ]
+    },
     "pfb_ip_suppressed": {
         "returnsRef": false,
         "returnType": "bool",


### PR DESCRIPTION
Fixes #3150

Follow-up for the remaining `_255_agg` fan-out: #3167. `#3144` stays open until that init seam is touched.

## Problem

The v4 shell `suppress` verb no-ops when `/var/db/pfblockerng/pfbsuppression.txt` is absent or empty (`[ -e ] && [ -s ]`), but PHP still spawned it once per v4 alias (and once for `suppressheader`) whenever the Suppression toggle was on. On the reporting box that is 35 no-op process starts (~2 s/pass). Private/reserved-range filtering is PHP-side and is untouched.

v6 already gated on a nonempty customlist file; v4 did not.

## Fix

`pfb_ip_suppress_list_present($path)` is the same nonempty-readable-file predicate. The v4 `suppressheader` exec, the per-alias v4 `suppress` exec, and the v6 `pfb_suppress_file_v6()` call all dispatch through it. The toggle still has to be on; an empty list no longer buys a spawn.

## Test-first red→green

`tests/php/IpSuppressListPresentTest.php` — missing/empty file inactive, nonempty present, plus source pins that live v4 header/body and v6 body call the helper.

- Red-time `git hash-object tests/php/IpSuppressListPresentTest.php` = `287c9e98640ad486c887ea70db8c57883a6c6c91`; post-green hash identical (frozen byte-identical).

**RED** (helper absent, call sites ungated):

```
EEEFF                                                               5 / 5 (100%)
ERRORS!
Tests: 5, Assertions: 14, Errors: 3, Failures: 2.
```

3 errors: `Call to undefined function pfb_ip_suppress_list_present()`.
2 failures: source pins for the v4 execs and the v6 sibling.

**GREEN** (helper + gated call sites, tests byte-identical):

```
.....                                                               5 / 5 (100%)
OK (5 tests, 18 assertions)
```

## Gates

- `php -l` on the three touched PHP files: pass.
- `composer phpstan`: `[OK] No errors`.
- `composer phpcs -- --standard=phpcs.xml.dist` on the touched files: pass (empty).
- Focused PHPUnit: `OK (5 tests, 18 assertions)` plus sibling `IpSuppressBodyActiveTest` / `IpRecomputeRanWiringTest` / `FunctionInventoryParityTest` — `OK (20 tests, 69 assertions)`.
- Full `vendor/bin/phpunit` on this Debian host: `Tests: 6509, Errors: 29, Failures: 14` — the known host-toolchain failure (#3103), unrelated to this diff.

## Files (4)

- `src/usr/local/pkg/pfblockerng/pfblockerng.inc` — `pfb_ip_suppress_list_present()`.
- `src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc` — v4 header/body and v6 body dispatch through it.
- `tests/php/IpSuppressListPresentTest.php` — red→green pin.
- `tests/php/fixtures/function_inventory.json` — new function snapshot.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Suppression processing now runs only when a non-empty suppression list is available.
  * Prevents unnecessary suppression commands when the custom suppression file is missing or empty.

* **Tests**
  * Added coverage for missing, empty, and populated suppression lists.
  * Added checks confirming suppression processing is correctly gated for IPv4 and IPv6.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->