### PR TITLE
agent: suppress default diffs for the tracked graph

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,10 +6,10 @@
 legacy/** linguist-documentation
 docs/** linguist-documentation
 # The tracked root graph is generated output: `graphify update` rewrites it whole, so
-# suppressing its diff is the point — linguist-generated collapses it in pull-request
-# diffs and drops it from the language stats, while merge=graphify keeps resolving
-# parallel updates through the union driver.
-graphify-out/graph.json merge=graphify linguist-generated=true
+# suppressing its diff is the point — linguist-generated collapses GitHub's web
+# diff and language stats, -diff suppresses local git diff and patch output, and
+# merge=graphify keeps resolving parallel updates through the union driver.
+graphify-out/graph.json merge=graphify linguist-generated=true -diff
 # Records are prose reviewed in diffs, so they stay out of the language stats without
 # linguist-generated, which would suppress the diffs they exist to be read in.
 graphify-out/memory/** linguist-documentation

--- a/tests/test_cross_agent_tooling.py
+++ b/tests/test_cross_agent_tooling.py
@@ -338,10 +338,10 @@ def test_repository_intelligence_initializes_each_worktree_directly() -> None:
     attrs_text = (ROOT / ".gitattributes").read_text(encoding="utf-8")
     assert attrs_text.strip(), ".gitattributes must not be empty"
     attrs = attrs_text.splitlines()
-    # linguist-generated collapses the whole-file rewrites in pull-request diffs and
-    # keeps them out of the language stats; merge=graphify still resolves parallel
-    # updates, so both attributes must ride on the row.
-    graphify_attribute = "graphify-out/graph.json merge=graphify linguist-generated=true"
+    # linguist-generated collapses GitHub's web diff and language stats; -diff
+    # suppresses local git diff and patch output (issue #3161); merge=graphify
+    # still union-merges. All three attributes must ride on the row.
+    graphify_attribute = "graphify-out/graph.json merge=graphify linguist-generated=true -diff"
     assert attrs.count(graphify_attribute) == 1, f"expected exact .gitattributes row: {graphify_attribute}"
     # The root graph plus the query-outcome records are tracked (issue #2823). Records are
     # named per query and accumulate, so the durable contract is the SET of allowed


### PR DESCRIPTION
## Summary

Add `-diff` to the tracked Graphify graph's `.gitattributes` row so local `git diff` and patch output no longer dump the whole rewrite. `linguist-generated=true` already collapsed GitHub's web UI; it does not affect patch readers (`pr://N/diff/all`) or a local `git diff`. `merge=graphify` stays on the same row.

A reviewer who wants the graph content can still use `git diff --text`.

## Evidence

- Red: `test_repository_intelligence_initializes_each_worktree_directly` failed on the exact-row pin (`git hash-object tests/test_cross_agent_tooling.py` = `4e54fca3f5296d9b840e844285961aa58ab2f5d7`).
- Green: same frozen test passed after the attribute change (hash unchanged).
- `git check-attr`: `merge: graphify`, `diff: unset`, `linguist-generated: true`.
- Default `git diff` over a graph edit: 3 lines (`Binary files ... differ`). `git diff --text` still shows the patch.
- Merge-driver specs: `tests/shell/agent_graphify_merge_driver_spec.sh` 7/7; `tests/test_ci_graphify_merge_driver.py` plus `tests/test_cross_agent_tooling.py` 42 passed.

Fixes #3161
