### PR TITLE
run-gates: select the pytest gate for a skip-allowlist-only diff

### DIFF
--- a/.agents/policy/delegation.md
+++ b/.agents/policy/delegation.md
@@ -173,6 +173,7 @@ change table and runner together.
 | PHP (`*.php`/`*.inc`) | `php -l` per touched file · `vendor/bin/phpunit` · `composer phpstan` · `composer phpcs -- --standard=phpcs.xml.dist src/` |
 | Shell (`*.sh`) | `sh -n` · `shellcheck` (only `src/`, `scripts/`, `.claude/hooks/` — the scope `.githooks/pre-commit` + CI use; `tests/` shellspec specs trip SC2034 false-positives) · `shellspec --shell "$(command -v dash)"` (where specs exist; dash = strict-POSIX ash sibling of FreeBSD sh — bash-as-sh masks appliance divergences. Dash missing ⇒ this hand-run substitution goes empty and shellspec silently auto-detects, while the runner's own `$(command -v dash \|\| command -v sh)` falls back to `sh` — either way, INSTALL dash (`brew`/`apt install dash`) instead of dropping the pin; plain `shellspec` is a last resort and says so in the handoff) |
 | Markdown (`*.md`) | `npx markdownlint-cli2` |
+| `tests/skip-allowlist.txt` | `python3 -m pytest` — the skip-set checker and its red canary ride the pytest gate, which also carries the two tests that parse the real file (issue #3166) |
 | `www/` | Reachable UI coverage exists for the change per test mandate #4 |
 
 ## Validating workflow records

--- a/scripts/agent/run-gates.sh
+++ b/scripts/agent/run-gates.sh
@@ -87,8 +87,17 @@ gates_for() {
 		files=$(printf '%s\n' "$files" | grep -v '[^A-Za-z0-9._/-]' || true)
 		out="${out}printf 'unsafe filename in diff\\n' >&2; false${nl}"
 	fi
+	pytest_emitted=0
 	if printf '%s\n' "$files" | grep -q '\.py$'; then
 		out="${out}uv run --locked pytest${nl}uv run --locked ruff check .${nl}uv run --locked ruff format --check .${nl}uv run --locked mypy tests/${nl}"
+		pytest_emitted=1
+	fi
+	# issue #3166: the skip gate READS tests/skip-allowlist.txt, and the checker plus its red
+	# canary ride on the pytest gate (which also carries the two tests that parse the real
+	# file) -- but a .txt path matched no extension bucket, so an allowlist-only diff selected
+	# no suite and a malformed allowlist first failed in CI. Select pytest for it.
+	if [ "$pytest_emitted" != 1 ] && printf '%s\n' "$files" | grep -qx 'tests/skip-allowlist\.txt'; then
+		out="${out}uv run --locked pytest${nl}"
 	fi
 	if printf '%s\n' "$files" | grep -Eq '\.(php|inc)$'; then
 		out="${out}uv run --locked python scripts/check_composer_vendor.py${nl}"

--- a/scripts/agent/run-gates.sh
+++ b/scripts/agent/run-gates.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
-# run-gates.sh -- run the CLAUDE.md canonical gates for whatever a diff touches.
-# Mechanical runner for the "Canonical gates" table (CLAUDE.md stays the documented
-# source; this script implements it -- change them together).
+# run-gates.sh -- run the canonical gates for whatever a diff touches.
+# Mechanical runner for the "Canonical gates" table (.agents/policy/delegation.md stays
+# the documented source; this script implements it -- change them together).
 #
 # Gates run against the host toolchain: Python through the locked uv environment
 # (`uv sync --locked --group dev`), PHP and the shell tools from the versions
@@ -87,16 +87,12 @@ gates_for() {
 		files=$(printf '%s\n' "$files" | grep -v '[^A-Za-z0-9._/-]' || true)
 		out="${out}printf 'unsafe filename in diff\\n' >&2; false${nl}"
 	fi
-	pytest_emitted=0
 	if printf '%s\n' "$files" | grep -q '\.py$'; then
 		out="${out}uv run --locked pytest${nl}uv run --locked ruff check .${nl}uv run --locked ruff format --check .${nl}uv run --locked mypy tests/${nl}"
-		pytest_emitted=1
-	fi
-	# issue #3166: the skip gate READS tests/skip-allowlist.txt, and the checker plus its red
-	# canary ride on the pytest gate (which also carries the two tests that parse the real
-	# file) -- but a .txt path matched no extension bucket, so an allowlist-only diff selected
-	# no suite and a malformed allowlist first failed in CI. Select pytest for it.
-	if [ "$pytest_emitted" != 1 ] && printf '%s\n' "$files" | grep -qx 'tests/skip-allowlist\.txt'; then
+	# issue #3166: the skip gate READS tests/skip-allowlist.txt, and its checker plus red
+	# canary ride the pytest gate, which also carries the two tests that parse the real file.
+	# A .txt path matched no bucket, so an allowlist-only diff selected no suite at all.
+	elif printf '%s\n' "$files" | grep -qx 'tests/skip-allowlist\.txt'; then
 		out="${out}uv run --locked pytest${nl}"
 	fi
 	if printf '%s\n' "$files" | grep -Eq '\.(php|inc)$'; then

--- a/tests/shell/agent_run_gates_spec.sh
+++ b/tests/shell/agent_run_gates_spec.sh
@@ -208,6 +208,31 @@ Describe 'run-gates.sh gates_for()'
     The output should not include 'unsafe filename'
   End
 
+  # issue #3166: the skip gate READS tests/skip-allowlist.txt, but a .txt path matched no
+  # extension bucket, so an allowlist-only diff selected no suite at all -- and the
+  # allowlist checker plus its red canary ride on the pytest gate, as do the two tests that
+  # parse the real file. A malformed allowlist has to fail locally, not first in CI.
+  It 'maps a skip-allowlist-only diff to the pytest gate'
+    Data "tests/skip-allowlist.txt"
+    When call gates_for
+    The output should equal 'uv run --locked pytest'
+  End
+
+  It 'emits the pytest gate once when the diff touches both the allowlist and a Python file'
+    Data
+      #|tests/skip-allowlist.txt
+      #|tests/test_x.py
+    End
+    When call gates_for
+    The output should equal "$(printf '%s\n%s\n%s\n%s' 'uv run --locked pytest' 'uv run --locked ruff check .' 'uv run --locked ruff format --check .' 'uv run --locked mypy tests/')"
+  End
+
+  It 'leaves an unrelated .txt path gate-less'
+    Data "tests/fixtures/other.txt"
+    When call gates_for
+    The output should equal ''
+  End
+
   It 'emits nothing for file types with no gates'
     Data "src/usr/local/pkg/pfblockerng/info.xml"
     When call gates_for

--- a/tests/shell/agent_run_gates_spec.sh
+++ b/tests/shell/agent_run_gates_spec.sh
@@ -1,7 +1,8 @@
 #shellcheck shell=sh
 # run-gates.sh gates_for(): the touched-file-type -> canonical-gate-command mapping
-# (CLAUDE.md "Canonical gates" table). Pins per-file gates (php -l / sh -n / shellcheck
-# emit one command per file), whole-suite gates firing once, and empty input -> no gates.
+# (.agents/policy/delegation.md "Canonical gates" table). Pins per-file gates (php -l /
+# sh -n / shellcheck emit one command per file), whole-suite gates firing once, and empty
+# input -> no gates.
 
 Describe 'run-gates.sh gates_for()'
   # shellcheck disable=SC2034 # consumed by the Included script's source-only guard
@@ -208,10 +209,8 @@ Describe 'run-gates.sh gates_for()'
     The output should not include 'unsafe filename'
   End
 
-  # issue #3166: the skip gate READS tests/skip-allowlist.txt, but a .txt path matched no
-  # extension bucket, so an allowlist-only diff selected no suite at all -- and the
-  # allowlist checker plus its red canary ride on the pytest gate, as do the two tests that
-  # parse the real file. A malformed allowlist has to fail locally, not first in CI.
+  # issue #3166: the allowlist checker and its red canary ride the pytest gate, so an
+  # allowlist-only diff must select that gate -- a malformed allowlist has to fail locally.
   It 'maps a skip-allowlist-only diff to the pytest gate'
     Data "tests/skip-allowlist.txt"
     When call gates_for
@@ -227,8 +226,14 @@ Describe 'run-gates.sh gates_for()'
     The output should equal "$(printf '%s\n%s\n%s\n%s' 'uv run --locked pytest' 'uv run --locked ruff check .' 'uv run --locked ruff format --check .' 'uv run --locked mypy tests/')"
   End
 
-  It 'leaves an unrelated .txt path gate-less'
-    Data "tests/fixtures/other.txt"
+  # The arm matches the whole line: a near-miss path must stay gate-less, or an unrelated
+  # .txt edit pays for the pytest suite.
+  It 'leaves a .txt that is not the allowlist gate-less'
+    Data
+      #|tests/fixtures/other.txt
+      #|tests/skip-allowlist.txt.bak
+      #|other/tests/skip-allowlist.txt
+    End
     When call gates_for
     The output should equal ''
   End


### PR DESCRIPTION
Fixes #3166

`gates_for()` in `scripts/agent/run-gates.sh` selected gates purely by file extension, so a diff whose only touched path was `tests/skip-allowlist.txt` matched no bucket and selected no suite at all — the one file the skip gate reads was invisible to the local gate runner. A malformed allowlist (parse error, mistyped id, missing `# <reason>`) passed locally and first failed in CI; that happened on two consecutive changes to the file (`ec53a84a` / #3116, and #3164 / #3148).

## Change

- `gates_for()` gains an arm for `tests/skip-allowlist.txt` that selects `uv run --locked pytest`. That gate carries the allowlist checker and its red canary through `gate_command()`, plus `tests/test_check_skip_allowlist.py::test_real_allowlist_file_parses_cleanly` and `::test_canary_fixture_is_never_on_the_real_allowlist`, which read the real file.
- The arm is the `.py` bucket's `elif`, so a diff touching both the allowlist and a Python file emits the gate exactly once with no state variable. Only the pytest gate is selected — `ruff`/`mypy` cannot be affected by a `.txt` edit.
- `.agents/policy/delegation.md` "Canonical gates" gains the matching row; the header of the runner requires the table and the runner change together.

## Red → green proof (test-first)

Three examples added to `tests/shell/agent_run_gates_spec.sh`; frozen at `git hash-object` = `0d58743abc7626de4d21599dab1662b1e259ec15` from the red run through the green run (byte-identical, re-verified). The proof was re-executed twice rather than carried over: once when the review round changed the spec, and once when the rebase onto `a1dde5cd` replayed it over `devel`'s own edits to the same file (which is why the red count is 52 and not 49 — `devel` added three examples).

Red, on untouched `run-gates.sh`:

```
$ shellspec --shell /usr/bin/dash tests/shell/agent_run_gates_spec.sh
  1) run-gates.sh gates_for() maps a skip-allowlist-only diff to the pytest gate
     1.1) The output should equal uv run --locked pytest
            expected: "uv run --locked pytest"
                 got: ""
52 examples, 1 failure
```

Green, same file, after the fix:

```
$ git hash-object tests/shell/agent_run_gates_spec.sh
0d58743abc7626de4d21599dab1662b1e259ec15
$ shellspec --shell /usr/bin/dash tests/shell/agent_run_gates_spec.sh tests/shell/agent_run_gates_git_spec.sh
73 examples, 0 failures
```

| Frozen RED test | git hash-object | RED run tail |
| --- | --- | --- |
| `tests/shell/agent_run_gates_spec.sh` | `0d58743abc7626de4d21599dab1662b1e259ec15` | `1) run-gates.sh gates_for() maps a skip-allowlist-only diff to the pytest gate: expected "uv run --locked pytest", got "" — 52 examples, 1 failure` |

## Newly wired gate proves its red path (testing.md #29)

A scratch worktree at `origin/devel` with one appended malformed row (a bare id with no `# reason`) as its only diff. `origin/devel`'s runner:

```
$ git -C /var/tmp/pfb-3166-demo diff --name-only
tests/skip-allowlist.txt
$ sh /var/tmp/pfb-3166-demo/scripts/agent/run-gates.sh --worktree /var/tmp/pfb-3166-demo --diff origin/devel
GATE PASS: python3 scripts/check_coverage_pairing.py --name-status-z
GATES: PASS
exit=0
```

The runner from this branch, same tree, same diff:

```
$ sh scripts/agent/run-gates.sh --worktree /var/tmp/pfb-3166-demo --diff origin/devel
FAILED tests/test_check_skip_allowlist.py::test_real_allowlist_file_parses_cleanly
  check_skip_allowlist.AllowlistError: tests/skip-allowlist.txt:94: allowlist entry needs
  a reason after two spaces and a '#': 'pytest:tests/test_bogus.py::test_bogus_id_with_no_reason'
FAILED tests/test_check_skip_allowlist.py::test_canary_fixture_is_never_on_the_real_allowlist[pytest]
FAILED tests/test_check_skip_allowlist.py::test_canary_fixture_is_never_on_the_real_allowlist[phpunit]
FAILED tests/test_check_skip_allowlist.py::test_canary_fixture_is_never_on_the_real_allowlist[shellspec]
FAILED tests/test_check_skip_allowlist.py::test_default_smoke_skips_are_allowlisted
7 failed, 5906 passed, 7 skipped in 88.02s
GATE FAIL: uv run --locked pytest
GATES: FAIL
```

The scratch worktree was removed afterwards.

## Canonical gates

`sh scripts/agent/run-gates.sh --diff origin/devel` on the rebased head: coverage pairing, `check-graph-fresh.sh`, re-entry bounds (+ self-test), `sh -n` and `shellcheck` on both touched shell files, ShellSpec, and `markdownlint-cli2` — all PASS.

Two notes on the base move to `a1dde5cd`. The ShellSpec gate failed on this uid-0 workstation before the rebase because three `Skip if` rows in `tests/shell/pfblockerng_recompute_spec.sh` were missing from `tests/skip-allowlist.txt`; `devel` commit `e299d3f3` allowlisted them, so that caveat is obsolete and #3170 is closed as a duplicate of #3148. And `devel` commit `49d25ea0` added `check-graph-fresh.sh` to the canonical gates: this branch edits indexed shell sources, so `graphify-out/graph.json` is refreshed in `7fb388e9` and the gate now reports `graph is fresh`.

## Findings ledger (review round 1, four legs)

| # | Leg | Finding | Outcome |
| --- | --- | --- | --- |
| 1 | correctness N1 | `pytest_emitted` meant "the `.py` bucket emitted pytest", not "pytest is emitted"; a future third arm would double-emit | fixed@`1f4b8159` — the flag is gone, the arm is the bucket's `elif` |
| 2 | over-engineering P1 | the flag duplicates what `elif` gives for free; the branches are adjacent, unlike `reentry_emitted`'s | fixed@`1f4b8159` (same edit as 1) |
| 3 | correctness N2 / test-honesty | the `-x` whole-line anchor was unasserted — mutating `grep -qx` → `grep -q` left all 49 examples green | fixed@`1f4b8159` — the negative example now carries `tests/skip-allowlist.txt.bak` and `other/tests/skip-allowlist.txt`; that mutation is now caught |
| 4 | correctness N4 / contract OD-3 | both file headers named CLAUDE.md as the source of the "Canonical gates" table, which lives in `.agents/policy/delegation.md` | fixed@`1f4b8159` |
| 5 | over-engineering P2 | the runner's comment block ran to 4 lines; `coding.md:11` budgets ≤3 and forbids restatement | fixed@`1f4b8159` |
| 6 | over-engineering P3 | the spec's comment block was a third copy of the same argument | fixed@`1f4b8159` — 2 lines, intent only |
| 7 | correctness N3 | a delete-only or rename-only diff of the allowlist selects no pytest gate | skipped: the leg's own refutation holds — the path is hardcoded in 12 files including 9 `.py`/`.sh`, so any coherent rename selects pytest through the `.py` bucket, and live-file-only lint mapping is the runner's documented contract (`--diff-filter=ACMRT`, header at `:23-25`). Changing it is a design decision, not a defect |
| 8 | contract OD-1 | a `tests/fixtures/skip-allowlist-canary.xml`-only diff still selects no suite — the same hole, for the other file the gates read | deferred: #3174 |
| 9 | correctness O1 | `gates_for()`'s UTF-8 `grep` drops a non-UTF-8 filename before the unsafe-filename guard sees it | deferred: #3175 |
| 10 | contract OD-2 | `skip-allowlist-node-canary.test.mjs` is also unselected | skipped: its only consumers are `test.yml:971` and `:1009`; the local runner has no Node suite for it to be dropped from, so there is nothing to select it into |
| 11 | correctness O2 / contract NIT-1 | the table row says `python3 -m pytest` while the runner emits `uv run --locked pytest` | skipped: the pre-existing Python row at `delegation.md:171` uses the same logical-tool-name idiom; matching it is the house convention, and no test parses the table |
| 12 | correctness O3 | `diff.relative=true` plus `--worktree <subdir>`, and `ls-files --others` without `--full-name`, can break root-relativity | skipped: out of the documented `--worktree` contract and pre-existing — the same exposure already governs the `legacy/` filter and the shellcheck scope, so the new arm adds no class |
| 13 | contract NIT-2 | cost note: an allowlist edit now costs the full pytest suite (~88 s) | skipped: #3166 offered the cheaper `--allowlist` self-test and this takes the more complete option deliberately — the parse test reads the whole file and the canary test is parametrized over all three suites |

No blocking findings in round 1. Every fix above implements the finding leg's own concrete suggestion; #3 merges the correctness leg's suggested near-miss case into the existing negative example rather than adding a fourth, per the over-engineering leg's cut list.

### Mutation evidence for the round-1 fixes

```
$ sed -i "s/grep -qx 'tests\/skip-allowlist/grep -q 'tests\/skip-allowlist/" scripts/agent/run-gates.sh
$ shellspec --shell /usr/bin/dash tests/shell/agent_run_gates_spec.sh
  1) run-gates.sh gates_for() leaves a .txt that is not the allowlist gate-less
     1.1) The output should equal
            expected: ""
                 got: "uv run --locked pytest"
49 examples, 1 failure
```

```
$ # elif split back into a second `if`
$ shellspec --shell /usr/bin/dash tests/shell/agent_run_gates_spec.sh
  1) run-gates.sh gates_for() emits the pytest gate once when the diff touches both the allowlist and a Python file
            … uv run --locked mypy tests/
            uv run --locked pytest"
49 examples, 1 failure
```

## Findings ledger (review round 2, three legs)

Round 2 re-reviewed the round-1 fix delta. The contract leg sat it out: the delta changed the arm's shape, not what it selects (the correctness leg's 22-case output matrix is byte-identical to round 1's), and the one contract-relevant edit was that leg's own OD-3 finding, verified by the correctness leg instead.

| # | Leg | Finding | Outcome |
| --- | --- | --- | --- |
| 14 | correctness C1 (**blocking**) | the rebase replayed the spec over `devel`'s own 131-line edit to the same file, so the recorded frozen hash and red count no longer described the head that would land | fixed@this body revision — hash `0d58743a…`, red 52/1, green 73/0, all re-executed on the rebased head; no code change |
| 15 | over-engineering OE-1 | `other/tests/skip-allowlist.txt` is surplus because a prefix and a suffix near-miss "die identically under every realistic anchor mutation" | skipped: premise refuted by execution — under the half-anchored mutant `grep -q 'tests/skip-allowlist\.txt$'` the three-path example fails (52/1) but OE-1's proposed cut makes the mutant survive (52/0). The correctness leg reached the same conclusion independently this round |

Round 2's other verdicts: correctness marked N1, N2 and N4 resolved and mutation-proven, and N3/O1/O2/O3 unchanged; test honesty re-executed the whole matrix with all five mutations caught and no survivor; over-engineering confirmed the cut list landed and corrected its own round-1 estimate (the delta's real net is +1 line, not −7, because the anchor fence and header repoint add 7).
