### PR TITLE
pfblockerng.sh: observe the deny concatenation's producer status

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.sh
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.sh
@@ -2258,7 +2258,11 @@ closingprocess() {
 		# issue #3154: one concat+sort feeds s2 and s4; a short write (exhausted tmpdir) makes
 		# the count unreliable either way, so an unchecked one could print PASSED over a real
 		# mismatch -- a truncation inside a placeholder row even RAISES it.
-		if find "${pfbdeny}"*.txt -type f 2>/dev/null | xargs awk 1 | LC_ALL=C sort > "${tempfile}"; then
+		# issue #3165: one awk over the shell's own glob -- `find | xargs` hid a producer
+		# failing mid-stream behind `sort`'s exit 0 and mis-split a name holding whitespace.
+		set -- "${pfbdeny}"*.txt
+		[ -e "${1}" ] || set -- /dev/null	# unmatched glob: concatenate nothing
+		if awk 1 "$@" > "${tempfile}" && LC_ALL=C sort -o "${tempfile}" "${tempfile}"; then
 			s2="$(grep -cv "^${ip_placeholder2}$" "${tempfile}")"
 			s4="$(LC_ALL=C uniq -d "${tempfile}" | tail -30 | grep -v "^${ip_placeholder2}$")"
 		else

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.sh
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.sh
@@ -2252,16 +2252,14 @@ closingprocess() {
 		countm="$(grep -c ^ "${masterfile}")"
 		echo; echo "   [ Final IP Count  ]  [ ${countm} ]"; echo
 
-		# issue #1084 review: mastercat (s1/s3) carries BOTH families' rows (v6 Deny joined
-		# cross-list dedup), so the shared deny concatenation (s2/s4) must include v6 too.
-		# issue #1263: awk 1 -- an unterminated deny file no longer welds into its neighbour.
-		# issue #3154: one concat+sort feeds s2 and s4; a short write (exhausted tmpdir) makes
-		# the count unreliable either way, so an unchecked one could print PASSED over a real
-		# mismatch -- a truncation inside a placeholder row even RAISES it.
-		# issue #3165: one awk over the shell's own glob -- `find | xargs` hid a producer
-		# failing mid-stream behind `sort`'s exit 0 and mis-split a name holding whitespace.
+		# issue #1084: mastercat (s1/s3) carries BOTH families, so the deny concat (s2/s4) must.
+		# issue #1263: awk 1 supplies a missing record terminator -- no weld into the neighbour.
+		# issue #3154/#3165: one producer, one in-place sort, both behind a checked status -- a
+		# failed stage or a short write (skewing the count either way) must refuse the verdict.
 		set -- "${pfbdeny}"*.txt
-		[ -e "${1}" ] || set -- /dev/null	# unmatched glob: concatenate nothing
+		# Only an unmatched glob leaves the pattern itself in $1; a real path awk cannot open
+		# has to reach awk, so the count refuses instead of reading zero.
+		case "${1}" in "${pfbdeny}*.txt") [ -e "${1}" ] || set -- /dev/null ;; esac
 		if awk 1 "$@" > "${tempfile}" && LC_ALL=C sort -o "${tempfile}" "${tempfile}"; then
 			s2="$(grep -cv "^${ip_placeholder2}$" "${tempfile}")"
 			s4="$(LC_ALL=C uniq -d "${tempfile}" | tail -30 | grep -v "^${ip_placeholder2}$")"

--- a/tests/shell/pfblockerng_adr26_locale_spec.sh
+++ b/tests/shell/pfblockerng_adr26_locale_spec.sh
@@ -119,7 +119,7 @@ Describe 'ADR-26 — pfblockerng.sh locale/portability source invariants (Phases
     The status should be success
   End
   It 'prefixes the deny-folder concatenation sink with LC_ALL=C'
-    When call has 'find "${pfbdeny}"*.txt -type f 2>/dev/null | xargs awk 1 | LC_ALL=C sort > "${tempfile}"'
+    When call has 'LC_ALL=C sort -o "${tempfile}" "${tempfile}"'
     The status should be success
   End
   It 'prefixes the s4 deny-folder duplicate probe with LC_ALL=C'

--- a/tests/shell/pfblockerng_closing_producer_spec.sh
+++ b/tests/shell/pfblockerng_closing_producer_spec.sh
@@ -1,0 +1,124 @@
+#shellcheck shell=sh
+# issue #3165: closingprocess()'s deny-folder concatenation must refuse a verdict when the
+# PRODUCER breaks, not just when the write does. `if <pipeline>` observes only the last
+# stage, so a deny file awk could not open -- or a name `find | xargs` mis-split -- left
+# `sort` exit 0 over partial input, and the resulting low count read as agreement with the
+# masterfile. That verdict is not display-only: pfb_sync_status_dedup_check() closes the
+# ip/dedup ledger key on PASSED.
+
+Describe 'closingprocess() deny concatenation producer status (#3165)'
+  setup() {
+    work="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/closingproducer.XXXXXX")"
+    pfborig="${work}/orig/"; pfbdeny="${work}/deny/"
+    pfbpermit="${work}/permit/"; pfbmatch="${work}/match/"; pfbnative="${work}/native/"
+    pfbmatchgen="${pfbmatch}generated/"
+    mkdir -p "$pfborig" "$pfbdeny" "$pfbpermit" "$pfbmatch" "$pfbnative" "$pfbmatchgen"
+    pfsensealias="${work}/alias/"; mkdir -p "$pfsensealias"
+    masterfile="${work}/masterfile"; mastercat="${work}/mastercat"
+    tempfile="${work}/t1"; errorlog="${work}/err.log"; now="now"
+    ip_placeholder2="127.0.0.1"
+    alias="on"
+    pathpfctl="${work}/pfctl"; printf '#!/bin/sh\n' > "$pathpfctl"; chmod +x "$pathpfctl"
+  }
+  cleanup() { rm -rf "$work"; }
+  BeforeAll 'pfb_source'
+  Before 'setup'
+  After 'cleanup'
+
+  # A deny folder holding 4 rows across two files, against a mastercat holding only the
+  # single row the FIRST file contributes: a producer that gives up after that file lands
+  # the deny count exactly on the masterfile count, so the report agrees with itself while
+  # three rows on disk were never read.
+  hidden_mismatch_fixture() {
+    printf 'A 1.2.3.4\n' > "$masterfile"
+    printf '1.2.3.4\n'   > "$mastercat"
+    printf '1.2.3.4\n'                   > "${pfbdeny}A.txt"
+    printf '5.6.7.8\n9.9.9.9\n7.7.7.7\n' > "${pfbdeny}B.txt"
+  }
+
+  It 'refuses a verdict when the concatenation cannot read every deny file (S1)'
+    # Given that hidden mismatch and an `awk` that aborts on the second file after emitting
+    # what it already read -- what one-true-awk does on a file it cannot open (FATAL, exit
+    # 2), which on the appliance is a deny file left mode-000 by a failed write.
+    hidden_mismatch_fixture
+    mkdir -p "${work}/bin"
+    real_awk="$(command -v awk)"
+    {
+      printf '#!/bin/sh\n'
+      printf 'case " $* " in\n'
+      printf '\t*" %sB.txt "*)\n' "$pfbdeny"
+      printf '\t\t%s 1 %sA.txt\n' "$real_awk" "$pfbdeny"
+      printf '\t\techo "awk: cannot open \\"%sB.txt\\" (Permission denied)" >&2\n' "$pfbdeny"
+      printf '\t\texit 2 ;;\n'
+      printf 'esac\n'
+      printf 'exec %s "$@"\n' "$real_awk"
+    } > "${work}/bin/awk"
+    chmod +x "${work}/bin/awk"
+    PATH="${work}/bin:${PATH}"
+
+    # When the final report runs.
+    When call closingprocess
+
+    # Then the count says `incomplete` rather than the partial stream's total, the verdict
+    # stays FAILED, and the failure is logged -- the producer really did fail (stderr).
+    The status should be success
+    The stdout should not include 'PASSED'
+    The stdout should include 'Database Sanity check [  FAILED  ]'
+    The stdout should include 'Deny folder Count   [ incomplete ]'
+    The stdout should include 'deny folder concatenation'
+    The stderr should include 'cannot open'
+    The contents of the file "$errorlog" should include 'sanity counts unreliable'
+  End
+
+  It 'refuses a verdict when a deny file is genuinely unreadable (S2)'
+    # Given the same hidden mismatch with the real fault instead of a shim: the second deny
+    # file is mode-000, so the concatenation reads one row of the four on disk.
+    Skip if 'root bypasses file permissions, so a mode-000 file stays readable' [ "$(id -u)" -eq 0 ]
+    hidden_mismatch_fixture
+    chmod 000 "${pfbdeny}B.txt"
+
+    # When the final report runs.
+    When call closingprocess
+
+    # Then the same refusal, driven by a permission denial no shim manufactured.
+    The status should be success
+    The stdout should not include 'PASSED'
+    The stdout should include 'Database Sanity check [  FAILED  ]'
+    The stdout should include 'Deny folder Count   [ incomplete ]'
+    The stderr should include 'B.txt'
+    The contents of the file "$errorlog" should include 'sanity counts unreliable'
+  End
+
+  It 'counts a deny file whose name holds whitespace (S3)'
+    # Given a deny filename with a space in it -- what a list header carrying one produces
+    # -- holding two of the masterfile's three rows.
+    printf 'A 1.2.3.4\nB 5.6.7.8\nB 9.9.9.9\n' > "$masterfile"
+    printf '1.2.3.4\n5.6.7.8\n9.9.9.9\n'       > "$mastercat"
+    printf '1.2.3.4\n'          > "${pfbdeny}A.txt"
+    printf '5.6.7.8\n9.9.9.9\n' > "${pfbdeny}B C.txt"
+
+    # When the final report runs.
+    When call closingprocess
+
+    # Then its rows are counted like any other file's -- the sides agree, and nothing
+    # complained about a fragment of the name.
+    The status should be success
+    The stdout should include 'Database Sanity check [  PASSED  ]'
+    The stderr should equal ''
+  End
+
+  It 'concatenates nothing when the deny folder is empty (S4)'
+    # Given no deny files at all: an unmatched glob must still yield an empty concatenation
+    # and a zero count, never a refusal and never a read of the caller's stdin.
+    true > "$masterfile"
+    true > "$mastercat"
+
+    # When the final report runs.
+    When call closingprocess
+
+    # Then the two empty sides agree.
+    The status should be success
+    The stdout should include 'Database Sanity check [  PASSED  ]'
+    The stderr should equal ''
+  End
+End

--- a/tests/shell/pfblockerng_closing_producer_spec.sh
+++ b/tests/shell/pfblockerng_closing_producer_spec.sh
@@ -36,6 +36,11 @@ Describe 'closingprocess() deny concatenation producer status (#3165)'
     printf '5.6.7.8\n9.9.9.9\n7.7.7.7\n' > "${pfbdeny}B.txt"
   }
 
+  # The report driven with rows on its own stdin, which shellspec otherwise leaves empty.
+  closing_with_stdin() {
+    closingprocess < "${work}/stdin_rows"
+  }
+
   It 'refuses a verdict when the concatenation cannot read every deny file (S1)'
     # Given that hidden mismatch and an `awk` that aborts on the second file after emitting
     # what it already read -- what one-true-awk does on a file it cannot open (FATAL, exit
@@ -66,7 +71,7 @@ Describe 'closingprocess() deny concatenation producer status (#3165)'
     The stdout should include 'Database Sanity check [  FAILED  ]'
     The stdout should include 'Deny folder Count   [ incomplete ]'
     The stdout should include 'deny folder concatenation'
-    The stderr should include 'cannot open'
+    The stderr should include 'B.txt'
     The contents of the file "$errorlog" should include 'sanity counts unreliable'
   End
 
@@ -107,18 +112,46 @@ Describe 'closingprocess() deny concatenation producer status (#3165)'
     The stderr should equal ''
   End
 
-  It 'concatenates nothing when the deny folder is empty (S4)'
-    # Given no deny files at all: an unmatched glob must still yield an empty concatenation
-    # and a zero count, never a refusal and never a read of the caller's stdin.
+  It 'concatenates nothing, and reads no stdin, when the deny folder is empty (S4)'
+    # Given no deny files at all and five unrelated rows offered on the function's own
+    # stdin: an unmatched glob must yield an empty concatenation and a zero count, never a
+    # refusal, and never those rows -- a concatenation with no file operand at all would
+    # read them, and a raised count is how a false agreement gets manufactured.
     true > "$masterfile"
     true > "$mastercat"
+    printf '8.8.8.8\n8.8.4.4\n1.1.1.1\n2.2.2.2\n3.3.3.3\n' > "${work}/stdin_rows"
+
+    # When the final report runs with those rows on stdin.
+    When call closing_with_stdin
+
+    # Then the two empty sides agree and no count was printed at all.
+    The status should be success
+    The stdout should include 'Database Sanity check [  PASSED  ]'
+    The stdout should not include 'Deny folder Count'
+    The stderr should equal ''
+  End
+
+  It 'refuses a verdict when the first deny entry cannot be read (S5)'
+    # Given a deny folder whose first entry in byte order cannot be stat'ed -- here a
+    # dangling symlink, as a half-finished write or an unsearchable folder also produces --
+    # in front of a file holding three rows, against an empty mastercat. Discarding the
+    # whole match list on that entry would read zero rows and agree with the empty side,
+    # which is the false PASSED this check exists to prevent.
+    true > "$masterfile"
+    true > "$mastercat"
+    ln -s "${pfbdeny}no-such-target" "${pfbdeny}A.txt"
+    printf '1.1.1.1\n2.2.2.2\n3.3.3.3\n' > "${pfbdeny}B.txt"
 
     # When the final report runs.
     When call closingprocess
 
-    # Then the two empty sides agree.
+    # Then the unreadable entry reaches awk and the count refuses, rather than the three
+    # readable rows being thrown away.
     The status should be success
-    The stdout should include 'Database Sanity check [  PASSED  ]'
-    The stderr should equal ''
+    The stdout should not include 'PASSED'
+    The stdout should include 'Database Sanity check [  FAILED  ]'
+    The stdout should include 'Deny folder Count   [ incomplete ]'
+    The stderr should include 'A.txt'
+    The contents of the file "$errorlog" should include 'sanity counts unreliable'
   End
 End

--- a/tests/shell/pfblockerng_closing_sort_spec.sh
+++ b/tests/shell/pfblockerng_closing_sort_spec.sh
@@ -32,8 +32,10 @@ Describe 'closingprocess() dedup-mode sort trim (#3154)'
     sed -n '/^closingprocess()/,/^}/p' "${PFB_PKGDIR}/pfblockerng.sh"
   }
 
+  # issue #3165 replaced the `find | xargs` walk with the shell's own glob; either shape
+  # counts here, so a second concatenation is still caught whichever one reintroduces it.
   deny_concat_count() {
-    closing_body | grep -c 'find "${pfbdeny}"'
+    closing_body | grep -c 'set -- "${pfbdeny}"\|find "${pfbdeny}"'
   }
 
   It 'leaves mastercat in byte order, not octet-numeric order (C1)'
@@ -101,6 +103,7 @@ Describe 'closingprocess() dedup-mode sort trim (#3154)'
     The status should be success
     The output should include 'closingprocess()'
     The output should not include 'sort -t .'
+    The output should not include 'find "${pfbdeny}"'
     The output should include 'uniq -d'
     The result of function deny_concat_count should equal 1
   End
@@ -135,10 +138,18 @@ Describe 'closingprocess() dedup-mode sort trim (#3154)'
     printf '1.2.3.4\n5.6.7.8\n9.9.9.9\n' > "${pfbdeny}B.txt"
     mkdir -p "${work}/bin"
     real_sort="$(command -v sort)"
+    # issue #3165 moved the write: awk concatenates into tempfile and `sort -o` orders it
+    # in place, so the modelled fault is that in-place sort. Every other sort in the report
+    # (masterfile, mastercat) must still succeed, or the row stops isolating one bad write.
     {
       printf '#!/bin/sh\n'
-      printf 'case " $* " in *" -o "*) exec %s "$@" ;; esac\n' "$real_sort"
-      printf '%s "$@" | head -2\nexit 2\n' "$real_sort"
+      printf 'case " $* " in\n'
+      printf '\t*" -o %s "*)\n' "$tempfile"
+      printf '\t\t%s "$3" | head -2 > "$2.part"\n' "$real_sort"
+      printf '\t\tmv -f "$2.part" "$2"\n'
+      printf '\t\texit 2 ;;\n'
+      printf 'esac\n'
+      printf 'exec %s "$@"\n' "$real_sort"
     } > "${work}/bin/sort"
     chmod +x "${work}/bin/sort"
     PATH="${work}/bin:${PATH}"

--- a/tests/skip-allowlist.txt
+++ b/tests/skip-allowlist.txt
@@ -63,6 +63,7 @@ shellspec:tests/shell/precommit_identity_spec.sh::.githooks/check-commit-identit
 shellspec:tests/shell/pfblockerng_recompute_spec.sh::pfb_recompute() hostile inputs aborts cleanly (log + .new cleanup, live files untouched) when a Stage-A snapshot copy fails (source unreadable, issue #1084 review)  # root bypasses file permissions — denial cannot be simulated
 shellspec:tests/shell/pfblockerng_recompute_spec.sh::pfb_recompute() hostile inputs aborts the masterfile-strip pass cleanly (no masterfile.new debris) when it fails mid-write (issue #1084 review)  # root bypasses file permissions — denial cannot be simulated
 shellspec:tests/shell/pfblockerng_recompute_spec.sh::pfb_recompute() hostile inputs stops the swap and logs the failing artifact -- without rolling anything back -- when the deny dir denies the mv (EACCES mid-swap, issue #1084 review)  # root bypasses directory permissions — denial cannot be simulated
+shellspec:tests/shell/pfblockerng_closing_producer_spec.sh::closingprocess() deny concatenation producer status (#3165) refuses a verdict when a deny file is genuinely unreadable (S2)  # root bypasses file permissions — a mode-000 deny file stays readable
 
 # pytest -- 4 observed on the Linux CI runner.
 pytest:tests.test_build_pkg_origins::test_print_build_origins_includes_expected_dirs  # FreeBSD-ports checkout not present on the runner


### PR DESCRIPTION
## What

`closingprocess()`'s dedup-mode sanity check built the deny-folder side of its comparison from a pipeline whose non-final stages were unobserved:

```sh
if find "${pfbdeny}"*.txt -type f 2>/dev/null | xargs awk 1 | LC_ALL=C sort > "${tempfile}"; then
```

`if <pipeline>` observes only the last stage, so when `find`, `xargs` or `awk` failed mid-stream, `sort` still succeeded on the partial input it did receive, `s2` came out low, and `[ "${s1}" = "${s2}" ]` could print `PASSED` over a real masterfile/deny mismatch. #3162 guarded the *write* half of the same statement; a producer failing while `sort` exits 0 was outside that guard. The verdict is not display-only: `pfblockerng_apply.inc` → `pfb_sync_status_dedup_check()` greps the last `Sanity check` line and closes the ip/dedup ledger key on `PASSED`.

The same statement also mis-split any deny filename containing whitespace, so such a file was never counted at all.

Now the producer is one command whose status the guard reads directly:

```sh
set -- "${pfbdeny}"*.txt
# Only an unmatched glob leaves the pattern itself in $1; a real path awk cannot open
# has to reach awk, so the count refuses instead of reading zero.
case "${1}" in "${pfbdeny}*.txt") [ -e "${1}" ] || set -- /dev/null ;; esac
if awk 1 "$@" > "${tempfile}" && LC_ALL=C sort -o "${tempfile}" "${tempfile}"; then
```

There is no non-final stage left to hide behind: `awk` aborts with status 2 on a file it cannot open, and `&&` sees it. The shell's own glob passes each pathname as one argv entry, so whitespace in a name is no longer a word boundary — and it is the shape this function already uses for the same directory twice over (`pfb_count_table "${pfbdeny}"*.txt`, the `emptylists` grep). The check itself (`s1 == s2`, both duplicate listings, the `incomplete` refusal path, the log line) is unchanged.

The unmatched-glob substitution tests the *pattern*, not one pathname's `stat()`. Round-1 review found that `[ -e "${1}" ]` discarded the whole match list when the first `*.txt` entry was unstattable (dangling symlink, symlink loop, unsearchable directory, unlink race). Against an empty or placeholder-only `mastercat` (`s1=0`) that printed `PASSED` over a real mismatch — a class the base got right. `/dev/null` is substituted only when `$1` is still the unexpanded glob.

Details worth naming:

- **`set --` is function-local.** POSIX restores the caller's positional parameters on return, and nothing else in `closingprocess()` reads `$1`/`$@` (the only `$2` in the rest of the function is an awk field). Verified in `dash`.
- **The unmatched glob is handled, not inherited.** `awk` with zero file operands reads stdin, so an unmatched glob substitutes `/dev/null` and concatenates nothing — the same `s2=0` the old shape produced by accident (its `awk` inherited the already-exhausted pipe from `find`). The `/dev/null` operand is load-bearing: without it a live tty hangs, and a pipe of unrelated rows raises `s2`.
- **`awk`'s stderr stays unredirected**, so the diagnostic still names the file that broke.
- **`-type f` is no longer applied.** A non-regular `*.txt` entry in the deny folder now makes the concatenation refuse a verdict instead of being silently dropped. On the appliance every deny file is written by pfBlockerNG itself.

## Reproduction

Both triggers from #3165, plus the collapse class found in review, executed against the landed base (`23cb2a0a`) and against this head.

| fault | base `23cb2a0a` | this head |
| --- | --- | --- |
| a deny file `awk` cannot open (3 of 4 rows unread, `mastercat` sized to the 1 row read) | `Database Sanity check [  PASSED  ]` | `FAILED`, `Deny folder Count   [ incomplete ]`, logged |
| the same fault with **real permissions** (mode-000 deny file, uid 65534) | `Database Sanity check [  PASSED  ]` | `FAILED`, `Deny folder Count   [ incomplete ]`, logged |
| deny file named `B C.txt` holding 2 of the masterfile's 3 rows | `FAILED`, `Deny folder Count   [ 1 ]` | `PASSED`, empty stderr |
| empty deny folder, five unrelated rows on stdin | `PASSED`, `s2=0` | `PASSED`, `s2=0` (stdin unread) |
| dangling symlink first + empty `mastercat` (3 readable rows behind it) | `FAILED`, `Deny folder Count   [ 3 ]` | `FAILED`, `[ incomplete ]`, logged |

## Tests

`tests/shell/pfblockerng_closing_producer_spec.sh` (new, 5 rows):

- **S1** a shimmed `awk` that emits what it read and exits 2 — what one-true-awk does on a file it cannot open. RED on the base, which printed `PASSED`. Stderr pin is the filename, not mawk's `cannot open` wording (the appliance emits `can't open file`).
- **S2** the same hidden mismatch with a mode-000 deny file. Skipped under uid 0 and allowlisted; it runs on CI's non-root runner.
- **S3** a deny file named `B C.txt`. RED on the base (`FAILED`, `Deny folder Count [ 1 ]`).
- **S4** an empty deny folder, with five unrelated rows on the function's own stdin. Asserts `PASSED` and that no `Deny folder Count` is printed — so a zero-operand `awk 1` that ingested those rows cannot hide behind `s1 = s2 = 0`.
- **S5** a dangling symlink as the first `*.txt` entry, three readable rows behind it, empty `mastercat`. Asserts `PASSED` is absent and `incomplete` is present. RED on the unpatched head (`a33c6f80` / `e611cbf0`), which printed `PASSED`.

Red→green, spec frozen byte-identical across the pair (`git hash-object` = `90ec0b8b0c11c402e94cf13dc54ada6cdcff1543` at both runs, equal to the committed blob):

- production reverted to `origin/devel` (`23cb2a0a`), this spec unchanged → `5 examples, 3 failures, 1 skip` (S1, S3, S5);
- production restored → `5 examples, 0 failures, 1 skip`.

Mutations caught by the new rows, each applied alone:

- `set --` (empty) instead of `/dev/null` → S4 FAILED
- `[ -e "${1}" ] || set -- /dev/null` (the unpatched guard) → S5 FAILED
- the guard dropped entirely → S4 FAILED

Two pins from #3162 moved with the behaviour they pin, neither weakened (round-1 test-honesty and contract legs both mutation-checked this):

- `pfblockerng_closing_sort_spec.sh` **C6** now fails the in-place `sort -o "${tempfile}"`. All six of its assertions are unchanged.
- **C4** matches either concatenation shape and additionally asserts `find "${pfbdeny}"` is absent from the function.
- `pfblockerng_adr26_locale_spec.sh`'s deny-concatenation pin follows the new sink.

`sh -n`, `shellcheck -s sh`, `check_comment_narration.py` and `check_skip_allowlist.py` clean. Canonical gates `PASS` on the fix head.

## Out of scope

- `counto` (`pfblockerng.sh:2217` and `:2219`) and the two `reputation_pmax()` walks (`:1931`, `:1948`) carry the identical `find … | xargs` shape and the identical word-split / unobserved-producer exposure. None is on the verdict/ledger path, so they are left alone here rather than widening a verdict-path fix into display-only and reputation code.
- The FreeBSD-only residual #3165 records under *Related* is unchanged: `usr.bin/sort`'s `closefile()` drops the status of the final `fflush()` for stdout *and* of `fclose()` for a named `-o` file, so moving from `sort > file` to `sort -o file file` neither widens nor narrows it. #3162 already dispositioned the sentinel-row hardening against it.
- On FreeBSD the in-place `sort -o` transiently needs a second full copy of the concatenation in `${tmpdir}` (`usr.bin/sort` writes `FILE.tmp` then `rename`s). Peak usage for the deny side goes from ~1× to ~2×. Safe direction, and `:2225`/`:2228` already pay it.

Fixes #3165


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved deny-list processing reliability when files cannot be read, concatenation fails, or sorting is incomplete.
  - Prevented inaccurate sanity counts and false “PASSED” results; affected checks now report an incomplete status.
  - Correctly handles deny-list filenames containing spaces and empty deny-list folders.

- **Tests**
  - Expanded coverage for processing failures, unreadable files, empty folders, whitespace-containing filenames, and sorting behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->