### PR TITLE
pfblockerng.sh: remove remaining find xargs walks

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.sh
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.sh
@@ -1958,8 +1958,26 @@ EOF
 reputation_pmax(){
 	echo; echo; echo '===[ Reputation - pMax ]======================================'
 	echo; echo "  Querying for repeat offenders ( pMax=${max} ) [ ${now} ]"
-	data="$(find "${pfbdeny}"*.txt ! -name 'pfB*.txt' ! -name '*_v6.txt' -type f | xargs cut -d '.' -f 1-3 |
-		awk -v max="${max}" '{a[$0]++}END{for(i in a){if(a[i] > max){print i}}}' | grep -v "^${ip_placeholder3}$")"
+	set -- "${pfbdeny}"*.txt
+	case "${1}" in "${pfbdeny}"\*.txt) set -- /dev/null ;; esac
+	if ! true > "${tempfile}"; then
+		log="reputation_pmax: cannot create [ ${tempfile} ]; aborting, keeping existing lists."
+		echo "${log}" | tee -a "${errorlog}"
+		return
+	fi
+	for pfbfile do
+		case "${pfbfile##*/}" in pfB*.txt|*_v6.txt) continue ;; esac
+		if ! cut -d '.' -f 1-3 "${pfbfile}" >> "${tempfile}"; then
+			log='reputation_pmax: deny-folder source scan failed; aborting, keeping existing lists.'
+			echo "${log}" | tee -a "${errorlog}"
+			return
+		fi
+	done
+	if ! data="$(awk -v max="${max}" -v placeholder="${ip_placeholder3}" '{a[$0]++}END{for(i in a){if(a[i] > max && i != placeholder){print i}}}' "${tempfile}")"; then
+		log='reputation_pmax: deny-folder source scan failed; aborting, keeping existing lists.'
+		echo "${log}" | tee -a "${errorlog}"
+		return
+	fi
 
 	if [ -n "${data}" ]; then
 		# Find repeat offenders in each individual blocklist outfile
@@ -1975,7 +1993,26 @@ reputation_pmax(){
 			pfb_is_octet_prefix "${ip}" || continue
 			count="$((count + 1))"
 			runonce=0; ii="$(pfb_anchor_octet_pattern "${ip}.")"
-			list="$(find "${pfbdeny}"*.txt ! -name 'pfB*.txt' ! -name '*_v6.txt' -type f | xargs grep -al "${ii}")"
+			if ! true > "${tempfile2}"; then
+				log="reputation_pmax: cannot create [ ${tempfile2} ]; aborting, keeping existing lists."
+				echo "${log}" | tee -a "${errorlog}"
+				return
+			fi
+			for pfbfile do
+				case "${pfbfile##*/}" in pfB*.txt|*_v6.txt) continue ;; esac
+				grep -al "${ii}" "${pfbfile}" >> "${tempfile2}"
+				grep_rc=$?
+				if [ "${grep_rc}" -gt 1 ]; then
+					log='reputation_pmax: deny-folder match scan failed; aborting, keeping existing lists.'
+					echo "${log}" | tee -a "${errorlog}"
+					return
+				fi
+			done
+			if ! list="$(cat "${tempfile2}")"; then
+				log='reputation_pmax: deny-folder match scan failed; aborting, keeping existing lists.'
+				echo "${log}" | tee -a "${errorlog}"
+				return
+			fi
 
 			# Iterate the matched blocklist files via a here-doc (no IFS re-split)
 			# so the inner body's ${runonce}/file accumulation stays in THIS shell.
@@ -2233,20 +2270,47 @@ processxlsx() {
 }
 
 
+# Concatenate globbed files record-by-record so producer failures are observable.
+pfb_concat_records() {
+	_pfb_concat_output="$1"; shift
+	if ! true > "${_pfb_concat_output}"; then
+		return 1
+	fi
+	for _pfb_concat_file do
+		if ! awk 1 "${_pfb_concat_file}" >> "${_pfb_concat_output}"; then
+			return 1
+		fi
+	done
+}
+
 # Function to report final pfBlockerNG statistics.
 closingprocess() {
 	counto=0
 	echo; echo '===[ FINAL Processing ]====================================='; echo
 	if [ -d "${pfborig}" ] && [ "$(ls -A "${pfborig}")" ]; then
-		# Sum the per-feed aggregated "Original" counts written by pfb_ip_recompute_write_snapshot()
-		# (pfblockerng.inc) -- these reflect the CIDR-aggregated input when aggregation ran. Fall back
-		# to the raw *_v4.orig total when no sidecars exist (no snapshot was ever written this pass).
-		# issue #1263: awk 1 (not cat) supplies a missing record terminator --
-		# a welded pair of unterminated counts would otherwise concatenate
-		# digits (e.g. "100" + "200" -> "100200") instead of summing to 300.
-		counto="$(find "${pfborig}"*_v4.aggcount 2>/dev/null | xargs awk 1 2>/dev/null | awk '{s += $1} END {print s + 0}')"
-		if [ "${counto}" -eq 0 ]; then
-			counto="$(find "${pfborig}"*_v4.orig 2>/dev/null | xargs awk 1 | grep -cv '^#\|^$')"
+		# Sum each globbed file as a separate awk input so missing record terminators
+		# cannot weld adjacent files, and a producer failure remains observable.
+		set -- "${pfborig}"*_v4.aggcount
+		case "${1}" in "${pfborig}"\*_v4.aggcount) set -- /dev/null ;; esac
+		if pfb_concat_records "${tempfile}" "$@" &&
+			counto="$(awk '{s += $1} END {print s + 0}' "${tempfile}")"; then
+			:
+		else
+			counto='incomplete'
+			log='closing: original count producer failed; count unreliable.'
+			echo "${log}" | tee -a "${errorlog}"
+		fi
+		if [ "${counto}" = 0 ]; then
+			set -- "${pfborig}"*_v4.orig
+			case "${1}" in "${pfborig}"\*_v4.orig) set -- /dev/null ;; esac
+			if pfb_concat_records "${tempfile}" "$@" &&
+				counto="$(awk '!/^#|^$/{n++} END {print n + 0}' "${tempfile}")"; then
+				:
+			else
+				counto='incomplete'
+				log='closing: original count fallback producer failed; count unreliable.'
+				echo "${log}" | tee -a "${errorlog}"
+			fi
 		fi
 	fi
 

--- a/tests/shell/pfblockerng_cat_weld_spec.sh
+++ b/tests/shell/pfblockerng_cat_weld_spec.sh
@@ -42,6 +42,51 @@ Describe 'closingprocess() Original IP count: aggcount sum never welds digits to
   End
 End
 
+Describe 'closingprocess() Original IP count: whitespace sidecar names stay whole (issue #3176)'
+  setup() {
+    work="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/aggspace.XXXXXX")"
+    pfborig="${work}/orig/"; pfbdeny="${work}/deny/"
+    pfbpermit="${work}/permit/"; pfbmatch="${work}/match/"; pfbnative="${work}/native/"
+    mkdir -p "$pfborig" "$pfbdeny" "$pfbpermit" "$pfbmatch" "$pfbnative"
+    masterfile="${work}/masterfile"; mastercat="${work}/mastercat"
+    tempfile="${work}/t1"; errorlog="${work}/err.log"; now="now"
+    ip_placeholder2="127.0.0.1"
+    pathpfctl="${work}/pfctl"; printf '#!/bin/sh\n' > "$pathpfctl"; chmod +x "$pathpfctl"
+    alias='off'
+    printf '10' > "${pfborig}Feed A_v4.aggcount"
+    printf '5'  > "${pfborig}FeedB_v4.aggcount"
+  }
+  cleanup() { rm -rf "$work"; }
+  BeforeAll 'pfb_source'
+  Before 'setup'
+  After 'cleanup'
+
+  It 'sums sidecars without splitting a whitespace-bearing pathname'
+    When call closingprocess
+    The status should be success
+    The stdout should include '[ Original IP count   ]  [ 15 ]'
+  End
+
+  It 'marks the original count incomplete when its producer fails (issue #3176)'
+    mkdir -p "${work}/bin"
+    real_awk="$(command -v awk)"
+    cat > "${work}/bin/awk" <<EOF
+#!/bin/sh
+case " \$* " in
+  *aggcount*) printf '10\n'; exit 2 ;;
+  *) exec "${real_awk}" "\$@" ;;
+esac
+EOF
+    chmod +x "${work}/bin/awk"
+    PATH="${work}/bin:${PATH}"
+
+    When call closingprocess
+    The status should be success
+    The stdout should include '[ Original IP count   ]  [ incomplete ]'
+    The stdout should include 'original count'
+  End
+End
+
 Describe 'closingprocess() Original IP count: raw *_v4.orig fallback never welds lines together (issue #1263 site 4)'
   setup() {
     work="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/origweld.XXXXXX")"

--- a/tests/shell/pfblockerng_ip_dedup_oracle_spec.sh
+++ b/tests/shell/pfblockerng_ip_dedup_oracle_spec.sh
@@ -91,6 +91,34 @@ Describe 'reputation_pmax() collapse (no GeoIP, block-only)'
 		The contents of file "$masterfile" should not include 'PALIAS_v4 198.51.100.1'
 		The contents of file "$masterfile" should include 'PALIAS_v4 198.51.100.0/24'
 	End
+
+It 'collapses a repeat offender in a deny filename containing whitespace (issue #3176)'
+		alias='PALIAS SPACE'
+		rm -f "${pfbdeny}"*.txt
+		printf '198.51.100.1\n198.51.100.2\n198.51.100.3\n' > "${pfbdeny}${alias}.txt"
+
+		When call reputation_pmax
+		The status should be success
+		The stdout should include 'Reputation - pMax Stats'
+		The contents of file "${pfbdeny}${alias}.txt" should include '198.51.100.0/24'
+	End
+
+It 'aborts without mutation when the pMax source scan fails (issue #3176)'
+		errorlog="${work}/err.log"
+		mkdir -p "${work}/bin"
+		cat > "${work}/bin/cut" <<'EOF'
+#!/bin/sh
+printf '198.51.100\n'
+exit 2
+EOF
+		chmod +x "${work}/bin/cut"
+		PATH="${work}/bin:${PATH}"
+
+		When call reputation_pmax
+		The status should be success
+		The contents of file "${pfbdeny}PALIAS_v4.txt" should not include '198.51.100.0/24'
+		The stdout should include 'source scan'
+	End
 End
 
 Describe 'process255() collapses >253 same-/24 members within one feed'


### PR DESCRIPTION
## What

Fixes the three remaining `find | xargs` walk sites in `pfblockerng.sh` (the two `reputation_pmax()` scans and both `closingprocess()` original-count scans). Shell glob arguments preserve whitespace-bearing filenames, unmatched globs use `/dev/null`, and each producer status is checked before mutation or publication of a count. Original-count failures are reported as `incomplete`.

## Verification

- Frozen red proof on base: `shellspec --shell "$(command -v dash)" tests/shell/pfblockerng_ip_dedup_oracle_spec.sh tests/shell/pfblockerng_cat_weld_spec.sh` → 15 examples, 4 failures (the new whitespace and producer-failure cases).
- Frozen green proof on this head: same command → 15 examples, 0 failures; both test-file hashes remained `130cc661b4bb8993d014f8ade945ae6830e4827d` and `60214e30036ba6c93c7c6d8a024406d09a057e35`.
- `sh -n`, `shellcheck -s sh`, `git diff --check`, and `scripts/agent/check-graph-fresh.sh` pass.
- `scripts/agent/run-gates.sh --diff origin/devel` passed all selected code and shell gates; its first run required the deterministic graph refresh, which is included in this commit.

Closes #3176

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reputation processing for entries with whitespace in their names.
  * Prevented incomplete source scans from modifying deny lists.
  * Improved original IP count reporting when count data cannot be read, clearly identifying the result as incomplete.
  * Improved handling of filenames without trailing line breaks and ensured accurate count totals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->