### PR TITLE
policy: enforce scratch-tree boundaries at Bash guard

### DIFF
--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -19,7 +19,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "root=$(git rev-parse --show-toplevel) && python3 -c \"import hashlib,sys; p,e=sys.argv[1:]; a=hashlib.sha256(open(p,'rb').read()).hexdigest(); print(f'codex-hook-integrity: {p} hash {a}, expected {e}',file=sys.stderr) if a != e else None; sys.exit(a != e)\" \"$root/scripts/claude-bash-guard.sh\" f0e39d08a8b0f8f36019037c733db52cc88faedd069869291a8aca46500feeff && exec sh \"$root/scripts/claude-bash-guard.sh\"",
+            "command": "root=$(git rev-parse --show-toplevel) && python3 -c \"import hashlib,sys; p,e=sys.argv[1:]; a=hashlib.sha256(open(p,'rb').read()).hexdigest(); print(f'codex-hook-integrity: {p} hash {a}, expected {e}',file=sys.stderr) if a != e else None; sys.exit(a != e)\" \"$root/scripts/claude-bash-guard.sh\" 8c5ef8380e54beabb2a8f98b74b21fab277a4550d3f8fe9afb58072eceb5b4e8 && exec sh \"$root/scripts/claude-bash-guard.sh\"",
             "timeout": 10,
             "statusMessage": "Checking repository Git policy"
           }

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -19,7 +19,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "root=$(git rev-parse --show-toplevel) && python3 -c \"import hashlib,sys; p,e=sys.argv[1:]; a=hashlib.sha256(open(p,'rb').read()).hexdigest(); print(f'codex-hook-integrity: {p} hash {a}, expected {e}',file=sys.stderr) if a != e else None; sys.exit(a != e)\" \"$root/scripts/claude-bash-guard.sh\" 344059df3e09f3f3c9ffb15ace84b48d8a7cfcf57d6243fa93f1cd219c58e81f && exec sh \"$root/scripts/claude-bash-guard.sh\"",
+            "command": "root=$(git rev-parse --show-toplevel) && python3 -c \"import hashlib,sys; p,e=sys.argv[1:]; a=hashlib.sha256(open(p,'rb').read()).hexdigest(); print(f'codex-hook-integrity: {p} hash {a}, expected {e}',file=sys.stderr) if a != e else None; sys.exit(a != e)\" \"$root/scripts/claude-bash-guard.sh\" f0e39d08a8b0f8f36019037c733db52cc88faedd069869291a8aca46500feeff && exec sh \"$root/scripts/claude-bash-guard.sh\"",
             "timeout": 10,
             "statusMessage": "Checking repository Git policy"
           }

--- a/scripts/claude-bash-guard.sh
+++ b/scripts/claude-bash-guard.sh
@@ -1,10 +1,11 @@
 #!/bin/sh
-# scripts/claude-bash-guard.sh -- PreToolUse Bash guard: deny 4 agent footguns.
+# scripts/claude-bash-guard.sh -- PreToolUse Bash guard: deny 5 agent footguns.
 #
 # Wired in .claude/settings.json as a PreToolUse hook matching the Bash tool.
-# Denies, at the TOOL layer (before the command ever runs), four operations an
-# AGENT must not run -- three git bypasses a human may legitimately use, plus a
-# wait-launch shape that silently strands the turn:
+# Denies, at the TOOL layer (before the command ever runs), five operations an
+# AGENT must not run -- three git bypasses a human may legitimately use, a
+# wait-launch shape that silently strands the turn, and the scratch-tree
+# shapes that share or strand a git tree (issue #3101):
 #
 #   Rule A -- `git commit` with `--no-verify` (long flag, standalone -n, or a
 #             clustered short flag like -an/-anm)   : the pre-commit lint
@@ -27,10 +28,34 @@
 #             the turn stalls while the wait has already finished (#1225).
 #             Whole-payload, not per-segment: `&` is one of the characters
 #             $segs splits on.
+#   Rule E -- (1) a `cp -a`/`cp -R`/`cp -r`/`cp -al`/`rsync` whose SOURCE
+#             carries a `.git` entry : the copy-a-worktree shape -- the copy
+#             keeps the source's `.git` pointer, so every git command in the
+#             copy drives the ORIGINAL tree's index, `HEAD`, and refs (issue
+#             #3101, observed writing another session's `ORIG_HEAD` and index).
+#             Sanctioned: `git archive <sha> | tar -x` (read-only) or
+#             `wt switch --create --base <sha>` (throwaway worktree).
+#             (2) a `git clone`/`git worktree add` whose TARGET resolves under
+#             the system temp dir (`/tmp`, `/private/tmp`, or `$TMPDIR` when
+#             it resolves inside either) : an unregistered tree no
+#             `git worktree list`, prune, or `wt remove` can reach, on a
+#             RAM-backed tmpfs on Linux. Sanctioned: `/var/tmp/agents`
+#             (CLAUDE.md scratch trees).
+#
+# Rule E is the ONLY rule that touches the filesystem, and only for (1): a
+# text scan cannot see a `.git` entry, so it probes the resolved SOURCE
+# argument (`test -e <src>/.git` -- a DIRECTORY in a main checkout, a FILE in
+# a linked worktree; `-e` covers both). A source that does not exist or does
+# not resolve probes FALSE (fail-open); a relative source resolves from the
+# HOOK's CWD, which differs from the agent's when the agent cd'd -- the
+# accepted gap, same class as the git-alias accepted limitation above. (2) is
+# per-segment text like the rest: a boundary-anchored path token in a git
+# clone / worktree add segment, so `/var/tmp/...`, `/tmpfoo`, and an
+# unrelated `/tmp` in another segment never match (spec E10/E11/E14).
 #
 # Rule D runs first (whole-payload). Then the per-segment rules: segments are
 # scanned left to right (see MATCHING below); within one segment, A, then B,
-# then C. First matching pair wins.
+# then C, then E. First matching pair wins.
 #
 # FAIL-OPEN CONTRACT: this hook must NEVER block a legitimate Bash call
 # because of a parsing failure. Empty stdin, garbled/non-JSON stdin, or no
@@ -268,6 +293,96 @@ _has_force_refspec() {
 	printf '%s' "$seg" | grep -Eq "(^|${_SEP})\\+${_SEP_NOT}"
 }
 
+# _copy_srcs <anchor> -- sets _srcs to the candidate SOURCE tokens of the
+# CURRENT SEGMENT's cp/rsync, space-separated, for tool+flag anchor $1
+# (`cp -a` ... `rsync`): every non-flag token after the LAST anchor
+# occurrence except the last one (the destination), with the trailing JSON
+# braces the normalization leaves fused onto tokens stripped. The caller
+# gates on the anchor being present first (see _has_copy_source_git), so
+# the `##*` cut always lands on the real command, never the JSON prefix.
+_copy_srcs() {
+	_srcs=""
+	_last_tok=""
+	_rest="${seg##*"$1 "}"
+	for _w in $_rest; do    # shellcheck disable=SC2086  # intentional: word-splitting into tokens
+		case "$_w" in
+		-*) continue ;;
+		esac
+		while true; do
+			case "$_w" in
+			*"}" ) _w="${_w%?}" ;;
+			*) break ;;
+			esac
+		done
+		[ -n "$_w" ] || continue
+		_srcs="${_srcs:+$_srcs }$_last_tok"
+		_last_tok="$_w"
+	done
+}
+
+# _any_src_has_git -- true iff any candidate source in _srcs carries a .git
+# entry: a DIRECTORY in a main checkout, a FILE (a gitdir pointer) in a
+# linked worktree -- -e covers both. A source that does not exist or does
+# not resolve probes false: fail-open, the contract for every parse failure
+# in this guard.
+_any_src_has_git() {
+	[ -n "$_srcs" ] || return 1
+	for _w in $_srcs; do   # shellcheck disable=SC2086  # intentional: word-splitting into tokens
+		[ -e "$_w/.git" ] && return 0
+	done
+	return 1
+}
+
+# _has_copy_source_git -- true iff the CURRENT SEGMENT is a copy of a
+# git-bearing tree: cp -a/-R/-r/-al (the recursive spellings a
+# copy-a-worktree takes) or rsync, whose SOURCE contains a .git entry.
+_has_copy_source_git() {
+	if _contains 'cp -a '; then
+		_copy_srcs 'cp -a'
+		_any_src_has_git && return 0
+	fi
+	if _contains 'cp -R '; then
+		_copy_srcs 'cp -R'
+		_any_src_has_git && return 0
+	fi
+	if _contains 'cp -r '; then
+		_copy_srcs 'cp -r'
+		_any_src_has_git && return 0
+	fi
+	if _contains 'cp -al '; then
+		_copy_srcs 'cp -al'
+		_any_src_has_git && return 0
+	fi
+	if _contains 'rsync '; then
+		_copy_srcs 'rsync'
+		_any_src_has_git && return 0
+	fi
+	return 1
+}
+
+# _tmp_target -- true iff the CURRENT SEGMENT carries a path token under the
+# system temp dir as written in the command: /tmp or /tmp/..., /private/tmp
+# or /private/tmp/..., or $TMPDIR/$TMPDIR/... where $TMPDIR (this hook's
+# environment, the one the agent shell inherits) resolves inside either.
+# Boundary-anchored like the force-flag boundary, so /var/tmp/... and a
+# /tmpfoo directory never match, and neither does /tmp inside a URL path
+# (the character before a URL's /tmp is never a boundary).
+_tmp_target() {
+	if printf '%s' "$seg" | grep -Eq "(^|${_SEP})(/tmp|/private/tmp)(/|${_SEP})"; then
+		return 0
+	fi
+	case "${TMPDIR:-}" in
+	/tmp*|/private/tmp*)
+		# shellcheck disable=SC2016  # intentional: match the literal $TMPDIR token
+		if _contains '$TMPDIR' &&
+			printf '%s' "$seg" | grep -Eq "(^|${_SEP})\\\$TMPDIR(/|${_SEP})"; then
+			return 0
+		fi
+		;;
+	esac
+	return 1
+}
+
 # _deny <reason> -- print the PreToolUse deny JSON and exit 0 (exit 0 is
 # required even for a deny: Claude Code reads the decision from stdout, not
 # from the process exit status). <reason> must contain no " or \ so it can
@@ -284,7 +399,7 @@ if printf '%s' "$norm_bg" | grep -Eq 'wait-[a-z0-9_-]*\.sh.*&'; then
 	_deny "a wait script backgrounded with & is invisible to the harness: no completion notification fires, so the turn stalls while the wait has already finished (issue #1225). Launch it as its OWN Bash call with run_in_background: true -- backgrounding is a property of the tool call, not of shell syntax (CLAUDE.md No orphaned waits)"
 fi
 
-# Walk $segs one segment at a time, applying rules A-C to each ($seg
+# Walk $segs one segment at a time, applying rules A-C and E to each ($seg
 # is read by _contains / _has_force_flag above). Fed via a heredoc (not a
 # `| while`) so this loop runs in the CURRENT shell, not a subshell: dash (the
 # box's /bin/sh) forks a subshell for the reader end of a pipe, which would
@@ -308,6 +423,18 @@ while IFS= read -r seg; do
 
 	if _contains 'git worktree remove' && _has_force_flag; then
 		_deny "CLAUDE.md forbids force-removing a worktree you do not own"
+	fi
+
+	# Rule E1: a copy of a git-bearing tree -- the copy keeps the source's
+	# .git, so its git commands drive the ORIGINAL's index/HEAD/refs (#3101).
+	if _has_copy_source_git; then
+		_deny "a cp/rsync of a git checkout keeps the source's .git, so the copy's git commands drive the ORIGINAL checkout's index, HEAD, and refs (CLAUDE.md scratch trees). Use git archive <sha> | tar -x for a read-only extraction, or wt switch --create --base <sha> for a throwaway worktree"
+	fi
+
+	# Rule E2: a clone / worktree add whose target resolves under the system
+	# temp dir -- a tree no worktree list, prune, or wt remove can reach.
+	if { _contains 'git clone' || _contains 'git worktree add'; } && _tmp_target; then
+		_deny "a clone or worktree under the system temp dir is unreclaimable: no git worktree list entry, no prune or wt remove can reach it, and /tmp is RAM-backed tmpfs on Linux. Use /var/tmp/agents for scratch trees, or wt switch --create --base <sha> for a throwaway worktree"
 	fi
 
 done <<_PFB_SEGS_

--- a/scripts/claude-bash-guard.sh
+++ b/scripts/claude-bash-guard.sh
@@ -233,6 +233,13 @@ _contains() {
 # the closing `}}` with no other separator left to match.
 _SEP='[[:space:];|&(){}<>,]'
 
+# _has_command -- true iff the CURRENT SEGMENT contains the command prefix
+# $1 at a non-alphanumeric boundary. This keeps a command such as `scp -r`
+# from being mistaken for `cp -r` while retaining the normalized JSON prefix.
+_has_command() {
+	printf '%s' "$seg" | grep -Eq "(^|[^[:alnum:]_])$1"
+}
+
 # _has_force_flag -- true iff the CURRENT SEGMENT ($seg) carries a force
 # flag:
 #   * the literal substring --force (covers --force and --force-with-lease
@@ -337,23 +344,23 @@ _any_src_has_git() {
 # git-bearing tree: cp -a/-R/-r/-al (the recursive spellings a
 # copy-a-worktree takes) or rsync, whose SOURCE contains a .git entry.
 _has_copy_source_git() {
-	if _contains 'cp -a '; then
+	if _has_command 'cp -a '; then
 		_copy_srcs 'cp -a'
 		_any_src_has_git && return 0
 	fi
-	if _contains 'cp -R '; then
+	if _has_command 'cp -R '; then
 		_copy_srcs 'cp -R'
 		_any_src_has_git && return 0
 	fi
-	if _contains 'cp -r '; then
+	if _has_command 'cp -r '; then
 		_copy_srcs 'cp -r'
 		_any_src_has_git && return 0
 	fi
-	if _contains 'cp -al '; then
+	if _has_command 'cp -al '; then
 		_copy_srcs 'cp -al'
 		_any_src_has_git && return 0
 	fi
-	if _contains 'rsync '; then
+	if _has_command 'rsync '; then
 		_copy_srcs 'rsync'
 		_any_src_has_git && return 0
 	fi
@@ -372,7 +379,7 @@ _tmp_target() {
 		return 0
 	fi
 	case "${TMPDIR:-}" in
-	/tmp*|/private/tmp*)
+	/tmp|/tmp/*|/private/tmp|/private/tmp/*)
 		# shellcheck disable=SC2016  # intentional: match the literal $TMPDIR token
 		if _contains '$TMPDIR' &&
 			printf '%s' "$seg" | grep -Eq "(^|${_SEP})\\\$TMPDIR(/|${_SEP})"; then
@@ -433,7 +440,7 @@ while IFS= read -r seg; do
 
 	# Rule E2: a clone / worktree add whose target resolves under the system
 	# temp dir -- a tree no worktree list, prune, or wt remove can reach.
-	if { _contains 'git clone' || _contains 'git worktree add'; } && _tmp_target; then
+	if { _has_command 'git clone ' || _has_command 'git worktree add '; } && _tmp_target; then
 		_deny "a clone or worktree under the system temp dir is unreclaimable: no git worktree list entry, no prune or wt remove can reach it, and /tmp is RAM-backed tmpfs on Linux. Use /var/tmp/agents for scratch trees, or wt switch --create --base <sha> for a throwaway worktree"
 	fi
 

--- a/tests/shell/claude_bash_guard_spec.sh
+++ b/tests/shell/claude_bash_guard_spec.sh
@@ -1344,7 +1344,7 @@ Describe 'claude-bash-guard.sh'
       Data
         #|{"tool_name":"Bash","tool_input":{"command":"git clone https://example.com/r.git $TMPDIR/r"}}
       End
-      When run env TMPDIR=/tmpfoo script "$GUARD"
+      When run env TMPDIR=/tmpfoo sh "$GUARD"
       The status should be success
       The output should equal ""
     End
@@ -1353,7 +1353,7 @@ Describe 'claude-bash-guard.sh'
       Data
         #|{"tool_name":"Bash","tool_input":{"command":"git clone https://example.com/r.git $TMPDIR/r"}}
       End
-      When run env TMPDIR=/tmp script "$GUARD"
+      When run env TMPDIR=/tmp sh "$GUARD"
       The status should be success
       The output should include '"permissionDecision":"deny"'
     End

--- a/tests/shell/claude_bash_guard_spec.sh
+++ b/tests/shell/claude_bash_guard_spec.sh
@@ -1239,6 +1239,15 @@ Describe 'claude-bash-guard.sh'
       The output should include '"permissionDecision":"deny"'
     End
 
+    It 'E5b: scp -r is not mistaken for cp -r -> PASS'
+      Data
+        #|{"tool_name":"Bash","tool_input":{"command":"scp -r . /var/tmp/agents/guard-e5b"}}
+      End
+      When run script "$GUARD"
+      The status should be success
+      The output should equal ""
+    End
+
     It 'E6: cp -a of a non-repo directory (tests/ has no .git entry) -> PASS'
       Data
         #|{"tool_name":"Bash","tool_input":{"command":"cp -a tests /var/tmp/agents/guard-e6"}}
@@ -1329,6 +1338,24 @@ Describe 'claude-bash-guard.sh'
       When run script "$GUARD"
       The status should be success
       The output should equal ""
+    End
+
+    It 'E14b: TMPDIR=/tmpfoo is not the system temp dir (boundary) -> PASS'
+      Data
+        #|{"tool_name":"Bash","tool_input":{"command":"git clone https://example.com/r.git $TMPDIR/r"}}
+      End
+      When run env TMPDIR=/tmpfoo script "$GUARD"
+      The status should be success
+      The output should equal ""
+    End
+
+    It 'E14c: TMPDIR=/tmp is the system temp dir -> DENY'
+      Data
+        #|{"tool_name":"Bash","tool_input":{"command":"git clone https://example.com/r.git $TMPDIR/r"}}
+      End
+      When run env TMPDIR=/tmp script "$GUARD"
+      The status should be success
+      The output should include '"permissionDecision":"deny"'
     End
 
     It 'E15 (F5 full JSON validity): exact deny JSON names /var/tmp/agents'

--- a/tests/shell/claude_bash_guard_spec.sh
+++ b/tests/shell/claude_bash_guard_spec.sh
@@ -24,6 +24,15 @@
 #              at all, and NEVER lease-protected, so it denies even
 #              alongside --force-with-lease)
 #   Rule C  -- git worktree remove + force flag                -> DENY
+#   Rule E  -- (1) a cp -a/-R/-r/-al or rsync whose SOURCE carries a .git
+#              entry (the copy-a-worktree shape, #3101)                -> DENY
+#              (the guard probes the resolved source argument -- the only
+#              rule that touches the filesystem; a source without a .git
+#              entry passes)
+#              (2) git clone / git worktree add whose TARGET resolves
+#              under the system temp dir (/tmp, /private/tmp, or
+#              $TMPDIR when it resolves inside either)                 -> DENY
+#              (boundary-anchored: /var/tmp/... and /tmpfoo never match)
 #   fail-open -- empty / garbled stdin, no rule match           -> PASS
 #   -f boundary -- standalone -f / an f-bearing short-flag cluster,
 #                  never matching inside --force/-force/a token
@@ -1167,6 +1176,168 @@ Describe 'claude-bash-guard.sh'
       When run script "$GUARD"
       The status should be success
       The output should include '"permissionDecision":"deny"'
+    End
+  End
+
+  # ── Rule E: scratch trees -- copy a git-bearing tree / clone into system tmp ──
+  #
+  # The scratch-tree rule (#3089 prose, #3101 mechanical): a scratch tree is a
+  # throwaway worktree or a git archive extraction -- never a cp/rsync of a
+  # git-bearing tree (the copy keeps the source's .git, so its git commands
+  # drive the ORIGINAL's index, HEAD, and refs), never a tree under the
+  # system temp dir (invisible to git worktree list; no prune can reach it).
+  #
+  # E1 probes the resolved SOURCE argument -- the only rule that touches the
+  # filesystem. The `.` source resolves against the guard's CWD, which under
+  # the canonical invocation (shellspec from the repo root, CI, run-gates.sh)
+  # is the checkout root: a real .git, the strongest fixture available. The
+  # non-repo case uses tests/ (no .git entry) and passes from any CWD.
+
+  Describe 'Rule E1: cp/rsync of a git-bearing tree'
+    It 'E1: cp -a of the current checkout (a real .git) -> DENY'
+      Data
+        #|{"tool_name":"Bash","tool_input":{"command":"cp -a . /var/tmp/agents/guard-e1"}}
+      End
+      When run script "$GUARD"
+      The status should be success
+      The output should include '"permissionDecision":"deny"'
+    End
+
+    It 'E2: cp -R of the current checkout -> DENY'
+      Data
+        #|{"tool_name":"Bash","tool_input":{"command":"cp -R . /var/tmp/agents/guard-e2"}}
+      End
+      When run script "$GUARD"
+      The status should be success
+      The output should include '"permissionDecision":"deny"'
+    End
+
+    It 'E3: cp -r of the current checkout -> DENY'
+      Data
+        #|{"tool_name":"Bash","tool_input":{"command":"cp -r . /var/tmp/agents/guard-e3"}}
+      End
+      When run script "$GUARD"
+      The status should be success
+      The output should include '"permissionDecision":"deny"'
+    End
+
+    It 'E4: cp -al of the current checkout -> DENY'
+      Data
+        #|{"tool_name":"Bash","tool_input":{"command":"cp -al . /var/tmp/agents/guard-e4"}}
+      End
+      When run script "$GUARD"
+      The status should be success
+      The output should include '"permissionDecision":"deny"'
+    End
+
+    It 'E5: rsync -a of the current checkout -> DENY'
+      Data
+        #|{"tool_name":"Bash","tool_input":{"command":"rsync -a . /var/tmp/agents/guard-e5"}}
+      End
+      When run script "$GUARD"
+      The status should be success
+      The output should include '"permissionDecision":"deny"'
+    End
+
+    It 'E6: cp -a of a non-repo directory (tests/ has no .git entry) -> PASS'
+      Data
+        #|{"tool_name":"Bash","tool_input":{"command":"cp -a tests /var/tmp/agents/guard-e6"}}
+      End
+      When run script "$GUARD"
+      The status should be success
+      The output should equal ""
+    End
+
+    It 'E6b: cp -a of a source that does not exist (probe is fail-open) -> PASS'
+      Data
+        #|{"tool_name":"Bash","tool_input":{"command":"cp -a /nonexistent/wt /var/tmp/agents/guard-e6b"}}
+      End
+      When run script "$GUARD"
+      The status should be success
+      The output should equal ""
+    End
+
+    It 'E7 (F5 full JSON validity): exact deny JSON names the two sanctioned alternatives'
+      Data
+        #|{"tool_name":"Bash","tool_input":{"command":"cp -a . /var/tmp/agents/guard-e1"}}
+      End
+      When run script "$GUARD"
+      The status should be success
+      The output should equal '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"a cp/rsync of a git checkout keeps the source'"'"'s .git, so the copy'"'"'s git commands drive the ORIGINAL checkout'"'"'s index, HEAD, and refs (CLAUDE.md scratch trees). Use git archive <sha> | tar -x for a read-only extraction, or wt switch --create --base <sha> for a throwaway worktree"}}'
+    End
+  End
+
+  Describe 'Rule E2: git clone / worktree add into the system temp dir'
+    It 'E8: git clone into /tmp/... -> DENY'
+      Data
+        #|{"tool_name":"Bash","tool_input":{"command":"git clone https://example.com/r.git /tmp/r"}}
+      End
+      When run script "$GUARD"
+      The status should be success
+      The output should include '"permissionDecision":"deny"'
+    End
+
+    It 'E9: git clone into exactly /tmp -> DENY'
+      Data
+        #|{"tool_name":"Bash","tool_input":{"command":"git clone https://example.com/r.git /tmp"}}
+      End
+      When run script "$GUARD"
+      The status should be success
+      The output should include '"permissionDecision":"deny"'
+    End
+
+    It 'E10: git clone into /var/tmp/agents -> PASS (/var/tmp is not /tmp)'
+      Data
+        #|{"tool_name":"Bash","tool_input":{"command":"git clone https://example.com/r.git /var/tmp/agents/r"}}
+      End
+      When run script "$GUARD"
+      The status should be success
+      The output should equal ""
+    End
+
+    It 'E11: compound command mentioning /tmp unrelated to the clone target -> PASS'
+      Data
+        #|{"tool_name":"Bash","tool_input":{"command":"git clone https://example.com/r.git /var/tmp/agents/r && echo /tmp/junk"}}
+      End
+      When run script "$GUARD"
+      The status should be success
+      The output should equal ""
+    End
+
+    It 'E12: git worktree add under /tmp -> DENY'
+      Data
+        #|{"tool_name":"Bash","tool_input":{"command":"git worktree add /tmp/wt deadbeef"}}
+      End
+      When run script "$GUARD"
+      The status should be success
+      The output should include '"permissionDecision":"deny"'
+    End
+
+    It 'E13: git worktree add under /var/tmp/agents -> PASS'
+      Data
+        #|{"tool_name":"Bash","tool_input":{"command":"git worktree add /var/tmp/agents/wt deadbeef"}}
+      End
+      When run script "$GUARD"
+      The status should be success
+      The output should equal ""
+    End
+
+    It 'E14: /tmpfoo is not the system temp dir (boundary) -> PASS'
+      Data
+        #|{"tool_name":"Bash","tool_input":{"command":"git clone https://example.com/r.git /tmpfoo/r"}}
+      End
+      When run script "$GUARD"
+      The status should be success
+      The output should equal ""
+    End
+
+    It 'E15 (F5 full JSON validity): exact deny JSON names /var/tmp/agents'
+      Data
+        #|{"tool_name":"Bash","tool_input":{"command":"git clone https://example.com/r.git /tmp/r"}}
+      End
+      When run script "$GUARD"
+      The status should be success
+      The output should equal '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"a clone or worktree under the system temp dir is unreclaimable: no git worktree list entry, no prune or wt remove can reach it, and /tmp is RAM-backed tmpfs on Linux. Use /var/tmp/agents for scratch trees, or wt switch --create --base <sha> for a throwaway worktree"}}'
     End
   End
 


### PR DESCRIPTION
Fixes #3101

Adds Rule E to the shared Bash guard:
- deny recursive cp/rsync of a source containing `.git`, with sanctioned `git archive` and `wt` alternatives;
- deny `git clone` and `git worktree add` targets under `/tmp` or `/private/tmp`, including `$TMPDIR` when it resolves there;
- preserve boundary-scoped compound-command behavior and fail-open handling.

Adds shellspec coverage for all requested flag spellings, non-repository sources, `/tmp` versus `/var/tmp/agents`, compound commands, command-name boundaries, and TMPDIR boundaries. Updates the Codex guard integrity hash.

Verification: `scripts/agent/run-gates.sh --diff origin/devel` passed (1961 examples, 9 environment skips).

| Frozen RED test | git hash-object | RED run tail |
| --- | --- | --- |
| `tests/shell/claude_bash_guard_spec.sh` | `14a7c8c067e823bd04cf5582de4f9ee47a217a04` | `shellspec --shell "$(command -v dash)" tests/shell/claude_bash_guard_spec.sh: 135 examples, 2 failures (E5b, E14b against parent guard)` |