### PR TITLE
policy: named tickets are orchestrator sessions

### DIFF
--- a/.agents/policy/delegation.md
+++ b/.agents/policy/delegation.md
@@ -23,12 +23,14 @@ gating is what make cheaper implementer safe. Ticket execution follow fresh-sess
 ([`workflow.md`](workflow.md)); ad-hoc coding follow same shape. Higher model may implement
 fix **directly** when small and doable in one step — and always handle **docs / config /
 settings / skills** directly. Delegation for non-trivial, multi-step `src/`/`tests/`/CI work.
-**Review-fix rounds are canonical direct case** (owner, 2026-08-08): small fix session
-understand — or reviewer's proposed solution it agree with — applied by session itself, tests
-included, never spawned to sub-agent. **Ticket pickup follow same rule**: session that
-analyzed ticket implement it directly when change small-ish — max handful of lines in one
-production file + couple tests + few doc files; handing that to implementer is waste. Hard
-constraint on ALL direct work: session context usage ≤ 50% — past 50% session MUST delegate.
+**Review-fix rounds are canonical direct case** (owner, 2026-08-08): small fix the
+**work agent** understands — or reviewer's proposed solution it agree with — applied by
+that session itself, tests included, never spawned onward. **Ticket pickup is
+orchestrator per workflow.md**: the top-level session named the issue spawns a work
+agent; it does not implement the ticket. The work agent still does small one-step
+fixes directly (max handful of lines in one production file + couple tests + few doc
+files). Hard constraint on ALL direct work: session context usage ≤ 50% — past 50%
+session MUST delegate. Owner override: "implement here" / "no spawn".
 
 - **Per-step verifier always small tier** (owner directive 2026-07-14) — never top-tier model
   that authored brief; different model read with different blind spots. Top model's

--- a/.agents/policy/delegation.md
+++ b/.agents/policy/delegation.md
@@ -20,9 +20,10 @@ unavailable) and **implemented by small-tier** sub-agents: planner split task in
 small-tier implementer execute each, **independent small-tier verifier gate every step**
 (never brief author's model), planner validate returned records before next — that per-step
 gating is what make cheaper implementer safe. Ticket execution follow fresh-session workflow
-([`workflow.md`](workflow.md)); ad-hoc coding follow same shape. Higher model may implement
-fix **directly** when small and doable in one step — and always handle **docs / config /
-settings / skills** directly. Delegation for non-trivial, multi-step `src/`/`tests/`/CI work.
+([`workflow.md`](workflow.md)); ad-hoc coding follow same shape. The **work agent** may
+implement a small one-step fix **directly**, including **docs / config / settings /
+skills**. Named GitHub issues still spawn. Delegation for non-trivial, multi-step
+`src/`/`tests/`/CI work.
 **Review-fix rounds are canonical direct case** (owner, 2026-08-08): small fix the
 **work agent** understands — or reviewer's proposed solution it agree with — applied by
 that session itself, tests included, never spawned onward. **Ticket pickup is

--- a/.agents/policy/workflow.md
+++ b/.agents/policy/workflow.md
@@ -24,22 +24,12 @@
 
 When the owner names a GitHub issue to execute ("work on #N", a list, or equivalent),
 the receiving top-level session is **orchestrator** (every client): spawn one work agent
-per ticket with a complete task packet (this file).
-
-- The orchestrator does not cut that ticket's worktree, write its patches, or substitute
-  for [`landing.md`](landing.md)'s four review legs.
-- Gate every handoff: packet completeness, executed evidence, no silently narrowed
-  scope.
-- The work agent claims, implements, spawns the four independent read-only legs,
-  runs the fix→re-review loop, asks the review bot once at the merge gate (or
-  records a never-asked miss for test-only mechanical PRs per
-  [`coderabbit.md`](coderabbit.md)), and lands.
-- Small one-step fixes and review-fix APPLY stay with the **work agent** (no second
-  spawn). Named GitHub issues still go through a work agent even when they are
-  docs/config/settings/skills.
-- Owner override, that item only: "implement here" / "no spawn".
-- Sequential by default. Parallel work agents only when tickets are independent
-  and do not share a live-VM box or the review-bot slot.
+per ticket with a complete task packet (this file). It does not implement.
+Owner override, that item only: "implement here" / "no spawn". Small one-step
+fixes and review-fix APPLY stay with the work agent (no second spawn). Named
+GitHub issues still go through a work agent even when they are
+docs/config/settings/skills. The work agent runs [`landing.md`](landing.md)'s
+four independent legs and lands.
 
 ## Artifacts and schemas
 

--- a/.agents/policy/workflow.md
+++ b/.agents/policy/workflow.md
@@ -3,14 +3,15 @@
 - **Scope:** vendor-neutral protocol, map issue to landed change plus terminal PR (wayfinder map
   [#1383](https://github.com/pfBlockerNG/pfBlockerNG/issues/1383), resolved by ticket
   [#1385](https://github.com/pfBlockerNG/pfBlockerNG/issues/1385)).
-- **Load-when:** coordinate, claim, execute, review, or continue GitHub ticket under
-  fresh-session workflow.
-- **Owner:** repo owner. **Last-verified:** 2026-09-01.
+- **Load-when:** coordinate, claim, execute, review, continue, or orchestrate GitHub
+  tickets under fresh-session workflow.
+- **Owner:** repo owner. **Last-verified:** 2026-09-03.
 
 ## Principles (fixed by the map)
 
 - GitHub Issues and PRs = durable execution state. Session transcripts disposable.
-- One bounded ticket per fresh top-level session (wayfinder research fan-out excepted).
+- One bounded ticket per work agent (wayfinder research fan-out excepted). The
+  orchestrator may be given a list; it dispatches one work agent per ticket.
 - No worker inherits parent transcript. Workers get task packet.
 - Explorer, implementer, reviewer run fresh bounded contexts. Reviewer independent and
   read-only.
@@ -18,6 +19,27 @@
 - Compaction near = checkpoint and terminate. Correctness-critical work never continues
   through compaction.
 - No committed plan or handoff ledger duplicates GitHub state.
+
+## Orchestrator session
+
+When the owner names a GitHub issue to execute ("work on #N", a list, or equivalent),
+the receiving top-level session is **orchestrator** (every client): spawn one work agent
+per ticket with a complete task packet (this file).
+
+- The orchestrator does not cut that ticket's worktree, write its patches, or substitute
+  for [`landing.md`](landing.md)'s four review legs.
+- Gate every handoff: packet completeness, executed evidence, no silently narrowed
+  scope.
+- The work agent claims, implements, spawns the four independent read-only legs,
+  runs the fix→re-review loop, asks the review bot once at the merge gate (or
+  records a never-asked miss for test-only mechanical PRs per
+  [`coderabbit.md`](coderabbit.md)), and lands.
+- Small one-step fixes and review-fix APPLY stay with the **work agent** (no second
+  spawn). Named GitHub issues still go through a work agent even when they are
+  docs/config/settings/skills.
+- Owner override, that item only: "implement here" / "no spawn".
+- Sequential by default. Parallel work agents only when tickets are independent
+  and do not share a live-VM box or the review-bot slot.
 
 ## Artifacts and schemas
 
@@ -187,7 +209,7 @@ parity check are [#1387](https://github.com/pfBlockerNG/pfBlockerNG/issues/1387)
 
 ## Acceptance
 
-Fresh Claude or Codex session can take one frontier ticket, load only bootstrap routing
-rows plus packet's Required reading, complete or checkpoint it, and different fresh session
-can continue from checkpoint alone. Map's pilots validate this contract before any
-superseded flow retires.
+A fresh top-level session named an issue is orchestrator: it spawns a work agent
+from bootstrap routing plus the packet. That work agent completes or checkpoints;
+a later work agent continues from the checkpoint alone. Map's pilots validate this
+contract before any superseded flow retires.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,7 +79,7 @@ Serena, and Graphify, and it carries the hard invariants for the per-worktree
 | Task touches | Read first |
 | ------------ | ---------- |
 | delegating any step; validating a handoff | `.agents/policy/delegation.md` |
-| a ticket / fresh-session execution | `.agents/policy/workflow.md` (roles: `agent-roles.md`) |
+| a ticket / fresh-session execution (orchestrator spawns) | `.agents/policy/workflow.md` (roles: `agent-roles.md`) |
 | waiting on anything external | `.agents/policy/waits.md` |
 | committing, branching, worktrees, attribution | `.agents/policy/git.md` |
 | session layouts, managed-remote, resume | `.agents/policy/sessions.md` |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,8 +103,9 @@ Serena, and Graphify, and it carries the hard invariants for the per-worktree
 
 Delegation shape: substantial coding work planned/gated by **top tier**, implemented
 by **small-tier** sub-agents, every step gated by independent small-tier verifier via
-brief → handoff → gate contract; top tier handle small one-step fixes and
-docs/config/settings/skills direct. Tiers top/mid/small map to models in
+brief → handoff → gate contract; named issues spawn a work agent; that agent
+handle small one-step fixes and docs/config/settings/skills direct. Tiers
+top/mid/small map to models in
 `.agents/model-tiers.conf` (disjoint from effort words — "high" always effort value).
 New implementation-plan ADRs stopped (wayfinder map #1383).
 

--- a/tests/test_cross_agent_tooling.py
+++ b/tests/test_cross_agent_tooling.py
@@ -273,6 +273,23 @@ def test_repository_intelligence_routing_is_canonical_for_every_client() -> None
     assert heading not in codex, "Codex must not own a second routing policy"
 
 
+def test_named_tickets_are_orchestrator_sessions() -> None:
+    bootstrap = (ROOT / "AGENTS.md").read_text(encoding="utf-8")
+    assert "orchestrator spawns" in bootstrap, "bootstrap routing must name orchestrator ticket pickup"
+    workflow = (ROOT / ".agents/policy/workflow.md").read_text(encoding="utf-8")
+    for contract in (
+        "## Orchestrator session",
+        "spawn one work agent",
+        "four independent",
+        "implement here",
+    ):
+        assert contract in workflow, f"orchestrator contract lost {contract}"
+    delegation = (ROOT / ".agents/policy/delegation.md").read_text(encoding="utf-8")
+    assert "orchestrator per workflow.md" in delegation, (
+        "delegation still tells the analyzing session to implement named tickets"
+    )
+
+
 def test_repository_intelligence_initializes_each_worktree_directly() -> None:
     routing = (ROOT / ".agents/context/repository-intelligence.md").read_text(encoding="utf-8")
     assert routing.strip(), "repository-intelligence routing must not be empty"


### PR DESCRIPTION
Grok and Claude top-level sessions that are told to work a GitHub issue spawn a work agent instead of implementing in-session. Owner override: `implement here` / `no spawn`.

The work agent still does small one-step fixes and review-fix APPLY without a second spawn. Named docs/config/settings/skills issues still spawn. The work agent runs landing.md's four independent legs and lands. The orchestrator gates handoffs.

## Test-first proof

`test_named_tickets_are_orchestrator_sessions` RED on untouched policy (`orchestrator spawns` missing from `AGENTS.md`), then GREEN on this head with the test file unchanged after ruff wrap.

| Frozen RED test | `git hash-object` | RED run tail |
| --- | --- | --- |
| `tests/test_cross_agent_tooling.py` | `1586c55bd69f24f2a6ebdad5cd5d983a93bac878` | `AssertionError: bootstrap routing must name orchestrator ticket pickup` |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage verifying orchestrator ticket pickup during canonical bootstrap.
  * Confirmed workflow policies preserve the orchestrator-session contract.
  * Verified analyzing sessions are no longer instructed to implement named tickets directly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->