### PR TITLE
pfblockerng.sh: use exported mfs state

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.sh
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.sh
@@ -47,7 +47,11 @@ pfb_ensure_tmpdir() {
 # issue #3167/#3144: config.xml grep + df only for aliastables().
 pfb_ensure_mfs() {
 	[ -n "${pfb_mfs_ready:-}" ] && return 0
-	USE_MFS_TMPVAR="${PFB_USE_MFS_TMPVAR:-$(/usr/bin/grep -c use_mfs_tmpvar /cf/conf/config.xml)}"
+	case "${PFB_USE_MFS_TMPVAR:-}" in
+	0|1) USE_MFS_TMPVAR="${PFB_USE_MFS_TMPVAR}" ;;
+	'') USE_MFS_TMPVAR="$(/usr/bin/grep -c use_mfs_tmpvar /cf/conf/config.xml)" ;;
+	*) USE_MFS_TMPVAR=0 ;;
+	esac
 	DISK_NAME="$(/bin/df /var/db/rrd | /usr/bin/tail -1 | /usr/bin/awk '{print $1;}')"
 	DISK_TYPE="$(/usr/bin/basename "${DISK_NAME}" | /usr/bin/cut -c1-2)"
 	pfb_mfs_ready=1

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.sh
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.sh
@@ -47,7 +47,7 @@ pfb_ensure_tmpdir() {
 # issue #3167/#3144: config.xml grep + df only for aliastables().
 pfb_ensure_mfs() {
 	[ -n "${pfb_mfs_ready:-}" ] && return 0
-	USE_MFS_TMPVAR="$(/usr/bin/grep -c use_mfs_tmpvar /cf/conf/config.xml)"
+	USE_MFS_TMPVAR="${PFB_USE_MFS_TMPVAR:-$(/usr/bin/grep -c use_mfs_tmpvar /cf/conf/config.xml)}"
 	DISK_NAME="$(/bin/df /var/db/rrd | /usr/bin/tail -1 | /usr/bin/awk '{print $1;}')"
 	DISK_TYPE="$(/usr/bin/basename "${DISK_NAME}" | /usr/bin/cut -c1-2)"
 	pfb_mfs_ready=1

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
@@ -984,9 +984,10 @@ function sync_package_pfblockerng($cron='', ?string &$deferred_by = NULL): bool 
 	$pfb['kstates'] 	= PfbConfig::read('ip/killstates');				// Firewall states removal
 
 	$pfb['ip_ph']		= pfb_filter($pfb['ipconfig']['ip_placeholder'], PFB_FILTER_IPV4, 'Placeholder IP Address', '127.1.7.7');	// Placeholder IP Address
-	// issue #3140: pfblockerng.sh init prefers these over two read_xml_tag.sh execs per
-	// invocation (~160 ms on a 500 KB config); unset (boot/hand-run) still reads config.xml.
+	// issue #3140/#3144: pfblockerng.sh init prefers PHP-exported values and keeps
+	// read_xml_tag.sh only as the boot/hand-run fallback.
 	putenv("PFB_IP_PLACEHOLDER={$pfb['ip_ph']}"); putenv('PFB_REENTRY_TIMEOUT=' . pfb_reentry_budget(NULL));
+	putenv('PFB_USE_MFS_TMPVAR=' . (config_path_enabled('system', 'use_mfs_tmpvar') ? '1' : '0'));
 
 	// DNSBL settings
 	$pfb['dnsbl_ip']	= pfb_dnsblip_action_value($pfb['dnsblconfig']['action'] ?? NULL);	// Enable/Disable IP blocking from DNSBL lists

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
@@ -984,8 +984,8 @@ function sync_package_pfblockerng($cron='', ?string &$deferred_by = NULL): bool 
 	$pfb['kstates'] 	= PfbConfig::read('ip/killstates');				// Firewall states removal
 
 	$pfb['ip_ph']		= pfb_filter($pfb['ipconfig']['ip_placeholder'], PFB_FILTER_IPV4, 'Placeholder IP Address', '127.1.7.7');	// Placeholder IP Address
-	// issue #3140/#3144: pfblockerng.sh init prefers PHP-exported values and keeps
-	// read_xml_tag.sh only as the boot/hand-run fallback.
+	// issue #3140/#3144: pfblockerng.sh init prefers the PHP-exported values; its shell
+	// config.xml fallbacks remain for boot and hand-run invocations.
 	putenv("PFB_IP_PLACEHOLDER={$pfb['ip_ph']}"); putenv('PFB_REENTRY_TIMEOUT=' . pfb_reentry_budget(NULL));
 	putenv('PFB_USE_MFS_TMPVAR=' . (config_path_enabled('system', 'use_mfs_tmpvar') ? '1' : '0'));
 

--- a/tests/php/ScriptEnvExportTest.php
+++ b/tests/php/ScriptEnvExportTest.php
@@ -22,6 +22,11 @@ final class ScriptEnvExportTest extends TestCase
 			$source,
 			'sync_package_pfblockerng must export the two shell init values from the resolved placeholder'
 		);
+		$this->assertStringContainsString(
+			'putenv(\'PFB_USE_MFS_TMPVAR=\' . (config_path_enabled(\'system\', \'use_mfs_tmpvar\') ? \'1\' : \'0\'));',
+			$source,
+			'sync_package_pfblockerng must export the RAM-disk presence flag for shell init'
+		);
 		$this->assertStringNotContainsString('pfb_script_env_export', $source, 'the export is inline; no wrapper');
 	}
 }

--- a/tests/php/ScriptEnvExportTest.php
+++ b/tests/php/ScriptEnvExportTest.php
@@ -7,20 +7,20 @@ use PHPUnit\Framework\TestCase;
 /**
  * issue #3140 — every pfblockerng.sh invocation paid two read_xml_tag.sh execs for
  * values PHP already holds when it drives the pass. The sync pass exports
- * PFB_IP_PLACEHOLDER and PFB_REENTRY_TIMEOUT once; the shell init prefers the
- * environment and falls back to read_xml_tag.sh when unset (boot-time and hand-run
+ * PFB_IP_PLACEHOLDER, PFB_REENTRY_TIMEOUT, and PFB_USE_MFS_TMPVAR once; the shell init prefers
+ * the environment and falls back to read_xml_tag.sh/config.xml when unset (boot-time and hand-run
  * invocations). Shell-side rows: tests/shell/pfblockerng_init_env_spec.sh.
  */
 final class ScriptEnvExportTest extends TestCase
 {
-	/** #3140: the sync pass exports both init values right after the placeholder is resolved. */
-	public function testSyncPassExportsTheTwoInitValues(): void
+	/** #3140/#3144: the sync pass exports all three init values right after the placeholder is resolved. */
+	public function testSyncPassExportsTheThreeInitValues(): void
 	{
 		$source = php_strip_whitespace(dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc');
 		$this->assertStringContainsString(
 			'putenv("PFB_IP_PLACEHOLDER={$pfb[\'ip_ph\']}"); putenv(\'PFB_REENTRY_TIMEOUT=\' . pfb_reentry_budget(NULL));',
 			$source,
-			'sync_package_pfblockerng must export the two shell init values from the resolved placeholder'
+			'sync_package_pfblockerng must export the three shell init values from the resolved placeholder'
 		);
 		$this->assertStringContainsString(
 			'putenv(\'PFB_USE_MFS_TMPVAR=\' . (config_path_enabled(\'system\', \'use_mfs_tmpvar\') ? \'1\' : \'0\'));',

--- a/tests/shell/pfblockerng_init_env_spec.sh
+++ b/tests/shell/pfblockerng_init_env_spec.sh
@@ -74,6 +74,34 @@ run_placeholder_lines() {
 	printf 'ph=%s|reads=%s\n' "${ip_placeholder}" "$(wc -l < "${reader_log}")"
 }
 
+# The shipped USE_MFS_TMPVAR assignment, with its config.xml reader replaced by a
+# recording fake so the exported environment can be tested without appliance paths.
+mfs_assignment() {
+    grep -E '^[[:space:]]*USE_MFS_TMPVAR=' "${PFB_PKGDIR}/pfblockerng.sh" |
+        sed "s|/usr/bin/grep -c use_mfs_tmpvar /cf/conf/config.xml|${fake_mfs_reader}|"
+}
+
+make_mfs_reader() {
+    fake_mfs_reader="${work}/grep"
+    {
+        printf '#!/bin/sh\n'
+        printf 'printf "%%s\\n" "$0 $*" >> "%s"\n' "${mfs_reader_log}"
+        printf 'printf "1\\n"\n'
+    } > "${fake_mfs_reader}"
+    chmod +x "${fake_mfs_reader}"
+}
+
+run_mfs_assignment() {
+    if [ "${1:-}" = '__UNSET__' ]; then
+        unset PFB_USE_MFS_TMPVAR
+    else
+        PFB_USE_MFS_TMPVAR="$1"
+    fi
+    true > "${mfs_reader_log}"
+    eval "$(mfs_assignment)"
+    printf 'mfs=%s|reads=%s\n' "${USE_MFS_TMPVAR}" "$(wc -l < "${mfs_reader_log}")"
+}
+
 Describe 'pfblockerng.sh init: re-entry timeout prefers the exported environment (issue #3140)'
 	setup() {
 		work="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/pfbinitenv.XXXXXX")"
@@ -168,5 +196,35 @@ Describe 'pfblockerng.sh init: ip_placeholder prefers the exported environment (
 		When call run_placeholder_lines '10.0.0.1;rm' ''
 		The output should equal 'ph=10.0.0.1;rm|reads=0'
 		The file "${canary}" should be exist
+	End
+End
+
+Describe 'pfblockerng.sh aliastables: mfs state prefers the exported environment (issue #3144)'
+	setup() {
+		work="$(mktemp -d "${SHELLSPEC_TMPBASE:-/tmp}/pfbinitmfs.XXXXXX")"
+		mfs_reader_log="${work}/reader.log"
+		make_mfs_reader
+	}
+	cleanup() {
+		unset PFB_USE_MFS_TMPVAR USE_MFS_TMPVAR
+		rm -rf "${work}"
+	}
+	BeforeAll 'pfb_source'
+	Before 'setup'
+	After 'cleanup'
+
+	It 'honours an enabled exported flag without invoking the config reader'
+		When call run_mfs_assignment 1
+		The output should equal 'mfs=1|reads=0'
+	End
+
+	It 'honours a disabled exported flag without invoking the config reader'
+		When call run_mfs_assignment 0
+		The output should equal 'mfs=0|reads=0'
+	End
+
+	It 'falls back to the config reader when the export is unset'
+		When call run_mfs_assignment '__UNSET__'
+		The output should equal 'mfs=1|reads=1'
 	End
 End

--- a/tests/shell/pfblockerng_init_env_spec.sh
+++ b/tests/shell/pfblockerng_init_env_spec.sh
@@ -77,29 +77,29 @@ run_placeholder_lines() {
 # The shipped USE_MFS_TMPVAR assignment, with its config.xml reader replaced by a
 # recording fake so the exported environment can be tested without appliance paths.
 mfs_assignment() {
-    grep -E '^[[:space:]]*USE_MFS_TMPVAR=' "${PFB_PKGDIR}/pfblockerng.sh" |
-        sed "s|/usr/bin/grep -c use_mfs_tmpvar /cf/conf/config.xml|${fake_mfs_reader}|"
+	sed -n '/^[[:space:]]*case "${PFB_USE_MFS_TMPVAR:-}" in/,/^[[:space:]]*esac$/p' "${PFB_PKGDIR}/pfblockerng.sh" |
+		sed "s|/usr/bin/grep -c use_mfs_tmpvar /cf/conf/config.xml|${fake_mfs_reader}|"
 }
 
 make_mfs_reader() {
-    fake_mfs_reader="${work}/grep"
-    {
-        printf '#!/bin/sh\n'
-        printf 'printf "%%s\\n" "$0 $*" >> "%s"\n' "${mfs_reader_log}"
-        printf 'printf "1\\n"\n'
-    } > "${fake_mfs_reader}"
-    chmod +x "${fake_mfs_reader}"
+	fake_mfs_reader="${work}/grep"
+	{
+		printf '#!/bin/sh\n'
+		printf 'printf "%%s\\n" "$0 $*" >> "%s"\n' "${mfs_reader_log}"
+		printf 'printf "1\\n"\n'
+	} > "${fake_mfs_reader}"
+	chmod +x "${fake_mfs_reader}"
 }
 
 run_mfs_assignment() {
-    if [ "${1:-}" = '__UNSET__' ]; then
-        unset PFB_USE_MFS_TMPVAR
-    else
-        PFB_USE_MFS_TMPVAR="$1"
-    fi
-    true > "${mfs_reader_log}"
-    eval "$(mfs_assignment)"
-    printf 'mfs=%s|reads=%s\n' "${USE_MFS_TMPVAR}" "$(wc -l < "${mfs_reader_log}")"
+	if [ "${1:-}" = '__UNSET__' ]; then
+		unset PFB_USE_MFS_TMPVAR
+	else
+		PFB_USE_MFS_TMPVAR="$1"
+	fi
+	true > "${mfs_reader_log}"
+	eval "$(mfs_assignment)"
+	printf 'mfs=%s|reads=%s\n' "${USE_MFS_TMPVAR}" "$(wc -l < "${mfs_reader_log}")"
 }
 
 Describe 'pfblockerng.sh init: re-entry timeout prefers the exported environment (issue #3140)'
@@ -226,5 +226,10 @@ Describe 'pfblockerng.sh aliastables: mfs state prefers the exported environment
 	It 'falls back to the config reader when the export is unset'
 		When call run_mfs_assignment '__UNSET__'
 		The output should equal 'mfs=1|reads=1'
+	End
+
+	It 'normalizes a nonnumeric exported flag to disabled without invoking the reader'
+		When call run_mfs_assignment 'not-a-number'
+		The output should equal 'mfs=0|reads=0'
 	End
 End


### PR DESCRIPTION
## Summary
- export the `use_mfs_tmpvar` presence state once from the PHP sync pass
- prefer that value in `pfb_ensure_mfs()` while retaining the config.xml fallback for boot and hand-run invocations
- add shell and PHP regression coverage

## Verification
- `shellspec --shell dash tests/shell/pfblockerng_init_env_spec.sh` — 14 examples, 0 failures
- `vendor/bin/phpunit tests/php/ScriptEnvExportTest.php` — 1 test, 3 assertions
- `COMPOSER_ALLOW_SUPERUSER=1 composer phpstan` — no errors
- `COMPOSER_ALLOW_SUPERUSER=1 composer phpcs -- --standard=phpcs.xml.dist src/` — pass
- `sh scripts/agent/check-graph-fresh.sh` — graph is fresh

The full local PHPUnit gate is environment-red on this host with 14 failures, 29 errors, 67 warnings, and 44 skips in pre-existing appliance-dependent tests; the focused changed-contract tests pass. CI is authoritative.

Fixes #3144