### PR TITLE
pkg: serialize uninstall disable sync

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -20167,6 +20167,13 @@ function pfblockerng_php_pre_deinstall_command() {
 	// DEFERS on contention (#3062 install shape; architecture-notes.md "The uninstall holds it too").
 	update_status("Serialising against any in-flight pfBlockerNG feed pass...");
 	update_status(pfb_install_feed_pass_hold(PFB_INSTALL_FEED_PASS_WAIT, 'uninstall') ? " done.\n" : " lock not taken; continuing anyway.\n");
+	// issue #3107: the feed-pass hold does not imply dispatcher ownership; a cron tick can
+	// still hold that lock while the uninstall reaches its disable sync. Keep the same
+	// bounded package-operation wait so the disable pass is not silently skipped.
+	update_status("Serialising against any in-flight scheduler tick...");
+	$pfb_dispatch_contended = FALSE;
+	update_status(pfb_schedule_dispatch_begin(PFB_INSTALL_FEED_PASS_WAIT, $pfb_dispatch_contended)
+		? " done.\n" : " lock not taken; continuing anyway.\n");
 
 	update_status("Removing pfBlockerNG...");
 	sync_package_pfblockerng();

--- a/tests/php/InstallFeedPassInterlockTest.php
+++ b/tests/php/InstallFeedPassInterlockTest.php
@@ -330,4 +330,26 @@ final class InstallFeedPassInterlockTest extends TestCase
 				"the interlock must be taken BEFORE the pre-deinstall reaches [ {$shared} ]");
 		}
 	}
+	/**
+	 * issue #3107: the uninstall's disable sync must wait on the dispatcher lock too.
+	 * The feed-pass hold does not imply dispatcher ownership when a tick is already
+	 * in its scheduler window, so the sync needs the same bounded package-operation wait.
+	 */
+	public function testPreDeinstallTakesDispatcherHoldBeforeTheDisableSync(): void
+	{
+		$path = dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng.inc';
+		$src = (string) @php_strip_whitespace($path);
+		$this->assertNotSame('', $src, "could not read {$path}");
+
+		$start = strpos($src, 'function pfblockerng_php_pre_deinstall_command');
+		$this->assertNotFalse($start, 'pre-deinstall controller must remain defined');
+		$dispatch = strpos($src, 'pfb_schedule_dispatch_begin(PFB_INSTALL_FEED_PASS_WAIT', $start);
+		$this->assertNotFalse($dispatch,
+			'the uninstall must wait for the dispatcher lock before running its disable pass (issue #3107)');
+		$sync = strpos($src, 'sync_package_pfblockerng(', $start);
+		$this->assertNotFalse($sync, 'the pre-deinstall disable sync must remain present');
+		$this->assertLessThan($sync, $dispatch,
+			'the bounded dispatcher hold must be taken before the uninstall disable sync');
+	}
+
 }


### PR DESCRIPTION
Fixes #3107

The uninstall path now acquires the scheduler dispatcher lock with the existing bounded package-operation wait before calling the disable sync, preventing a cron tick's dispatcher hold from silently skipping teardown. Adds an executable ordering regression test.

Verification:
- Frozen regression test red before production edit, hash `49327a48cc4b82e11ce3567f3e62517cc0afac67`; green after: `9 tests, 54 assertions`
- Focused lock suite: `36 tests, 171 assertions` (1 environment skip)
- PHP syntax, PHPStan, PHPCS, and graph freshness pass
- Full local gate reached the expected repository test environment failures (`/sbin/mount` unavailable, existing undefined `save` notices, and root Composer plugin policy); no changed-test failure was reported

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pfBlockerNG uninstall reliability by synchronizing with in-progress scheduler activity before disabling services.
  * Added a bounded wait so uninstall can proceed safely without becoming indefinitely blocked.
  * Added status handling when scheduler access cannot be acquired within the wait period.

* **Tests**
  * Added coverage to verify that uninstall performs the required synchronization in the correct order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->