### PR TITLE
ci: give run-gates.sh composer gates COMPOSER_ALLOW_SUPERUSER=1

### DIFF
--- a/scripts/agent/run-gates.sh
+++ b/scripts/agent/run-gates.sh
@@ -153,6 +153,13 @@ gate_command() {
 	'shellspec --shell $(command -v dash || command -v sh)')
 		printf '%s' 'shellspec --shell $(command -v dash || command -v sh) -o junit --reportdir "$PFB_SKIP_REPORT_DIR/shellspec" || exit $?; python3 scripts/check_skip_allowlist.py --suite shellspec --allowlist tests/skip-allowlist.txt tests/fixtures/skip-allowlist-canary.xml && :; canary_status=$?; [ "$canary_status" -eq 1 ] || { echo "red canary failed: an unlisted skip did not fail the gate (checker exit $canary_status, expected 1)"; exit 1; }; python3 scripts/check_skip_allowlist.py --suite shellspec --allowlist tests/skip-allowlist.txt "$PFB_SKIP_REPORT_DIR/shellspec/results_junit.xml"'
 		;;
+	# issue #3143: a root runner aborts composer before loading plugins unless
+	# COMPOSER_ALLOW_SUPERUSER=1 is present. Scoped to the composer invocation: it only
+	# lets composer load plugins, so it can never read as a skip, a pass, or a
+	# missing tool -- a missing composer stays a missing tool.
+	'composer '*)
+		printf '%s' "COMPOSER_ALLOW_SUPERUSER=1 $1"
+		;;
 	*) printf '%s' "$1" ;;
 	esac
 }

--- a/tests/shell/agent_run_gates_spec.sh
+++ b/tests/shell/agent_run_gates_spec.sh
@@ -124,6 +124,17 @@ Describe 'run-gates.sh gates_for()'
     The output should include '--suite shellspec'
     The output should include 'skip-allowlist-canary.xml'
   End
+  # issue #3143: a root runner aborts composer before loading plugins unless
+  # COMPOSER_ALLOW_SUPERUSER=1, so both composer gates must carry it.
+  It 'wraps the composer phpstan gate with COMPOSER_ALLOW_SUPERUSER=1'
+    When call gate_command 'composer phpstan'
+    The output should equal 'COMPOSER_ALLOW_SUPERUSER=1 composer phpstan'
+  End
+
+  It 'wraps the composer phpcs gate with COMPOSER_ALLOW_SUPERUSER=1'
+    When call gate_command 'composer phpcs -- --standard=phpcs.xml.dist src/'
+    The output should equal 'COMPOSER_ALLOW_SUPERUSER=1 composer phpcs -- --standard=phpcs.xml.dist src/'
+  End
 
   It 'syntax-checks an out-of-scope shell file but does not shellcheck it'
     # The hook + CI shellcheck only src/, scripts/ and .claude/hooks/; tests/ specs and
@@ -373,6 +384,20 @@ Describe 'run-gates.sh Composer vendor guard'
     Assert [ -e "$php_marker" ]
     Assert [ -e "$composer_marker" ]
     Assert [ -e "$phpunit_marker" ]
+  End
+  # issue #3143: the var must reach the composer process in a real gate run, not just
+  # appear in the gate text -- a root runner aborts before loading plugins without it.
+  It 'runs both composer gates with COMPOSER_ALLOW_SUPERUSER=1 in their environment'
+    printf '#!/bin/sh\ntouch "%s"\nexit 0\n' "$checker_marker" > "$stubdir/uv"
+    chmod +x "$stubdir/uv"
+    composer_env_file="$stubdir/composer-env"
+    printf '#!/bin/sh\nprintf "%%s" "$COMPOSER_ALLOW_SUPERUSER" > "%s"\ntouch "%s"\nexit 0\n' "$composer_env_file" "$composer_marker" > "$stubdir/composer"
+    chmod +x "$stubdir/composer"
+    When run sh "$script" --worktree "$repo" --diff "$base_sha"
+    The status should equal 0
+    The output should include 'GATE PASS: composer phpstan'
+    The output should include 'GATE PASS: composer phpcs -- --standard=phpcs.xml.dist src/'
+    The contents of file "$composer_env_file" should equal '1'
   End
 End
 


### PR DESCRIPTION
Root runners (agent hosts) abort `composer` before loading plugins, so `composer phpstan` / `composer phpcs` in run-gates.sh failed for a reason unrelated to the diff under test.

`gate_command()` now wraps the composer gates in `COMPOSER_ALLOW_SUPERUSER=1` (scoped to the composer invocation only: it lets composer load plugins and cannot read as a skip, a pass, or a missing tool — a missing composer stays a missing tool).

Red→green in `tests/shell/agent_run_gates_spec.sh`: two `gate_command` wrap pins plus an end-to-end row whose composer stub records the process environment (RED: 3 failures on the clean base; GREEN: 55/0). Sibling `agent_run_gates_git_spec.sh` 21/0.

| Frozen RED test | git hash-object | RED run tail |
| --- | --- | --- |
| `tests/shell/agent_run_gates_spec.sh` | a0d32d4125a3ff79b04fd6446d45fd280b64112b | 55 examples, 3 failures |

Fixes #3143
