### PR TITLE
fix: preserve aggregate tables during rule changes

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -8173,6 +8173,27 @@ function pfb_select_reload_aliases(
 }
 
 /**
+ * Return the aliases that rule-change cleanup must keep alive.
+ *
+ * Aggregate aliases are registered urltables without firewall rules. Only canonical aggregate
+ * names present in the current registration are added; unrelated orphan tables remain removable.
+ */
+function pfb_rule_change_keep_aliases(array $active_aliases, array $registered_aliases): array {
+	$aggregate_aliases = array();
+	foreach (array('Deny', 'Permit', 'Match', 'Native') as $type) {
+		foreach (array('v4', 'v6') as $family) {
+			$aggregate_aliases[] = "pfB_{$type}_Aggregated_{$family}";
+		}
+	}
+
+	return array_values(array_unique(array_merge(
+		$active_aliases,
+		array_intersect($registered_aliases, $aggregate_aliases)
+	)));
+}
+
+
+/**
  * Concatenate the content of the member .txt files for one alias.
  *
  * The current aliasdir file is a raw concatenation of each enabled member feed's .txt

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -8178,11 +8178,12 @@ function pfb_select_reload_aliases(
 }
 
 /**
- * Return the rule-referenced aliases plus the currently registered aggregate aliases that
- * rule-change cleanup must keep alive. Aggregate aliases are registered urltables without
- * firewall rules; unrelated orphan tables remain removable.
+ * Return the currently registered aggregate aliases that rule-change cleanup must keep alive.
+ *
+ * Aggregate aliases are registered urltables without firewall rules; unrelated orphan tables
+ * remain removable and rule-referenced aliases stay in the caller's active set.
  */
-function pfb_rule_change_keep_aliases(array $active_aliases, array $registered_aliases): array {
+function pfb_rule_change_keep_aliases(array $registered_aliases): array {
 	$aggregate_aliases = array();
 	foreach (PFB_AGGREGATE_TYPES as $type) {
 		foreach (array('v4', 'v6') as $family) {
@@ -8190,10 +8191,7 @@ function pfb_rule_change_keep_aliases(array $active_aliases, array $registered_a
 		}
 	}
 
-	return array_values(array_unique(array_merge(
-		$active_aliases,
-		array_intersect($registered_aliases, $aggregate_aliases)
-	)));
+	return array_values(array_intersect($registered_aliases, $aggregate_aliases));
 }
 
 

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -355,7 +355,7 @@ foreach (array('existing', 'actual') as $pftype) {
 	$pfb[$pftype]['dnsbl']	= array();
 }
 
-// Canonical action types supported by aggregate aliases and their firewall rules.
+// Canonical action types supported by aggregate aliases; Native intentionally has no firewall rule.
 const PFB_AGGREGATE_TYPES = array('Deny', 'Permit', 'Match', 'Native');
 
 

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -355,6 +355,10 @@ foreach (array('existing', 'actual') as $pftype) {
 	$pfb[$pftype]['dnsbl']	= array();
 }
 
+// Canonical action types supported by aggregate aliases and their firewall rules.
+const PFB_AGGREGATE_TYPES = array('Deny', 'Permit', 'Match', 'Native');
+
+
 // issue #2658: ceilings on how much one feed may pull down and how much it may
 // expand to. Real feeds are tens to low hundreds of MB, so both sit far above
 // anything legitimate -- they exist to stop a pathological body or an expansion
@@ -3304,10 +3308,10 @@ function pfb_global() {
 	$pfb['keep']		= PfbConfig::read('gen/pfb_keep');		// Keep blocklists on pfBlockerNG Disable (default ON via registry; #281)
 
 	// ADR-11: opt-in per-type aggregate ("Uber") aliases. CSV scalar of the action types
-	// to aggregate (subset of Deny/Permit/Match/Native), default NONE -> [] -> no-op pass.
+	// to aggregate (subset of PFB_AGGREGATE_TYPES), default NONE -> [] -> no-op pass.
 	// CSV (a single string, like blacklist_selected) so it round-trips with no '<0>' list XML.
 	$pfb['agg_types']	= array_values(array_intersect(
-					array('Deny', 'Permit', 'Match', 'Native'),
+					PFB_AGGREGATE_TYPES,
 					array_filter(explode(',', PfbConfig::read('gen/pfb_agg_types')))));
 
 	$pfb['supp']		= PfbConfig::read('ip/suppression');					// Enable Suppression (default on, issue #1907)
@@ -8016,7 +8020,8 @@ function pfb_aggregate_read(string $path) {
 function pfb_build_aggregate_aliases(array &$new_aliases, array &$new_aliases_list, array &$pfb_alias_lists, array &$pfb_alias_prev_sets) {
 	global $pfb;
 
-	$all_types	= array('Deny', 'Permit', 'Match', 'Native');
+	$all_types	= PFB_AGGREGATE_TYPES;
+
 	$selected	= is_array($pfb['agg_types'] ?? null) ? $pfb['agg_types'] : array();
 
 	// Disabled pfBlockerNG => nothing is selected effectively (tear all down below).
@@ -8173,14 +8178,13 @@ function pfb_select_reload_aliases(
 }
 
 /**
- * Return the aliases that rule-change cleanup must keep alive.
- *
- * Aggregate aliases are registered urltables without firewall rules. Only canonical aggregate
- * names present in the current registration are added; unrelated orphan tables remain removable.
+ * Return the rule-referenced aliases plus the currently registered aggregate aliases that
+ * rule-change cleanup must keep alive. Aggregate aliases are registered urltables without
+ * firewall rules; unrelated orphan tables remain removable.
  */
 function pfb_rule_change_keep_aliases(array $active_aliases, array $registered_aliases): array {
 	$aggregate_aliases = array();
-	foreach (array('Deny', 'Permit', 'Match', 'Native') as $type) {
+	foreach (PFB_AGGREGATE_TYPES as $type) {
 		foreach (array('v4', 'v6') as $family) {
 			$aggregate_aliases[] = "pfB_{$type}_Aggregated_{$family}";
 		}

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
@@ -4799,7 +4799,7 @@ function sync_package_pfblockerng($cron='', ?string &$deferred_by = NULL): bool 
 			// to pre-sync the kernel before filter_configure runs. The delta apply
 			// (pfb_apply_alias_delta) is used only on the no-rule-change path below.
 			$pfb_active_aliases = isset($pfb_active_aliases) ? array_unique($pfb_active_aliases) : [];
-			$pfb_table_keep_aliases = pfb_rule_change_keep_aliases($pfb_active_aliases, $new_aliases_list);
+			$pfb_table_keep_aliases = pfb_rule_change_keep_aliases($new_aliases_list);
 			$final_alias        = empty($pfb_alias_lists)
 				? []
 				: array_values(array_intersect(array_unique($pfb_alias_lists), $pfb_active_aliases));

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
@@ -4799,6 +4799,7 @@ function sync_package_pfblockerng($cron='', ?string &$deferred_by = NULL): bool 
 			// to pre-sync the kernel before filter_configure runs. The delta apply
 			// (pfb_apply_alias_delta) is used only on the no-rule-change path below.
 			$pfb_active_aliases = isset($pfb_active_aliases) ? array_unique($pfb_active_aliases) : [];
+			$pfb_table_keep_aliases = pfb_rule_change_keep_aliases($pfb_active_aliases, $new_aliases_list);
 			$final_alias        = empty($pfb_alias_lists)
 				? []
 				: array_values(array_intersect(array_unique($pfb_alias_lists), $pfb_active_aliases));
@@ -4810,6 +4811,10 @@ function sync_package_pfblockerng($cron='', ?string &$deferred_by = NULL): bool 
 						// before filter_configure() rebuilds the ruleset from the aliasdir file.
 						pfb_pfctl_table_op($pfb_table, 'replace', "-f {$pfb_table_path_esc}");
 					}
+				} elseif (in_array($pfb_table, $pfb_table_keep_aliases)) {
+					// Aggregates are urltable aliases, so ADR-11 deliberately gives them no rule.
+					// Keep selected registrations for filter_configure() to rebuild below.
+					continue;
 				} else {
 					// Remove inactive pfB aliastables
 					pfb_pfctl_table_op($pfb_table, 'kill');

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
@@ -4811,7 +4811,7 @@ function sync_package_pfblockerng($cron='', ?string &$deferred_by = NULL): bool 
 						// before filter_configure() rebuilds the ruleset from the aliasdir file.
 						pfb_pfctl_table_op($pfb_table, 'replace', "-f {$pfb_table_path_esc}");
 					}
-				} elseif (in_array($pfb_table, $pfb_table_keep_aliases)) {
+				} elseif (in_array($pfb_table, $pfb_table_keep_aliases, TRUE)) {
 					// Aggregates are urltable aliases, so ADR-11 deliberately gives them no rule.
 					// Keep selected registrations for filter_configure() to rebuild below.
 					continue;

--- a/tests/php/AliasReloadScopeTest.php
+++ b/tests/php/AliasReloadScopeTest.php
@@ -152,7 +152,6 @@ final class AliasReloadScopeTest extends TestCase
 	 */
 	public function testRuleChangeKeepsSelectedAggregatesButKillsOrphans(): void
 	{
-		$active = ['pfB_FeedA_v4'];
 		$registered = [
 			'pfB_Deny_Aggregated_v4',
 			'pfB_Deny_Aggregated_v6',
@@ -160,10 +159,10 @@ final class AliasReloadScopeTest extends TestCase
 			'pfB_Custom_Aggregated_v4',
 		];
 
-		$result = pfb_rule_change_keep_aliases($active, $registered);
+		$result = pfb_rule_change_keep_aliases($registered);
 
 		$this->assertSame(
-			['pfB_FeedA_v4', 'pfB_Deny_Aggregated_v4', 'pfB_Deny_Aggregated_v6'],
+			['pfB_Deny_Aggregated_v4', 'pfB_Deny_Aggregated_v6'],
 			$result,
 			'selected aggregate tables survive cleanup, while non-aggregate tables still require a rule'
 		);

--- a/tests/php/AliasReloadScopeTest.php
+++ b/tests/php/AliasReloadScopeTest.php
@@ -145,6 +145,32 @@ final class AliasReloadScopeTest extends TestCase
 	}
 
 	/**
+	 * Rule-change cleanup keeps registered aggregate tables without reviving orphan tables.
+	 *
+	 * Aggregates are urltable aliases with no firewall rule by design, so they must be kept
+	 * separately from the rule-referenced active set while filter_configure() rebuilds tables.
+	 */
+	public function testRuleChangeKeepsSelectedAggregatesButKillsOrphans(): void
+	{
+		$active = ['pfB_FeedA_v4'];
+		$registered = [
+			'pfB_Deny_Aggregated_v4',
+			'pfB_Deny_Aggregated_v6',
+			'pfB_Orphan_v4',
+			'pfB_Custom_Aggregated_v4',
+		];
+
+		$result = pfb_rule_change_keep_aliases($active, $registered);
+
+		$this->assertSame(
+			['pfB_FeedA_v4', 'pfB_Deny_Aggregated_v4', 'pfB_Deny_Aggregated_v6'],
+			$result,
+			'selected aggregate tables survive cleanup, while non-aggregate tables still require a rule'
+		);
+	}
+
+
+	/**
 	 * Oracle: active_aliases null → no intersect (file-write and no-rule-change paths).
 	 *
 	 * The two call sites that do NOT intersect pass null (default). The result is the

--- a/tests/php/fixtures/function_inventory.json
+++ b/tests/php/fixtures/function_inventory.json
@@ -10320,6 +10320,26 @@
             }
         ]
     },
+    "pfb_rule_change_keep_aliases": {
+        "returnsRef": false,
+        "returnType": "array",
+        "params": [
+            {
+                "name": "active_aliases",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            },
+            {
+                "name": "registered_aliases",
+                "byRef": false,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            }
+        ]
+    },
     "pfb_run_hooks": {
         "returnsRef": false,
         "returnType": null,

--- a/tests/php/fixtures/function_inventory.json
+++ b/tests/php/fixtures/function_inventory.json
@@ -10325,13 +10325,6 @@
         "returnType": "array",
         "params": [
             {
-                "name": "active_aliases",
-                "byRef": false,
-                "variadic": false,
-                "type": "array",
-                "default": null
-            },
-            {
                 "name": "registered_aliases",
                 "byRef": false,
                 "variadic": false,


### PR DESCRIPTION
## Summary

- preserve currently registered aggregate (`pfB_<Type>_Aggregated_<fam>`) tables during rule-change cleanup
- continue killing genuinely orphaned pfB tables
- add a focused regression covering aggregate retention and orphan exclusion

## Verification

- Red: `vendor/bin/phpunit tests/php/AliasReloadScopeTest.php --filter testRuleChangeKeepsSelectedAggregatesButKillsOrphans` failed on base with the expected undefined-helper error; test hash at red time: `cb3016338d05fd235d7d8a73a69d88a96c8437d2`
- Green: focused test passed (`1 test, 1 assertion`)
- Focused aggregate tests passed (`25 tests, 125 assertions`)
- PHPStan passed
- PHPCS passed
- `php -l` passed for both production files and the changed test

Fixes #3159

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Aggregate firewall aliases are now preserved during rule changes, allowing filter configurations to rebuild them correctly.
  * Orphaned and unrelated aliases continue to be removed during cleanup.

* **Tests**
  * Added coverage verifying that selected IPv4 and IPv6 aggregate tables remain available while custom and orphaned tables are removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->