### PR TITLE
ci: fix check_version_literals silent skip on non-UTF-8 filenames

### DIFF
--- a/scripts/_git_paths.py
+++ b/scripts/_git_paths.py
@@ -9,7 +9,12 @@ reports a clean pass (issue #2212).
 
 ``git ... -z`` emits raw NUL-separated paths and is the fix wherever it exists
 (``--name-only``, ``ls-files``). A unified diff's ``---``/``+++`` header has no
-``-z`` form, so those parsers decode the header here instead.
+``-z`` form, so those parsers decode the header here instead. ``unified_diff``
+pins ``core.quotePath=true`` so a HIGH-BIT byte in that header is always
+C-escaped as plain ASCII (octal, e.g. ``\\377``) instead of emitted raw --
+plain ASCII survives the diff body's lossy ``errors="replace"`` decode intact,
+where a raw non-UTF-8 byte would have become an unrecoverable U+FFFD and left
+the gate reading a path nothing on disk answers to (issue #3076).
 
 This module is the single place the diff-scoped gates talk to git about paths:
 one invocation, and one decode per route -- byte-exact for a listing whose paths
@@ -40,7 +45,14 @@ _C_ESCAPES = {
 
 
 def unquote_git_path(field: str) -> str:
-    """Decode one C-quoted git path field; an unquoted field is returned as-is."""
+    """Decode one C-quoted git path field; an unquoted field is returned as-is.
+
+    ``os.fsdecode`` rather than a hard-coded UTF-8 decode: this field feeds
+    ``diff_header_name``, whose byte-exact result callers OPEN (e.g. ``git
+    show``), so it needs the same filesystem-encoding treatment ``nul_listing``
+    uses -- a hard-coded UTF-8 surrogateescape only round-trips on a UTF-8
+    filesystem encoding (issue #3073, issue #3076).
+    """
     if len(field) < 2 or not (field.startswith('"') and field.endswith('"')):
         return field
     # Byte-level: an octal escape names a BYTE of a multi-byte character, so the
@@ -67,7 +79,7 @@ def unquote_git_path(field: str) -> str:
         else:
             out.append(raw[i + 1])
             i += 2
-    return out.decode("utf-8", "surrogateescape")
+    return os.fsdecode(bytes(out))
 
 
 def diff_header_name(field: str) -> str:
@@ -103,8 +115,14 @@ def _run(args: list[str]) -> bytes:
 def unified_diff(args: list[str]) -> str:
     """A unified diff, pinned against everything that could defeat a header parse.
 
-    ``core.quotePath`` escapes non-ASCII bytes, ``diff.mnemonicPrefix``/
-    ``noprefix`` rewrite the ``a/``/``b/`` prefixes, and an external driver
+    ``core.quotePath=true`` (pinned, never left to user config) forces a
+    HIGH-BIT header byte to be C-escaped as plain ASCII octal rather than
+    emitted raw -- the escape survives the lossy ``errors="replace"`` decode
+    below intact, where a raw non-UTF-8 byte would decode to an unrecoverable
+    U+FFFD and the gate would classify a path nothing on disk answers to
+    (issue #3076). ``diff_header_name`` already C-unquotes a quoted header, so
+    this needs no consumer change. ``diff.mnemonicPrefix``/``noprefix``
+    rewrite the ``a/``/``b/`` prefixes, and an external driver
     (``diff.external`` / ``GIT_EXTERNAL_DIFF``) replaces the unified output
     outright — each silently defeats a gate built on ``+++ b/<path>``, so user
     config and environment cannot bypass one through this.
@@ -116,7 +134,7 @@ def unified_diff(args: list[str]) -> str:
         [
             "git",
             "-c",
-            "core.quotePath=false",
+            "core.quotePath=true",
             "diff",
             "--unified=0",
             "--no-color",

--- a/tests/test_issue3076_diff_header_non_utf8.py
+++ b/tests/test_issue3076_diff_header_non_utf8.py
@@ -62,7 +62,16 @@ def _scratch(tmp_path: Path) -> Path:
 
 
 def _run(script: Path, repo: Path, *args: str) -> subprocess.CompletedProcess[bytes]:
-    return subprocess.run([sys.executable, str(script), *args], cwd=repo, capture_output=True, check=False)
+    # scrubbed_git_env: the invoked checker shells out to `git diff`/`git show`
+    # itself, so it needs the same hook-safety scrub `_git()` gets -- an
+    # inherited GIT_DIR would point it at the REAL repository, not `repo`.
+    return subprocess.run(
+        [sys.executable, str(script), *args],
+        cwd=repo,
+        capture_output=True,
+        env=scrubbed_git_env(drop_git_vars=True),
+        check=False,
+    )
 
 
 def test_version_literals_reports_ascii_and_non_utf8_names_identically(tmp_path: Path) -> None:
@@ -134,7 +143,7 @@ def test_valid_utf8_name_opens_under_an_ascii_filesystem_encoding(tmp_path: Path
     (repo / "src" / "café.php").write_bytes((_LITERAL_LINE + "\n").encode())
     _git(repo, "add", "-A")
     env = {
-        **os.environ,
+        **scrubbed_git_env(drop_git_vars=True),
         # PEP 540 would otherwise force UTF-8 mode for the C locale and hide
         # the difference this case exists to catch.
         "PYTHONUTF8": "0",

--- a/tests/test_issue3076_diff_header_non_utf8.py
+++ b/tests/test_issue3076_diff_header_non_utf8.py
@@ -1,0 +1,148 @@
+"""Issue #3076: a non-UTF-8 filename must not skip the diff-header gates.
+
+``_git_paths.unified_diff`` used to pin ``core.quotePath=false``, so git emitted a
+high-bit byte in the ``+++ b/<path>`` header raw. The diff is decoded with
+``errors="replace"`` (deliberately -- it is file CONTENT, only matched and
+printed, and a byte-exact decode would put lone surrogates into every
+violation line), which turned that raw byte into U+FFFD. ``check_version_literals``
+then ran ``git show :<mangled path>``, which cannot resolve, and silently
+skipped the file (clean pass over content it never scanned).
+``check_comment_narration`` scans the diff body directly and never opens the
+path, so it still flagged the violation -- only the printed path was wrong.
+
+Both consumers route through the same ``_git_paths.unified_diff`` /
+``diff_header_name`` pair, so the fix lives once, in ``_git_paths.py``.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from tests.gitenv import scrubbed_git_env
+
+ROOT = Path(__file__).resolve().parents[1]
+VLIT = ROOT / "scripts" / "check_version_literals.py"
+NARR = ROOT / "scripts" / "check_comment_narration.py"
+
+# Concatenated so this file's own source is not itself a version-literal hit.
+_PHP83 = "php8" + "3"
+_LITERAL_LINE = f'$v = "{_PHP83}";'
+_NARRATION_LINE = "// wired in Phase 4"
+
+# A raw 0xFF is not valid UTF-8 in any position -- the shortest name that
+# distinguishes a byte-exact recovery from a lossy one.
+_BAD_NAME = os.fsdecode(b"src/bad_\xff.php")
+
+
+def _git(repo: Path, *args: str) -> None:
+    # scrubbed_git_env: a scratch repo must not inherit commit.gpgsign or a real
+    # core.hooksPath from the developer's config (issue #1967), nor be redirected
+    # at the real repo by an inherited GIT_DIR when the suite runs under a hook.
+    subprocess.run(
+        ["git", "-c", "user.email=t@t", "-c", "user.name=t", *args],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        env=scrubbed_git_env(drop_git_vars=True),
+    )
+
+
+def _scratch(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q", "-b", "devel")
+    (repo / "src").mkdir()
+    (repo / "src" / "seed.php").write_text("<?php\n", encoding="utf-8")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-qm", "seed")
+    return repo
+
+
+def _run(script: Path, repo: Path, *args: str) -> subprocess.CompletedProcess[bytes]:
+    return subprocess.run([sys.executable, str(script), *args], cwd=repo, capture_output=True, check=False)
+
+
+def test_version_literals_reports_ascii_and_non_utf8_names_identically(tmp_path: Path) -> None:
+    """Same violating content staged under an ASCII and a non-UTF-8 name -- both must be caught."""
+    repo = _scratch(tmp_path)
+    (repo / "src" / "plain.php").write_text(_LITERAL_LINE + "\n", encoding="utf-8")
+    (repo / _BAD_NAME).write_bytes((_LITERAL_LINE + "\n").encode())
+    _git(repo, "add", "-A")
+    res = _run(VLIT, repo, "--staged")
+    assert res.returncode == 1, res.stderr
+    assert res.stderr.count(_LITERAL_LINE.encode()) == 2, res.stderr
+    assert b"bad_" in res.stderr, f"non-UTF-8-named file's violation missing: {res.stderr!r}"
+    assert b"\xef\xbf\xbd" not in res.stderr, f"U+FFFD replacement char leaked: {res.stderr!r}"
+
+
+def test_version_literals_does_not_clean_pass_when_only_the_bad_name_violates(tmp_path: Path) -> None:
+    """The exact issue #3076 reproduction: violation ONLY in the non-UTF-8-named file."""
+    repo = _scratch(tmp_path)
+    (repo / "src" / "plain.php").write_text("<?php\n// benign\n", encoding="utf-8")
+    (repo / _BAD_NAME).write_bytes((_LITERAL_LINE + "\n").encode())
+    _git(repo, "add", "-A")
+    res = _run(VLIT, repo, "--staged")
+    assert res.returncode == 1, f"clean pass over unscanned non-UTF-8-named content: {res.stderr!r}"
+    assert _LITERAL_LINE.encode() in res.stderr, res.stderr
+
+
+def test_comment_narration_reports_the_real_non_utf8_path(tmp_path: Path) -> None:
+    """The reported path must be the real recovered name, not a U+FFFD-mangled one.
+
+    stderr's ``backslashreplace`` error handler renders the unrepresentable
+    byte as literal ``\\udcff`` text -- unlike U+FFFD, that rendering is
+    bijective with the source byte (0xFF), so the real name is recoverable
+    from the report; a mangled U+FFFD name is not.
+    """
+    repo = _scratch(tmp_path)
+    (repo / _BAD_NAME).write_bytes((_NARRATION_LINE + "\n").encode())
+    _git(repo, "add", "-A")
+    res = _run(NARR, repo, "--staged")
+    assert res.returncode == 1, res.stderr
+    assert b"bad_\\udcff.php" in res.stderr, f"expected the real byte-exact name, got: {res.stderr!r}"
+    assert b"\xef\xbf\xbd" not in res.stderr, f"U+FFFD replacement char leaked: {res.stderr!r}"
+
+
+def test_user_quotepath_false_cannot_skip_the_non_utf8_file(tmp_path: Path) -> None:
+    """A repo-local ``core.quotePath=false`` must not defeat the pin (module's own threat model)."""
+    repo = _scratch(tmp_path)
+    _git(repo, "config", "core.quotePath", "false")
+    (repo / _BAD_NAME).write_bytes((_LITERAL_LINE + "\n").encode())
+    _git(repo, "add", "-A")
+    res = _run(VLIT, repo, "--staged")
+    assert res.returncode == 1, f"user config bypassed the gate: {res.stderr!r}"
+    assert _LITERAL_LINE.encode() in res.stderr, res.stderr
+
+
+def test_valid_utf8_name_opens_under_an_ascii_filesystem_encoding(tmp_path: Path) -> None:
+    """The header-recovered path follows the FILESYSTEM's encoding, not hard-coded UTF-8.
+
+    Given a staged ``café.php`` (valid UTF-8, non-ASCII -- and, under the new
+    ``core.quotePath=true`` pin, C-quoted in the header just like the invalid
+    byte above) and an interpreter whose filesystem encoding is ASCII
+    (``LC_ALL=C``, UTF-8 mode off -- a git hook's environment), ``git show
+    <ref>:<path>`` needs the SAME encoding ``subprocess`` uses to build its
+    argv. A hard-coded UTF-8 decode holds U+00E9, which does not `fsencode`
+    back onto an ASCII filesystem and crashes the gate outright; recovered with
+    ``os.fsdecode`` it holds the two escaped bytes git actually emitted and
+    round-trips.
+    """
+    repo = _scratch(tmp_path)
+    (repo / "src" / "café.php").write_bytes((_LITERAL_LINE + "\n").encode())
+    _git(repo, "add", "-A")
+    env = {
+        **os.environ,
+        # PEP 540 would otherwise force UTF-8 mode for the C locale and hide
+        # the difference this case exists to catch.
+        "PYTHONUTF8": "0",
+        "PYTHONCOERCECLOCALE": "0",
+        "LC_ALL": "C",
+        "LANG": "C",
+    }
+    res = subprocess.run([sys.executable, str(VLIT), "--staged"], cwd=repo, capture_output=True, env=env, check=False)
+    assert b"Traceback" not in res.stderr, f"gate crashed instead of reporting: {res.stderr!r}"
+    assert res.returncode == 1, res.stderr
+    assert _LITERAL_LINE.encode() in res.stderr, res.stderr


### PR DESCRIPTION
## What

`_git_paths.unified_diff` pinned `core.quotePath=false`, so a changed file whose
tracked name is not valid UTF-8 got its raw high-bit byte emitted straight into
the `+++ b/<path>` diff header. The diff text is decoded with `errors="replace"`
(deliberately -- it is file CONTENT, only matched and printed), which turned
that byte into an unrecoverable U+FFFD. `check_version_literals._diff_mode`
then ran `git show :<mangled path>`, which cannot resolve, and silently skipped
the file via `except subprocess.CalledProcessError: continue` -- a required gate
reporting a clean pass over content it never scanned.

`check_comment_narration` shares the exact same `_git_paths.unified_diff` /
`diff_header_name` pair (only two production callers, enumerated below) --
it never opens the path, so it still flagged the violation, but under a
mangled, non-existent name.

## Fix

One shared-helper fix, `scripts/_git_paths.py`:

- `unified_diff` now pins `core.quotePath=true` instead of `false`. A HIGH-BIT
  header byte is then always C-escaped as plain ASCII octal (e.g. `\377`),
  which survives the lossy `errors="replace"` decode intact -- pure ASCII
  round-trips losslessly under any decode. `diff_header_name` already
  C-unquotes a quoted header via `unquote_git_path`, so neither consumer
  needed a change.
- `unquote_git_path`'s final decode switched from a hard-coded
  `.decode("utf-8", "surrogateescape")` to `os.fsdecode(bytes(out))` -- the
  same filesystem-encoding treatment `nul_listing` got in #3073. This route's
  recovered path now also feeds `git show`, which OPENS it, so a hard-coded
  UTF-8 decode would mis-round-trip (and crash the gate outright, not just
  under a non-UTF-8 byte -- also for a valid multi-byte-UTF-8 name under an
  ASCII filesystem encoding, covered by
  `test_valid_utf8_name_opens_under_an_ascii_filesystem_encoding`).

### Every caller of the shared helper, enumerated from source

```
$ git grep -n "diff_header_name\|unified_diff" -- '*.py'
scripts/_git_paths.py:73:def diff_header_name(field: str) -> str:
scripts/_git_paths.py:103:def unified_diff(args: list[str]) -> str:
scripts/check_comment_narration.py:34:from _git_paths import diff_header_name, unified_diff
scripts/check_comment_narration.py:92:            name = diff_header_name(raw[4:])
scripts/check_comment_narration.py:117:            diff = unified_diff(["--cached"])
scripts/check_comment_narration.py:119:            diff = unified_diff([f"{argv[1]}...HEAD"])
scripts/check_version_literals.py:80:from _git_paths import diff_header_name, unified_diff
scripts/check_version_literals.py:488:                name = diff_header_name(raw[4:])
scripts/check_version_literals.py:519:        diff_text = unified_diff(diff_args)
```

Both production consumers route through the fixed helper; both are covered by
the new test.

## Frozen RED evidence

| Frozen RED test | git hash-object | RED run tail |
| --- | --- | --- |
| `tests/test_issue3076_diff_header_non_utf8.py` | `f9d38b36599844401d748d7c89fa8acafde37102` | `5 failed in 0.81s -- silent skip, mangled narration path, ASCII-locale UnicodeEncodeError crash` |

Post-fix run of the **same file, zero edits** (hash unchanged:
`f9d38b36599844401d748d7c89fa8acafde37102`): `5 passed in 0.64s`.

(This hash reflects the file after a Copilot-review-fix commit that scrubbed
`GIT_*`/hook config from the checker-subprocess env; the full red→green→mutation
cycle was independently re-run against that commit -- see review thread.)

**Mutation proof** (each fix component independently reverted, same frozen test file):

- `core.quotePath=true` reverted to `false` → 5/5 tests fail.
- `os.fsdecode(bytes(out))` reverted to hard-coded `.decode("utf-8", "surrogateescape")` → `test_valid_utf8_name_opens_under_an_ascii_filesystem_encoding` fails (gate crashes with `UnicodeEncodeError` instead of reporting).

## Canonical gates

`scripts/agent/run-gates.sh --diff origin/devel`: pytest, ruff check, ruff format --check, mypy, coverage-pairing all PASS. Graph freshness gate rebuilt and staged `graphify-out/graph.json` in each commit (via pre-commit hook).

Fixes #3076


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of filenames containing non-UTF-8 characters during diff-based checks.
  * Reports now preserve the original filename accurately instead of replacing characters with unreadable placeholders.
  * Repository settings that alter Git path quoting no longer interfere with filename processing.
  * Valid non-ASCII filenames continue to work correctly in environments using ASCII filesystem encoding.

* **Tests**
  * Added regression coverage for non-UTF-8 and non-ASCII filename scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->