### PR TITLE
dnsbl: keep broadest whitelist on colliding apex forms

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -5024,8 +5024,10 @@ def _dnsbl_normalise_whitelist(
 ) -> dict[str, dict[str, Any]]:
     """User-whitelist normalisation (mirrors PHP's pfb_unbound_python_whitelist()) into the
     query-time whiteDB shape: www-strip; leading-dot -> wildcard True else False.
-    TOP1M entries are loaded ONLY when enabled as validated canonical bare domains;
-    retired comma-framed records and invalid domains are explicitly rejected by normalise().
+    Colliding lines that collapse to one apex widen (broadest wildcard, any important,
+    max band) rather than last-wins. TOP1M entries are loaded ONLY when enabled as
+    validated canonical bare domains; retired comma-framed records and invalid
+    domains are explicitly rejected by normalise().
     No build-time list pruning -- this only populates whiteDB.
 
     ADR-07: the whiteDB value widens from a bare ``bool`` (wildcard?) to
@@ -5042,10 +5044,12 @@ def _dnsbl_normalise_whitelist(
             continue
         if line.startswith("www."):
             line = line[4:]
-        if line.startswith("."):
-            white_db[line.lstrip(".")] = {"wildcard": True, "important": True, "band": PRIO_USER_ALLOW}
-        else:
-            white_db[line] = {"wildcard": False, "important": True, "band": PRIO_USER_ALLOW}
+        wildcard = line.startswith(".")
+        domain = line.lstrip(".")
+        new_entry: dict[str, Any] = {"wildcard": wildcard, "important": True, "band": PRIO_USER_ALLOW}
+        existing = white_db.get(domain)
+        # issue #3191: colliding `.apex` / `www.apex` / bare apex widen, never last-wins demote.
+        white_db[domain] = new_entry if existing is None else _white_widen_entry(existing, new_entry)
 
     if top1m_enabled:
         for raw in top1m_lines:
@@ -5404,11 +5408,7 @@ def build(
         if existing is None:
             white_db[domain] = unlock_entry
             continue
-        white_db[domain] = {
-            "wildcard": _white_entry_wildcard(existing) or _white_entry_wildcard(unlock_entry),
-            "important": _white_entry_important(existing) or _white_entry_important(unlock_entry),
-            "band": max(_white_entry_band(existing), _white_entry_band(unlock_entry)),
-        }
+        white_db[domain] = _white_widen_entry(existing, unlock_entry)
 
     # ADR-07: an ABP-shaped line (any feed -- #1083 retired the whole-feed
     # format_hint dispatch) is routed by the per-line capture guard to the typed
@@ -6184,6 +6184,18 @@ def _white_entry_band(entry: Any) -> int:
             return band
         return PRIO_USER_ALLOW if entry.get("important", False) else PRIO_FEED_ALLOW
     return PRIO_FEED_ALLOW
+
+
+def _white_widen_entry(existing: Any, new: Any) -> dict[str, Any]:
+    """User-allow collision merge: broadest wildcard, any important, max band.
+
+    Drops feed ``index``; permit/ABP insert paths keep their own band-monotonic merge.
+    """
+    return {
+        "wildcard": _white_entry_wildcard(existing) or _white_entry_wildcard(new),
+        "important": _white_entry_important(existing) or _white_entry_important(new),
+        "band": max(_white_entry_band(existing), _white_entry_band(new)),
+    }
 
 
 def whitelist_lookup_domain(name: str, white_db: dict[str, Any], tld_seg: int) -> tuple[bool, bool]:

--- a/tests/smoke/test_smoke_matrix.py
+++ b/tests/smoke/test_smoke_matrix.py
@@ -440,6 +440,35 @@ def test_dnsbl_whitelist_passthrough(deployed_vm: SmokeVM, client_vm: SmokeVM, m
         assert not h.is_null_ip(answer), f"whitelisted {domain} wrongly null-IP: {answer}"
 
 
+def test_dnsbl_whitelist_wildcard_not_demoted_by_www(
+    deployed_vm: SmokeVM, client_vm: SmokeVM, mock_feeds: _MockFeedServer
+) -> None:
+    """WHITELIST: `.apex` plus later `www.apex` must still cover `sub.apex` (issue #3191).
+
+    Last-wins normalisation used to demote the leading-dot wildcard to exact when a
+    www-stripped line collided on the same key, so a feed block of ``sub.{apex}``
+    leaked through as VIP/NULL. Exact-name passthrough would not have caught that.
+    """
+    apex = h.unique_domain("wlwild")
+    blocked = f"sub.{apex}"
+    feed_url = h.write_local_feed(deployed_vm, "smoke_dnsbl_white_wild.txt", f"{blocked}\n")
+    spec = h.DnsblCase(
+        aliasname="smokewlwild",
+        feed_url=feed_url,
+        header="smokewlwild",
+        mode=h.DnsblMode.VIP,
+        whitelist=[f".{apex}", f"www.{apex}"],
+    )
+    with h.CaseContext(deployed_vm, spec):
+        h.unblock_egress()
+        answer = h.dns_probe_client(client_vm, blocked, "A")
+        assert h.resolves_to(answer, STUB_DNS_A), (
+            f"wildcard-whitelisted {blocked} should resolve via stub, got {answer}"
+        )
+        assert not h.is_vip(answer), f"wildcard-whitelisted {blocked} wrongly VIP-blocked: {answer}"
+        assert not h.is_null_ip(answer), f"wildcard-whitelisted {blocked} wrongly null-IP: {answer}"
+
+
 # ADR-10: several bounded wait-for-apply round-trips per case (each swap blocks PHP
 # until the watcher confirms the applied generation -- seconds, not the old async poll)
 # plus per-case setup exceed the smoke harness's 30s per-test cap; override it.

--- a/tests/test_adr06_build_module.py
+++ b/tests/test_adr06_build_module.py
@@ -301,6 +301,52 @@ class TestWhitelistNormalisation:
             "band": pfb_unbound.PRIO_USER_ALLOW,
         }
 
+    def _assert_apex_wildcard_covers_deep(self, white_db: dict[str, Any], apex: str) -> None:
+        assert white_db[apex]["wildcard"] is True
+        assert pfb_unbound.whitelist_check_domain(f"stun.l.{apex}", white_db, 1) is True
+        assert pfb_unbound.whitelist_check_domain(f"a.b.{apex}", white_db, 1) is True
+
+    def test_leading_dot_then_www_keeps_wildcard(self) -> None:
+        """Colliding `.apex` then `www.apex` must keep subtree coverage (issue #3191)."""
+        apex = "collapex.com"
+        wl = pfb_unbound._dnsbl_normalise_whitelist([f".{apex}", f"www.{apex}"], [], False)
+        self._assert_apex_wildcard_covers_deep(wl, apex)
+
+    def test_leading_dot_then_bare_apex_keeps_wildcard(self) -> None:
+        """Colliding `.apex` then bare `apex` must keep subtree coverage (issue #3191)."""
+        apex = "collapex.com"
+        wl = pfb_unbound._dnsbl_normalise_whitelist([f".{apex}", apex], [], False)
+        self._assert_apex_wildcard_covers_deep(wl, apex)
+
+    def test_www_then_leading_dot_keeps_wildcard(self) -> None:
+        """Widen is order-independent: `www.apex` then `.apex` still covers the subtree."""
+        apex = "collapex.com"
+        wl = pfb_unbound._dnsbl_normalise_whitelist([f"www.{apex}", f".{apex}"], [], False)
+        self._assert_apex_wildcard_covers_deep(wl, apex)
+
+    def test_www_then_bare_apex_stays_exact(self) -> None:
+        """Without a leading-dot line, www-strip + bare apex stay exact; deep names miss."""
+        apex = "collapex.com"
+        wl = pfb_unbound._dnsbl_normalise_whitelist([f"www.{apex}", apex], [], False)
+        assert wl[apex]["wildcard"] is False
+        assert pfb_unbound.whitelist_check_domain(f"stun.l.{apex}", wl, 1) is False
+        assert pfb_unbound.whitelist_check_domain(f"a.b.{apex}", wl, 1) is False
+
+    def test_leading_dot_plus_mail_keeps_two_keys(self) -> None:
+        """A different hostname is a second key; the `.apex` wildcard is not demoted."""
+        apex = "collapex.com"
+        wl = pfb_unbound._dnsbl_normalise_whitelist([f".{apex}", f"mail.{apex}"], [], False)
+        assert set(wl) == {apex, f"mail.{apex}"}
+        assert wl[apex]["wildcard"] is True
+        assert wl[f"mail.{apex}"]["wildcard"] is False
+        assert pfb_unbound.whitelist_check_domain(f"stun.l.{apex}", wl, 1) is True
+
+    def test_user_wildcard_not_overwritten_by_top1m(self) -> None:
+        """TOP1M setdefault must not collapse an existing user `.apex` wildcard to exact."""
+        apex = "collapex.com"
+        wl = pfb_unbound._dnsbl_normalise_whitelist([f".{apex}"], [apex], True)
+        self._assert_apex_wildcard_covers_deep(wl, apex)
+
 
 # --------------------------------------------------------------------------- #
 # build() end-to-end vs the Phase-2 DECISION oracle


### PR DESCRIPTION
Fixes #3191

## Objective

Query-time `whiteDB` must keep the **broadest** user-whitelist coverage when several textarea lines collapse to the same apex. A leading-dot wildcard (`.apex`) plus a later exact/`www.` line must still cover deep subdomains.

## Change

- `_dnsbl_normalise_whitelist` widens colliding user-whitelist forms for one apex (broadest wildcard, any important, max band) instead of last-wins assign.
- Unlock merge reuses the same `_white_widen_entry` helper. Permit-feed band-monotonic insert and ABP `allow_domains` band compare are unchanged.
- TOP1M `setdefault` still will not overwrite an existing user `.apex` wildcard.

## Frozen RED evidence

Production at red time was untouched `origin/devel` `28116049e34299a96f660d911d5ace16fdc7d0ba`. Tests were added first; no production edit yet.

| Frozen RED test | git hash-object | RED run tail |
| --- | --- | --- |
| `tests/test_adr06_build_module.py` | `1ee11f171371b620bf7dddcd281382d24547457b` | `2 failed, 7 passed` — `test_leading_dot_then_www_keeps_wildcard` and `test_leading_dot_then_bare_apex_keeps_wildcard` asserted `white_db[apex]["wildcard"] is True` and got `False` (last-wins demotion). Reverse-order, exact-only, two-key, TOP1M, and the pre-existing rows stayed green. |

GREEN (byte-identical): `git hash-object tests/test_adr06_build_module.py` → `1ee11f171371b620bf7dddcd281382d24547457b`

```text
uv run pytest tests/test_adr06_build_module.py::TestWhitelistNormalisation \
  tests/test_branch_coverage_gaps.py::TestNormaliseWhitelistBlanks
12 passed
```

## Smoke

```text
ssh smoke pfb-test smoke --ref 9b39d06c0e38bb20720455634b4ef90c6cda111f \
  --filter test_dnsbl_whitelist_wildcard_not_demoted_by_www
pfb-test: PASSED in 214s. Artifacts: /srv/Smoke/results/20260903T234104Z-smoke
```

## Verification

- `scripts/agent/run-gates.sh --diff origin/devel` → `GATES: PASS`
- Permit `@@` insert and ABP `allow_domains` merge are outside this diff.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved wildcard whitelist coverage when entries for the same apex domain are combined, regardless of entry order.
  * Prevented broader wildcard rules from being unintentionally narrowed to exact-match rules.
  * Ensured separate hostnames remain distinct while apex and `www` entries retain their intended matching behavior.

* **Tests**
  * Added coverage for wildcard, apex, `www`, and distinct-hostname whitelist combinations.
  * Added smoke testing to verify blocked subdomains resolve correctly through the configured upstream.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->