### PR TITLE
tests: resolve bsdtar cleanly by platform and fail fast at bootstrap

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -130,6 +130,13 @@ jobs:
           php-version: ${{ fromJSON(needs.read-matrix.outputs.php_versions)[0] }}
           tools: none
 
+      - name: Install libarchive-tools
+        # The PHP test bootstrap (tests/php/bootstrap.php) requires bsdtar on Linux;
+        # Python tests shelling out to PHP load that bootstrap.
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends libarchive-tools
+
       - name: Install uv
         # astral-sh/setup-uv publishes no floating major tag past v7 — later majors ship
         # exact versions only. enable-cache persists uv's download cache between runs.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -826,30 +826,12 @@ jobs:
       - name: Sync the test environment
         run: uv sync --locked --group dev
 
-      - name: Put bsdtar at /usr/bin/tar
-        # The appliance's /usr/bin/tar is bsdtar, which reads ZIP; Debian's is GNU tar,
-        # which does not. The ADR-45 archive cases and the TOP1M/GeoIP zip publication
-        # cases probe that exact path and SKIP when it cannot read a zip, so without this
-        # they vanish from the run while the suite still reads green (issue #2356).
-        # --no-rename plus an explicit mv, not --rename: dpkg-divert refuses to rename a
-        # file out of an Essential package, and the diversion keeps a future tar upgrade
-        # from overwriting the symlink.
-        #
-        # GNU tar moves to /usr/sbin/tar rather than going away, and the runner's PATH
-        # searches /usr/sbin before /usr/bin, so everything resolving `tar` by NAME still
-        # gets it — dpkg-deb passes the GNU-only --warning=no-timestamp, and actions/cache
-        # and the release tarball step read GNU archives. Hence the two checks: the
-        # absolute path the code under test hardcodes must be bsdtar, and the second is
-        # deliberately a BARE `tar`, because a name lookup is the only thing that proves
-        # what those callers get.
+      - name: Install libarchive-tools for bsdtar
+        # Issue #3195: bootstrap resolves bsdtar cleanly on Linux; install libarchive-tools
+        # without mutating host binaries or dpkg-divert.
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends libarchive-tools
-          sudo dpkg-divert --no-rename --divert /usr/sbin/tar --add /usr/bin/tar
-          sudo mv /usr/bin/tar /usr/sbin/tar
-          sudo ln -s bsdtar /usr/bin/tar
-          /usr/bin/tar --version | grep -q '^bsdtar'
-          tar --version | grep -q 'GNU tar'
 
       - name: Put bsdunzip at /usr/bin/unzip
         # Same reasoning as the tar step above, for the binary issue #3068 moved the ZIP

--- a/scripts/agent/setup-agent-tools.sh
+++ b/scripts/agent/setup-agent-tools.sh
@@ -31,7 +31,7 @@ install_from_url() {
 install_linux_prerequisites() {
 	require_tool dpkg-query
 	set --
-	for package in ca-certificates curl git; do
+	for package in ca-certificates curl git libarchive-tools; do
 		if ! dpkg-query -W -f='${Status}' "$package" 2>/dev/null |
 			grep -q 'install ok installed'; then
 			set -- "$@" "$package"

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -1160,7 +1160,8 @@ function pfb_archive_probe(string $canonical_type): ?array {
 		case 'application/x-bzip2':
 			return array('/usr/bin/bzip2', '-t');
 		case 'application/x-tar':
-			return array('/usr/bin/tar', '-tf');
+			global $pfb;
+			return array($pfb['tar'] ?? '/usr/bin/tar', '-tf');
 		default:
 			return NULL;
 	}
@@ -1180,6 +1181,10 @@ function pfb_validate_archive(string $file, string $canonical_type, ?callable $r
 	$argv[] = $file;    // file appended here, escaped in the runner
 	if ($runner === NULL) {
 		$runner = function (array $a): int {
+			global $pfb;
+			if ($a[0] === '/usr/bin/tar' && isset($pfb['tar'])) {
+				$a[0] = $pfb['tar'];
+			}
 			$cmd = implode(' ', array_map('escapeshellarg', $a));
 			exec($cmd . ' >/dev/null 2>&1', $out, $rv);
 			return (int) $rv;
@@ -1256,9 +1261,11 @@ function pfb_reject_detail_summary(array $reject_detail): string {
 // rc != 0 here and must be rejected, not fail-open extracted. A genuinely intact
 // archive always lists rc 0, so this rejects nothing legitimate.
 function pfb_archive_member_names(string $file, string $canonical_type): ?array {
+	global $pfb;
+	$tar_bin = $pfb['tar'] ?? '/usr/bin/tar';
 	$lister = $canonical_type === 'application/zip'
 		? '/usr/bin/unzip -Z1 '
-		: '/usr/bin/tar -tf ';
+		: escapeshellcmd($tar_bin) . ' -tf ';
 	$output = array();
 	$retval = 1;
 	exec($lister . escapeshellarg($file) . ' 2>/dev/null', $output, $retval);
@@ -4424,9 +4431,10 @@ function pfb_geoip_extract_tar_to_share(
 	// published only once tar reports success, so a failure part-way -- a killed
 	// child at issue #2658's ceiling, ENOSPC, a member libarchive refuses -- leaves
 	// the share already in service byte-identical.
+	$tar_bin = escapeshellcmd($pfb['tar'] ?? '/usr/bin/tar');
 	if (!pfb_stage_publish_dir_merge($pfb['geoipshare'],
-	    static function (string $staged) use ($file_dwn_esc, &$output, &$retval): int {
-		exec(pfb_extract_cmd("/usr/bin/tar -xf {$file_dwn_esc} " . PFB_TAR_EXTRACT_FLAGS . " --strip=1 -C " . escapeshellarg($staged) . " >/dev/null 2>&1"), $output, $retval);
+	    static function (string $staged) use ($file_dwn_esc, $tar_bin, &$output, &$retval): int {
+		exec(pfb_extract_cmd("{$tar_bin} -xf {$file_dwn_esc} " . PFB_TAR_EXTRACT_FLAGS . " --strip=1 -C " . escapeshellarg($staged) . " >/dev/null 2>&1"), $output, $retval);
 		return $retval;
 	})) {
 		unlink_if_exists($file_download);
@@ -15613,9 +15621,10 @@ function pfb_download_fetch(PfbDownloadRequest $request): PfbDownloadResult {
 					// success, so a failure part-way leaves the publication already
 					// in service byte-identical.
 					$retval = pfb_download_initial_retval();
+					$tar_bin = escapeshellcmd($pfb['tar'] ?? '/usr/bin/tar');
 					if (!pfb_stage_publish_dir_merge($head_download,
-					    static function (string $staged) use ($file_dwn_esc, &$output, &$retval): int {
-						exec(pfb_extract_cmd("/usr/bin/tar -xf {$file_dwn_esc} " . PFB_TAR_EXTRACT_FLAGS . " --strip=1 -C " . escapeshellarg($staged) . " >/dev/null 2>&1"), $output, $retval);
+					    static function (string $staged) use ($file_dwn_esc, $tar_bin, &$output, &$retval): int {
+						exec(pfb_extract_cmd("{$tar_bin} -xf {$file_dwn_esc} " . PFB_TAR_EXTRACT_FLAGS . " --strip=1 -C " . escapeshellarg($staged) . " >/dev/null 2>&1"), $output, $retval);
 						return $retval;
 					})) {
 						pfb_logger("\n[pfb_download] {$type} zip " . pfb_stage_publish_failure_note($retval), 2);
@@ -15627,9 +15636,10 @@ function pfb_download_fetch(PfbDownloadRequest $request): PfbDownloadResult {
 				}
 				// ADR-46: stdout extraction -- member names never reach the filesystem.
 				$retval = pfb_download_initial_retval();
+				$tar_bin = escapeshellcmd($pfb['tar'] ?? '/usr/bin/tar');
 				if (!pfb_stage_publish($head_download,
-				    static function (string $staged) use ($file_dwn_esc, &$output, &$retval): int {
-					exec(pfb_extract_cmd("/usr/bin/tar -xOf {$file_dwn_esc} > " . escapeshellarg($staged)), $output, $retval);
+				    static function (string $staged) use ($file_dwn_esc, $tar_bin, &$output, &$retval): int {
+					exec(pfb_extract_cmd("{$tar_bin} -xOf {$file_dwn_esc} > " . escapeshellarg($staged)), $output, $retval);
 					return $retval;
 				})) {
 					pfb_logger("\n[pfb_download] {$type} zip extraction failed (tar exit {$retval})" . pfb_extract_cap_note($retval), 2);
@@ -15667,7 +15677,8 @@ function pfb_download_fetch(PfbDownloadRequest $request): PfbDownloadResult {
 				}
 				$header_esc = escapeshellarg($top1m_stage);
 				$strip = $top1m_target_dir ? ' --strip=1' : '';
-				exec(pfb_extract_cmd("/usr/bin/tar -xf {$file_dwn_esc}{$strip} " . PFB_TAR_EXTRACT_FLAGS . " -C {$header_esc} >/dev/null 2>&1"), $output, $retval);
+				$tar_bin = escapeshellcmd($pfb['tar'] ?? '/usr/bin/tar');
+				exec(pfb_extract_cmd("{$tar_bin} -xf {$file_dwn_esc}{$strip} " . PFB_TAR_EXTRACT_FLAGS . " -C {$header_esc} >/dev/null 2>&1"), $output, $retval);
 				if (!pfb_download_extraction_succeeded($retval)) {
 					pfb_logger("\n[pfb_download] {$type} zip extraction failed (tar exit {$retval})" . pfb_extract_cap_note($retval), 2);
 					rmdir_recursive($top1m_stage);
@@ -15799,7 +15810,9 @@ function pfb_download_fetch(PfbDownloadRequest $request): PfbDownloadResult {
 			*/
 	
 			// Check if ZIP archive contains xlsx files
-			$xlsxtest = exec("/usr/bin/tar -tf {$file_dwn_esc}");
+			global $pfb;
+			$tar_bin = escapeshellcmd($pfb['tar'] ?? '/usr/bin/tar');
+			$xlsxtest = exec("{$tar_bin} -tf {$file_dwn_esc} 2>/dev/null");
 			if (strpos($xlsxtest, '.xlsx') !== FALSE) {
 				// issue #2684: the helper unpacks the workbook into its OWN per-run temp
 				// directory (`mktemp -d "${TMPDIR:-/tmp}/pfb.XXXXXXXX"`), which the
@@ -15839,10 +15852,11 @@ function pfb_download_fetch(PfbDownloadRequest $request): PfbDownloadResult {
 				$reject_detail = array();
 				$inner_rejected = FALSE;
 				$pfb_sanity = NULL;
+				$tar_bin = escapeshellcmd($pfb['tar'] ?? '/usr/bin/tar');
 				if (!pfb_stage_publish($orig_download,
-				    static function (string $staged) use ($file_dwn_esc, $list_download,
+				    static function (string $staged) use ($file_dwn_esc, $list_download, $tar_bin,
 				        &$output, &$retval, &$reject_detail, &$inner_rejected, &$pfb_sanity): int {
-					exec(pfb_extract_cmd("set -o pipefail; /usr/bin/tar -xOf {$file_dwn_esc} | /usr/bin/sed 's/,[[:space:]]/; /g' | /usr/bin/tr ',' '\n' > " . escapeshellarg($staged)), $output, $retval);
+					exec(pfb_extract_cmd("set -o pipefail; {$tar_bin} -xOf {$file_dwn_esc} | /usr/bin/sed 's/,[[:space:]]/; /g' | /usr/bin/tr ',' '\n' > " . escapeshellarg($staged)), $output, $retval);
 					if ($retval !== 0) {
 						return $retval;
 					}
@@ -16074,7 +16088,9 @@ function pfb_download_fetch(PfbDownloadRequest $request): PfbDownloadResult {
 					$pfb_sanity = NULL;
 					if (!pfb_stage_publish($orig_download,
 					    static function (string $staged) use ($file_dwn_esc, &$output, &$retval, &$pfb_sanity): int {
-						exec(pfb_extract_cmd("/usr/bin/tar -xOf {$file_dwn_esc} > " . escapeshellarg($staged)), $output, $retval);
+						global $pfb;
+						$tar_bin = escapeshellcmd($pfb['tar'] ?? '/usr/bin/tar');
+						exec(pfb_extract_cmd("{$tar_bin} -xOf {$file_dwn_esc} > " . escapeshellarg($staged)), $output, $retval);
 						$pfb_sanity = pfb_extracted_text_sanity($staged, $retval);
 						return $pfb_sanity === NULL ? $retval : pfb_download_initial_retval();
 					})) {

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -1181,10 +1181,6 @@ function pfb_validate_archive(string $file, string $canonical_type, ?callable $r
 	$argv[] = $file;    // file appended here, escaped in the runner
 	if ($runner === NULL) {
 		$runner = function (array $a): int {
-			global $pfb;
-			if ($a[0] === '/usr/bin/tar' && isset($pfb['tar'])) {
-				$a[0] = $pfb['tar'];
-			}
 			$cmd = implode(' ', array_map('escapeshellarg', $a));
 			exec($cmd . ' >/dev/null 2>&1', $out, $rv);
 			return (int) $rv;
@@ -14767,6 +14763,7 @@ function pfb_download_fetch(PfbDownloadRequest $request): PfbDownloadResult {
 	global $pfb;
 	$http_status = '';
 	$elog = ">> {$pfb['log']} 2>&1";
+	$tar_bin = escapeshellarg($pfb['tar'] ?? '/usr/bin/tar');
 
 	// Remove any leading/trailing whitespace
 	$list_url = trim($list_url);
@@ -15501,8 +15498,8 @@ function pfb_download_fetch(PfbDownloadRequest $request): PfbDownloadResult {
 					// the category contents already in service untouched.
 					$retval = pfb_download_initial_retval();
 					if (!pfb_stage_publish_dir("{$pfb['dbdir']}/{$filename}",
-					    static function (string $staged) use ($file_dwn, $filename, $cmd, &$output, &$retval): int {
-						exec(pfb_extract_cmd("/usr/bin/tar -xf " . escapeshellarg("{$file_dwn}") . " " . PFB_TAR_EXTRACT_FLAGS . " {$cmd} -C " . escapeshellarg("{$staged}/") . " >/dev/null 2>&1"), $output, $retval);
+					    static function (string $staged) use ($file_dwn, $filename, $cmd, $tar_bin, &$output, &$retval): int {
+						exec(pfb_extract_cmd("{$tar_bin} -xf " . escapeshellarg("{$file_dwn}") . " " . PFB_TAR_EXTRACT_FLAGS . " {$cmd} -C " . escapeshellarg("{$staged}/") . " >/dev/null 2>&1"), $output, $retval);
 						return pfb_blacklist_tar_finalize_staged($staged, $filename, $retval);
 					})) {
 						pfb_logger("\n[pfb_download] blacklist extraction failed (tar exit {$retval})" . pfb_extract_cap_note($retval), 2);
@@ -15529,9 +15526,9 @@ function pfb_download_fetch(PfbDownloadRequest $request): PfbDownloadResult {
 				$extract_tar = ($inner_type == 'application/x-tar');
 				$pfb_sanity = NULL;
 				if (!pfb_stage_publish($orig_download,
-				    static function (string $staged) use ($file_dwn_esc, $extract_tar, &$output, &$retval, &$pfb_sanity): int {
+				    static function (string $staged) use ($file_dwn_esc, $extract_tar, $tar_bin, &$output, &$retval, &$pfb_sanity): int {
 					if ($extract_tar) {
-						exec(pfb_extract_cmd("set -o pipefail; /usr/bin/gunzip -c {$file_dwn_esc} | /usr/bin/tar -xOf - > " . escapeshellarg($staged)), $output, $retval);
+						exec(pfb_extract_cmd("set -o pipefail; /usr/bin/gunzip -c {$file_dwn_esc} | {$tar_bin} -xOf - > " . escapeshellarg($staged)), $output, $retval);
 					} else {
 						exec(pfb_extract_cmd("/usr/bin/gunzip -c {$file_dwn_esc} > " . escapeshellarg($staged)), $output, $retval);
 					}
@@ -15571,9 +15568,9 @@ function pfb_download_fetch(PfbDownloadRequest $request): PfbDownloadResult {
 			$extract_tar = ($inner_type == 'application/x-tar');
 			$pfb_sanity = NULL;
 			if (!pfb_stage_publish($orig_download,
-			    static function (string $staged) use ($file_dwn_esc, $extract_tar, &$output, &$retval, &$pfb_sanity): int {
+			    static function (string $staged) use ($file_dwn_esc, $extract_tar, $tar_bin, &$output, &$retval, &$pfb_sanity): int {
 				if ($extract_tar) {
-					exec(pfb_extract_cmd("set -o pipefail; /usr/bin/bzip2 -dkc {$file_dwn_esc} | /usr/bin/tar -xOf - > " . escapeshellarg($staged)), $output, $retval);
+					exec(pfb_extract_cmd("set -o pipefail; /usr/bin/bzip2 -dkc {$file_dwn_esc} | {$tar_bin} -xOf - > " . escapeshellarg($staged)), $output, $retval);
 				} else {
 					exec(pfb_extract_cmd("/usr/bin/bzip2 -dkc {$file_dwn_esc} > " . escapeshellarg($staged)), $output, $retval);
 				}
@@ -15905,8 +15902,8 @@ function pfb_download_fetch(PfbDownloadRequest $request): PfbDownloadResult {
 						return pfb_geoip_extract_tar_to_share($header, $file_download, $file_dwn_esc, $retval);
 					}
 					if (!pfb_stage_publish($head_download,
-					    static function (string $staged) use ($file_dwn_esc, &$output, &$retval): int {
-						exec(pfb_extract_cmd("/usr/bin/tar -xOf {$file_dwn_esc} > " . escapeshellarg($staged)), $output, $retval);
+					    static function (string $staged) use ($file_dwn_esc, $tar_bin, &$output, &$retval): int {
+						exec(pfb_extract_cmd("{$tar_bin} -xOf {$file_dwn_esc} > " . escapeshellarg($staged)), $output, $retval);
 						return $retval;
 					})) {
 						unlink_if_exists($file_download);
@@ -15948,7 +15945,7 @@ function pfb_download_fetch(PfbDownloadRequest $request): PfbDownloadResult {
 					}
 					$top1m_stage_esc = escapeshellarg($top1m_stage);
 					$retval = pfb_download_initial_retval();
-					exec(pfb_extract_cmd("/usr/bin/tar -xOf {$file_dwn_esc} > {$top1m_stage_esc}"), $output, $retval);
+					exec(pfb_extract_cmd("{$tar_bin} -xOf {$file_dwn_esc} > {$top1m_stage_esc}"), $output, $retval);
 					if (!pfb_download_extraction_succeeded($retval)) {
 						unlink_if_exists($file_download);
 						unlink_if_exists($top1m_stage);
@@ -16061,8 +16058,8 @@ function pfb_download_fetch(PfbDownloadRequest $request): PfbDownloadResult {
 					$cmd = "--include='*domains' -s',.*/\\(.*\\)/\\(.*\\)/domains,{$filename}_\\1_\\2,' -s',.*/\\(.*\\)/domains,{$filename}_\\1,'";
 					$retval = pfb_download_initial_retval();
 					if (!pfb_stage_publish_dir("{$pfb['dbdir']}/{$filename}",
-					    static function (string $staged) use ($file_dwn, $filename, $cmd, &$output, &$retval): int {
-						exec(pfb_extract_cmd("/usr/bin/tar -xf " . escapeshellarg("{$file_dwn}") . " " . PFB_TAR_EXTRACT_FLAGS . " {$cmd} -C " . escapeshellarg("{$staged}/") . " >/dev/null 2>&1"), $output, $retval);
+					    static function (string $staged) use ($file_dwn, $filename, $cmd, $tar_bin, &$output, &$retval): int {
+						exec(pfb_extract_cmd("{$tar_bin} -xf " . escapeshellarg("{$file_dwn}") . " " . PFB_TAR_EXTRACT_FLAGS . " {$cmd} -C " . escapeshellarg("{$staged}/") . " >/dev/null 2>&1"), $output, $retval);
 						return pfb_blacklist_tar_finalize_staged($staged, $filename, $retval);
 					})) {
 						pfb_logger("\n[pfb_download] blacklist extraction failed (tar exit {$retval})" . pfb_extract_cap_note($retval), 2);
@@ -16086,9 +16083,7 @@ function pfb_download_fetch(PfbDownloadRequest $request): PfbDownloadResult {
 					$retval = pfb_download_initial_retval();
 					$pfb_sanity = NULL;
 					if (!pfb_stage_publish($orig_download,
-					    static function (string $staged) use ($file_dwn_esc, &$output, &$retval, &$pfb_sanity): int {
-						global $pfb;
-						$tar_bin = escapeshellcmd($pfb['tar'] ?? '/usr/bin/tar');
+					    static function (string $staged) use ($file_dwn_esc, $tar_bin, &$output, &$retval, &$pfb_sanity): int {
 						exec(pfb_extract_cmd("{$tar_bin} -xOf {$file_dwn_esc} > " . escapeshellarg($staged)), $output, $retval);
 						$pfb_sanity = pfb_extracted_text_sanity($staged, $retval);
 						return $pfb_sanity === NULL ? $retval : pfb_download_initial_retval();

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -15809,10 +15809,9 @@ function pfb_download_fetch(PfbDownloadRequest $request): PfbDownloadResult {
 			}
 			*/
 	
-			// Check if ZIP archive contains xlsx files
 			global $pfb;
 			$tar_bin = escapeshellcmd($pfb['tar'] ?? '/usr/bin/tar');
-			$xlsxtest = exec("{$tar_bin} -tf {$file_dwn_esc} 2>/dev/null");
+			$xlsxtest = exec("{$tar_bin} -tf {$file_dwn_esc}");
 			if (strpos($xlsxtest, '.xlsx') !== FALSE) {
 				// issue #2684: the helper unpacks the workbook into its OWN per-run temp
 				// directory (`mktemp -d "${TMPDIR:-/tmp}/pfb.XXXXXXXX"`), which the

--- a/tests/php/ArchiveProbeTest.php
+++ b/tests/php/ArchiveProbeTest.php
@@ -56,7 +56,7 @@ final class ArchiveProbeTest extends TestCase
 	{
 		// issue #2638: a newly accepted archive type must have a structural probe;
 		// without it pfb_validate_archive() treats x-tar as "non-archive: nothing to test".
-		$this->assertSame(['/usr/bin/tar', '-tf'], pfb_archive_probe('application/x-tar'));
+		$this->assertSame([pfb_test_tar(), '-tf'], pfb_archive_probe('application/x-tar'));
 	}
 
 	public function test_probe_removed_archive_returns_null(): void

--- a/tests/php/ArchiveValidateWiringTest.php
+++ b/tests/php/ArchiveValidateWiringTest.php
@@ -238,7 +238,7 @@ final class ArchiveValidateWiringTest extends TestCase
 		$this->assertNotFalse(file_put_contents($member, "203.0.113.7\n"));
 		$output = [];
 		$retval = 1;
-		exec(escapeshellcmd(pfb_test_tar()) . ' -czf ' . escapeshellarg($tgz) . ' -C ' . escapeshellarg($this->dir)
+		exec(escapeshellarg(pfb_test_tar()) . ' -czf ' . escapeshellarg($tgz) . ' -C ' . escapeshellarg($this->dir)
 			. ' member.txt 2>/dev/null', $output, $retval);
 		$this->assertSame(0, $retval, 'the fixture tarball must be built');
 

--- a/tests/php/ArchiveValidateWiringTest.php
+++ b/tests/php/ArchiveValidateWiringTest.php
@@ -238,7 +238,7 @@ final class ArchiveValidateWiringTest extends TestCase
 		$this->assertNotFalse(file_put_contents($member, "203.0.113.7\n"));
 		$output = [];
 		$retval = 1;
-		exec('/usr/bin/tar -czf ' . escapeshellarg($tgz) . ' -C ' . escapeshellarg($this->dir)
+		exec(escapeshellcmd(pfb_test_tar()) . ' -czf ' . escapeshellarg($tgz) . ' -C ' . escapeshellarg($this->dir)
 			. ' member.txt 2>/dev/null', $output, $retval);
 		$this->assertSame(0, $retval, 'the fixture tarball must be built');
 

--- a/tests/php/BootstrapArchiverResolutionTest.php
+++ b/tests/php/BootstrapArchiverResolutionTest.php
@@ -29,7 +29,7 @@ final class BootstrapArchiverResolutionTest extends TestCase
 		$tar = pfb_test_tar();
 		$output = [];
 		$retval = 1;
-		exec(escapeshellcmd($tar) . ' --version 2>&1', $output, $retval);
+		exec(escapeshellarg($tar) . ' --version 2>&1', $output, $retval);
 		$this->assertSame(0, $retval, "Failed to execute [{$tar} --version]");
 		$firstLine = (string) ($output[0] ?? '');
 		$this->assertTrue(
@@ -50,7 +50,7 @@ final class BootstrapArchiverResolutionTest extends TestCase
 
 		$output = [];
 		$retval = 1;
-		exec(escapeshellcmd($tar) . ' -tf ' . escapeshellarg($tmpZip) . ' 2>/dev/null', $output, $retval);
+		exec(escapeshellarg($tar) . ' -tf ' . escapeshellarg($tmpZip) . ' 2>/dev/null', $output, $retval);
 		unlink($tmpZip);
 
 		$this->assertSame(0, $retval, "Archiver [{$tar}] must be capable of reading ZIP containers");
@@ -67,19 +67,41 @@ final class BootstrapArchiverResolutionTest extends TestCase
 
 	public function test_archiver_resolver_selects_usr_bin_tar_on_bsd(): void
 	{
-		$resolved = pfb_resolve_archiver('BSD', static fn(string $cmd): string => '/unused/path');
+		$resolved = pfb_resolve_archiver('BSD', static fn(string $cmd): string => '/unused/path', static fn(string $path): bool => true);
 		$this->assertSame('/usr/bin/tar', $resolved);
+	}
+
+	public function test_archiver_resolver_fails_on_bsd_when_tar_not_executable(): void
+	{
+		$this->expectException(RuntimeException::class);
+		$this->expectExceptionMessage('bsdtar binary missing on host (BSD)');
+		pfb_resolve_archiver('BSD', static fn(string $cmd): string => '/unused/path', static fn(string $path): bool => false);
 	}
 
 	public function test_archiver_resolver_selects_usr_bin_tar_on_darwin(): void
 	{
-		$resolved = pfb_resolve_archiver('Darwin', static fn(string $cmd): string => '/unused/path');
+		$resolved = pfb_resolve_archiver('Darwin', static fn(string $cmd): string => '/unused/path', static fn(string $path): bool => true);
 		$this->assertSame('/usr/bin/tar', $resolved);
+	}
+
+	public function test_archiver_resolver_fails_on_darwin_when_tar_not_executable(): void
+	{
+		$this->expectException(RuntimeException::class);
+		$this->expectExceptionMessage('bsdtar binary missing on host (Darwin)');
+		pfb_resolve_archiver('Darwin', static fn(string $cmd): string => '/unused/path', static fn(string $path): bool => false);
 	}
 
 	public function test_archiver_resolver_locates_bsdtar_on_linux(): void
 	{
-		$resolved = pfb_resolve_archiver('Linux', static fn(string $cmd): string => '/custom/bin/bsdtar');
+		$resolved = pfb_resolve_archiver('Linux', static fn(string $cmd): string => '/custom/bin/bsdtar', static fn(string $path): bool => true);
 		$this->assertSame('/custom/bin/bsdtar', $resolved);
+	}
+
+	public function test_archiver_path_with_spaces_is_handled(): void
+	{
+		$resolved = pfb_resolve_archiver('Linux', static fn(string $cmd): string => '/path with spaces/bsdtar', static fn(string $path): bool => true);
+		$this->assertSame('/path with spaces/bsdtar', $resolved);
+		$escaped = escapeshellarg($resolved);
+		$this->assertSame("'/path with spaces/bsdtar'", $escaped);
 	}
 }

--- a/tests/php/BootstrapArchiverResolutionTest.php
+++ b/tests/php/BootstrapArchiverResolutionTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Issue #3195: verify platform-aware archiver resolution in test bootstrap.
+ *
+ * FreeBSD and macOS appliance environments ship bsdtar at /usr/bin/tar.
+ * Linux development hosts provide bsdtar via libarchive-tools (typically at /usr/bin/bsdtar).
+ * Bootstrap resolves this cleanly without mutating host system binaries via dpkg-divert.
+ */
+final class BootstrapArchiverResolutionTest extends TestCase
+{
+	public function test_bootstrap_populates_executable_tar_in_globals(): void
+	{
+		$this->assertArrayHasKey('tar', $GLOBALS['pfb'], '$GLOBALS[\'pfb\'][\'tar\'] must be populated by bootstrap');
+		$tar = $GLOBALS['pfb']['tar'];
+		$this->assertIsString($tar);
+		$this->assertNotEmpty($tar);
+		$this->assertFileExists($tar);
+		$this->assertTrue(is_executable($tar), "Resolved archiver [{$tar}] must be executable");
+		$this->assertSame($tar, pfb_test_tar(), 'pfb_test_tar() helper must return the resolved tar binary');
+	}
+
+	public function test_bootstrap_tar_is_bsdtar(): void
+	{
+		$tar = pfb_test_tar();
+		$output = [];
+		$retval = 1;
+		exec(escapeshellcmd($tar) . ' --version 2>&1', $output, $retval);
+		$this->assertSame(0, $retval, "Failed to execute [{$tar} --version]");
+		$firstLine = (string) ($output[0] ?? '');
+		$this->assertTrue(
+			str_contains($firstLine, 'bsdtar') || str_contains($firstLine, 'libarchive'),
+			"Archiver [{$tar}] must be bsdtar/libarchive, got: [{$firstLine}]"
+		);
+	}
+
+	public function test_bootstrap_tar_can_read_zip_container(): void
+	{
+		$tar = pfb_test_tar();
+		$tmpZip = tempnam(sys_get_temp_dir(), 'pfb_zip_test_');
+		$this->assertNotFalse($tmpZip);
+		$zip = new ZipArchive();
+		$this->assertTrue($zip->open($tmpZip, ZipArchive::CREATE | ZipArchive::OVERWRITE));
+		$this->assertTrue($zip->addFromString('test.txt', "hello\n"));
+		$this->assertTrue($zip->close());
+
+		$output = [];
+		$retval = 1;
+		exec(escapeshellcmd($tar) . ' -tf ' . escapeshellarg($tmpZip) . ' 2>/dev/null', $output, $retval);
+		unlink($tmpZip);
+
+		$this->assertSame(0, $retval, "Archiver [{$tar}] must be capable of reading ZIP containers");
+		$this->assertContains('test.txt', $output);
+	}
+
+	public function test_archiver_resolver_fails_fast_when_missing(): void
+	{
+		$this->expectException(RuntimeException::class);
+		$this->expectExceptionMessage('bsdtar binary missing on host (Linux)');
+
+		pfb_resolve_archiver('Linux', static fn(string $cmd): string => '');
+	}
+
+	public function test_archiver_resolver_selects_usr_bin_tar_on_bsd(): void
+	{
+		$resolved = pfb_resolve_archiver('BSD', static fn(string $cmd): string => '/unused/path');
+		$this->assertSame('/usr/bin/tar', $resolved);
+	}
+
+	public function test_archiver_resolver_selects_usr_bin_tar_on_darwin(): void
+	{
+		$resolved = pfb_resolve_archiver('Darwin', static fn(string $cmd): string => '/unused/path');
+		$this->assertSame('/usr/bin/tar', $resolved);
+	}
+
+	public function test_archiver_resolver_locates_bsdtar_on_linux(): void
+	{
+		$resolved = pfb_resolve_archiver('Linux', static fn(string $cmd): string => '/custom/bin/bsdtar');
+		$this->assertSame('/custom/bin/bsdtar', $resolved);
+	}
+}

--- a/tests/php/DownloadExtractRestrictiveFlagsTest.php
+++ b/tests/php/DownloadExtractRestrictiveFlagsTest.php
@@ -84,7 +84,7 @@ final class DownloadExtractRestrictiveFlagsTest extends TestCase
 	{
 		$found = array();
 		foreach (self::$sources as $path => $source) {
-			if (!preg_match_all('#/usr/bin/tar -x([a-zA-Z]*)f#', $source, $m, PREG_OFFSET_CAPTURE)) {
+			if (!preg_match_all('#(?:/usr/bin/tar|\{\$tar_bin\}) -x([a-zA-Z]*)f#', $source, $m, PREG_OFFSET_CAPTURE)) {
 				continue;
 			}
 			foreach ($m[0] as $i => [$call, $offset]) {
@@ -223,7 +223,7 @@ final class DownloadExtractRestrictiveFlagsTest extends TestCase
 	{
 		$output = array();
 		$retval = 1;
-		exec('/usr/bin/tar --version 2>&1', $output, $retval);
+		exec(escapeshellcmd(pfb_test_tar()) . ' --version 2>&1', $output, $retval);
 		return $retval === 0 && $output !== array() ? trim((string) $output[0]) : 'unknown tar';
 	}
 
@@ -253,7 +253,7 @@ final class DownloadExtractRestrictiveFlagsTest extends TestCase
 		$archive = "{$this->dir}/foreign.tar";
 		$output = array();
 		$retval = 1;
-		exec('/usr/bin/tar -cf ' . escapeshellarg($archive)
+		exec(escapeshellcmd(pfb_test_tar()) . ' -cf ' . escapeshellarg($archive)
 			. ' --uid 12345 --gid 12345 --uname pfbfake --gname pfbfake -C '
 			. escapeshellarg("{$this->dir}/build") . ' member.dat 2>/dev/null', $output, $retval);
 		if ($retval !== 0) {
@@ -276,7 +276,7 @@ final class DownloadExtractRestrictiveFlagsTest extends TestCase
 		$this->assertTrue(mkdir($target, 0755));
 		$output = array();
 		$retval = 1;
-		exec(pfb_extract_cmd('/usr/bin/tar -xf ' . escapeshellarg($archive) . $flags . ' -C '
+		exec(pfb_extract_cmd(escapeshellcmd(pfb_test_tar()) . ' -xf ' . escapeshellarg($archive) . $flags . ' -C '
 			. escapeshellarg($target) . ' 2>&1'), $output, $retval);
 		$this->assertSame(0, $retval,
 			"extraction with '{$flags}' failed on " . $this->tarVersion() . ': ' . implode(' ', $output));
@@ -322,7 +322,7 @@ final class DownloadExtractRestrictiveFlagsTest extends TestCase
 		$probe = "{$this->dir}/repack_" . basename(dirname($path)) . '.tar';
 		$output = array();
 		$retval = 1;
-		exec('/usr/bin/tar -cf ' . escapeshellarg($probe) . ' -C ' . escapeshellarg(dirname($path))
+		exec(escapeshellcmd(pfb_test_tar()) . ' -cf ' . escapeshellarg($probe) . ' -C ' . escapeshellarg(dirname($path))
 			. ' ' . escapeshellarg(basename($path)) . ' 2>/dev/null', $output, $retval);
 		$this->assertSame(0, $retval, 'the extracted file must be re-archivable for its metadata to be read');
 		$bytes = file_get_contents($probe);

--- a/tests/php/DownloadExtractRestrictiveFlagsTest.php
+++ b/tests/php/DownloadExtractRestrictiveFlagsTest.php
@@ -223,7 +223,7 @@ final class DownloadExtractRestrictiveFlagsTest extends TestCase
 	{
 		$output = array();
 		$retval = 1;
-		exec(escapeshellcmd(pfb_test_tar()) . ' --version 2>&1', $output, $retval);
+		exec(escapeshellarg(pfb_test_tar()) . ' --version 2>&1', $output, $retval);
 		return $retval === 0 && $output !== array() ? trim((string) $output[0]) : 'unknown tar';
 	}
 
@@ -253,7 +253,7 @@ final class DownloadExtractRestrictiveFlagsTest extends TestCase
 		$archive = "{$this->dir}/foreign.tar";
 		$output = array();
 		$retval = 1;
-		exec(escapeshellcmd(pfb_test_tar()) . ' -cf ' . escapeshellarg($archive)
+		exec(escapeshellarg(pfb_test_tar()) . ' -cf ' . escapeshellarg($archive)
 			. ' --uid 12345 --gid 12345 --uname pfbfake --gname pfbfake -C '
 			. escapeshellarg("{$this->dir}/build") . ' member.dat 2>/dev/null', $output, $retval);
 		if ($retval !== 0) {
@@ -276,7 +276,7 @@ final class DownloadExtractRestrictiveFlagsTest extends TestCase
 		$this->assertTrue(mkdir($target, 0755));
 		$output = array();
 		$retval = 1;
-		exec(pfb_extract_cmd(escapeshellcmd(pfb_test_tar()) . ' -xf ' . escapeshellarg($archive) . $flags . ' -C '
+		exec(pfb_extract_cmd(escapeshellarg(pfb_test_tar()) . ' -xf ' . escapeshellarg($archive) . $flags . ' -C '
 			. escapeshellarg($target) . ' 2>&1'), $output, $retval);
 		$this->assertSame(0, $retval,
 			"extraction with '{$flags}' failed on " . $this->tarVersion() . ': ' . implode(' ', $output));
@@ -322,7 +322,7 @@ final class DownloadExtractRestrictiveFlagsTest extends TestCase
 		$probe = "{$this->dir}/repack_" . basename(dirname($path)) . '.tar';
 		$output = array();
 		$retval = 1;
-		exec(escapeshellcmd(pfb_test_tar()) . ' -cf ' . escapeshellarg($probe) . ' -C ' . escapeshellarg(dirname($path))
+		exec(escapeshellarg(pfb_test_tar()) . ' -cf ' . escapeshellarg($probe) . ' -C ' . escapeshellarg(dirname($path))
 			. ' ' . escapeshellarg(basename($path)) . ' 2>/dev/null', $output, $retval);
 		$this->assertSame(0, $retval, 'the extracted file must be re-archivable for its metadata to be read');
 		$bytes = file_get_contents($probe);

--- a/tests/php/DownloadExtractedPayloadSanityTest.php
+++ b/tests/php/DownloadExtractedPayloadSanityTest.php
@@ -296,14 +296,14 @@ final class DownloadExtractedPayloadSanityTest extends TestCase
 				$this->assertTrue($zip->open($path, ZipArchive::CREATE | ZipArchive::OVERWRITE));
 				$this->assertTrue($zip->addFromString('payload.txt', $payload));
 				$this->assertTrue($zip->close());
-				exec('/usr/bin/tar -tf ' . escapeshellarg($path) . ' >/dev/null 2>&1', $out, $rc);
-				$this->assertSame(0, $rc, '/usr/bin/tar cannot read ZIP on this host; the appliance uses bsdtar');
+				exec(escapeshellcmd(pfb_test_tar()) . ' -tf ' . escapeshellarg($path) . ' >/dev/null 2>&1', $out, $rc);
+				$this->assertSame(0, $rc, 'the archive tool cannot read ZIP on this host; the appliance uses bsdtar');
 				return $path;
 			case 'tar':
 				$path = "{$this->dir}/feed.tar";
-				exec('/usr/bin/tar -cf ' . escapeshellarg($path) . ' -C ' . escapeshellarg($this->dir)
+				exec(escapeshellcmd(pfb_test_tar()) . ' -cf ' . escapeshellarg($path) . ' -C ' . escapeshellarg($this->dir)
 					. ' payload.txt', $out, $rc);
-				$this->assertSame(0, $rc, '/usr/bin/tar could not build the fixture');
+				$this->assertSame(0, $rc, 'the archive tool could not build the fixture');
 				return $path;
 		}
 		throw new InvalidArgumentException("unknown archive kind [{$kind}]");

--- a/tests/php/DownloadExtractedPayloadSanityTest.php
+++ b/tests/php/DownloadExtractedPayloadSanityTest.php
@@ -296,12 +296,12 @@ final class DownloadExtractedPayloadSanityTest extends TestCase
 				$this->assertTrue($zip->open($path, ZipArchive::CREATE | ZipArchive::OVERWRITE));
 				$this->assertTrue($zip->addFromString('payload.txt', $payload));
 				$this->assertTrue($zip->close());
-				exec(escapeshellcmd(pfb_test_tar()) . ' -tf ' . escapeshellarg($path) . ' >/dev/null 2>&1', $out, $rc);
+				exec(escapeshellarg(pfb_test_tar()) . ' -tf ' . escapeshellarg($path) . ' >/dev/null 2>&1', $out, $rc);
 				$this->assertSame(0, $rc, 'the archive tool cannot read ZIP on this host; the appliance uses bsdtar');
 				return $path;
 			case 'tar':
 				$path = "{$this->dir}/feed.tar";
-				exec(escapeshellcmd(pfb_test_tar()) . ' -cf ' . escapeshellarg($path) . ' -C ' . escapeshellarg($this->dir)
+				exec(escapeshellarg(pfb_test_tar()) . ' -cf ' . escapeshellarg($path) . ' -C ' . escapeshellarg($this->dir)
 					. ' payload.txt', $out, $rc);
 				$this->assertSame(0, $rc, 'the archive tool could not build the fixture');
 				return $path;

--- a/tests/php/DownloadExtractionExitCodeTest.php
+++ b/tests/php/DownloadExtractionExitCodeTest.php
@@ -170,7 +170,7 @@ final class DownloadExtractionExitCodeTest extends TestCase
 		$this->assertNotFalse($blacklist);
 		$this->assertNotFalse($end);
 		$scope = substr(self::$source, $blacklist, $end - $blacklist);
-		$this->assertMatchesRegularExpression('/exec\(pfb_extract_cmd\(".*tar -xf .*\\$output, \\$retval\);/', $scope);
+		$this->assertMatchesRegularExpression('/exec\(pfb_extract_cmd\(".*tar.* -xf .*\\$output, \\$retval\);/', $scope);
 		$this->assertStringContainsString('pfb_archive_unsafe_member', $scope);
 		$this->assertStringContainsString(
 			'pfb_blacklist_tar_finalize_staged($staged, $filename, $retval)',
@@ -263,7 +263,7 @@ final class DownloadExtractionExitCodeTest extends TestCase
 		$scope = substr(self::$source, $blacklist, $end - $blacklist);
 		$this->assertStringContainsString("if (\$file_type == 'application/x-tar') {", $scope);
 		$this->assertStringContainsString('pfb_stage_publish_dir', $scope);
-		$this->assertStringContainsString('/usr/bin/tar -xf', $scope);
+		$this->assertMatchesRegularExpression('/.*tar.* -xf/', $scope);
 		// issue #2632 smoke: downloadPath may end in .tar, not .tar.gz; WORD rejects a leftover dot.
 		$this->assertStringContainsString("basename(basename(\"{\$file_esc}\", '.tar.gz'), '.tar')", $scope);
 		$this->assertStringContainsString('pfb_archive_unsafe_member', $scope);
@@ -412,8 +412,8 @@ final class DownloadExtractionExitCodeTest extends TestCase
 			$scope,
 			'inner tar extract must be gated on application/x-tar'
 		);
-		$this->assertStringContainsString(
-			'tar -xOf -',
+		$this->assertMatchesRegularExpression(
+			'/tar.* -xOf -/',
 			$scope,
 			'gzip inner tar must stdout-extract (-O); dropping it writes a tar archive as a feed'
 		);
@@ -533,7 +533,7 @@ final class DownloadExtractionExitCodeTest extends TestCase
 		$this->assertNotFalse($blacklist);
 		$scope = substr(self::$source, $top1m, $blacklist - $top1m);
 		$this->assertStringContainsString("if (\$file_type == 'application/x-tar') {", $scope);
-		$this->assertStringContainsString('tar -xOf', $scope);
+		$this->assertMatchesRegularExpression('/tar.* -xOf/', $scope);
 		$this->assertStringContainsString('count($archive_members) !== 1', $scope);
 	}
 

--- a/tests/php/DownloadExtractionExitCodeTest.php
+++ b/tests/php/DownloadExtractionExitCodeTest.php
@@ -296,9 +296,9 @@ final class DownloadExtractionExitCodeTest extends TestCase
 		// and publishes the members only on a clean exit, so its -C is the staged
 		// path rather than the live publication. issue #2659: the disk-writing mode
 		// carries the restriction flags; the stdout mode below must not.
-		$this->assertStringContainsString('exec(pfb_extract_cmd("/usr/bin/tar -xf {$file_dwn_esc} " . PFB_TAR_EXTRACT_FLAGS . " --strip=1 -C " . escapeshellarg($staged) . " >/dev/null 2>&1"), $output, $retval);', $scope);
-		$this->assertStringContainsString(
-			'exec(pfb_extract_cmd("/usr/bin/tar -xOf {$file_dwn_esc} > " . escapeshellarg($staged)), $output, $retval);', $scope);
+		$this->assertMatchesRegularExpression('/exec\(pfb_extract_cmd\(".*tar.* -xf {\$file_dwn_esc} " \. PFB_TAR_EXTRACT_FLAGS \. " --strip=1 -C " \. escapeshellarg\(\$staged\) \. " >\/dev\/null 2>&1"\), \$output, \$retval\);/', $scope);
+		$this->assertMatchesRegularExpression(
+			'/exec\(pfb_extract_cmd\(".*tar.* -xOf {\$file_dwn_esc} > " \. escapeshellarg\(\$staged\)\), \$output, \$retval\);/', $scope);
 		// issue #2169: the stdout mode publishes through the staged helper; the
 		// directory mode publishes through the staged merge helper.
 		$this->assertStringContainsString('if (!pfb_stage_publish($head_download,', $scope);
@@ -321,7 +321,7 @@ final class DownloadExtractionExitCodeTest extends TestCase
 		$this->assertNotFalse($top1m);
 		$this->assertNotFalse($blacklist);
 		$scope = substr(self::$source, $top1m, $blacklist - $top1m);
-		$this->assertMatchesRegularExpression('/exec\(pfb_extract_cmd\(".*tar -xf .*\\$output, \\$retval\);/', $scope);
+		$this->assertMatchesRegularExpression('/exec\(pfb_extract_cmd\(".*tar.* -xf .*\\$output, \\$retval\);/', $scope);
 		$this->assertStringContainsString('pfb_download_extraction_succeeded($retval)', $scope);
 	}
 
@@ -515,7 +515,7 @@ final class DownloadExtractionExitCodeTest extends TestCase
 		$this->assertStringNotContainsString('-C {$pfb[\'geoipshare\']}', $body);
 		$this->assertStringNotContainsString('-C {$header_esc}', $body);
 		$this->assertStringContainsString('pfb_archive_unsafe_member', $body);
-		$this->assertMatchesRegularExpression('/exec\(pfb_extract_cmd\(".*tar -xf .*\\$output, \\$retval\);/', $body);
+		$this->assertMatchesRegularExpression('/exec\(pfb_extract_cmd\(".*tar.* -xf .*\\$output, \\$retval\);/', $body);
 	}
 
 	/**

--- a/tests/php/DownloadGeoipStagePublishTest.php
+++ b/tests/php/DownloadGeoipStagePublishTest.php
@@ -112,7 +112,7 @@ final class DownloadGeoipStagePublishTest extends TestCase
 		$archive = "{$this->dir}/{$name}";
 		$retval = 1;
 		$output = array();
-		exec('cd ' . escapeshellarg($this->build) . ' && /usr/bin/tar -czf ' . escapeshellarg($archive)
+		exec('cd ' . escapeshellarg($this->build) . ' && ' . escapeshellcmd(pfb_test_tar()) . ' -czf ' . escapeshellarg($archive)
 			. ' ' . escapeshellarg('GeoLite2-Country_20260801'), $output, $retval);
 		$this->assertSame(0, $retval, 'the fixture archive must be built');
 		return $archive;
@@ -131,7 +131,7 @@ final class DownloadGeoipStagePublishTest extends TestCase
 	 */
 	private function extractCmd(string $archive, string $into, int $blocks): string
 	{
-		return pfb_extract_cmd('/usr/bin/tar -xf ' . escapeshellarg($archive) . ' --strip=1 -C '
+		return pfb_extract_cmd(escapeshellcmd(pfb_test_tar()) . ' -xf ' . escapeshellarg($archive) . ' --strip=1 -C '
 			. escapeshellarg($into) . ' >/dev/null 2>&1', $blocks);
 	}
 
@@ -165,10 +165,10 @@ final class DownloadGeoipStagePublishTest extends TestCase
 		$this->assertNotFalse(file_put_contents("{$probe}/src/probe.txt", "probe\n"));
 		$output = array();
 		$retval = 1;
-		exec('/usr/bin/tar -cf ' . escapeshellarg("{$probe}/probe.tar") . ' -C '
+		exec(escapeshellcmd(pfb_test_tar()) . ' -cf ' . escapeshellarg("{$probe}/probe.tar") . ' -C '
 			. escapeshellarg("{$probe}/src") . ' probe.txt 2>/dev/null', $output, $retval);
 		$this->assertSame(0, $retval, 'the capability probe must be able to build a one-member tar');
-		exec('/usr/bin/tar -xf ' . escapeshellarg("{$probe}/probe.tar") . ' ' . PFB_TAR_EXTRACT_FLAGS
+		exec(escapeshellcmd(pfb_test_tar()) . ' -xf ' . escapeshellarg("{$probe}/probe.tar") . ' ' . PFB_TAR_EXTRACT_FLAGS
 			. ' -C ' . escapeshellarg("{$probe}/out") . ' 2>/dev/null', $output, $retval);
 		if ($retval === 0) {
 			$this->assertFileExists("{$probe}/out/probe.txt",
@@ -181,7 +181,7 @@ final class DownloadGeoipStagePublishTest extends TestCase
 	private function tarVersion(): string
 	{
 		$version = array();
-		exec('/usr/bin/tar --version 2>&1', $version);
+		exec(escapeshellcmd(pfb_test_tar()) . ' --version 2>&1', $version);
 		return trim((string) ($version[0] ?? 'unknown tar'));
 	}
 
@@ -202,11 +202,9 @@ final class DownloadGeoipStagePublishTest extends TestCase
 		$retval = $this->shippedExtractionFlagsExitCode();
 		if ($retval !== 0) {
 			$this->markTestSkipped(
-				'/usr/bin/tar on this host (' . $this->tarVersion() . ') rejects the shipped '
+				'The archiver on this host (' . $this->tarVersion() . ') rejects the shipped '
 				. 'PFB_TAR_EXTRACT_FLAGS with exit ' . $retval . ' -- it is not libarchive. The appliance '
-				. 'ships bsdtar and CI installs it; to run this case here: apt-get install libarchive-tools '
-				. '&& dpkg-divert --no-rename --divert /usr/sbin/tar --add /usr/bin/tar '
-				. '&& mv /usr/bin/tar /usr/sbin/tar && ln -s bsdtar /usr/bin/tar'
+				. 'ships bsdtar; install libarchive-tools to run this case.'
 			);
 		}
 	}
@@ -379,7 +377,7 @@ final class DownloadGeoipStagePublishTest extends TestCase
 		$archive = "{$this->dir}/feed.tar.gz";
 		$retval = 1;
 		$output = array();
-		exec('cd ' . escapeshellarg($this->build) . ' && /usr/bin/tar -czf ' . escapeshellarg($archive)
+		exec('cd ' . escapeshellarg($this->build) . ' && ' . escapeshellcmd(pfb_test_tar()) . ' -czf ' . escapeshellarg($archive)
 			. ' GeoLite2-Country_20260801/GeoLite2-Country.mmdb GeoLite2-Country_20260801/sub/two.csv',
 			$output, $retval);
 		$this->assertSame(0, $retval);

--- a/tests/php/DownloadGeoipStagePublishTest.php
+++ b/tests/php/DownloadGeoipStagePublishTest.php
@@ -112,7 +112,7 @@ final class DownloadGeoipStagePublishTest extends TestCase
 		$archive = "{$this->dir}/{$name}";
 		$retval = 1;
 		$output = array();
-		exec('cd ' . escapeshellarg($this->build) . ' && ' . escapeshellcmd(pfb_test_tar()) . ' -czf ' . escapeshellarg($archive)
+		exec('cd ' . escapeshellarg($this->build) . ' && ' . escapeshellarg(pfb_test_tar()) . ' -czf ' . escapeshellarg($archive)
 			. ' ' . escapeshellarg('GeoLite2-Country_20260801'), $output, $retval);
 		$this->assertSame(0, $retval, 'the fixture archive must be built');
 		return $archive;
@@ -131,7 +131,7 @@ final class DownloadGeoipStagePublishTest extends TestCase
 	 */
 	private function extractCmd(string $archive, string $into, int $blocks): string
 	{
-		return pfb_extract_cmd(escapeshellcmd(pfb_test_tar()) . ' -xf ' . escapeshellarg($archive) . ' --strip=1 -C '
+		return pfb_extract_cmd(escapeshellarg(pfb_test_tar()) . ' -xf ' . escapeshellarg($archive) . ' --strip=1 -C '
 			. escapeshellarg($into) . ' >/dev/null 2>&1', $blocks);
 	}
 
@@ -165,10 +165,10 @@ final class DownloadGeoipStagePublishTest extends TestCase
 		$this->assertNotFalse(file_put_contents("{$probe}/src/probe.txt", "probe\n"));
 		$output = array();
 		$retval = 1;
-		exec(escapeshellcmd(pfb_test_tar()) . ' -cf ' . escapeshellarg("{$probe}/probe.tar") . ' -C '
+		exec(escapeshellarg(pfb_test_tar()) . ' -cf ' . escapeshellarg("{$probe}/probe.tar") . ' -C '
 			. escapeshellarg("{$probe}/src") . ' probe.txt 2>/dev/null', $output, $retval);
 		$this->assertSame(0, $retval, 'the capability probe must be able to build a one-member tar');
-		exec(escapeshellcmd(pfb_test_tar()) . ' -xf ' . escapeshellarg("{$probe}/probe.tar") . ' ' . PFB_TAR_EXTRACT_FLAGS
+		exec(escapeshellarg(pfb_test_tar()) . ' -xf ' . escapeshellarg("{$probe}/probe.tar") . ' ' . PFB_TAR_EXTRACT_FLAGS
 			. ' -C ' . escapeshellarg("{$probe}/out") . ' 2>/dev/null', $output, $retval);
 		if ($retval === 0) {
 			$this->assertFileExists("{$probe}/out/probe.txt",
@@ -181,7 +181,7 @@ final class DownloadGeoipStagePublishTest extends TestCase
 	private function tarVersion(): string
 	{
 		$version = array();
-		exec(escapeshellcmd(pfb_test_tar()) . ' --version 2>&1', $version);
+		exec(escapeshellarg(pfb_test_tar()) . ' --version 2>&1', $version);
 		return trim((string) ($version[0] ?? 'unknown tar'));
 	}
 
@@ -377,7 +377,7 @@ final class DownloadGeoipStagePublishTest extends TestCase
 		$archive = "{$this->dir}/feed.tar.gz";
 		$retval = 1;
 		$output = array();
-		exec('cd ' . escapeshellarg($this->build) . ' && ' . escapeshellcmd(pfb_test_tar()) . ' -czf ' . escapeshellarg($archive)
+		exec('cd ' . escapeshellarg($this->build) . ' && ' . escapeshellarg(pfb_test_tar()) . ' -czf ' . escapeshellarg($archive)
 			. ' GeoLite2-Country_20260801/GeoLite2-Country.mmdb GeoLite2-Country_20260801/sub/two.csv',
 			$output, $retval);
 		$this->assertSame(0, $retval);

--- a/tests/php/DownloadRejectValidatorClearTest.php
+++ b/tests/php/DownloadRejectValidatorClearTest.php
@@ -667,7 +667,7 @@ final class DownloadRejectValidatorClearTest extends TestCase
 	{
 		$this->write('payload.txt', $bytes);
 		$path = "{$this->dir}/body.tar";
-		exec(escapeshellcmd(pfb_test_tar()) . ' -cf ' . escapeshellarg($path) . ' -C ' . escapeshellarg($this->dir)
+		exec(escapeshellarg(pfb_test_tar()) . ' -cf ' . escapeshellarg($path) . ' -C ' . escapeshellarg($this->dir)
 			. ' payload.txt', $out, $rc);
 		$this->assertSame(0, $rc, 'the archive tool could not build the fixture');
 		return $path;
@@ -703,7 +703,7 @@ final class DownloadRejectValidatorClearTest extends TestCase
 		$this->assertTrue($zip->open($probe, ZipArchive::CREATE | ZipArchive::OVERWRITE));
 		$this->assertTrue($zip->addFromString('probe.txt', "192.0.2.1\n"));
 		$this->assertTrue($zip->close());
-		exec(escapeshellcmd(pfb_test_tar()) . ' -tf ' . escapeshellarg($probe) . ' >/dev/null 2>&1', $out, $rc);
+		exec(escapeshellarg(pfb_test_tar()) . ' -tf ' . escapeshellarg($probe) . ' >/dev/null 2>&1', $out, $rc);
 		unlink($probe);
 		if ($rc !== 0) {
 			$this->markTestSkipped('the archive tool cannot read ZIP on this host; the appliance uses bsdtar');

--- a/tests/php/DownloadRejectValidatorClearTest.php
+++ b/tests/php/DownloadRejectValidatorClearTest.php
@@ -667,9 +667,9 @@ final class DownloadRejectValidatorClearTest extends TestCase
 	{
 		$this->write('payload.txt', $bytes);
 		$path = "{$this->dir}/body.tar";
-		exec('/usr/bin/tar -cf ' . escapeshellarg($path) . ' -C ' . escapeshellarg($this->dir)
+		exec(escapeshellcmd(pfb_test_tar()) . ' -cf ' . escapeshellarg($path) . ' -C ' . escapeshellarg($this->dir)
 			. ' payload.txt', $out, $rc);
-		$this->assertSame(0, $rc, '/usr/bin/tar could not build the fixture');
+		$this->assertSame(0, $rc, 'the archive tool could not build the fixture');
 		return $path;
 	}
 
@@ -703,10 +703,10 @@ final class DownloadRejectValidatorClearTest extends TestCase
 		$this->assertTrue($zip->open($probe, ZipArchive::CREATE | ZipArchive::OVERWRITE));
 		$this->assertTrue($zip->addFromString('probe.txt', "192.0.2.1\n"));
 		$this->assertTrue($zip->close());
-		exec('/usr/bin/tar -tf ' . escapeshellarg($probe) . ' >/dev/null 2>&1', $out, $rc);
+		exec(escapeshellcmd(pfb_test_tar()) . ' -tf ' . escapeshellarg($probe) . ' >/dev/null 2>&1', $out, $rc);
 		unlink($probe);
 		if ($rc !== 0) {
-			$this->markTestSkipped('/usr/bin/tar cannot read ZIP on this host; the appliance uses bsdtar');
+			$this->markTestSkipped('the archive tool cannot read ZIP on this host; the appliance uses bsdtar');
 		}
 	}
 

--- a/tests/php/DownloadSizeCeilingTest.php
+++ b/tests/php/DownloadSizeCeilingTest.php
@@ -307,7 +307,7 @@ final class DownloadSizeCeilingTest extends TestCase
 			'exec("{$pfb[\'script\']} whoisconvert {$header_esc} {$vtype} {$list_url_esc} {$elog}");',
 			'exec("{$pfb[\'script\']} asn_table {$elog}");',
 			// Lists an archive; extracts nothing.
-			'exec("/usr/bin/tar -tf {$file_dwn_esc}");',
+			'exec("{$tar_bin} -tf {$file_dwn_esc}");',
 			// Capped. This one stays a prefix: it covers every capped call site, each
 			// with its own argument list. So a command concatenated onto a capped call
 			// is invisible HERE -- but not uncapped: ulimit is process-scoped, so the

--- a/tests/php/GeoipZipPublicationTest.php
+++ b/tests/php/GeoipZipPublicationTest.php
@@ -73,7 +73,7 @@ final class GeoipZipPublicationTest extends TestCase
 			'geoip/one.dat' => "one\n",
 			'geoip/two.dat' => "two\n",
 		]);
-		exec(escapeshellcmd(pfb_test_tar()) . ' -tf ' . escapeshellarg($archive) . ' >/dev/null 2>&1', $output, $status);
+		exec(escapeshellarg(pfb_test_tar()) . ' -tf ' . escapeshellarg($archive) . ' >/dev/null 2>&1', $output, $status);
 		if ($status !== 0) {
 			$this->markTestSkipped('the archiver cannot read ZIP on this host; pfSense uses bsdtar');
 		}

--- a/tests/php/GeoipZipPublicationTest.php
+++ b/tests/php/GeoipZipPublicationTest.php
@@ -73,9 +73,9 @@ final class GeoipZipPublicationTest extends TestCase
 			'geoip/one.dat' => "one\n",
 			'geoip/two.dat' => "two\n",
 		]);
-		exec('/usr/bin/tar -tf ' . escapeshellarg($archive) . ' >/dev/null 2>&1', $output, $status);
+		exec(escapeshellcmd(pfb_test_tar()) . ' -tf ' . escapeshellarg($archive) . ' >/dev/null 2>&1', $output, $status);
 		if ($status !== 0) {
-			$this->markTestSkipped('/usr/bin/tar cannot read ZIP on this host; pfSense uses bsdtar');
+			$this->markTestSkipped('the archiver cannot read ZIP on this host; pfSense uses bsdtar');
 		}
 		$base = "{$this->dir}/geoip-feed";
 		$target = "{$this->dir}/geoip-share";

--- a/tests/php/README.md
+++ b/tests/php/README.md
@@ -72,26 +72,21 @@ Deep pfSense-runtime integration (config apply, service reloads, pf/Unbound
 wiring, URL/MIME validation that shells out to `/usr/bin/file` or resolves
 hosts) stays the live-VM smoke's job — see `legacy/ADRs/ADR_04_VM_Smoke_Tests/`.
 
-## Host archive toolchain (why some cases skip locally)
+## Host archive toolchain
 
-The package execs absolute paths, and on FreeBSD `/usr/bin/tar` is **bsdtar** and
-`/usr/bin/unzip` is **bsdunzip** — both libarchive. Debian puts GNU tar and Info-ZIP
-there instead, and they are not interchangeable: GNU tar rejects the shipped
-`PFB_TAR_EXTRACT_FLAGS` (`--no-fflags`) with exit 64 before reading the archive. Cases
-that drive a real extraction therefore skip on such a host, naming that reason.
+On FreeBSD and macOS, `/usr/bin/tar` is **bsdtar** (libarchive). On Linux,
+`bsdtar` is provided by `libarchive-tools` (typically at `/usr/bin/bsdtar`).
 
-CI installs the appliance's binaries rather than living with the gap, and a dev host
-can do the same (`test.yml`, jobs "Put bsdtar at /usr/bin/tar" and "Put bsdunzip at
-/usr/bin/unzip"):
+The PHPUnit test bootstrap resolves the platform archiver cleanly and asserts
+`bsdtar` is executable, crashing fast on startup if missing on Linux.
+Linux development seats install it via `sh scripts/agent/setup-agent-tools.sh`
+or directly via:
 
 ```sh
 sudo apt-get install -y --no-install-recommends libarchive-tools
-sudo dpkg-divert --no-rename --divert /usr/sbin/tar --add /usr/bin/tar
-sudo mv /usr/bin/tar /usr/sbin/tar && sudo ln -s bsdtar /usr/bin/tar
 ```
 
-`/usr/sbin` precedes `/usr/bin` on PATH, so a bare `tar` still resolves to GNU tar for
-everything else. Reverse it with `dpkg-divert --remove` after moving the binary back.
+No `dpkg-divert` or host binary mutation is required.
 
 ## Adding a test
 

--- a/tests/php/Top1mDccDetectorTest.php
+++ b/tests/php/Top1mDccDetectorTest.php
@@ -484,7 +484,7 @@ PHP;
 
 	private function tarReadsZip(string $archive): bool
 	{
-		exec(escapeshellcmd(pfb_test_tar()) . ' -tf ' . escapeshellarg($archive) . ' >/dev/null 2>&1', $output, $status);
+		exec(escapeshellarg(pfb_test_tar()) . ' -tf ' . escapeshellarg($archive) . ' >/dev/null 2>&1', $output, $status);
 		return $status === 0;
 	}
 

--- a/tests/php/Top1mDccDetectorTest.php
+++ b/tests/php/Top1mDccDetectorTest.php
@@ -478,13 +478,13 @@ PHP;
 	private function requireZipTarSupport(string $archive): void
 	{
 		if (!$this->tarReadsZip($archive)) {
-			$this->markTestSkipped('/usr/bin/tar cannot read ZIP on this host; pfSense uses bsdtar');
+			$this->markTestSkipped('the archiver cannot read ZIP on this host; pfSense uses bsdtar');
 		}
 	}
 
 	private function tarReadsZip(string $archive): bool
 	{
-		exec('/usr/bin/tar -tf ' . escapeshellarg($archive) . ' >/dev/null 2>&1', $output, $status);
+		exec(escapeshellcmd(pfb_test_tar()) . ' -tf ' . escapeshellarg($archive) . ' >/dev/null 2>&1', $output, $status);
 		return $status === 0;
 	}
 

--- a/tests/php/Top1mSemanticMatrixTest.php
+++ b/tests/php/Top1mSemanticMatrixTest.php
@@ -357,7 +357,7 @@ PHP;
 
 	private function tarReadsZip(string $archive): bool
 	{
-		exec('/usr/bin/tar -tf ' . escapeshellarg($archive) . ' >/dev/null 2>&1', $output, $status);
+		exec(escapeshellcmd(pfb_test_tar()) . ' -tf ' . escapeshellarg($archive) . ' >/dev/null 2>&1', $output, $status);
 		return $status === 0;
 	}
 

--- a/tests/php/Top1mSemanticMatrixTest.php
+++ b/tests/php/Top1mSemanticMatrixTest.php
@@ -357,7 +357,7 @@ PHP;
 
 	private function tarReadsZip(string $archive): bool
 	{
-		exec(escapeshellcmd(pfb_test_tar()) . ' -tf ' . escapeshellarg($archive) . ' >/dev/null 2>&1', $output, $status);
+		exec(escapeshellarg(pfb_test_tar()) . ' -tf ' . escapeshellarg($archive) . ' >/dev/null 2>&1', $output, $status);
 		return $status === 0;
 	}
 

--- a/tests/php/bootstrap.php
+++ b/tests/php/bootstrap.php
@@ -114,18 +114,21 @@ unset($pfb_test_timeout_out, $pfb_test_timeout_rc, $pfb_test_timeout);
  * If bsdtar cannot be resolved on the host, crash fast with RuntimeException.
  *
  * @param ?callable(string): string $lookup
+ * @param ?callable(string): bool   $executable_check
  */
-function pfb_resolve_archiver(?string $os_family = NULL, ?callable $lookup = NULL): string
+function pfb_resolve_archiver(?string $os_family = NULL, ?callable $lookup = NULL, ?callable $executable_check = NULL): string
 {
 	$family = $os_family ?? PHP_OS_FAMILY;
+	$is_exec = $executable_check ?? 'is_executable';
 	if ($family === 'BSD' || $family === 'Darwin') {
-		return '/usr/bin/tar';
+		$tar = '/usr/bin/tar';
+	} else {
+		$finder = $lookup ?? static function (string $cmd): string {
+			return trim((string) shell_exec('command -v ' . escapeshellarg($cmd) . ' 2>/dev/null'));
+		};
+		$tar = $finder('bsdtar');
 	}
-	$finder = $lookup ?? static function (string $cmd): string {
-		return trim((string) shell_exec('command -v ' . escapeshellarg($cmd) . ' 2>/dev/null'));
-	};
-	$tar = $finder('bsdtar');
-	if ($tar === '' || ($lookup === NULL && !is_executable($tar))) {
+	if ($tar === '' || !call_user_func($is_exec, $tar)) {
 		throw new RuntimeException("bsdtar binary missing on host ({$family})");
 	}
 	return $tar;

--- a/tests/php/bootstrap.php
+++ b/tests/php/bootstrap.php
@@ -106,6 +106,37 @@ if ($pfb_test_timeout_rc !== 0 || !is_executable($pfb_test_timeout)) {
 }
 $GLOBALS['pfb']['timeout'] = $pfb_test_timeout;
 unset($pfb_test_timeout_out, $pfb_test_timeout_rc, $pfb_test_timeout);
+/**
+ * Issue #3195: resolve the host's bsdtar binary.
+ *
+ * FreeBSD and macOS ship bsdtar at /usr/bin/tar.
+ * Linux development seats provide bsdtar via libarchive-tools.
+ * If bsdtar cannot be resolved on the host, crash fast with RuntimeException.
+ *
+ * @param ?callable(string): string $lookup
+ */
+function pfb_resolve_archiver(?string $os_family = NULL, ?callable $lookup = NULL): string
+{
+	$family = $os_family ?? PHP_OS_FAMILY;
+	if ($family === 'BSD' || $family === 'Darwin') {
+		return '/usr/bin/tar';
+	}
+	$finder = $lookup ?? static function (string $cmd): string {
+		return trim((string) shell_exec('command -v ' . escapeshellarg($cmd) . ' 2>/dev/null'));
+	};
+	$tar = $finder('bsdtar');
+	if ($tar === '' || ($lookup === NULL && !is_executable($tar))) {
+		throw new RuntimeException("bsdtar binary missing on host ({$family})");
+	}
+	return $tar;
+}
+
+function pfb_test_tar(): string
+{
+	return $GLOBALS['pfb']['tar'] ?? '/usr/bin/tar';
+}
+
+$GLOBALS['pfb']['tar'] = pfb_resolve_archiver();
 
 // Snapshot the SHIPPED $pfb['mime_types'] allow-list exactly as the just-loaded
 // production source defines it, before any test mutates/unsets $GLOBALS['pfb']

--- a/tests/shell/agent_tools_setup_spec.sh
+++ b/tests/shell/agent_tools_setup_spec.sh
@@ -356,14 +356,14 @@ GROK
   AfterEach 'cleanup'
 
   It 'installs only missing Linux prerequisites through sudo for a non-root user'
-    export DEBIAN_MISSING_PACKAGES=ca-certificates,curl,git
+    export DEBIAN_MISSING_PACKAGES=ca-certificates,curl,git,libarchive-tools
     When run env DEBIAN_TEST_UID=1000 sh "$script_abs" "$repository"
     The status should equal 0
     The contents of file "$apt_log" should equal "$(printf '%s\n' \
       'sudo:apt-get update' \
       'apt-get:update' \
-      'sudo:apt-get install -y ca-certificates curl git' \
-      'apt-get:install -y ca-certificates curl git')"
+      'sudo:apt-get install -y ca-certificates curl git libarchive-tools' \
+      'apt-get:install -y ca-certificates curl git libarchive-tools')"
   End
 
   It 'runs apt-get directly as Linux root and installs only the missing package subset'


### PR DESCRIPTION
Fixes #3195

## What

Replace host OS binary diversion (`dpkg-divert` and symlinks over `/usr/bin/tar`) with platform-aware archiver resolution, fail-fast test bootstrap checks, and clean developer prerequisite provisioning:

1. **`scripts/agent/setup-agent-tools.sh`**: Add `libarchive-tools` to `install_linux_prerequisites()`. Installs `/usr/bin/bsdtar` cleanly via `apt-get` with zero host OS binary hijacking.
2. **`tests/php/bootstrap.php`**: Add `pfb_resolve_archiver()` and `pfb_test_tar()`. Resolves `/usr/bin/tar` on BSD/macOS and `command -v bsdtar` on Linux; fails fast at startup with `RuntimeException("bsdtar binary missing on host (Linux)")` if missing on Linux. Populates `$GLOBALS['pfb']['tar']`.
3. **`src/usr/local/pkg/pfblockerng/pfblockerng.inc`**: Mirror the established off-appliance injection pattern (`$pfb['timeout']`, `$pfb['php']`, `$pfb['rsync_bin']`) with `$pfb['tar'] ?? '/usr/bin/tar'` for `pfb_validate_archive()`, `pfb_archive_member_names()`, and `pfb_download()` extraction paths. On-appliance default remains `/usr/bin/tar`.
4. **`tests/php/*Test.php`**: Use `pfb_test_tar()` in test fixture creation, extraction commands, and assertion probes across `DownloadExtractedPayloadSanityTest`, `DownloadRejectValidatorClearTest`, `DownloadGeoipStagePublishTest`, `DownloadExtractRestrictiveFlagsTest`, `DownloadExtractionExitCodeTest`, `ArchiveProbeTest`, `ArchiveValidateWiringTest`, `GeoipZipPublicationTest`, `Top1mDccDetectorTest`, and `Top1mSemanticMatrixTest`.
5. **`tests/php/README.md`**: Update "Host archive toolchain" documentation.
6. **`.github/workflows/test.yml`**: Install `libarchive-tools` in the `test` (pytest) job so tests invoking `php tests/php/bootstrap.php` have `bsdtar` available; remove `dpkg-divert` and host binary mutation from `php-unit` job.

## Red→Green (executed)

| Frozen RED test | git hash-object | RED run tail |
| --- | --- | --- |
| `tests/php/ArchiveProbeTest.php` | ea75e410b9a6d38c07865fd544540b48cb0e45c5 | 1 failure (expected /usr/bin/tar, got /usr/bin/bsdtar) |
| `tests/php/ArchiveValidateWiringTest.php` | 27697d162dc5c667cd999582e0b29784a51a1204 | pfb_test_tar() integration |
| `tests/php/BootstrapArchiverResolutionTest.php` | f9819f88e258ec939962d578d550cf77dde27f37 | 7 tests, 5 errors, 2 failures |
| `tests/php/DownloadExtractRestrictiveFlagsTest.php` | cf7a475fbde83e27c0c63eeb08bf9d30334e564a | pfb_test_tar() integration |
| `tests/php/DownloadExtractedPayloadSanityTest.php` | 568585efaa0240852d830fe1da2253c9fc905c6e | 6 failures on zip rows |
| `tests/php/DownloadExtractionExitCodeTest.php` | a32c1d487c814f09f07aae0620b92a8eb61bad26 | tar_bin regex alignment |
| `tests/php/DownloadGeoipStagePublishTest.php` | 30e58934c1a050c13585dc35178053ee0d360b26 | 6 skips on GNU tar |
| `tests/php/DownloadRejectValidatorClearTest.php` | e2f509836b230d58831e9f3469ee5e5687f140ec | 1 failure on tar-bad probe |
| `tests/php/DownloadSizeCeilingTest.php` | 4fd5680dedb66c99af2fdcd4261a6423238687ab | tar_bin allowlist entry |
| `tests/php/GeoipZipPublicationTest.php` | aed8f370de4108d58bab9d7cf77c16b24f679ab3 | 1 failure on zip download |
| `tests/php/Top1mDccDetectorTest.php` | 501376857ee7723e573ea8db134b19049d8fce61 | pfb_test_tar() integration |
| `tests/php/Top1mSemanticMatrixTest.php` | 501e2f9129125a2c804201ee36113a24a436df3c | pfb_test_tar() integration |
| `tests/php/bootstrap.php` | f40987c652466048a4f14c289b0bbe2e0c398475 | pfb_resolve_archiver() bootstrap |
| `tests/shell/agent_tools_setup_spec.sh` | 933755951b60eb7483365fc296d0fd4853d684a8 | 1 failure (missing libarchive-tools) |

## Verification

- **PHPUnit:** 121 tests, 1442 assertions, 0 failures, 0 errors.
- **ShellSpec:** 43 examples, 0 failures.
- **Static analysis:**
  - `phpstan analyse src/`: OK, no errors
  - `phpcs src/`: clean
  - `shellcheck scripts/agent/setup-agent-tools.sh`: clean
  - `markdownlint-cli2`: clean (0 issues in 89 files)
  - `check_coverage_pairing.py`: Coverage pairing OK
  - `check_composer_vendor.py`: OK
  - `check_toggle_registry.py`: OK
  - `check_reentry_bounds.py`: OK
  - `check-graph-fresh.sh`: graph is fresh
