### PR TITLE
feeds: point both Maltrail feeds at their live endpoints (release/3.3)

### DIFF
--- a/src/usr/local/www/pfblockerng/pfblockerng_feeds.json
+++ b/src/usr/local/www/pfblockerng/pfblockerng_feeds.json
@@ -556,7 +556,7 @@
 				{
 					"feed":		"Maltrail",
 					"website":	"https://github.com/stamparm/maltrail",
-					"url":		"https://raw.githubusercontent.com/stamparm/maltrail/master/trails/static/mass_scanner.txt",
+					"url":		"https://raw.githubusercontent.com/stamparm/maltrail/refs/heads/master/data/mass_scanner.txt",
 					"header":	"Maltrail_Scanners_All"
 				}
 			]
@@ -1330,7 +1330,7 @@
 				{
 					"feed":		"Maltrail",
 					"website":	"https://github.com/stamparm/maltrail",
-					"url":		"https://raw.githubusercontent.com/stamparm/aux/master/maltrail-malware-domains.txt",
+					"url":		"https://github.com/stamparm/trails/releases/latest/download/maltrail-malware-domains.txt",
 					"header":	"Maltrail_BD"
 				},
 				{

--- a/tests/test_feeds_maltrail_urls_3_3.py
+++ b/tests/test_feeds_maltrail_urls_3_3.py
@@ -13,39 +13,32 @@ from pathlib import Path
 
 _FEEDS_JSON = Path(__file__).parents[1] / "src/usr/local/www/pfblockerng/pfblockerng_feeds.json"
 
-_LIVE_URLS = (
-    "https://raw.githubusercontent.com/stamparm/maltrail/refs/heads/master/data/mass_scanner.txt",
-    "https://github.com/stamparm/trails/releases/latest/download/maltrail-malware-domains.txt",
+# (retired 404 endpoint, live endpoint) per Maltrail feed: the ipv4 scanner list
+# and the DNSBL malware-domain list.
+_MALTRAIL_URLS = (
+    (
+        "https://raw.githubusercontent.com/stamparm/maltrail/master/trails/static/mass_scanner.txt",
+        "https://raw.githubusercontent.com/stamparm/maltrail/refs/heads/master/data/mass_scanner.txt",
+    ),
+    (
+        "https://raw.githubusercontent.com/stamparm/aux/master/maltrail-malware-domains.txt",
+        "https://github.com/stamparm/trails/releases/latest/download/maltrail-malware-domains.txt",
+    ),
 )
-
-_RETIRED_URLS = (
-    "https://raw.githubusercontent.com/stamparm/maltrail/master/trails/static/mass_scanner.txt",
-    "https://raw.githubusercontent.com/stamparm/aux/master/maltrail-malware-domains.txt",
-)
-
-
-def _catalog_urls() -> set[str]:
-    """Every 'url' the catalogue offers, across sections, feeds, and alternates."""
-    urls: set[str] = set()
-
-    def walk(node: object) -> None:
-        if isinstance(node, dict):
-            url = node.get("url")
-            if isinstance(url, str):
-                urls.add(url)
-            for value in node.values():
-                walk(value)
-        elif isinstance(node, list):
-            for item in node:
-                walk(item)
-
-    walk(json.loads(_FEEDS_JSON.read_text(encoding="utf-8")))
-    return urls
 
 
 def test_maltrail_feeds_use_their_live_endpoints() -> None:
-    urls = _catalog_urls()
-    missing = [url for url in _LIVE_URLS if url not in urls]
-    assert missing == [], f"live Maltrail endpoints missing from the catalogue: {missing}"
-    stale = [url for url in _RETIRED_URLS if url in urls]
-    assert stale == [], f"retired (404) Maltrail endpoints still shipped: {stale}"
+    text = _FEEDS_JSON.read_text(encoding="utf-8")
+    catalog = json.loads(text)
+    shipped = {
+        feed["url"]
+        for section in ("ipv4", "ipv6", "dnsbl")
+        for group in catalog.get(section, {}).values()
+        for feed in group.get("feeds", [])
+        if "url" in feed
+    }
+    for retired, live in _MALTRAIL_URLS:
+        assert live in shipped, f"live Maltrail endpoint missing from the catalogue: {live}"
+        # Scanned in the file text, not the parsed feed rows: the retired endpoint
+        # must be gone from alternates and comments too, not just from a feed row.
+        assert retired not in text, f"retired (404) Maltrail endpoint still shipped: {retired}"

--- a/tests/test_feeds_maltrail_urls_3_3.py
+++ b/tests/test_feeds_maltrail_urls_3_3.py
@@ -1,0 +1,51 @@
+"""The shipped Maltrail feed URLs must be the ones that still serve (issue #3205).
+
+The scanner trail moved inside ``stamparm/maltrail`` and the malware-domain list
+moved out of the retired ``stamparm/aux`` repository into ``stamparm/trails``
+release assets. Both former URLs answer HTTP 404, so an update run stores
+GitHub's 14-byte error page instead of a list.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+_FEEDS_JSON = Path(__file__).parents[1] / "src/usr/local/www/pfblockerng/pfblockerng_feeds.json"
+
+_LIVE_URLS = (
+    "https://raw.githubusercontent.com/stamparm/maltrail/refs/heads/master/data/mass_scanner.txt",
+    "https://github.com/stamparm/trails/releases/latest/download/maltrail-malware-domains.txt",
+)
+
+_RETIRED_URLS = (
+    "https://raw.githubusercontent.com/stamparm/maltrail/master/trails/static/mass_scanner.txt",
+    "https://raw.githubusercontent.com/stamparm/aux/master/maltrail-malware-domains.txt",
+)
+
+
+def _catalog_urls() -> set[str]:
+    """Every 'url' the catalogue offers, across sections, feeds, and alternates."""
+    urls: set[str] = set()
+
+    def walk(node: object) -> None:
+        if isinstance(node, dict):
+            url = node.get("url")
+            if isinstance(url, str):
+                urls.add(url)
+            for value in node.values():
+                walk(value)
+        elif isinstance(node, list):
+            for item in node:
+                walk(item)
+
+    walk(json.loads(_FEEDS_JSON.read_text(encoding="utf-8")))
+    return urls
+
+
+def test_maltrail_feeds_use_their_live_endpoints() -> None:
+    urls = _catalog_urls()
+    missing = [url for url in _LIVE_URLS if url not in urls]
+    assert missing == [], f"live Maltrail endpoints missing from the catalogue: {missing}"
+    stale = [url for url in _RETIRED_URLS if url in urls]
+    assert stale == [], f"retired (404) Maltrail endpoints still shipped: {stale}"

--- a/tests/test_feeds_maltrail_urls_3_3.py
+++ b/tests/test_feeds_maltrail_urls_3_3.py
@@ -13,16 +13,20 @@ from pathlib import Path
 
 _FEEDS_JSON = Path(__file__).parents[1] / "src/usr/local/www/pfblockerng/pfblockerng_feeds.json"
 
-# (retired 404 endpoint, live endpoint) per Maltrail feed: the ipv4 scanner list
-# and the DNSBL malware-domain list.
-_MALTRAIL_URLS = (
+# (retired 404 endpoint, live endpoint, section, feed header) per Maltrail feed:
+# the ipv4 scanner list and the DNSBL malware-domain list.
+_MALTRAIL_FEEDS = (
     (
         "https://raw.githubusercontent.com/stamparm/maltrail/master/trails/static/mass_scanner.txt",
         "https://raw.githubusercontent.com/stamparm/maltrail/refs/heads/master/data/mass_scanner.txt",
+        "ipv4",
+        "Maltrail_Scanners_All",
     ),
     (
         "https://raw.githubusercontent.com/stamparm/aux/master/maltrail-malware-domains.txt",
         "https://github.com/stamparm/trails/releases/latest/download/maltrail-malware-domains.txt",
+        "dnsbl",
+        "Maltrail_BD",
     ),
 )
 
@@ -30,15 +34,16 @@ _MALTRAIL_URLS = (
 def test_maltrail_feeds_use_their_live_endpoints() -> None:
     text = _FEEDS_JSON.read_text(encoding="utf-8")
     catalog = json.loads(text)
-    shipped = {
-        feed["url"]
-        for section in ("ipv4", "ipv6", "dnsbl")
-        for group in catalog.get(section, {}).values()
-        for feed in group.get("feeds", [])
-        if "url" in feed
-    }
-    for retired, live in _MALTRAIL_URLS:
-        assert live in shipped, f"live Maltrail endpoint missing from the catalogue: {live}"
+    for retired, live, section, header in _MALTRAIL_FEEDS:
+        urls = [
+            feed.get("url")
+            for group in catalog.get(section, {}).values()
+            for feed in group.get("feeds", [])
+            if feed.get("header") == header
+        ]
+        # Pinned to the feed record, not to the catalogue at large: swapping the two
+        # Maltrail URLs between their feeds must fail as loudly as dropping one.
+        assert urls == [live], f"{header} must carry its live endpoint in the {section} section — got {urls}"
         # Scanned in the file text, not the parsed feed rows: the retired endpoint
         # must be gone from alternates and comments too, not just from a feed row.
         assert retired not in text, f"retired (404) Maltrail endpoint still shipped: {retired}"


### PR DESCRIPTION
Both Maltrail entries in the shipped catalogue answer HTTP 404: the scanner trail moved inside `stamparm/maltrail` (`trails/static/` → `data/mass_scanner.txt`), and the malware-domain list moved out of the retired `stamparm/aux` repository into `stamparm/trails` release assets. An update run for `Maltrail_Scanners_All` (ipv4 SCANNERS) and `Maltrail_BD` (dnsbl Malware) therefore downloads GitHub's 14-byte error page instead of a list.

Same correction as pfsense/FreeBSD-ports#1458, which carries it for the Ports copy of the same file — this line's catalogue is byte-identical to it, so the diff matches upstream's blob for blob.

Refs #3205. Ships on the stable line as a patch release; the `devel` counterpart is #3207.

## Endpoint evidence (executed 2026-09-05)

```
$ curl -sSL -o /dev/null -w '%{http_code} %{size_download}\n' --max-time 25 <url>
https://raw.githubusercontent.com/stamparm/maltrail/master/trails/static/mass_scanner.txt   404 14
https://raw.githubusercontent.com/stamparm/maltrail/refs/heads/master/data/mass_scanner.txt 200 665163
https://raw.githubusercontent.com/stamparm/aux/master/maltrail-malware-domains.txt          404 14
https://github.com/stamparm/trails/releases/latest/download/maltrail-malware-domains.txt    200 18607620
```

The replacement malware-domains URL is a release asset and answers through one redirect to `release-assets.githubusercontent.com`; the feed downloader follows redirects (`CURLOPT_FOLLOWLOCATION`), so no download-path change is needed.

## Test proof (red → green, same bytes)

`tests/test_feeds_maltrail_urls_3_3.py` pins both halves: each live endpoint is present in the parsed feed rows, and neither retired endpoint appears anywhere in the catalogue text (so alternates and comments are covered too).

The guard was simplified after review (`e1e7722e`, over-engineering leg: the recursive catalogue walker was unused generality) and then bound to each feed record (`498690ef`, external reviewer: a flattened URL set would have passed with the two URLs swapped between their feeds). Proof below is for the shipped form; the earlier forms' proofs are in the review threads.

```
$ git hash-object tests/test_feeds_maltrail_urls_3_3.py
2df15bd65c17869dcd52aa3943b815b736fe57dc
$ python3 -m pytest tests/test_feeds_maltrail_urls_3_3.py      # catalogue reverted to the retired URLs
FAILED tests/test_feeds_maltrail_urls_3_3.py::test_maltrail_feeds_use_their_live_endpoints
  AssertionError: Maltrail_Scanners_All must carry its live endpoint in the ipv4 section — got
  ['https://raw.githubusercontent.com/stamparm/maltrail/master/trails/static/mass_scanner.txt']
1 failed in 0.03s

# … catalogue restored, test file untouched …
$ git hash-object tests/test_feeds_maltrail_urls_3_3.py
2df15bd65c17869dcd52aa3943b815b736fe57dc
$ python3 -m pytest tests/test_feeds_maltrail_urls_3_3.py
1 passed in 0.02s
```

Mutations, each with the other half left intact:

```
# retired URL planted inside an `alternate` list, both live URLs present
AssertionError: retired (404) Maltrail endpoint still shipped:
  https://raw.githubusercontent.com/stamparm/aux/master/maltrail-malware-domains.txt

# the two live URLs swapped between their feeds
AssertionError: Maltrail_Scanners_All must carry its live endpoint in the ipv4 section — got
  ['https://github.com/stamparm/trails/releases/latest/download/maltrail-malware-domains.txt']
```

```
$ python3 -m pytest                                            # whole branch suite
45 passed in 1.07s

$ git grep -n -e 'stamparm/aux' -e 'trails/static/mass_scanner' -- src
(no output)
```

## Out of scope

`tests/fixtures/feed_corpus/` is not refreshed. It is a one-time first-8-KiB snapshot whose integrity test compares the manifest against its own samples, never against the catalogue, and its README makes the refresh trigger a material catalogue change; two URL corrections are not that, and a refresh would re-fetch ~295 live feeds. (This line ships no corpus at all.)
