### PR TITLE
feeds: point both Maltrail feeds at their live endpoints

### DIFF
--- a/src/usr/local/www/pfblockerng/pfblockerng_feeds.json
+++ b/src/usr/local/www/pfblockerng/pfblockerng_feeds.json
@@ -559,7 +559,7 @@
 				{
 					"feed":		"Maltrail",
 					"website":	"https://github.com/stamparm/maltrail",
-					"url":		"https://raw.githubusercontent.com/stamparm/maltrail/master/trails/static/mass_scanner.txt",
+					"url":		"https://raw.githubusercontent.com/stamparm/maltrail/refs/heads/master/data/mass_scanner.txt",
 					"header":	"Maltrail_Scanners_All"
 				}
 			]
@@ -1433,7 +1433,7 @@
 				{
 					"feed":		"Maltrail",
 					"website":	"https://github.com/stamparm/maltrail",
-					"url":		"https://raw.githubusercontent.com/stamparm/aux/master/maltrail-malware-domains.txt",
+					"url":		"https://github.com/stamparm/trails/releases/latest/download/maltrail-malware-domains.txt",
 					"header":	"Maltrail_BD"
 				},
 				{

--- a/tests/test_feeds_catalog.py
+++ b/tests/test_feeds_catalog.py
@@ -7,6 +7,8 @@ Pins that:
 - BlockListDE_6 references the same feed URLs as BlockListDE (same sources, IPv6-capable).
 - Every header in the whole catalog is unique (guards the _6-suffixed headers
   added by #318 and all existing headers against collision).
+- Both Maltrail feeds carry their live endpoints and neither retired (404) URL
+  is shipped anywhere in the catalog (issue #3205).
 """
 
 from __future__ import annotations

--- a/tests/test_feeds_catalog.py
+++ b/tests/test_feeds_catalog.py
@@ -109,3 +109,28 @@ def test_dead_malc0de_bl_boot_feed_is_discontinued(catalog: dict) -> None:  # ty
     assert feed.get("status") == "discontinued", (
         f"Malc0de bl/BOOT feed must be marked 'status': 'discontinued' (issue #372) — got status={feed.get('status')!r}"
     )
+
+
+def test_maltrail_feeds_use_their_live_endpoints(catalog: dict) -> None:  # type: ignore[type-arg]
+    """Both Maltrail feeds must point at endpoints that still serve (issue #3205).
+
+    The scanner trail moved inside stamparm/maltrail and the malware-domain list
+    moved out of the retired stamparm/aux repository into stamparm/trails release
+    assets. Both former URLs answer HTTP 404, so an update run stores GitHub's
+    14-byte error page instead of a list.
+    """
+    for url in (
+        "https://raw.githubusercontent.com/stamparm/maltrail/refs/heads/master/data/mass_scanner.txt",
+        "https://github.com/stamparm/trails/releases/latest/download/maltrail-malware-domains.txt",
+    ):
+        assert _find_feed_by_url(catalog, url) is not None, f"live Maltrail endpoint missing from the catalog: {url}"
+    raw = _FEEDS_JSON.read_text(encoding="utf-8")
+    stale = [
+        url
+        for url in (
+            "https://raw.githubusercontent.com/stamparm/maltrail/master/trails/static/mass_scanner.txt",
+            "https://raw.githubusercontent.com/stamparm/aux/master/maltrail-malware-domains.txt",
+        )
+        if url in raw
+    ]
+    assert stale == [], f"retired (404) Maltrail endpoints still shipped: {stale}"

--- a/tests/test_feeds_catalog.py
+++ b/tests/test_feeds_catalog.py
@@ -21,6 +21,23 @@ import pytest
 
 _FEEDS_JSON = Path(__file__).parent.parent / "src" / "usr" / "local" / "www" / "pfblockerng" / "pfblockerng_feeds.json"
 
+# (retired 404 endpoint, live endpoint, section, feed header) per Maltrail feed:
+# the ipv4 scanner list and the DNSBL malware-domain list (issue #3205).
+_MALTRAIL_FEEDS = (
+    (
+        "https://raw.githubusercontent.com/stamparm/maltrail/master/trails/static/mass_scanner.txt",
+        "https://raw.githubusercontent.com/stamparm/maltrail/refs/heads/master/data/mass_scanner.txt",
+        "ipv4",
+        "Maltrail_Scanners_All",
+    ),
+    (
+        "https://raw.githubusercontent.com/stamparm/aux/master/maltrail-malware-domains.txt",
+        "https://github.com/stamparm/trails/releases/latest/download/maltrail-malware-domains.txt",
+        "dnsbl",
+        "Maltrail_BD",
+    ),
+)
+
 
 @pytest.fixture(scope="module")
 def catalog() -> dict:  # type: ignore[type-arg]
@@ -114,25 +131,23 @@ def test_dead_malc0de_bl_boot_feed_is_discontinued(catalog: dict) -> None:  # ty
 
 
 def test_maltrail_feeds_use_their_live_endpoints(catalog: dict) -> None:  # type: ignore[type-arg]
-    """Both Maltrail feeds must point at endpoints that still serve (issue #3205).
+    """Each Maltrail feed must carry the endpoint that still serves (issue #3205).
 
     The scanner trail moved inside stamparm/maltrail and the malware-domain list
     moved out of the retired stamparm/aux repository into stamparm/trails release
     assets. Both former URLs answer HTTP 404, so an update run stores GitHub's
-    14-byte error page instead of a list.
+    14-byte error page instead of a list. Each URL is pinned to its own feed
+    record, so swapping the two would fail as loudly as dropping one.
     """
-    for url in (
-        "https://raw.githubusercontent.com/stamparm/maltrail/refs/heads/master/data/mass_scanner.txt",
-        "https://github.com/stamparm/trails/releases/latest/download/maltrail-malware-domains.txt",
-    ):
-        assert _find_feed_by_url(catalog, url) is not None, f"live Maltrail endpoint missing from the catalog: {url}"
     raw = _FEEDS_JSON.read_text(encoding="utf-8")
-    stale = [
-        url
-        for url in (
-            "https://raw.githubusercontent.com/stamparm/maltrail/master/trails/static/mass_scanner.txt",
-            "https://raw.githubusercontent.com/stamparm/aux/master/maltrail-malware-domains.txt",
-        )
-        if url in raw
-    ]
-    assert stale == [], f"retired (404) Maltrail endpoints still shipped: {stale}"
+    for retired, live, section, header in _MALTRAIL_FEEDS:
+        urls = [
+            feed.get("url")
+            for grp in catalog.get(section, {}).values()
+            for feed in grp.get("feeds", [])
+            if feed.get("header") == header
+        ]
+        assert urls == [live], f"{header} must carry its live endpoint in the {section} section — got {urls}"
+        # Scanned in the file text, not the parsed feed rows: the retired endpoint
+        # must be gone from alternates and comments too, not just from a feed row.
+        assert retired not in raw, f"retired (404) Maltrail endpoint still shipped: {retired}"


### PR DESCRIPTION
Both Maltrail entries in the shipped catalogue answer HTTP 404: the scanner trail moved inside `stamparm/maltrail` (`trails/static/` → `data/mass_scanner.txt`), and the malware-domain list moved out of the retired `stamparm/aux` repository into `stamparm/trails` release assets. An update run for `Maltrail_Scanners_All` (ipv4 SCANNERS) and `Maltrail_BD` (dnsbl Malware) therefore downloads GitHub's 14-byte error page instead of a list.

Same correction as pfsense/FreeBSD-ports#1458, which carries it for the Ports copy of the same file. Forward-port of #3206 (stable line `release/3.3`, shipping as a patch release); the catalogue hunks are identical, the guard is placed in this line's existing catalogue test instead of a new file.

Fixes #3205

## Endpoint evidence (executed 2026-09-05)

```
$ curl -sSL -o /dev/null -w '%{http_code} %{size_download}\n' --max-time 25 <url>
https://raw.githubusercontent.com/stamparm/maltrail/master/trails/static/mass_scanner.txt   404 14
https://raw.githubusercontent.com/stamparm/maltrail/refs/heads/master/data/mass_scanner.txt 200 665163
https://raw.githubusercontent.com/stamparm/aux/master/maltrail-malware-domains.txt          404 14
https://github.com/stamparm/trails/releases/latest/download/maltrail-malware-domains.txt    200 18607620
```

The replacement malware-domains URL is a release asset and answers through one redirect to `release-assets.githubusercontent.com`; the feed downloader follows redirects (`pfblockerng.inc` `CURLOPT_FOLLOWLOCATION`), so no download-path change is needed.

## Test proof (red → green, same bytes)

`tests/test_feeds_catalog.py::test_maltrail_feeds_use_their_live_endpoints` pins both halves per feed: each live endpoint is asserted on the feed row carrying its header, in its section (so swapping the two URLs fails), and neither retired endpoint appears anywhere in the file (so an `alternate` entry cannot hide one).

```
$ git hash-object tests/test_feeds_catalog.py
fc4ef2abb5b13a2c2978659cd883dff3dc54ffb7
$ uv run pytest tests/test_feeds_catalog.py            # before the catalogue edit
FAILED tests/test_feeds_catalog.py::test_maltrail_feeds_use_their_live_endpoints
  AssertionError: Maltrail_Scanners_All must carry its live endpoint in the ipv4 section — got
  ['https://raw.githubusercontent.com/stamparm/maltrail/master/trails/static/mass_scanner.txt']
1 failed, 6 passed in 0.62s

# … catalogue edit, test file untouched …
$ git hash-object tests/test_feeds_catalog.py
fc4ef2abb5b13a2c2978659cd883dff3dc54ffb7
$ uv run pytest tests/test_feeds_catalog.py
7 passed in 0.62s

# the two live URLs swapped between their feeds
AssertionError: Maltrail_Scanners_All must carry its live endpoint in the ipv4 section — got
  ['https://github.com/stamparm/trails/releases/latest/download/maltrail-malware-domains.txt']

$ git grep -n -e 'stamparm/aux' -e 'trails/static/mass_scanner' -- src
(no output)

$ scripts/agent/run-gates.sh --diff origin/devel
GATE PASS: sh scripts/agent/check-graph-fresh.sh
GATE PASS: uv run --locked pytest
GATE PASS: uv run --locked ruff check .
GATE PASS: uv run --locked ruff format --check .
GATE PASS: uv run --locked mypy tests/
```

no-test-needed: rule 2 (`www/**` ↔ `tests/smoke/ui/**`) only. The change is two URL strings in a data catalogue — no page, markup, or flow changes, so there is no new render-layer behaviour to pin, and the Feeds page's Tier-A `ui_render` coverage (`feeds_ipv4` / `feeds_ipv6` / `feeds_dnsbl` in `test_render_smoke.py`'s `PAGE_TABLE`) already parses this exact file on every smoke run. Rule 1 is satisfied normally: the catalogue contract is pinned by the paired `tests/test_feeds_catalog.py` guard above.

## Out of scope

`tests/fixtures/feed_corpus/` is not refreshed. It is a one-time first-8-KiB snapshot whose integrity test (`tests/php/FeedCorpusSurveyTest.php`) compares the manifest against its own samples, never against the catalogue, and `tests/fixtures/feed_corpus/README.md` makes the refresh trigger a material catalogue change; two URL corrections are not that, and a refresh would re-fetch ~295 live feeds.

`release/4.0` carries both stale URLs too and is not touched by this PR.
