### PR TITLE
release: run the draft job's Python helper from the trusted checkout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -985,8 +985,12 @@ jobs:
           # shell-expands env-map values (issue #2231).
           REPOSITORY="$GITHUB_WORKSPACE"
           git fetch origin '+refs/heads/release/*:refs/remotes/origin/release/*' --tags --force
+          # -P: `python3 -` would otherwise prepend the CWD — the RELEASED tree —
+          # to sys.path AHEAD of PYTHONPATH, so `scripts.release_version` resolved
+          # to the released line's copy instead of the trusted checkout, and a
+          # pre-signing trailer reader there rejected a signed tag (issue #3211).
           PYTHONPATH="${GITHUB_WORKSPACE}/pfblockerng-src" \
-            python3 - "$TAG" "$CHANNEL" "$SOURCE" "$PINNED_SHA" "$REPOSITORY" "$GITHUB_OUTPUT" <<'PY'
+            python3 -P - "$TAG" "$CHANNEL" "$SOURCE" "$PINNED_SHA" "$REPOSITORY" "$GITHUB_OUTPUT" <<'PY'
           import subprocess
           import sys
           from pathlib import Path

--- a/tests/test_release_tag_after_verify.py
+++ b/tests/test_release_tag_after_verify.py
@@ -487,6 +487,45 @@ def test_a_credentialled_job_runs_every_helper_from_a_trusted_checkout(
     assert not untrusted_calls, f"{job} executes helpers outside its trusted checkout: {untrusted_calls}"
 
 
+_SCRIPTS_IMPORT_RE = re.compile(r"^\s*(?:from|import)\s+scripts(?:\.|\s)", re.MULTILINE)
+_PYTHON_INVOCATION_RE = re.compile(r"python3(?P<flags>(?:\s+-\S+)*)\s")
+_TRUSTED_PYTHONPATH = 'PYTHONPATH="${GITHUB_WORKSPACE}/pfblockerng-src"'
+
+
+def test_a_credentialled_job_imports_python_helpers_from_the_trusted_checkout() -> None:
+    """Inline Python in a credentialled job must import `scripts/` from the trusted
+    checkout, not from the released tree the job is standing in (issue #3211).
+
+    `python3 -` prepends the CWD to `sys.path` AHEAD of `PYTHONPATH`, and the CWD is
+    the RELEASED tree, so setting `PYTHONPATH` alone silently runs the released
+    line's copy of the helper. That is how v3.3.8's cut died inside
+    `release/3.3`'s `release_version.py`, whose pre-signing trailer reader cannot
+    parse a signed tag. `-P` drops the CWD, leaving the trusted copy authoritative.
+
+    The sibling `sh`-execution guard cannot see this route: it matches helper paths,
+    and an import names a module.
+    """
+    checked = 0
+    for workflow, job, helper_root in CREDENTIALLED_JOBS:
+        for step in _steps(_jobs(workflow)[job]):
+            script = _step_run_script(step) if "run: |" in "\n".join(step) else ""
+            if not _SCRIPTS_IMPORT_RE.search(script):
+                continue
+            checked += 1
+            assert _TRUSTED_PYTHONPATH in script, (
+                f"{workflow.name}:{job}: inline Python imports scripts/ without pointing PYTHONPATH at "
+                f"{helper_root}:\n{script}"
+            )
+            commands = "\n".join(line for line in script.splitlines() if not line.lstrip().startswith("#"))
+            for match in _PYTHON_INVOCATION_RE.finditer(commands):
+                flags = match.group("flags").split()
+                assert "-P" in flags, (
+                    f"{workflow.name}:{job}: `python3{match.group('flags')}` imports scripts/ with the released "
+                    f"tree ahead of PYTHONPATH on sys.path -- pass -P so the trusted checkout wins (issue #3211)"
+                )
+    assert checked, "no credentialled job imports a Python helper any more -- has the pipeline shape changed?"
+
+
 @pytest.mark.parametrize(
     ("workflow", "job", "_helper_root"),
     CREDENTIALLED_JOBS,

--- a/tests/test_release_tag_after_verify.py
+++ b/tests/test_release_tag_after_verify.py
@@ -506,7 +506,7 @@ def test_a_credentialled_job_imports_python_helpers_from_the_trusted_checkout() 
     and an import names a module.
     """
     checked = 0
-    for workflow, job, helper_root in CREDENTIALLED_JOBS:
+    for workflow, job, _helper_root in CREDENTIALLED_JOBS:
         for step in _steps(_jobs(workflow)[job]):
             script = _step_run_script(step) if "run: |" in "\n".join(step) else ""
             if not _SCRIPTS_IMPORT_RE.search(script):
@@ -516,8 +516,9 @@ def test_a_credentialled_job_imports_python_helpers_from_the_trusted_checkout() 
             # assignment or invocation is not what the job executes.
             commands = "\n".join(line for line in script.splitlines() if not line.lstrip().startswith("#"))
             assert _TRUSTED_PYTHONPATH in commands, (
-                f"{workflow.name}:{job}: inline Python imports scripts/ without pointing PYTHONPATH at "
-                f"{helper_root}:\n{script}"
+                f"{workflow.name}:{job}: inline Python imports scripts/ without setting "
+                f"{_TRUSTED_PYTHONPATH} -- PYTHONPATH takes the trusted checkout ROOT, not its scripts/ "
+                f"directory:\n{script}"
             )
             invocations = list(_PYTHON_INVOCATION_RE.finditer(commands))
             assert invocations, (

--- a/tests/test_release_tag_after_verify.py
+++ b/tests/test_release_tag_after_verify.py
@@ -512,12 +512,19 @@ def test_a_credentialled_job_imports_python_helpers_from_the_trusted_checkout() 
             if not _SCRIPTS_IMPORT_RE.search(script):
                 continue
             checked += 1
-            assert _TRUSTED_PYTHONPATH in script, (
+            # Comment-stripped: the fix's own comment names `python3 -`, and a commented
+            # assignment or invocation is not what the job executes.
+            commands = "\n".join(line for line in script.splitlines() if not line.lstrip().startswith("#"))
+            assert _TRUSTED_PYTHONPATH in commands, (
                 f"{workflow.name}:{job}: inline Python imports scripts/ without pointing PYTHONPATH at "
                 f"{helper_root}:\n{script}"
             )
-            commands = "\n".join(line for line in script.splitlines() if not line.lstrip().startswith("#"))
-            for match in _PYTHON_INVOCATION_RE.finditer(commands):
+            invocations = list(_PYTHON_INVOCATION_RE.finditer(commands))
+            assert invocations, (
+                f"{workflow.name}:{job}: a scripts/ import with no live python3 invocation to enforce -P on "
+                f"-- orphaned by a comment or written in a shape this guard cannot see:\n{script}"
+            )
+            for match in invocations:
                 flags = match.group("flags").split()
                 assert "-P" in flags, (
                     f"{workflow.name}:{job}: `python3{match.group('flags')}` imports scripts/ with the released "

--- a/tests/test_release_tag_after_verify.py
+++ b/tests/test_release_tag_after_verify.py
@@ -488,7 +488,14 @@ def test_a_credentialled_job_runs_every_helper_from_a_trusted_checkout(
 
 
 _SCRIPTS_IMPORT_RE = re.compile(r"^\s*(?:from|import)\s+scripts(?:\.|\s)", re.MULTILINE)
-_PYTHON_INVOCATION_RE = re.compile(r"python3(?P<flags>(?:\s+-\S+)*)\s")
+# Anchored at a command position -- line start, optionally behind env assignments --
+# so `echo python3 -P -` cannot satisfy the guard while nothing trusted runs. An
+# invocation in a shape this misses (piped, `env`-prefixed) trips the no-invocation
+# assertion below instead of passing silently.
+_PYTHON_INVOCATION_RE = re.compile(
+    r"^[ \t]*(?:[A-Za-z_][A-Za-z0-9_]*=\S*[ \t]+)*python3(?P<flags>(?:[ \t]+-\S+)*)[ \t]",
+    re.MULTILINE,
+)
 _TRUSTED_PYTHONPATH = 'PYTHONPATH="${GITHUB_WORKSPACE}/pfblockerng-src"'
 
 


### PR DESCRIPTION
Cutting `v3.3.8` (stable, `source: release/3.3`) died in the `release` job at **Find the previous release tag (compare base)** — run [34017658032](https://github.com/pfBlockerNG/pfBlockerNG/actions/runs/34017658032) — with `ValueError: current tag 'v3.3.8' lacks the exact stable release trailer`, after the tag had already been pushed.

The tag was fine. The helper was the wrong one: `python3 -` prepends the current directory to `sys.path` **ahead of** `PYTHONPATH`, and in that job the current directory is the checkout of the *released* tree, so `from scripts.release_version import …` resolved to `release/3.3`'s copy instead of the trusted `pfblockerng-src` checkout the step deliberately makes. The traceback proves which file ran: `/home/runner/work/pfBlockerNG/pfBlockerNG/scripts/release_version.py`, line 160 — where `release/3.3`'s copy raises; `devel`'s raises at 152.

`release/3.3`'s copy predates the trailer-atom migration: it reads `%(contents)` and pipes it into `git interpret-trailers --parse`, which cannot see past the SSH signature block that tag signing (#3043) appends as the tag message's last paragraph. `devel`'s copy reads `%(trailers:unfold)` and is immune. `v3.3.7` was tagged unsigned by `github-actions[bot]`, which is why the previous stable cut sailed through the same code path.

`-P` drops the current directory from `sys.path`, so the trusted copy wins — which is what the step's own security comment already claims.

Fixes #3211

## Discriminating probe (executed)

Both copies of the helper, both tags, same repository:

```
release/3.3  v3.3.8 (signed):   ValueError: current tag 'v3.3.8' lacks the exact stable release trailer
release/3.3  v3.3.7 (unsigned): OK ('stable', 'testing', 'edge')
devel        v3.3.8 (signed):   OK ('stable', 'testing', 'edge')
devel        v3.3.7 (unsigned): OK ('stable', 'testing', 'edge')
```

Ruled out first: a git-version effect. The real signed tag object was replayed through `%(trailers:unfold)` and `%(trailers:key=…,valueonly)` under both the dev host's git 2.47.3 and the runner's git 2.55.0 (`alpine:edge` container) — both return `pfBlockerNG-Release-Channel: stable` correctly. The parse only fails in the pre-migration reader.

## Why the existing guard missed it

`test_a_credentialled_job_runs_every_helper_from_a_trusted_checkout` enforces exactly this property, but its scan is `\bsh\s+(\S*scripts/…)` — helper *paths*. An import names a module, so the Python route was never covered. The new test closes that hole for every credentialled job: inline Python importing `scripts.` must point `PYTHONPATH` at the trusted checkout **and** invoke `python3` with `-P`. It scans commands only, so a comment mentioning `python3 -` cannot satisfy or trip it, and it fails loudly if no credentialled job imports a Python helper any more (no silent vacuity).

## Frozen RED evidence

| Frozen RED test | git hash-object | RED run tail |
| --- | --- | --- |
| `tests/test_release_tag_after_verify.py` | `f0498505c8f62fe2bdee60d19734c82fe73bf14c` | `FAILED tests/test_release_tag_after_verify.py::test_a_credentialled_job_imports_python_helpers_from_the_trusted_checkout - AssertionError: release.yml:release: python3 imports scripts/ with the released tree ahead of PYTHONPATH on sys.path -- pass -P so the trusted checkout wins (issue #3211)` |

```
# RED: shipped test bytes against a workflow with the -P removed, in a scratch copy
$ python3 -m pytest tests/test_release_tag_after_verify.py -k trusted_checkout -q
AssertionError: release.yml:release: `python3` imports scripts/ with the released tree
  ahead of PYTHONPATH on sys.path -- pass -P so the trusted checkout wins (issue #3211)

# GREEN: same test bytes, workflow carrying -P
$ uv run pytest tests/test_release_tag_after_verify.py -q
143 passed in 1.83s
$ git hash-object tests/test_release_tag_after_verify.py
f0498505c8f62fe2bdee60d19734c82fe73bf14c   # identical across both runs

# the two other mutations, each on the shipped test bytes
comment out the invocation -> a scripts/ import with no live python3 invocation to enforce -P on
drop the trusted PYTHONPATH -> inline Python imports scripts/ without pointing PYTHONPATH at …

$ scripts/agent/run-gates.sh --diff origin/devel
GATE PASS: uv run --locked pytest / ruff check / ruff format --check / mypy tests/
```

The commit also carries the mandatory `graphify-out/graph.json` freshness refresh.

## Out of scope

`release/3.3`'s own `scripts/release_version.py` still carries the pre-migration trailer reader and is wrong on any signed tag whoever calls it. With this fix the release pipeline no longer reaches that copy; the backport is tracked separately in #3211's follow-up note rather than smuggled into a `devel` PR.
