### PR TITLE
install: close the console line before pfSense resumes its package framing

### DIFF
--- a/src/usr/local/pkg/pfblockerng.xml
+++ b/src/usr/local/pkg/pfblockerng.xml
@@ -93,6 +93,10 @@
 		global $pfb;
 		$pfb['save'] = TRUE;
 		sync_package_pfblockerng(array('scope' => 'both', 'force' => FALSE, 'trigger' => 'manual'));
+		// issue #3216: the pass mirrors its progress to the pkg output and can end mid-line
+		// ("Restarting DNSBL Service") -- close it so pfSense's own framing ("done.", the
+		// menu/service rows) starts on its own line in the install/upgrade log.
+		pfb_stdout_close_line();
 		]]>
 	</custom_php_resync_config_command>
 </packagegui>

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -4926,6 +4926,35 @@ function pfb_log_status_line($header, $status, $verdict = '') {
 	return $field . str_pad("{$status} ", 27) . $verdict;
 }
 
+// issue #3216: pfb_logger()'s STDOUT mirror (below) carries the LOG-FILE convention -- a
+// leading "\n" separates a message from the previous write, and a message may deliberately
+// end mid-line so a later write appends to it (" done.", the progress dots). pfSense's own
+// package framing (update_status(): "done.\n", "Menu items... ") is newline-TERMINATED
+// instead, so a pkg lifecycle callback that returns with the console mid-line gets core's
+// next line glued onto ours ("Restarting DNSBL Servicedone."). Record what the mirror last
+// wrote -- $mirrored is that chunk, NULL queries -- so a boundary can close the line. Empty
+// writes leave the state alone: they move no column.
+function pfb_stdout_mid_line(?string $mirrored = NULL): bool {
+	static $mid_line = FALSE;
+
+	if ($mirrored !== NULL && $mirrored !== '') {
+		$mid_line = !str_ends_with($mirrored, "\n");
+	}
+
+	return $mid_line;
+}
+
+// issue #3216: close a console line the mirror left open, so the status text that follows
+// starts in column 0. Called where our lifecycle work hands back to pfSense's framing. A
+// no-op when the mirror is silent (a cron/Run-Now pass) or already ended its line -- our own
+// update_status(" done.") appends MUST stay on the line they continue.
+function pfb_stdout_close_line(): void {
+	if (pfb_stdout_mid_line()) {
+		print "\n";
+		pfb_stdout_mid_line("\n");
+	}
+}
+
 function pfb_logger($log, $logtype) {
 	global $g, $pfb;
 
@@ -5010,6 +5039,7 @@ function pfb_logger($log, $logtype) {
 	// hooks and the detached rc.d daemons are untouched -- visibility only, not the process-safety.
 	if (($logtype == 1 || $logtype == 2) && pfb_run_streams_to_stdout()) {
 		print "{$log_out}";
+		pfb_stdout_mid_line($log_out);
 	}
 }
 
@@ -20261,6 +20291,10 @@ function pfblockerng_php_pre_deinstall_command() {
 	update_status("Removing pfBlockerNG...");
 	sync_package_pfblockerng();
 	pfb_top1m_teardown_call();
+
+	// issue #3216: the disable pass above mirrors its progress to the pkg output and can end
+	// mid-line -- close it so the teardown rows below start on their own line.
+	pfb_stdout_close_line();
 
 	// Live-object teardown always runs regardless of $pfb['keep'], so that uninstalling
 	// with the default keep=on still removes active pf tables, boot hooks, owned firewall

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -6731,6 +6731,9 @@ function pfb_mirror_hook_output(string $logfile, int $offset): void {
 	$body = @file_get_contents($logfile, FALSE, NULL, $offset, $end - $offset);
 	if (is_string($body) && $body !== '') {
 		print $body;
+		// issue #3216: raw hook output -- a hook whose last line is unterminated leaves the
+		// console mid-line, so the boundary must know about these bytes too.
+		pfb_stdout_mid_line($body);
 	}
 }
 
@@ -6933,6 +6936,7 @@ function pfb_run_hooks($when, $ctx = array()) {
 					$chunk = pfb_log_tail_chunk($logtarget, $off, FALSE);
 					if ($chunk['data'] !== '') {
 						print $chunk['data'];
+						pfb_stdout_mid_line($chunk['data']);	// issue #3216
 					}
 					$off = $chunk['offset'];
 					$st  = proc_get_status($proc);
@@ -6947,6 +6951,7 @@ function pfb_run_hooks($when, $ctx = array()) {
 				$chunk = pfb_log_tail_chunk($logtarget, $off, TRUE);
 				if ($chunk['data'] !== '') {
 					print $chunk['data'];
+					pfb_stdout_mid_line($chunk['data']);	// issue #3216
 				}
 				if (!$exited) {
 					// Cap exhausted with the child still "running" -- a pathologically wedged process.

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_install.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_install.inc
@@ -770,10 +770,14 @@ exec('/usr/local/pkg/pfblockerng/pfblockerng.sh dnsbl_cache stage >/dev/null 2>&
 
 if ($ufound) {
 	$final = pfb_stop_start_unbound('');
+	// issue #3216: the restart mirrors its own progress (dots, "\nStarting Unbound Resolver")
+	// to the pkg output and leaves the line open -- close it so the status below, and the
+	// migration rows after it, are not appended to that line.
+	pfb_stdout_close_line();
 	// issue #3094: the return value used to be assigned and never read, so an install
 	// could finish "successfully" with the resolver never restarted.
 	if (($final['retval'] ?? 0) != 0) {
-		update_status(" Unbound Resolver did not restart; see the pfBlockerNG log.");
+		update_status(" Unbound Resolver did not restart; see the pfBlockerNG log.\n");
 	}
 }
 

--- a/tests/php/LiveLogStdoutTest.php
+++ b/tests/php/LiveLogStdoutTest.php
@@ -26,6 +26,7 @@ use PHPUnit\Framework\TestCase;
  */
 #[CoversFunction('pfb_logger')]
 #[CoversFunction('pfb_run_streams_to_stdout')]
+#[CoversFunction('pfb_stdout_mid_line')]
 #[CoversFunction('pfb_stdout_close_line')]
 final class LiveLogStdoutTest extends TestCase
 {
@@ -223,5 +224,27 @@ final class LiveLogStdoutTest extends TestCase
 		$out = (string) ob_get_clean();
 
 		$this->assertSame('', $out, 'the boundary must not print for a pass that never mirrored');
+	}
+
+	/**
+	 * issue #3216: a write that mirrors NO bytes moves no column, so it must not disturb the
+	 * boundary state. pfb_logger('', 1) mirrors nothing whenever the log file is already
+	 * mid-line (the stamp is only inserted at a line start) -- e.g. the first write of an
+	 * install process whose log a previous pass left unterminated.
+	 */
+	#[RunInSeparateProcess]
+	public function testAWriteThatMirroredNothingLeavesTheBoundaryStateAlone(): void
+	{
+		global $pfb;
+		$pfb['hook_lifecycle'] = 'install';
+		@file_put_contents($pfb['log'], 'a previous pass left this line unterminated');
+
+		ob_start();
+		pfb_logger('', 1);
+		pfb_stdout_close_line();
+		print "done.\n";
+		$out = (string) ob_get_clean();
+
+		$this->assertSame("done.\n", $out, 'an empty mirror write must not make the boundary emit a newline');
 	}
 }

--- a/tests/php/LiveLogStdoutTest.php
+++ b/tests/php/LiveLogStdoutTest.php
@@ -26,6 +26,7 @@ use PHPUnit\Framework\TestCase;
  */
 #[CoversFunction('pfb_logger')]
 #[CoversFunction('pfb_run_streams_to_stdout')]
+#[CoversFunction('pfb_stdout_close_line')]
 final class LiveLogStdoutTest extends TestCase
 {
 	private ?string $origRunlog = null;
@@ -161,5 +162,66 @@ final class LiveLogStdoutTest extends TestCase
 		$pfb['hook_lifecycle'] = 'install';
 		$pfb['run_stdout_override'] = TRUE;
 		$this->assertSame('', $this->capture('extras-only detail', 3));
+	}
+
+	/**
+	 * issue #3216: the mirror carries the LOG-FILE convention -- a leading "\n" separates a
+	 * message from the previous write and a message may end mid-line so a later write appends
+	 * to it (" done.", the progress dots). pfSense's package framing is newline-TERMINATED, so
+	 * a lifecycle callback that hands control back mid-line gets core's next line glued onto
+	 * ours ("Restarting DNSBL Servicedone."). The boundary must close that line.
+	 */
+	#[RunInSeparateProcess]
+	public function testTheBoundaryClosesAConsoleLineTheMirrorLeftOpen(): void
+	{
+		global $pfb;
+		// Given the pkg resync callback, whose last progress write is deliberately mid-line
+		// (pfblockerng.inc's "\nRestarting DNSBL Service" -- nothing appends to it)...
+		$pfb['hook_lifecycle'] = 'install';
+
+		ob_start();
+		pfb_logger("\nRestarting DNSBL Service", 1);
+		// When the callback returns to pfSense, which resumes its own framing...
+		pfb_stdout_close_line();
+		print "done.\n";
+		$out = (string) ob_get_clean();
+
+		// Then core's line starts in column 0 instead of continuing ours.
+		$this->assertStringEndsWith("Restarting DNSBL Service\ndone.\n", $out,
+			"core's framing must start on its own line; got: " . var_export($out, TRUE));
+	}
+
+	#[RunInSeparateProcess]
+	public function testAMessageThatAlreadyEndedItsLineGainsNoBlankLine(): void
+	{
+		global $pfb;
+		// The other branch: a mirrored message that terminated its own line (apply.inc's
+		// "\n**Saving configuration**\n") must not be padded with a second newline.
+		$pfb['hook_lifecycle'] = 'install';
+
+		ob_start();
+		pfb_logger("\n**Saving configuration**\n", 1);
+		pfb_stdout_close_line();
+		print "done.\n";
+		$out = (string) ob_get_clean();
+
+		$this->assertStringEndsWith("**Saving configuration**\ndone.\n", $out,
+			'closing an already-closed line must not insert a blank one; got: ' . var_export($out, TRUE));
+	}
+
+	#[RunInSeparateProcess]
+	public function testAPassThatNeverMirroredPrintsNothing(): void
+	{
+		global $pfb;
+		// A normal cron/Run-Now pass never mirrors (STDOUT is a redirected log file), so the
+		// boundary has no line of ours to close and must stay silent.
+		unset($pfb['hook_lifecycle'], $pfb['run_stdout_override']);
+
+		ob_start();
+		pfb_logger("\nRestarting DNSBL Service", 1);
+		pfb_stdout_close_line();
+		$out = (string) ob_get_clean();
+
+		$this->assertSame('', $out, 'the boundary must not print for a pass that never mirrored');
 	}
 }

--- a/tests/php/PfbHookOutputMirrorTest.php
+++ b/tests/php/PfbHookOutputMirrorTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -20,6 +21,7 @@ use PHPUnit\Framework\TestCase;
  * bytes, plus the no-new-bytes and empty-path guards.
  */
 #[CoversFunction('pfb_mirror_hook_output')]
+#[CoversFunction('pfb_stdout_close_line')]
 final class PfbHookOutputMirrorTest extends TestCase
 {
 	private string $logfile = '';
@@ -96,5 +98,32 @@ final class PfbHookOutputMirrorTest extends TestCase
 		ob_start();
 		pfb_mirror_hook_output('', 0);
 		$this->assertSame('', (string) ob_get_clean());
+	}
+
+	/**
+	 * issue #3216: the mirrored body is the hook's OWN output, so a hand-written hook whose last
+	 * line has no trailing newline leaves the pkg console mid-line -- and pfSense's next framing
+	 * line ("done.") was glued onto it. The mirror must record what it printed so the lifecycle
+	 * boundary can close the line.
+	 */
+	#[RunInSeparateProcess]
+	public function testAHookBodyWithoutATrailingNewlineIsClosedAtTheBoundary(): void
+	{
+		global $pfb;
+		// Given a lifecycle callback and a hook that ends its output mid-line...
+		$pfb['hook_lifecycle'] = 'install';
+		$offset = $this->seedAndOffset("[ pfB Hook ] post haproxy (hook_post_haproxy.sh)\n");
+		@file_put_contents($this->logfile, 'Reloading HAProxy', FILE_APPEND);
+
+		ob_start();
+		pfb_mirror_hook_output($this->logfile, $offset);
+		// When the pass reaches the boundary and pfSense resumes its framing...
+		pfb_stdout_close_line();
+		print "done.\n";
+		$out = (string) ob_get_clean();
+
+		// Then the framing starts on its own line.
+		$this->assertSame("Reloading HAProxy\ndone.\n", $out,
+			"core's framing must not continue the hook's last line; got: " . var_export($out, TRUE));
 	}
 }

--- a/tests/php/fixtures/function_inventory.json
+++ b/tests/php/fixtures/function_inventory.json
@@ -12010,10 +12010,28 @@
             }
         ]
     },
+    "pfb_stdout_close_line": {
+        "returnsRef": false,
+        "returnType": "void",
+        "params": []
+    },
     "pfb_stdout_is_terminal": {
         "returnsRef": false,
         "returnType": "bool",
         "params": []
+    },
+    "pfb_stdout_mid_line": {
+        "returnsRef": false,
+        "returnType": "bool",
+        "params": [
+            {
+                "name": "mirrored",
+                "byRef": false,
+                "variadic": false,
+                "type": "?string",
+                "default": "NULL"
+            }
+        ]
     },
     "pfb_stop_start_unbound": {
         "returnsRef": false,


### PR DESCRIPTION
Fixes #3216

## What broke

`pfb_logger()`'s STDOUT mirror (issue #690 / ADR-58) carries the **log-file**
convention: a leading `"\n"` separates a message from the previous write, and a
message may deliberately end mid-line so a later write appends to it
(`" done."`, the progress dots). pfSense's package framing (`update_status()`)
is newline-**terminated** instead. So whenever a pkg lifecycle callback returned
with the console mid-line, core's next line was glued onto ours.

Reproduced against untouched `devel`, emulating the upgrade tail (real
`pfb_logger()` through the PHPUnit bootstrap; the first three lines are
byte-identical to the reported log):

```
Executing custom_php_resync_config_command()...
2026-09-06 15:19:46 **Saving configuration**

2026-09-06 15:19:46 Restarting DNSBL Servicedone.
Menu items... done.
```

`"\nRestarting DNSBL Service"` is the resync's last write and nothing appends to
it, so `done.` landed on that line.

## The change

`pfb_stdout_mid_line()` records what the mirror last wrote; `pfb_stdout_close_line()`
closes an open line. It is called at the three boundaries where our lifecycle work
hands control back to core:

- `pfblockerng.xml` `custom_php_resync_config_command` (the log above),
- `pfblockerng_php_pre_deinstall_command()` after the disable pass, before the
  teardown rows,
- `pfblockerng_install.inc` after `pfb_stop_start_unbound()` — whose own status
  line (`" Unbound Resolver did not restart..."`) was not newline-terminated
  either, so the next migration row landed on it.

A message that already ended its line, and a pass that never mirrored (cron,
Run-Now: STDOUT is a redirected log file), are untouched — our `" done."`
appends must keep landing on the line they continue.

Same emulation with the fix:

```
Executing custom_php_resync_config_command()...
2026-09-06 15:20:48 **Saving configuration**

2026-09-06 15:20:48 Restarting DNSBL Service
done.
Menu items... done.
Writing configuration... done.
```

Not ours, for the record: `Saving updated package information...` / `overwrite!`
on separate lines is core's own `install_package_xml()` output.

## Tests

Three cases added to `tests/php/LiveLogStdoutTest.php` (the mirror's contract
home), one per branch: mid-line close, already-closed line gains no blank line,
silent pass prints nothing.

- **RED** on untouched code: `Error: Call to undefined function pfb_stdout_close_line()`
  in all three; the six existing mirror tests stayed green.
  Frozen test file `git hash-object` at the red run: `1332652fbfe34115219debd54024a5dcf5aad107`.
- **GREEN** after the change with the file byte-identical (same hash):
  `OK (9 tests, 12 assertions)`.

`tests/php/fixtures/function_inventory.json` regenerated for the two new
functions (`PFB_UPDATE_FUNCTION_INVENTORY=1`).

`scripts/agent/run-gates.sh`: `phpstan` PASS, `phpcs` PASS. Full PHPUnit failure
set is **identical** on this branch and on clean `devel` (19 rows, all
pre-existing host divergence on the dev box — root uid, local PHP 8.4); diffing
the two full-suite failure lists is empty.

Live install/upgrade/uninstall log rendering on a real appliance is a smoke-seat
claim and is not made here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed console output formatting so status messages consistently begin on a new line after synchronization, resolver restarts, hooks, and log-tail output.
  * Prevented duplicated blank lines when output is already properly terminated.
  * Improved package disable and uninstall messaging boundaries.

* **Tests**
  * Added coverage for mid-line output, trailing-newline handling, and lifecycle boundary formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->