### PR TITLE
agent: run-gates canary-fixture selection, byte-wise guard, shell-suite host provisioning

### DIFF
--- a/scripts/agent/run-gates.sh
+++ b/scripts/agent/run-gates.sh
@@ -97,7 +97,10 @@ gates_for() {
 	# issue #3166: the skip gate READS tests/skip-allowlist.txt, and its checker plus red
 	# canary ride the pytest gate, which also carries the two tests that parse the real file.
 	# A .txt path matched no bucket, so an allowlist-only diff selected no suite at all.
-	elif printf '%s\n' "$files" | grep -qx 'tests/skip-allowlist\.txt'; then
+	# issue #3174: gate_command() points the same suite gates at the canary fixture, so a
+	# fixture-only diff must select that gate too -- a canary edited to pass would
+	# otherwise disarm every "red canary" claim with no run to notice it.
+	elif printf '%s\n' "$files" | grep -qEx 'tests/(skip-allowlist\.txt|fixtures/skip-allowlist-canary\.xml)'; then
 		out="${out}uv run --locked pytest${nl}"
 	fi
 	if printf '%s\n' "$files" | grep -Eq '\.(php|inc)$'; then

--- a/scripts/agent/run-gates.sh
+++ b/scripts/agent/run-gates.sh
@@ -74,6 +74,10 @@ git_statuses() {
 # Map a touched-file list (stdin, one path per line) to gate commands (stdout, one per
 # line). Per-file gates (php -l, sh -n, shellcheck) emit one command per touched file.
 gates_for() {
+	# Byte semantics for every grep below: under a UTF-8 locale GNU grep classifies a
+	# list holding an invalid UTF-8 byte as binary and suppresses its matching lines,
+	# so a hostile name never reaches the unsafe-filename guard (issue #3175).
+	export LC_ALL=C
 	files=$(grep -v '^legacy/' || true)
 	out=''
 	# issue #2016: the re-entry-bounds gate belongs to the .php/.inc AND .sh buckets --

--- a/scripts/agent/setup-agent-tools.sh
+++ b/scripts/agent/setup-agent-tools.sh
@@ -31,22 +31,41 @@ install_from_url() {
 install_linux_prerequisites() {
 	require_tool dpkg-query
 	set --
-	for package in ca-certificates curl git libarchive-tools; do
+	for package in ca-certificates curl git libarchive-tools iprange locales; do
 		if ! dpkg-query -W -f='${Status}' "$package" 2>/dev/null |
 			grep -q 'install ok installed'; then
 			set -- "$@" "$package"
 		fi
 	done
-	[ "$#" -gt 0 ] || return 0
-
-	require_tool apt-get
-	if [ "$(id -u)" -eq 0 ]; then
-		apt-get update
-		apt-get install -y "$@"
-	else
-		require_tool sudo
-		sudo apt-get update
-		sudo apt-get install -y "$@"
+	if [ "$#" -gt 0 ]; then
+		require_tool apt-get
+		if [ "$(id -u)" -eq 0 ]; then
+			apt-get update
+			apt-get install -y "$@"
+		else
+			require_tool sudo
+			sudo apt-get update
+			sudo apt-get install -y "$@"
+		fi
+	fi
+	# issue #3189: the shell gates fail a *.sh diff without the real iprange binary
+	# and CI's comma-decimal locale, so generate and verify de_DE.UTF-8 exactly like
+	# test.yml does -- a locale that generates but leaves awk dotted fails HERE.
+	if ! locale -a 2>/dev/null | LC_ALL=C grep -Eqi '^de_DE\.utf-?8$'; then
+		require_tool locale-gen
+		if [ "$(id -u)" -eq 0 ]; then
+			locale-gen de_DE.UTF-8
+		else
+			require_tool sudo
+			sudo locale-gen de_DE.UTF-8
+		fi
+		locale -a 2>/dev/null | LC_ALL=C grep -Eqi '^de_DE\.utf-?8$' ||
+			fail "de_DE.UTF-8 absent after locale-gen; run 'sudo locale-gen de_DE.UTF-8' manually"
+		LC_ALL=de_DE.UTF-8 locale -k LC_NUMERIC 2>/dev/null |
+			LC_ALL=C grep -Fq 'decimal_point=","' ||
+			fail "de_DE.UTF-8 lacks a comma decimal_point; check /etc/locale.gen and re-run 'sudo locale-gen de_DE.UTF-8'"
+		[ "$(LC_ALL=de_DE.UTF-8 awk 'BEGIN { printf "%.2f", 1.5 }' 2>/dev/null)" = '1,50' ] ||
+			fail 'de_DE.UTF-8 does not give awk a comma decimal; the comma-decimal specs would skip instead of run'
 	fi
 }
 
@@ -218,7 +237,13 @@ main() {
 	platform=$(uname -s)
 	case "$platform" in
 		Linux) install_linux_prerequisites ;;
-		Darwin) require_tool brew ;;
+		Darwin)
+			require_tool brew
+			brew list --versions iprange >/dev/null 2>&1 || brew install iprange
+			# macOS has no locale-gen: if the comma-decimal specs skip here, the
+			# skip-allowlist gate fails a *.sh diff until a locale is installed.
+			printf '%s\n' 'setup-agent-tools.sh: NOTE: macOS has no locale-gen; if the comma-decimal specs skip here, run-gates fails a *.sh diff on the unlisted skips -- install a comma-decimal locale manually or run the shell gates on Linux/CI'
+			;;
 		*) fail "unsupported platform '$platform' (expected Linux or Darwin)" ;;
 	esac
 

--- a/tests/shell/agent_run_gates_spec.sh
+++ b/tests/shell/agent_run_gates_spec.sh
@@ -209,6 +209,19 @@ Describe 'run-gates.sh gates_for()'
     The output should not include 'unsafe filename'
   End
 
+  # issue #3175: GNU grep under a UTF-8 locale classifies a path list holding an
+  # invalid UTF-8 byte as binary and suppresses the matching lines, so the legacy
+  # filter drops the name before the unsafe-filename guard ever sees it.
+  utf8_gates_for() {
+    LC_ALL=C.UTF-8
+    export LC_ALL=C.UTF-8
+    printf 'src/bad\377name.sh\n' | gates_for
+  }
+  It 'refuses a sh-path carrying an invalid UTF-8 byte even under a UTF-8 locale'
+    When call utf8_gates_for
+    The line 1 of output should equal "printf 'unsafe filename in diff\\n' >&2; false"
+  End
+
   # issue #3166: the allowlist checker and its red canary ride the pytest gate, so an
   # allowlist-only diff must select that gate -- a malformed allowlist has to fail locally.
   It 'maps a skip-allowlist-only diff to the pytest gate'

--- a/tests/shell/agent_run_gates_spec.sh
+++ b/tests/shell/agent_run_gates_spec.sh
@@ -217,6 +217,15 @@ Describe 'run-gates.sh gates_for()'
     The output should equal 'uv run --locked pytest'
   End
 
+  # issue #3174: gate_command() feeds every suite gate the canary fixture, so a
+  # fixture-only diff must select the gate that red-canaries it -- a canary edited
+  # to pass disarms the guard silently when its own diff selects no suite.
+  It 'maps a skip-allowlist-canary-fixture-only diff to the pytest gate'
+    Data "tests/fixtures/skip-allowlist-canary.xml"
+    When call gates_for
+    The output should equal 'uv run --locked pytest'
+  End
+
   It 'emits the pytest gate once when the diff touches both the allowlist and a Python file'
     Data
       #|tests/skip-allowlist.txt
@@ -227,12 +236,13 @@ Describe 'run-gates.sh gates_for()'
   End
 
   # The arm matches the whole line: a near-miss path must stay gate-less, or an unrelated
-  # .txt edit pays for the pytest suite.
-  It 'leaves a .txt that is not the allowlist gate-less'
+  # .txt/.xml edit pays for the pytest suite.
+  It 'leaves a near-miss allowlist or canary path gate-less'
     Data
       #|tests/fixtures/other.txt
       #|tests/skip-allowlist.txt.bak
       #|other/tests/skip-allowlist.txt
+      #|tests/fixtures/skip-allowlist-canary.xml.bak
     End
     When call gates_for
     The output should equal ''

--- a/tests/shell/agent_tools_setup_spec.sh
+++ b/tests/shell/agent_tools_setup_spec.sh
@@ -99,6 +99,29 @@ APT_GET
 printf 'sudo:%s\n' "$*" >> "$DEBIAN_APT_LOG"
 exec "$@"
 SUDO
+    cat > "$activebin/locale" <<'LOCALE'
+#!/bin/sh
+case "${1:-}" in
+  -a)
+    if [ "${DEBIAN_TEST_LOCALE:-present}" = present ] || [ -e "$DEBIAN_LOCALE_MARKER" ]; then
+      printf '%s\n' 'de_DE.utf8'
+    fi
+    ;;
+  -k)
+    case "${DEBIAN_TEST_LOCALE_PROBE:-ok}" in
+      dotted) printf '%s\n' 'decimal_point="."' ;;
+      *) printf '%s\n' 'decimal_point=","' ;;
+    esac
+    ;;
+esac
+LOCALE
+    cat > "$activebin/locale-gen" <<'LOCALE_GEN'
+#!/bin/sh
+printf 'locale-gen:%s\n' "$*" >> "$DEBIAN_APT_LOG"
+# A stub cannot generate libc locales: the marker stands in for the generated
+# locale so the verification probes see post-generation state.
+true > "$DEBIAN_LOCALE_MARKER"
+LOCALE_GEN
     cat > "$activebin/brew" <<'BREW'
 #!/bin/sh
 printf 'brew:%s\n' "$*" >> "$DEBIAN_TOOL_LOG"
@@ -115,6 +138,11 @@ case "$*" in
     cp "$DEBIAN_INSTALLABLES/uv" "$BREW_UV_PREFIX/bin/uv"
     ;;
   '--prefix uv') printf '%s\n' "$BREW_UV_PREFIX" ;;
+  'list --versions iprange')
+    [ "${BREW_IPRANGE_INSTALLED:-1}" -eq 1 ] || exit 1
+    ;;
+  'install iprange')
+    ;;
   *) exit 9 ;;
 esac
 BREW
@@ -322,13 +350,15 @@ case "$*" in
 esac
 GROK
     chmod +x "$activebin/id" "$activebin/uname" "$activebin/dpkg-query" \
-      "$activebin/apt-get" "$activebin/sudo" "$activebin/brew" "$activebin/curl" "$installables"/*
+      "$activebin/apt-get" "$activebin/sudo" "$activebin/brew" "$activebin/curl" \
+      "$activebin/locale" "$activebin/locale-gen" "$installables"/*
     for tool in uv serena codegraph graphify wt; do
       cp "$installables/$tool" "$activebin/$tool"
     done
 
     worktrunk_config="$xdg_config/worktrunk/config.toml"
     brew_prefix="$fixture/homebrew uv"
+    locale_marker="$fixture/de locale generated"
     export HOME="$home"
     export XDG_CONFIG_HOME="$xdg_config"
     export DEBIAN_HELPER_LOG="$helper_log"
@@ -338,16 +368,37 @@ GROK
     export DEBIAN_INSTALLABLES="$installables"
     export DEBIAN_REPOSITORY="$repository"
     export BREW_UV_PREFIX="$brew_prefix"
+    export DEBIAN_LOCALE_MARKER="$locale_marker"
     export SERENA_STATE_DIR="$serena_state"
     unset CLAUDECODE CODEX_THREAD_ID COPILOT_CLI GROK_AGENT GROK_SESSION_ID OMP_CLI PI_CLI
     unset DEBIAN_MISSING_PACKAGES SERENA_CONFIG_MODE SERENA_SETUP_MODE
     unset GROK_DOCTOR_RC AGENT_TEST_OS BREW_UV_INSTALLED XDG_BIN_HOME UV_TOOL_BIN_DIR
+    unset DEBIAN_TEST_LOCALE DEBIAN_TEST_LOCALE_PROBE BREW_IPRANGE_INSTALLED
     unset UV_OMIT_TOOL CODEGRAPH_BIN_DIR CARGO_HOME
     PATH="$activebin:$basebin"; export PATH
   }
 
   enable_client() {
     cp "$installables/$1" "$activebin/$1"
+  }
+
+  # The comma-decimal verification probe runs awk(1); the real awk under a stub
+  # locale-gen would make the examples host-dependent, so the probe is faked while
+  # everything else delegates to the real binary.
+  stub_locale_awk() {
+    real_awk=$(command -v awk)
+    cat > "$activebin/awk" <<AWK
+#!/bin/sh
+if [ "\${1:-}" = 'BEGIN { printf "%.2f", 1.5 }' ]; then
+  case "\${DEBIAN_TEST_LOCALE_PROBE:-ok}" in
+    dotted) printf '1.50' ;;
+    *) printf '1,50' ;;
+  esac
+  exit 0
+fi
+exec "$real_awk" "\$@"
+AWK
+    chmod +x "$activebin/awk"
   }
 
   cleanup() {
@@ -375,6 +426,36 @@ GROK
     The contents of file "$apt_log" should equal "$(printf '%s\n' \
       'apt-get:update' \
       'apt-get:install -y git')"
+  End
+
+  # issue #3189: run-gates fails a *.sh diff on a host without the real iprange
+  # binary or a comma-decimal locale (the unlisted-skip class). Provision both
+  # exactly like CI and verify the locale the same way the specs probe it.
+  It 'generates and verifies the de_DE.UTF-8 locale as Linux root'
+    stub_locale_awk
+    export DEBIAN_TEST_LOCALE=absent
+    When run env DEBIAN_TEST_UID=0 sh "$script_abs" "$repository"
+    The status should equal 0
+    The contents of file "$apt_log" should equal 'locale-gen:de_DE.UTF-8'
+  End
+
+  It 'generates the de_DE.UTF-8 locale through sudo for a non-root user'
+    stub_locale_awk
+    export DEBIAN_TEST_LOCALE=absent
+    When run env DEBIAN_TEST_UID=1000 sh "$script_abs" "$repository"
+    The status should equal 0
+    The contents of file "$apt_log" should equal "$(printf '%s\n' \
+      'sudo:locale-gen de_DE.UTF-8' \
+      'locale-gen:de_DE.UTF-8')"
+  End
+
+  It 'fails loudly naming the remedy when the generated locale stays dotted'
+    stub_locale_awk
+    export DEBIAN_TEST_LOCALE=absent
+    export DEBIAN_TEST_LOCALE_PROBE=dotted
+    When run env DEBIAN_TEST_UID=0 sh "$script_abs" "$repository"
+    The status should not equal 0
+    The stderr should include 'comma decimal'
   End
 
   It 'uses official installers and current-process user paths on an initial Linux setup'
@@ -479,7 +560,9 @@ UNMANAGED_UV
     chmod +x "$activebin/uv"
     When run env AGENT_TEST_OS=Darwin BREW_UV_INSTALLED=0 sh "$script_abs" "$repository"
     The status should equal 0
+    The output should include 'comma-decimal locale'
     The contents of file "$tool_log" should equal "$(printf '%s\n' \
+      'brew:list --versions iprange' \
       'brew:list --versions uv' \
       'brew:install uv' \
       'brew:--prefix uv' \
@@ -501,7 +584,9 @@ UNMANAGED_UV
     rm -f "$activebin/uv"
     When run env AGENT_TEST_OS=Darwin sh -c 'sh "$1" "$2" && sh "$1" "$2"' _ "$script_abs" "$repository"
     The status should equal 0
+    The output should include 'comma-decimal locale'
     The contents of file "$tool_log" should equal "$(printf '%s\n' \
+      'brew:list --versions iprange' \
       'brew:list --versions uv' \
       'brew:--prefix uv' \
       'uv:tool install --upgrade serena-agent' \
@@ -512,6 +597,7 @@ UNMANAGED_UV
       'codegraph:install -l global -y -t auto' \
       'wt:config shell install --yes' \
       'serena:init' \
+      'brew:list --versions iprange' \
       'brew:list --versions uv' \
       'brew:--prefix uv' \
       'uv:tool install --upgrade serena-agent' \
@@ -531,10 +617,12 @@ UNMANAGED_UV
     rm -f "$activebin/uv" "$activebin/codegraph"
     When run env AGENT_TEST_OS=Darwin sh "$script_abs" "$repository"
     The status should equal 0
+    The output should include 'comma-decimal locale'
     The contents of file "$curl_log" should equal "$(printf '%s\n%s' \
       'https://raw.githubusercontent.com/colbymchenry/codegraph/main/install.sh' \
       'https://github.com/max-sixty/worktrunk/releases/latest/download/worktrunk-installer.sh')"
     The contents of file "$tool_log" should equal "$(printf '%s\n' \
+      'brew:list --versions iprange' \
       'brew:list --versions uv' \
       'brew:--prefix uv' \
       'uv:tool install --upgrade serena-agent' \
@@ -556,6 +644,22 @@ UNMANAGED_UV
     The stderr should include 'brew'
     The file "$apt_log" should not be exist
     The file "$helper_log" should not be exist
+  End
+
+  It 'installs iprange through Homebrew on a Darwin setup'
+    export BREW_IPRANGE_INSTALLED=0
+    When run env AGENT_TEST_OS=Darwin sh "$script_abs" "$repository"
+    The status should equal 0
+    The contents of file "$tool_log" should include "$(printf '%s\n%s' \
+      'brew:list --versions iprange' \
+      'brew:install iprange')"
+    The output should include 'comma-decimal locale'
+  End
+
+  It 'names the unprovisionable comma-decimal locale loudly on Darwin'
+    When run env AGENT_TEST_OS=Darwin sh "$script_abs" "$repository"
+    The status should equal 0
+    The output should include 'comma-decimal locale'
   End
 
   It 'rejects an unsupported host before changing tools, helpers, or user configuration'


### PR DESCRIPTION
Fixes #3174. Fixes #3175. Fixes #3189.

Three independent defects in the local canonical-gate runner (`scripts/agent/run-gates.sh`) and the agent-host provisioner (`scripts/agent/setup-agent-tools.sh`), one commit each. All dev-tooling scope; no shipped `src/` behavior touched.

## 1. Canary-fixture diffs selected no gate (#3174)

`gates_for()` matched only `tests/skip-allowlist.txt`, so a `tests/fixtures/skip-allowlist-canary.xml`-only diff selected no suite: a canary edited to pass would have disarmed every "red canary" claim in the three suite gates with nothing locally to notice. The arm is widened to `grep -qEx 'tests/(skip-allowlist\.txt|fixtures/skip-allowlist-canary\.xml)'` (whole-line match preserved; near-miss paths stay gate-less).

Evidence: new spec example red before the fix (`expected "uv run --locked pytest", got ""`), green after, test file byte-identical red→green. Red-path demonstration per #3166's precedent: with both canary rows renamed to allowlisted ids the real checker exits 0 on the fixture, which `gate_command()` turns into `red canary failed`; the fixture was restored byte-identical (`git hash-object` verified).

## 2. Non-UTF-8 filenames bypassed the unsafe-filename guard (#3175)

Under a UTF-8 locale GNU grep classifies a path list holding an invalid UTF-8 byte as *binary* and suppresses the matching lines, so `gates_for()`'s leading `grep -v '^legacy/'` dropped a hostile filename before the guard at the top of the function: no `unsafe filename in diff` refusal, no `sh -n`, no `shellcheck`, and `GATES: PASS` still printed. The mapping now pins `LC_ALL=C` for its greps (scoped to the function; gate commands run in separate processes and keep the ambient locale).

Evidence: new spec example red with the bug's own signature in its output (`grep: (standard input): binary file matches`), green after; the example pins the refusal under an explicit `LC_ALL=C.UTF-8`, so it is hermetic of the host locale.

## 3. Shell gates red on unprovisioned hosts (#3189)

On a host without the real `iprange` binary or a comma-decimal locale, the `suppress()` oracle rows and the comma-decimal shard specs self-skip with reasons absent from `tests/skip-allowlist.txt`, so the skip-set checker failed the gate on an unmodified tree — a real regression indistinguishable from the host gap at the `GATES:` line. Owner direction: provision the host like CI, fail loudly, never silently skip.

`setup-agent-tools.sh` (the provisioner of record that already installs `libarchive-tools` for the same reason) now:

- adds `iprange` and `locales` to the Debian package set (same dpkg-query/apt/sudo dance, root or sudo);
- generates `de_DE.UTF-8` when absent and verifies it with the same probes CI runs (`locale -a` grep, `LC_NUMERIC` decimal point, awk comma-decimal probe), failing with the remedy instead of letting the specs skip;
- installs `iprange` through Homebrew on macOS, and prints a conditional note where macOS has no `locale-gen` (if the comma-decimal specs skip there, the gate stays red until a locale is installed manually or the gates run on Linux/CI).

End-to-end on the reporting host class (Debian 13): the full ShellSpec suite now runs the previously-skipping rows — the gate run on this branch shows 1964 examples, 0 failures, and only the nine allowlisted root-bypass skips.

## Frozen RED evidence

Blobs below are the shipped files (the checker verifies them against the working tree). Where the red-time blob differed — the #3174 example first ran red at `c451dbe9ccfc30c22f1da8cb1c897a7a5c983ebf`, and the agent-tools suite first ran red at `fd4d2ced7d1578444f7052b2e7dab0529ca78d94` — the deltas are the review-round updates disclosed above, not assertion changes to the red proofs.

| Frozen RED test | git hash-object | RED run tail |
| --- | --- | --- |
| `tests/shell/agent_run_gates_spec.sh` | `e4977282c7296bb938729464fc8d48783ee5da36` | `1) run-gates.sh gates_for() refuses a sh-path carrying an invalid UTF-8 byte even under a UTF-8 locale — stderr: grep: (standard input): binary file matches — 1 example, 1 failure` |
| `tests/shell/agent_tools_setup_spec.sh` | `f95e333b357819f75c6f2b80704ca7dc9cec74af` | `1) setup-agent-tools.sh generates and verifies the de_DE.UTF-8 locale as Linux root — apt_log missing locale-gen evidence — 48 examples, 5 failures` |

## Test evidence

- Red-first per repo testing policy; reproduction specs frozen and re-run green unchanged (blob hashes in the gate record).
- Canonical gates on the branch content: `GATES: PASS` — coverage pairing, graph freshness, re-entry bounds (+self-test), `sh -n`/`shellcheck` on every touched script, and the full ShellSpec gate with JUnit + red canary + skip-allowlist checker.
- One defect caught by the gates mid-flight and fixed before landing: the new locale-gen stub used a `: >` truncate, flagged by the structural retirement guard (`: >` → `true >`).

## Review

One condensed adversarial review pass (contract, correctness/hostile input, test honesty, over-engineering) returned APPROVE with three nitpick findings:

1. Deleting/renaming the allowlist or canary fixture selects no gate (name-only streams use `--diff-filter=ACMRT`) — pre-existing runner-wide property, fail-closed downstream (the next selectable diff fails loudly at the red-canary step). Documented here, not fixed in this PR.
2. "The commit title overstates the refusal class; valid-UTF-8 names like `café.php` are newly refused" — premise probed and disproven: `café.php` matched `[^A-Za-z0-9._/-]` under `LC_ALL=C.UTF-8` before the change too (exit 0), so the guard already refused it; `LC_ALL=C` only extends refusal to invalid-UTF-8 names.
3. The macOS note asserted the specs "will skip" — reworded conditionally as suggested.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved filename handling for paths containing invalid UTF-8 bytes.
  * Corrected skip-allowlist gate selection, including canary fixture changes.
  * Added required locale validation and `iprange` installation across supported platforms.

* **Tests**
  * Expanded coverage for unsafe filenames, allowlist and canary matching, locale setup, and platform-specific tool installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->