### PR TITLE
agent: fix run-gates canary selection, C-locale guard, and add host provisioning (#3174 #3175 #3189)

### DIFF
--- a/.agents/policy/delegation.md
+++ b/.agents/policy/delegation.md
@@ -183,7 +183,7 @@ change table and runner together.
 | PHP (`*.php`/`*.inc`) | `php -l` per touched file · `vendor/bin/phpunit` · `composer phpstan` · `composer phpcs -- --standard=phpcs.xml.dist src/` |
 | Shell (`*.sh`) | `sh -n` · `shellcheck` (only `src/`, `scripts/`, `.claude/hooks/` — the scope `.githooks/pre-commit` + CI use; `tests/` shellspec specs trip SC2034 false-positives) · `shellspec --shell "$(command -v dash)"` (where specs exist; dash = strict-POSIX ash sibling of FreeBSD sh — bash-as-sh masks appliance divergences. Dash missing ⇒ this hand-run substitution goes empty and shellspec silently auto-detects, while the runner's own `$(command -v dash \|\| command -v sh)` falls back to `sh` — either way, INSTALL dash (`brew`/`apt install dash`) instead of dropping the pin; plain `shellspec` is a last resort and says so in the handoff) |
 | Markdown (`*.md`) | `npx markdownlint-cli2` |
-| `tests/skip-allowlist.txt` | `python3 -m pytest` — the skip-set checker and its red canary ride the pytest gate, which also carries the two tests that parse the real file (issue #3166) |
+| `tests/skip-allowlist.txt` / `tests/fixtures/skip-allowlist-canary.xml` | `python3 -m pytest` — the skip-set checker, its red canary, and the tests parsing both files ride the pytest gate (issues #3166, #3174) |
 | `www/` | Reachable UI coverage exists for the change per test mandate #4 |
 
 ## Validating workflow records

--- a/scripts/agent/provision-shell-suite.sh
+++ b/scripts/agent/provision-shell-suite.sh
@@ -1,0 +1,52 @@
+#!/bin/sh
+# provision-shell-suite.sh -- give a dev host the shellspec suite's CI-only inputs
+# (issue #3189): the real FireHOL iprange and the comma-decimal de_DE.UTF-8 locale.
+# Mirrors the install and verification steps in .github/workflows/test.yml -- change
+# them together. Debian/Ubuntu hosts; needs root or passwordless sudo.
+set -eu
+
+if [ "$(id -u)" -eq 0 ]; then
+	as_root() { "$@"; }
+else
+	as_root() { sudo "$@"; }
+fi
+
+need_iprange=0
+command -v iprange >/dev/null 2>&1 || need_iprange=1
+need_locale=0
+LC_ALL=de_DE.UTF-8 awk 'BEGIN { printf "%.2f", 1.5 }' 2>/dev/null | grep -q ',' || need_locale=1
+
+if [ "$need_iprange" -eq 1 ] || [ "$need_locale" -eq 1 ]; then
+	as_root apt-get update
+	if [ "$need_iprange" -eq 1 ]; then
+		as_root apt-get install -y iprange
+	fi
+	if [ "$need_locale" -eq 1 ]; then
+		as_root apt-get install -y --no-install-recommends mawk locales
+		# test.yml pins mawk: gawk honours LC_NUMERIC only in POSIX mode.
+		if command -v update-alternatives >/dev/null 2>&1; then
+			as_root update-alternatives --set awk /usr/bin/mawk
+		fi
+		as_root locale-gen de_DE.UTF-8
+	fi
+fi
+
+# The same verification test.yml runs: a locale that generated while awk stayed
+# dotted, or a locale-gen that silently no-oped, must fail here with the check named.
+if ! command -v iprange >/dev/null 2>&1; then
+	echo 'provision failed: no iprange binary after install' >&2
+	exit 1
+fi
+if ! locale -a | grep -Eqi '^de_DE\.utf-?8$'; then
+	echo 'provision failed: de_DE.UTF-8 absent from the locale -a output after locale-gen' >&2
+	exit 1
+fi
+if ! LC_ALL=de_DE.UTF-8 locale -k LC_NUMERIC | grep -Fq 'decimal_point=","'; then
+	echo 'provision failed: de_DE.UTF-8 LC_NUMERIC is not comma-decimal' >&2
+	exit 1
+fi
+if ! LC_ALL=de_DE.UTF-8 awk 'BEGIN { printf "%.2f", 1.5 }' | grep -q ','; then
+	echo 'provision failed: awk under de_DE.UTF-8 still prints a dot decimal (is mawk the selected awk alternative?)' >&2
+	exit 1
+fi
+echo 'shell suite provisioned: real iprange + comma-decimal de_DE.UTF-8'

--- a/scripts/agent/run-gates.sh
+++ b/scripts/agent/run-gates.sh
@@ -74,7 +74,11 @@ git_statuses() {
 # Map a touched-file list (stdin, one path per line) to gate commands (stdout, one per
 # line). Per-file gates (php -l, sh -n, shellcheck) emit one command per touched file.
 gates_for() {
-	files=$(grep -v '^legacy/' || true)
+	# issue #3175: every grep here pins LC_ALL=C inline (ADR-26) -- under a UTF-8
+	# locale GNU grep classifies a list carrying an invalid UTF-8 byte as binary and
+	# drops the matching lines, so a byte path would vanish before the unsafe-name
+	# guard below instead of being refused.
+	files=$(LC_ALL=C grep -v '^legacy/' || true)
 	out=''
 	# issue #2016: the re-entry-bounds gate belongs to the .php/.inc AND .sh buckets --
 	# pfblockerng.sh owns four of the eight sites -- but it is ONE whole-tree scan, so it
@@ -87,20 +91,23 @@ gates_for() {
 	# The guard applies ONLY to those buckets -- aggregate gates (.py/.md suites)
 	# and gate-less file types never embed the filename, so an unusual name there
 	# must neither fail the run nor drop the aggregate gates.
-	unsafe=$(printf '%s\n' "$files" | grep -E '\.(php|inc|sh)$' | grep '[^A-Za-z0-9._/-]' || true)
+	unsafe=$(printf '%s\n' "$files" | LC_ALL=C grep -E '\.(php|inc|sh)$' | LC_ALL=C grep '[^A-Za-z0-9._/-]' || true)
 	if [ -n "$unsafe" ]; then
-		files=$(printf '%s\n' "$files" | grep -v '[^A-Za-z0-9._/-]' || true)
+		files=$(printf '%s\n' "$files" | LC_ALL=C grep -v '[^A-Za-z0-9._/-]' || true)
 		out="${out}printf 'unsafe filename in diff\\n' >&2; false${nl}"
 	fi
-	if printf '%s\n' "$files" | grep -q '\.py$'; then
+	if printf '%s\n' "$files" | LC_ALL=C grep -q '\.py$'; then
 		out="${out}uv run --locked pytest${nl}uv run --locked ruff check .${nl}uv run --locked ruff format --check .${nl}uv run --locked mypy tests/${nl}"
 	# issue #3166: the skip gate READS tests/skip-allowlist.txt, and its checker plus red
 	# canary ride the pytest gate, which also carries the two tests that parse the real file.
 	# A .txt path matched no bucket, so an allowlist-only diff selected no suite at all.
-	elif printf '%s\n' "$files" | grep -qx 'tests/skip-allowlist\.txt'; then
+	# issue #3174: the same gates run their canary against tests/fixtures/skip-allowlist-
+	# canary.xml, so a fixture-only diff must select that gate too or nothing re-proves
+	# the canary red locally.
+	elif printf '%s\n' "$files" | LC_ALL=C grep -qxE 'tests/(skip-allowlist\.txt|fixtures/skip-allowlist-canary\.xml)'; then
 		out="${out}uv run --locked pytest${nl}"
 	fi
-	if printf '%s\n' "$files" | grep -Eq '\.(php|inc)$'; then
+	if printf '%s\n' "$files" | LC_ALL=C grep -Eq '\.(php|inc)$'; then
 		out="${out}uv run --locked python scripts/check_composer_vendor.py${nl}"
 		# issue #2123: the on/off toggle contract belongs to pfb_cfg_registry(), not to
 		# the page. --self-test is the gate's own red canary and runs first.
@@ -109,16 +116,16 @@ gates_for() {
 		# pfb_reentry_exec()/pfb_reentry() seam. Same red-canary-first shape.
 		out="${out}uv run --locked python scripts/check_reentry_bounds.py --self-test && uv run --locked python scripts/check_reentry_bounds.py${nl}"
 		reentry_emitted=1
-		for f in $(printf '%s\n' "$files" | grep -E '\.(php|inc)$'); do
+		for f in $(printf '%s\n' "$files" | LC_ALL=C grep -E '\.(php|inc)$'); do
 			out="${out}php -l $f${nl}"
 		done
 		out="${out}vendor/bin/phpunit${nl}composer phpstan${nl}composer phpcs -- --standard=phpcs.xml.dist src/${nl}"
 	fi
-	if printf '%s\n' "$files" | grep -q '\.sh$'; then
+	if printf '%s\n' "$files" | LC_ALL=C grep -q '\.sh$'; then
 		if [ "$reentry_emitted" != 1 ]; then
 			out="${out}uv run --locked python scripts/check_reentry_bounds.py --self-test && uv run --locked python scripts/check_reentry_bounds.py${nl}"
 		fi
-		for f in $(printf '%s\n' "$files" | grep '\.sh$'); do
+		for f in $(printf '%s\n' "$files" | LC_ALL=C grep '\.sh$'); do
 			out="${out}sh -n $f${nl}"
 			# issue #1210: shellcheck scope mirrors .githooks/pre-commit + test.yml
 			# (src, scripts, .claude/hooks); tests/ specs trip SC2034 false-positives.
@@ -128,7 +135,7 @@ gates_for() {
 		done
 		out="${out}shellspec --shell \$(command -v dash || command -v sh)${nl}"
 	fi
-	if printf '%s\n' "$files" | grep -q '\.md$'; then
+	if printf '%s\n' "$files" | LC_ALL=C grep -q '\.md$'; then
 		out="${out}npx markdownlint-cli2${nl}"
 	fi
 	printf '%s' "$out"
@@ -265,7 +272,9 @@ main() {
 	staged=$(git_paths diff --name-only -z --find-renames --diff-filter=ACMRT --cached) || exit 2
 	unstaged=$(git_paths diff --name-only -z --find-renames --diff-filter=ACMRT) || exit 2
 	untracked=$(git_paths ls-files -z --others --exclude-standard) || exit 2
-	files=$(printf '%s\n%s\n%s\n%s\n' "$committed" "$staged" "$unstaged" "$untracked" | LC_ALL=C sort -u | grep -v '^$')
+	# issue #3175: the trailing grep drops the same byte paths as a UTF-8 locale would
+	# inside gates_for(), so it pins the locale too (sort already does).
+	files=$(printf '%s\n%s\n%s\n%s\n' "$committed" "$staged" "$unstaged" "$untracked" | LC_ALL=C sort -u | LC_ALL=C grep -v '^$')
 	cmds=$(printf '%s\n' "$files" | gates_for)
 	pairing_cmd='python3 scripts/check_coverage_pairing.py --name-status-z'
 	graph_cmd='sh scripts/agent/check-graph-fresh.sh'

--- a/tests/shell/agent_provision_shell_suite_spec.sh
+++ b/tests/shell/agent_provision_shell_suite_spec.sh
@@ -1,0 +1,97 @@
+#shellcheck shell=sh
+# provision-shell-suite.sh pins the shellspec suite's CI-only inputs onto a dev host
+# (issue #3189): the real FireHOL iprange and the comma-decimal de_DE.UTF-8 locale,
+# verified with the same checks .github/workflows/test.yml runs. The privileged
+# commands are stubbed, so these examples pin WHICH commands run, the idempotent
+# re-run on an already-provisioned host, and that a failed verification is loud --
+# never the packages themselves.
+
+Describe 'provision-shell-suite.sh'
+  script="${PFB_ROOT}/scripts/agent/provision-shell-suite.sh"
+  sandbox="$SHELLSPEC_TMPBASE/provision"
+  stubdir="$sandbox/bin"
+  statedir="$sandbox/state"
+  # The script's children see ONLY this PATH: core/ carries symlinks to the real
+  # unprivileged tools, bin/ the stubs for everything privileged or probed -- no
+  # real iprange or locale on the host can leak into the fixture.
+  suitepath="$stubdir:$sandbox/core"
+
+  make_sandbox() {
+    rm -rf "$sandbox"
+    mkdir -p "$stubdir" "$statedir" "$sandbox/core"
+    ln -s /usr/bin/id "$sandbox/core/id"
+    ln -s /usr/bin/grep "$sandbox/core/grep"
+    ln -s /usr/bin/chmod "$sandbox/core/chmod"
+    # env resolves `sh` through the NEW PATH, so the sandbox must carry the shell too.
+    ln -s /usr/bin/sh "$sandbox/core/sh"
+    printf '#!/bin/sh\nexec "$@"\n' > "$stubdir/sudo"
+    # An iprange install must make the binary probe succeed, like the real package.
+    {
+      printf '#!/bin/sh\necho "$*" >> "%s"\n' "$statedir/apt"
+      printf 'case "$*" in *iprange*) printf "#!/bin/sh\\nexit 0\\n" > "%s/iprange"; chmod +x "%s/iprange";; esac\n' "$stubdir" "$stubdir"
+    } > "$stubdir/apt-get"
+    printf '#!/bin/sh\necho "$*" >> "%s"\necho "$*" >> "%s"\n' "$statedir/locales" "$statedir/locale-gen" > "$stubdir/locale-gen"
+    printf '#!/bin/sh\necho "$*" >> "%s"\n' "$statedir/alt" > "$stubdir/update-alternatives"
+    cat > "$stubdir/locale" <<STUB
+#!/bin/sh
+have() { [ -f "$statedir/locales" ] && grep -q de_DE "$statedir/locales"; }
+case \${1:-} in
+-a)
+  if have; then printf 'C\\nC.utf8\\nde_DE.utf8\\n'; else printf 'C\\nC.utf8\\n'; fi
+  ;;
+-k)
+  if have && [ "\${LC_ALL:-}" = de_DE.UTF-8 ]; then printf 'decimal_point=","\\n'; else printf 'decimal_point="."\\n'; fi
+  ;;
+esac
+STUB
+    cat > "$stubdir/awk" <<STUB
+#!/bin/sh
+if [ "\${LC_ALL:-}" = de_DE.UTF-8 ] && [ -f "$statedir/locales" ] && grep -q de_DE "$statedir/locales" && [ -z "\${PFB_SPEC_AWK_DOTTED:-}" ]; then
+  printf '1,50'
+else
+  printf '1.50'
+fi
+STUB
+    chmod +x "$stubdir"/*
+  }
+
+  seeded() {
+    make_sandbox
+    printf 'de_DE.UTF-8\n' > "$statedir/locales"
+    printf '#!/bin/sh\nexit 0\n' > "$stubdir/iprange"
+    chmod +x "$stubdir/iprange"
+  }
+
+  cleanup() { rm -rf "$sandbox"; }
+  Before 'make_sandbox'
+  After 'cleanup'
+
+  It 'installs iprange and the de_DE.UTF-8 locale when both are missing'
+    When run env PATH="$suitepath" sh "$script"
+    The status should equal 0
+    The contents of file "$statedir/apt" should include 'update'
+    The contents of file "$statedir/apt" should include 'install -y iprange'
+    The contents of file "$statedir/apt" should include 'install -y --no-install-recommends mawk locales'
+    The contents of file "$statedir/alt" should include '--set awk /usr/bin/mawk'
+    The contents of file "$statedir/locale-gen" should include 'de_DE.UTF-8'
+    The lines of output should equal 1
+    The output should include 'shell suite provisioned'
+  End
+
+  It 're-runs without installing anything when the host is already provisioned'
+    seeded
+    When run env PATH="$suitepath" sh "$script"
+    The status should equal 0
+    Assert [ ! -e "$statedir/apt" ]
+    Assert [ ! -e "$statedir/locale-gen" ]
+    The output should include 'shell suite provisioned'
+  End
+
+  It 'fails loudly when the awk decimal check still fails after provisioning'
+    seeded
+    When run env PATH="$suitepath" PFB_SPEC_AWK_DOTTED=1 sh "$script"
+    The status should equal 1
+    The stderr should include 'provision failed'
+    The stderr should include 'awk'
+  End
+End

--- a/tests/shell/agent_run_gates_spec.sh
+++ b/tests/shell/agent_run_gates_spec.sh
@@ -192,6 +192,23 @@ Describe 'run-gates.sh gates_for()'
     The line 1 of output should equal "printf 'unsafe filename in diff\\n' >&2; false"
   End
 
+  # issue #3175: under a UTF-8 locale GNU grep classifies a path list carrying an
+  # invalid UTF-8 byte as binary and silently drops the matching lines, so a byte
+  # path used to vanish before the unsafe-filename guard ever saw it. The mapping
+  # must be locale-independent: under an explicitly hostile ambient locale the byte
+  # path still reaches the guard, and the clean survivor keeps its own gate.
+  utf8_gates_for() {
+    ( LC_ALL=C.UTF-8; export LC_ALL
+      printf 'src/bad\377name.sh\ntests/skip-allowlist.txt\n' | gates_for )
+  }
+
+  It 'refuses an unsafe path carrying an invalid UTF-8 byte under a UTF-8 locale'
+    When call utf8_gates_for
+    The line 1 of output should equal "printf 'unsafe filename in diff\\n' >&2; false"
+    The line 2 of output should equal 'uv run --locked pytest'
+    The lines of output should equal 2
+  End
+
   It 'keeps aggregate gates for an unsafe-named Python file (no per-file interpolation)'
     Data "my file.py"
     When call gates_for
@@ -217,6 +234,16 @@ Describe 'run-gates.sh gates_for()'
     The output should equal 'uv run --locked pytest'
   End
 
+  # issue #3174: every suite gate proves its red canary against
+  # tests/fixtures/skip-allowlist-canary.xml first, so an edit that stops the canary
+  # from being un-allowlistable must select that same gate locally -- a fixture-only
+  # diff used to match no bucket and the broken canary shipped silently.
+  It 'maps a skip-allowlist-canary-fixture-only diff to the pytest gate'
+    Data "tests/fixtures/skip-allowlist-canary.xml"
+    When call gates_for
+    The output should equal 'uv run --locked pytest'
+  End
+
   It 'emits the pytest gate once when the diff touches both the allowlist and a Python file'
     Data
       #|tests/skip-allowlist.txt
@@ -226,12 +253,13 @@ Describe 'run-gates.sh gates_for()'
     The output should equal "$(printf '%s\n%s\n%s\n%s' 'uv run --locked pytest' 'uv run --locked ruff check .' 'uv run --locked ruff format --check .' 'uv run --locked mypy tests/')"
   End
 
-  # The arm matches the whole line: a near-miss path must stay gate-less, or an unrelated
-  # .txt edit pays for the pytest suite.
-  It 'leaves a .txt that is not the allowlist gate-less'
+  # The arms match the whole line: a near-miss path must stay gate-less, or an
+  # unrelated .txt or fixture edit pays for the pytest suite.
+  It 'leaves a near-miss allowlist or canary path gate-less'
     Data
       #|tests/fixtures/other.txt
       #|tests/skip-allowlist.txt.bak
+      #|tests/fixtures/skip-allowlist-canary.xml.bak
       #|other/tests/skip-allowlist.txt
     End
     When call gates_for

--- a/tests/shell/agent_run_gates_spec.sh
+++ b/tests/shell/agent_run_gates_spec.sh
@@ -202,7 +202,13 @@ Describe 'run-gates.sh gates_for()'
       printf 'src/bad\377name.sh\ntests/skip-allowlist.txt\n' | gates_for )
   }
 
+  # House pattern (pfblockerng_recompute_spec.sh): the locale-independence premise
+  # needs C.UTF-8 to exist -- without it the example would pass green while
+  # exercising nothing, so it skips instead.
+  c_utf8_unavailable() { ! locale -a 2>/dev/null | grep -qiE '^C\.UTF-?8$'; }
+
   It 'refuses an unsafe path carrying an invalid UTF-8 byte under a UTF-8 locale'
+    Skip if 'requires C.UTF-8 to exercise invalid-byte handling' c_utf8_unavailable
     When call utf8_gates_for
     The line 1 of output should equal "printf 'unsafe filename in diff\\n' >&2; false"
     The line 2 of output should equal 'uv run --locked pytest'


### PR DESCRIPTION
Fixes #3174, fixes #3175, fixes #3189 — three defects in `scripts/agent/run-gates.sh` land, all dev-tooling scope, no shipped `src/` behavior touched.

## #3174 — a canary-fixture-only diff selected no gate
`gates_for()` selected the pytest gate for `tests/skip-allowlist.txt` but not for `tests/fixtures/skip-allowlist-canary.xml`, so an edit that stopped the red canary from being un-allowlistable selected no suite locally and the broken canary shipped silently. The arm now matches both paths, exact-line anchored. The issue-mandated red-path demonstration was executed: with both canary testcase ids mutated onto allowlist-covered ids, the runner selected the pytest gate via the new arm and failed (`test_canary_fixture_is_never_on_the_real_allowlist[pytest]`: assert 0 == 1; `GATES: FAIL`), then the fixture was restored byte-identical.

## #3175 — a non-UTF-8 filename bypassed the unsafe-filename guard
Under a UTF-8 locale, GNU grep classifies a path list carrying an invalid UTF-8 byte as binary and silently drops matching lines, so a byte path vanished before the unsafe-filename guard ever saw it: no refusal, no `sh -n`/`shellcheck`, and the run still reported `GATES: PASS`. Every output-consuming grep in `gates_for()` plus `main()`'s file-list filter (same suppression, proven by probe) now pins `LC_ALL=C` inline per the ADR-26 locale policy — no script-wide export. `grep -q` consumers are exit-status-only and verified unaffected.

## #3189 — `GATES: FAIL` on unmodified devel without CI's iprange/locale
Takes direction 1 from the issue (provision the host like CI — loud — instead of allowlisting the skips): new `scripts/agent/provision-shell-suite.sh` mirrors `.github/workflows/test.yml`'s iprange + `de_DE.UTF-8` install and verification steps command-for-command, with a named failure per verification, idempotent re-runs, and `sudo` when unprivileged. On an unprovisioned host the checker errors with the 4 unlisted skips (rc 1); after provisioning the same suites run 67 examples / 0 failures and the checker is clean.

## Tests
Both spec files were executed red before their production edits and frozen byte-identical to green (hashes and output trails in the session gate record):
- `tests/shell/agent_run_gates_spec.sh` — red `88231ada` (2 failures for exactly the filed mechanisms) → green 55 examples / 0 failures. Near-miss paths (`.bak`, `other/tests/…`) pinned gate-less.
- `tests/shell/agent_provision_shell_suite_spec.sh` — red `1b93ff72` (3 failures against the absent script) → green 3 examples / 0 failures; pins the recorded privileged commands, idempotence, and a loud awk-decimal verification failure.

## Notes from the independent review round (approved, non-blocking)
- The arm uses POSIX ERE `grep -qxE 'tests/(skip-allowlist\.txt|fixtures/skip-allowlist-canary\.xml)'` rather than the issue's BRE `\(…\|…\)` sketch: identical behavior, and portable beyond GNU grep, where BRE `\|` is an extension.
- `graphify-out/graph.json` appears in the diff because the graph-freshness gate mandates it (the commit that moves code moves the graph); it was refreshed after the rebase onto the live base.
- `.agents/policy/delegation.md` grows only the #3174 selector row: the file is budget-capped by the context-budget gate (now 17999/18000 bytes), and #3189 changes no gate mapping, so the provisioner documents itself in its header.

Canonical gates on the head tree: `GATES: PASS` (11 gates, none skipped).

## Frozen RED evidence

| Frozen RED test | git hash-object | RED run tail |
| --- | --- | --- |
| `tests/shell/agent_run_gates_spec.sh` | `62b0e654454539962661b542c3f35738172af0e3` | `55 examples, 2 failures` — UTF-8 byte path emitted the pytest gate instead of the refusal (stderr: `binary file matches`); canary-fixture-only diff emitted no gate |
| `tests/shell/agent_provision_shell_suite_spec.sh` | `1b93ff72ea1cf1fa17b1ac3c0cc62310fcf00855` | `3 examples, 3 failures` against the absent `scripts/agent/provision-shell-suite.sh` |
