### PR TITLE
pfb_unbound: NODATA+SOA for non-address DNSBL blocks (#3222)

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -7453,10 +7453,17 @@ def operate(id: int, event: int, qstate: module_qstate, qdata: Any) -> bool:
                 if dnsbl.idn_alert is not None and not (dnsbl.is_found and not dnsbl.in_whitelist):
                     _log_idn_alert(q_name, q_ip, dnsbl.idn_alert, get_q_type(qstate, None))
             elif isCNAME and dnsbl.is_found and not dnsbl.in_whitelist:
-                # Memo hit on the CNAME *target*: still answer in the original
-                # QNAME's bailiwick (issue #3222 review F3).
-                q_name = q_name_original
-                _decision_for(q_name_original, snap.gen).dnsbl = dnsbl
+                # Memo hit on the CNAME *target*: re-evaluate in the original
+                # QNAME's CNAME-chain context so orig's whitelist still applies
+                # (issue #3222 review F3 / round-2 B1). Then answer in orig's
+                # bailiwick only if that context is still a block.
+                cfg = _evaluate_cfg(snap)
+                dnsbl = evaluate_domain(
+                    q_name, q_name_original, get_tld_from_name(q_name), True, cfg, snap.containers()
+                )
+                if dnsbl.is_found and not dnsbl.in_whitelist:
+                    q_name = q_name_original
+                    _decision_for(q_name_original, snap.gen).dnsbl = dnsbl
 
             # Block iff found and not whitelisted; an allow decision falls through to
             # the resolver (the WAIT_MODULE below).

--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -7455,8 +7455,8 @@ def operate(id: int, event: int, qstate: module_qstate, qdata: Any) -> bool:
             elif isCNAME and dnsbl.is_found and not dnsbl.in_whitelist:
                 # Memo hit on the CNAME *target*: re-evaluate in the original
                 # QNAME's CNAME-chain context so orig's whitelist still applies
-                # (issue #3222 review F3 / round-2 B1). Then answer in orig's
-                # bailiwick only if that context is still a block.
+                # (issue #3222). Then answer in orig's bailiwick only if that
+                # context is still a block.
                 cfg = _evaluate_cfg(snap)
                 dnsbl = evaluate_domain(
                     q_name, q_name_original, get_tld_from_name(q_name), True, cfg, snap.containers()

--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -547,6 +547,12 @@ RELOAD_RAM_HEADROOM_BYTES = 64 * 1024 * 1024
 # stop Event is observed promptly). Best-effort -- a small delay is acceptable by design.
 RELOAD_POLL_INTERVAL = 2.0
 
+# issue #3222: RFC 2308 Type-2 NODATA for intercepted non-address qtypes
+# (HTTPS/SVCB/MX/…). MNAME/RNAME are RFC 2606 .invalid; MINIMUM is the
+# negative-cache TTL. There is no zone SOA to borrow — pfBlockerNG is not
+# authoritative for listed names.
+DNSBL_NODATA_SOA_RDATA = "pfb.invalid. nobody.invalid. 1 3600 1200 604800 300"
+
 
 def _reload_total_ram_bytes() -> int | None:
     """Best-effort TOTAL physical RAM in bytes, stdlib only.
@@ -7473,6 +7479,12 @@ def operate(id: int, event: int, qstate: module_qstate, qdata: Any) -> bool:
                     msg.answer.append(
                         "{}. 3600 IN AAAA {}".format(q_name, "::" if dnsbl.null_blocking else pfb["dnsbl_ipv6"])
                     )
+                # issue #3222: A/AAAA/ANY get a sinkhole RR; every other intercepted
+                # type was finishing as empty NOERROR with no SOA (RFC 2308 Type-3).
+                # Type-2 NODATA (NOERROR + SOA in AUTHORITY) matches "name exists
+                # (A/AAAA still sinkholed) but this type has no data".
+                if not msg.answer:
+                    msg.authority.append("{}. 3600 IN SOA {}".format(q_name, DNSBL_NODATA_SOA_RDATA))
 
                 if msg is None or not msg.set_return_msg(qstate):
                     qstate.ext_state[id] = MODULE_ERROR

--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -551,7 +551,7 @@ RELOAD_POLL_INTERVAL = 2.0
 # (HTTPS/SVCB/MX/…). MNAME/RNAME are RFC 2606 .invalid; MINIMUM is the
 # negative-cache TTL. There is no zone SOA to borrow — pfBlockerNG is not
 # authoritative for listed names.
-DNSBL_NODATA_SOA_RDATA = "pfb.invalid. nobody.invalid. 1 3600 1200 604800 300"
+DNSBL_NODATA_SOA_RDATA = "pfb.invalid. nobody.invalid. 1 3600 1200 604800 3600"
 
 
 def _reload_total_ram_bytes() -> int | None:
@@ -7452,6 +7452,11 @@ def operate(id: int, event: int, qstate: module_qstate, qdata: Any) -> bool:
                 # issue #1349: preserve block/alert exclusivity after cache retirement.
                 if dnsbl.idn_alert is not None and not (dnsbl.is_found and not dnsbl.in_whitelist):
                     _log_idn_alert(q_name, q_ip, dnsbl.idn_alert, get_q_type(qstate, None))
+            elif isCNAME and dnsbl.is_found and not dnsbl.in_whitelist:
+                # Memo hit on the CNAME *target*: still answer in the original
+                # QNAME's bailiwick (issue #3222 review F3).
+                q_name = q_name_original
+                _decision_for(q_name_original, snap.gen).dnsbl = dnsbl
 
             # Block iff found and not whitelisted; an allow decision falls through to
             # the resolver (the WAIT_MODULE below).
@@ -7479,10 +7484,7 @@ def operate(id: int, event: int, qstate: module_qstate, qdata: Any) -> bool:
                     msg.answer.append(
                         "{}. 3600 IN AAAA {}".format(q_name, "::" if dnsbl.null_blocking else pfb["dnsbl_ipv6"])
                     )
-                # issue #3222: A/AAAA/ANY get a sinkhole RR; every other intercepted
-                # type was finishing as empty NOERROR with no SOA (RFC 2308 Type-3).
-                # Type-2 NODATA (NOERROR + SOA in AUTHORITY) matches "name exists
-                # (A/AAAA still sinkholed) but this type has no data".
+                # issue #3222: empty answer → RFC 2308 Type-2 NODATA (SOA in AUTHORITY).
                 if not msg.answer:
                     msg.authority.append("{}. 3600 IN SOA {}".format(q_name, DNSBL_NODATA_SOA_RDATA))
 

--- a/stubs/python/unboundmodule.py
+++ b/stubs/python/unboundmodule.py
@@ -408,7 +408,7 @@ class reply_info(_Struct):
 class DNSMessage:
     """Reply-message builder.
 
-    Records every instance on the class so tests can inspect the answer section
+    Records every instance on the class so tests can inspect the RR sections
     of the reply that operate() constructed before it was discarded.
 
     Usage in ``operate()``::
@@ -435,7 +435,11 @@ class DNSMessage:
         self.qtype = qtype
         self.qclass = qclass
         self.flags = flags
-        self.answer: list[str] = []  # RR strings to include in the answer section
+        # Mirror Unbound pythonmod's DNSMessage (question/answer/authority/additional).
+        self.question: list[str] = []
+        self.answer: list[str] = []
+        self.authority: list[str] = []
+        self.additional: list[str] = []
         self._qstate: Any = None
         DNSMessage.instances.append(self)
 

--- a/tests/smoke/test_smoke_matrix.py
+++ b/tests/smoke/test_smoke_matrix.py
@@ -239,22 +239,18 @@ def _raw_drill(vm: SmokeVM, name: str, rtype: str) -> str:
     return result.stdout
 
 
-def test_dnsbl_https_svcb_vip_empty_noerror(
-    deployed_vm: SmokeVM, client_vm: SmokeVM, mock_feeds: _MockFeedServer
-) -> None:
-    """Issue #3222 live diagnosis: VIP-blocked HTTPS/SVCB vs A on real Unbound.
+def test_dnsbl_https_svcb_vip_nodata_soa(deployed_vm: SmokeVM, client_vm: SmokeVM, mock_feeds: _MockFeedServer) -> None:
+    """Issue #3222: VIP-blocked HTTPS/SVCB is RFC 2308 Type-2 NODATA (SOA), not empty NOERROR.
 
     Control: the listed name's A query is the VIP sinkhole, so DNSBL python-mode
     is armed. Then the same name is queried as HTTPS, TYPE65, TYPE64, and MX
     from both the LAN client (``dig``, the iOS-like path) and on-box
     (``drill @127.0.0.1``).
 
-    Current production synthesises A/AAAA only, so those non-address queries
-    are expected to return NOERROR with ANSWER 0 and AUTHORITY 0 — the reporter's
-    empty-NOERROR shape. A dnsbl.log line after the HTTPS query proves pythonmod
-    intercepted it (the stub upstream also answers non-A as empty NOERROR, so
-    the log is the discriminator). An unlisted control name is probed the same
-    way so a stub-NODATA reply is visible next to the blocked one.
+    Non-address intercepts must return NOERROR with ANSWER 0 and AUTHORITY 1
+    (a synthetic SOA). Empty AUTHORITY is the pre-fix defect. A dnsbl.log line
+    after the HTTPS query proves pythonmod intercepted it (the stub upstream
+    also answers non-A as empty NOERROR, so the log is the discriminator).
     """
     blocked = h.unique_domain("https3222")
     control = h.unique_domain("https3222ctl")
@@ -281,10 +277,11 @@ def test_dnsbl_https_svcb_vip_empty_noerror(
                 f"{blocked} {rtype} expected NOERROR, got {parsed.rcode} records={parsed.records!r}\n{dump}"
             )
             assert parsed.records == [], f"{blocked} {rtype} expected empty ANSWER, got {parsed.records!r}\n{dump}"
-            assert an == 0 and ns == 0, (
-                f"{blocked} {rtype} expected ANSWER=0 AUTHORITY=0, "
+            assert an == 0 and ns == 1, (
+                f"{blocked} {rtype} expected ANSWER=0 AUTHORITY=1 (SOA), "
                 f"got ANSWER={an} AUTHORITY={ns} ADDITIONAL={ar}\n{dump}"
             )
+            assert " SOA " in lan or " SOA " in box, f"{blocked} {rtype} expected an SOA in AUTHORITY\n{dump}"
 
         ctl_a = h.dns_probe_client(client_vm, control, "A")
         assert not h.is_vip(ctl_a), f"{control} A must not be VIP (unlisted), got {ctl_a}"

--- a/tests/smoke/test_smoke_matrix.py
+++ b/tests/smoke/test_smoke_matrix.py
@@ -238,7 +238,8 @@ def _raw_dig(client_vm: SmokeVM, name: str, rtype: str) -> str:
 
 
 def _raw_drill(vm: SmokeVM, name: str, rtype: str) -> str:
-    result = vm.ssh(f"{h.DRILL_BIN} {name} {rtype} @127.0.0.1", timeout=30.0)
+    drill_type = "TYPE65" if rtype == "HTTPS" else rtype
+    result = vm.ssh(f"{h.DRILL_BIN} {name} {drill_type} @127.0.0.1", timeout=30.0)
     return result.stdout
 
 
@@ -274,19 +275,23 @@ def test_dnsbl_https_svcb_vip_nodata_soa(deployed_vm: SmokeVM, client_vm: SmokeV
             box = _raw_drill(deployed_vm, blocked, rtype)
             dumps.append(f"=== blocked {rtype} LAN dig ===\n{lan}\n=== blocked {rtype} on-box drill ===\n{box}")
             parsed = h.dns_probe_client(client_vm, blocked, rtype)
-            an, ns, ar = _header_counts(lan)
+            lan_an, lan_ns, lan_ar = _header_counts(lan)
+            box_an, box_ns, box_ar = _header_counts(box)
             dump = "\n".join(dumps)
             assert parsed.rcode == "NOERROR", (
                 f"{blocked} {rtype} expected NOERROR, got {parsed.rcode} records={parsed.records!r}\n{dump}"
             )
             assert parsed.records == [], f"{blocked} {rtype} expected empty ANSWER, got {parsed.records!r}\n{dump}"
-            assert an == 0 and ns == 1, (
-                f"{blocked} {rtype} expected ANSWER=0 AUTHORITY=1 (SOA), "
-                f"got ANSWER={an} AUTHORITY={ns} ADDITIONAL={ar}\n{dump}"
+            assert lan_an == 0 and lan_ns == 1, (
+                f"{blocked} {rtype} LAN expected ANSWER=0 AUTHORITY=1 (SOA), "
+                f"got ANSWER={lan_an} AUTHORITY={lan_ns} ADDITIONAL={lan_ar}\n{dump}"
             )
-            assert rr_has_type(lan, "SOA") or rr_has_type(box, "SOA"), (
-                f"{blocked} {rtype} expected an SOA in AUTHORITY\n{dump}"
+            assert box_an == 0 and box_ns == 1, (
+                f"{blocked} {rtype} on-box expected ANSWER=0 AUTHORITY=1 (SOA), "
+                f"got ANSWER={box_an} AUTHORITY={box_ns} ADDITIONAL={box_ar}\n{dump}"
             )
+            assert rr_has_type(lan, "SOA"), f"{blocked} {rtype} LAN expected an SOA in AUTHORITY\n{dump}"
+            assert rr_has_type(box, "SOA"), f"{blocked} {rtype} on-box expected an SOA in AUTHORITY\n{dump}"
 
         ctl_a = h.dns_probe_client(client_vm, control, "A")
         assert not h.is_vip(ctl_a), f"{control} A must not be VIP (unlisted), got {ctl_a}"

--- a/tests/smoke/test_smoke_matrix.py
+++ b/tests/smoke/test_smoke_matrix.py
@@ -212,6 +212,98 @@ def test_dnsbl_python_exact_vip(deployed_vm: SmokeVM, client_vm: SmokeVM, mock_f
         assert not h.is_vip(passed), f"{sub} wrongly VIP-blocked (exact match, not wildcard): {passed}"
 
 
+_SECTION_COUNTS = re.compile(
+    r"ANSWER:\s*(\d+).*AUTHORITY:\s*(\d+).*ADDITIONAL:\s*(\d+)",
+    re.IGNORECASE | re.DOTALL,
+)
+
+
+def _header_counts(raw: str) -> tuple[int | None, int | None, int | None]:
+    """Parse ANSWER/AUTHORITY/ADDITIONAL counts from a dig or drill header line."""
+    m = _SECTION_COUNTS.search(raw)
+    if m is None:
+        return None, None, None
+    return int(m.group(1)), int(m.group(2)), int(m.group(3))
+
+
+def _raw_dig(client_vm: SmokeVM, name: str, rtype: str) -> str:
+    result = client_vm.ssh(
+        f"dig +tries=1 +time=5 {rtype} {name} @192.168.1.1",
+        timeout=30.0,
+    )
+    return result.stdout
+
+
+def _raw_drill(vm: SmokeVM, name: str, rtype: str) -> str:
+    result = vm.ssh(f"{h.DRILL_BIN} {name} {rtype} @127.0.0.1", timeout=30.0)
+    return result.stdout
+
+
+def test_dnsbl_https_svcb_vip_empty_noerror(
+    deployed_vm: SmokeVM, client_vm: SmokeVM, mock_feeds: _MockFeedServer
+) -> None:
+    """Issue #3222 live diagnosis: VIP-blocked HTTPS/SVCB vs A on real Unbound.
+
+    Control: the listed name's A query is the VIP sinkhole, so DNSBL python-mode
+    is armed. Then the same name is queried as HTTPS, TYPE65, TYPE64, and MX
+    from both the LAN client (``dig``, the iOS-like path) and on-box
+    (``drill @127.0.0.1``).
+
+    Current production synthesises A/AAAA only, so those non-address queries
+    are expected to return NOERROR with ANSWER 0 and AUTHORITY 0 — the reporter's
+    empty-NOERROR shape. A dnsbl.log line after the HTTPS query proves pythonmod
+    intercepted it (the stub upstream also answers non-A as empty NOERROR, so
+    the log is the discriminator). An unlisted control name is probed the same
+    way so a stub-NODATA reply is visible next to the blocked one.
+    """
+    blocked = h.unique_domain("https3222")
+    control = h.unique_domain("https3222ctl")
+    feed_url = h.write_local_feed(deployed_vm, "smoke_dnsbl_https3222.txt", f"{blocked}\n")
+    spec = h.DnsblCase(
+        aliasname="smokehttps3222",
+        feed_url=feed_url,
+        header="smokehttps3222",
+        mode=h.DnsblMode.VIP,
+    )
+    with h.CaseContext(deployed_vm, spec):
+        a = h.dns_probe_client(client_vm, blocked, "A")
+        assert h.is_vip(a), f"{blocked} A expected VIP {h.DEFAULT_DNSBL_VIP4}, got {a}"
+
+        dumps: list[str] = []
+        for rtype in ("HTTPS", "TYPE65", "TYPE64", "MX"):
+            lan = _raw_dig(client_vm, blocked, rtype)
+            box = _raw_drill(deployed_vm, blocked, rtype)
+            dumps.append(f"=== blocked {rtype} LAN dig ===\n{lan}\n=== blocked {rtype} on-box drill ===\n{box}")
+            parsed = h.dns_probe_client(client_vm, blocked, rtype)
+            an, ns, ar = _header_counts(lan)
+            dump = "\n".join(dumps)
+            assert parsed.rcode == "NOERROR", (
+                f"{blocked} {rtype} expected NOERROR, got {parsed.rcode} records={parsed.records!r}\n{dump}"
+            )
+            assert parsed.records == [], f"{blocked} {rtype} expected empty ANSWER, got {parsed.records!r}\n{dump}"
+            assert an == 0 and ns == 0, (
+                f"{blocked} {rtype} expected ANSWER=0 AUTHORITY=0, "
+                f"got ANSWER={an} AUTHORITY={ns} ADDITIONAL={ar}\n{dump}"
+            )
+
+        ctl_a = h.dns_probe_client(client_vm, control, "A")
+        assert not h.is_vip(ctl_a), f"{control} A must not be VIP (unlisted), got {ctl_a}"
+        ctl_https = _raw_dig(client_vm, control, "HTTPS")
+        dumps.append(f"=== unlisted HTTPS LAN dig ===\n{ctl_https}")
+
+        deadline = time.monotonic() + 20.0
+        hits = 0
+        while time.monotonic() < deadline:
+            hits = _dnsbl_log_hits(deployed_vm, blocked)
+            if hits >= 1:
+                break
+            time.sleep(1.0)
+        assert hits >= 1, (
+            f"no dnsbl.log line for {blocked} after HTTPS/SVCB queries "
+            f"(cannot tell pythonmod intercept from stub NODATA); dumps:\n" + "\n".join(dumps)
+        )
+
+
 def test_dnsbl_exact_null(deployed_vm: SmokeVM, client_vm: SmokeVM, mock_feeds: _MockFeedServer) -> None:
     """Python-mode null sinkhole: NOERROR + 0.0.0.0/::0 for a logging='disabled' feed.
 

--- a/tests/smoke/test_smoke_matrix.py
+++ b/tests/smoke/test_smoke_matrix.py
@@ -68,6 +68,8 @@ from collections.abc import Iterator
 
 import pytest
 
+from tests.test_issue3222_soa_wire import rr_has_type
+
 from . import helpers as h
 from .conftest import PFSENSE_LAN_IP, STUB_DNS_A, SmokeVM, _MockFeedServer, _StubDnsServer
 
@@ -227,15 +229,6 @@ def _header_counts(raw: str) -> tuple[int | None, int | None, int | None]:
     return int(m.group(1)), int(m.group(2)), int(m.group(3))
 
 
-def _rr_has_type(raw: str, rtype: str) -> bool:
-    """True if any RR line has ``rtype`` as the TYPE field (tab or space separated)."""
-    for line in raw.splitlines():
-        parts = line.split()
-        if len(parts) >= 4 and parts[3] == rtype:
-            return True
-    return False
-
-
 def _raw_dig(client_vm: SmokeVM, name: str, rtype: str) -> str:
     result = client_vm.ssh(
         f"dig +tries=1 +time=5 {shlex.quote(rtype)} {shlex.quote(name)} @{shlex.quote(PFSENSE_LAN_IP)}",
@@ -253,7 +246,7 @@ def test_dnsbl_https_svcb_vip_nodata_soa(deployed_vm: SmokeVM, client_vm: SmokeV
     """Issue #3222: VIP-blocked HTTPS/SVCB is RFC 2308 Type-2 NODATA (SOA), not empty NOERROR.
 
     Control: the listed name's A query is the VIP sinkhole, so DNSBL python-mode
-    is armed. Then the same name is queried as HTTPS, TYPE65, TYPE64, and MX
+    is armed. Then the same name is queried as HTTPS, TYPE64, and MX
     from both the LAN client (``dig``, the iOS-like path) and on-box
     (``drill @127.0.0.1``).
 
@@ -291,7 +284,7 @@ def test_dnsbl_https_svcb_vip_nodata_soa(deployed_vm: SmokeVM, client_vm: SmokeV
                 f"{blocked} {rtype} expected ANSWER=0 AUTHORITY=1 (SOA), "
                 f"got ANSWER={an} AUTHORITY={ns} ADDITIONAL={ar}\n{dump}"
             )
-            assert _rr_has_type(lan, "SOA") or _rr_has_type(box, "SOA"), (
+            assert rr_has_type(lan, "SOA") or rr_has_type(box, "SOA"), (
                 f"{blocked} {rtype} expected an SOA in AUTHORITY\n{dump}"
             )
 

--- a/tests/smoke/test_smoke_matrix.py
+++ b/tests/smoke/test_smoke_matrix.py
@@ -62,13 +62,14 @@ from __future__ import annotations
 import json
 import os
 import re
+import shlex
 import time
 from collections.abc import Iterator
 
 import pytest
 
 from . import helpers as h
-from .conftest import STUB_DNS_A, SmokeVM, _MockFeedServer, _StubDnsServer
+from .conftest import PFSENSE_LAN_IP, STUB_DNS_A, SmokeVM, _MockFeedServer, _StubDnsServer
 
 pytestmark = pytest.mark.smoke
 
@@ -226,9 +227,18 @@ def _header_counts(raw: str) -> tuple[int | None, int | None, int | None]:
     return int(m.group(1)), int(m.group(2)), int(m.group(3))
 
 
+def _rr_has_type(raw: str, rtype: str) -> bool:
+    """True if any RR line has ``rtype`` as the TYPE field (tab or space separated)."""
+    for line in raw.splitlines():
+        parts = line.split()
+        if len(parts) >= 4 and parts[3] == rtype:
+            return True
+    return False
+
+
 def _raw_dig(client_vm: SmokeVM, name: str, rtype: str) -> str:
     result = client_vm.ssh(
-        f"dig +tries=1 +time=5 {rtype} {name} @192.168.1.1",
+        f"dig +tries=1 +time=5 {shlex.quote(rtype)} {shlex.quote(name)} @{shlex.quote(PFSENSE_LAN_IP)}",
         timeout=30.0,
     )
     return result.stdout
@@ -248,9 +258,8 @@ def test_dnsbl_https_svcb_vip_nodata_soa(deployed_vm: SmokeVM, client_vm: SmokeV
     (``drill @127.0.0.1``).
 
     Non-address intercepts must return NOERROR with ANSWER 0 and AUTHORITY 1
-    (a synthetic SOA). Empty AUTHORITY is the pre-fix defect. A dnsbl.log line
-    after the HTTPS query proves pythonmod intercepted it (the stub upstream
-    also answers non-A as empty NOERROR, so the log is the discriminator).
+    (a synthetic SOA). Empty AUTHORITY is the pre-fix defect. dnsbl.log hits
+    must grow after the HTTPS/SVCB queries (the A control already logs one).
     """
     blocked = h.unique_domain("https3222")
     control = h.unique_domain("https3222ctl")
@@ -264,9 +273,10 @@ def test_dnsbl_https_svcb_vip_nodata_soa(deployed_vm: SmokeVM, client_vm: SmokeV
     with h.CaseContext(deployed_vm, spec):
         a = h.dns_probe_client(client_vm, blocked, "A")
         assert h.is_vip(a), f"{blocked} A expected VIP {h.DEFAULT_DNSBL_VIP4}, got {a}"
+        hits_after_a = _dnsbl_log_hits(deployed_vm, blocked)
 
         dumps: list[str] = []
-        for rtype in ("HTTPS", "TYPE65", "TYPE64", "MX"):
+        for rtype in ("HTTPS", "TYPE64", "MX"):
             lan = _raw_dig(client_vm, blocked, rtype)
             box = _raw_drill(deployed_vm, blocked, rtype)
             dumps.append(f"=== blocked {rtype} LAN dig ===\n{lan}\n=== blocked {rtype} on-box drill ===\n{box}")
@@ -281,23 +291,21 @@ def test_dnsbl_https_svcb_vip_nodata_soa(deployed_vm: SmokeVM, client_vm: SmokeV
                 f"{blocked} {rtype} expected ANSWER=0 AUTHORITY=1 (SOA), "
                 f"got ANSWER={an} AUTHORITY={ns} ADDITIONAL={ar}\n{dump}"
             )
-            assert " SOA " in lan or " SOA " in box, f"{blocked} {rtype} expected an SOA in AUTHORITY\n{dump}"
+            assert _rr_has_type(lan, "SOA") or _rr_has_type(box, "SOA"), (
+                f"{blocked} {rtype} expected an SOA in AUTHORITY\n{dump}"
+            )
 
         ctl_a = h.dns_probe_client(client_vm, control, "A")
         assert not h.is_vip(ctl_a), f"{control} A must not be VIP (unlisted), got {ctl_a}"
-        ctl_https = _raw_dig(client_vm, control, "HTTPS")
-        dumps.append(f"=== unlisted HTTPS LAN dig ===\n{ctl_https}")
 
-        deadline = time.monotonic() + 20.0
-        hits = 0
-        while time.monotonic() < deadline:
-            hits = _dnsbl_log_hits(deployed_vm, blocked)
-            if hits >= 1:
-                break
-            time.sleep(1.0)
-        assert hits >= 1, (
-            f"no dnsbl.log line for {blocked} after HTTPS/SVCB queries "
-            f"(cannot tell pythonmod intercept from stub NODATA); dumps:\n" + "\n".join(dumps)
+        dump = "\n".join(dumps)
+        h.wait_until(
+            lambda: _dnsbl_log_hits(deployed_vm, blocked) > hits_after_a,
+            timeout=20.0,
+            interval=1.0,
+        )
+        assert _dnsbl_log_hits(deployed_vm, blocked) > hits_after_a, (
+            f"dnsbl.log did not grow after HTTPS/SVCB queries (after A hits={hits_after_a}); dumps:\n{dump}"
         )
 
 

--- a/tests/test_issue3222_soa_wire.py
+++ b/tests/test_issue3222_soa_wire.py
@@ -1,0 +1,14 @@
+"""Issue #3222: dig/drill SOA presentation is tab-separated, not ' SOA '."""
+
+
+def test_space_wrapped_soa_misses_tab_separated_dig() -> None:
+    # Review B1: BIND dig and ldns drill print RR fields with tabs. A check for
+    # the substring " SOA " never matches a correct Type-2 NODATA reply.
+    raw = (
+        ";; flags: qr rd ra; QUERY: 1, ANSWER: 0, AUTHORITY: 1, ADDITIONAL: 0\n"
+        "example.com.\t3600\tIN\tSOA\tpfb.invalid. nobody.invalid. 1 3600 1200 604800 3600\n"
+    )
+    assert " SOA " not in raw, f"fixture must be tab-separated, got {raw!r}"
+    assert any(len(parts := line.split()) >= 4 and parts[3] == "SOA" for line in raw.splitlines()), (
+        f"expected a TYPE-field SOA in {raw!r}"
+    )

--- a/tests/test_issue3222_soa_wire.py
+++ b/tests/test_issue3222_soa_wire.py
@@ -11,8 +11,8 @@ def rr_has_type(raw: str, rtype: str) -> bool:
 
 
 def test_space_wrapped_soa_misses_tab_separated_dig() -> None:
-    # Review B1: BIND dig and ldns drill print RR fields with tabs. A check for
-    # the substring " SOA " never matches a correct Type-2 NODATA reply.
+    # BIND dig and ldns drill print RR fields with tabs. A check for the
+    # substring " SOA " never matches a correct Type-2 NODATA reply.
     raw = (
         ";; flags: qr rd ra; QUERY: 1, ANSWER: 0, AUTHORITY: 1, ADDITIONAL: 0\n"
         "example.com.\t3600\tIN\tSOA\tpfb.invalid. nobody.invalid. 1 3600 1200 604800 3600\n"

--- a/tests/test_issue3222_soa_wire.py
+++ b/tests/test_issue3222_soa_wire.py
@@ -1,6 +1,15 @@
 """Issue #3222: dig/drill SOA presentation is tab-separated, not ' SOA '."""
 
 
+def rr_has_type(raw: str, rtype: str) -> bool:
+    """True if any RR line has ``rtype`` as the TYPE field (tab or space separated)."""
+    for line in raw.splitlines():
+        parts = line.split()
+        if len(parts) >= 4 and parts[3] == rtype:
+            return True
+    return False
+
+
 def test_space_wrapped_soa_misses_tab_separated_dig() -> None:
     # Review B1: BIND dig and ldns drill print RR fields with tabs. A check for
     # the substring " SOA " never matches a correct Type-2 NODATA reply.
@@ -9,6 +18,4 @@ def test_space_wrapped_soa_misses_tab_separated_dig() -> None:
         "example.com.\t3600\tIN\tSOA\tpfb.invalid. nobody.invalid. 1 3600 1200 604800 3600\n"
     )
     assert " SOA " not in raw, f"fixture must be tab-separated, got {raw!r}"
-    assert any(len(parts := line.split()) >= 4 and parts[3] == "SOA" for line in raw.splitlines()), (
-        f"expected a TYPE-field SOA in {raw!r}"
-    )
+    assert rr_has_type(raw, "SOA"), f"expected a TYPE-field SOA in {raw!r}"

--- a/tests/test_pfb_unbound.py
+++ b/tests/test_pfb_unbound.py
@@ -1955,7 +1955,7 @@ class TestOperateDnsbl:
         assert any(a.startswith("orig.com. ") for a in answers), f"expected a match in {answers!r}"
 
     def test_cname_memoized_target_block_uses_original_qname(self, monkeypatch: Any) -> None:
-        # Issue #3222 / review F3: when the CNAME *target* is already memoized,
+        # Issue #3222: when the CNAME *target* is already memoized,
         # operate() used to keep q_name as the target, so A/SOA owners were
         # out-of-bailiwick. Query the target first, then the original with a
         # CNAME chain; both the A owner and a type-65 SOA owner must be orig.com.
@@ -1983,8 +1983,8 @@ class TestOperateDnsbl:
         assert soa and soa[0].startswith("orig.com. "), f"expected orig.com SOA owner, got {soa!r}"
 
     def test_cname_memoized_target_https_soa_owner_without_prior_orig_a(self, monkeypatch: Any) -> None:
-        # Round-2 N1: target memo, then orig type 65 with a CNAME chain and no
-        # intervening orig A, so the new elif (not orig's own memo) sets the SOA owner.
+        # Target memo, then orig type 65 with a CNAME chain and no intervening
+        # orig A, so the elif (not orig's own memo) sets the SOA owner.
         self._enable(monkeypatch)
         pfb_unbound.pfb["python_cname"] = True
         monkeypatch.setattr(pfb_unbound, "convert_other", lambda b: "evil-cname.com")
@@ -1999,7 +1999,7 @@ class TestOperateDnsbl:
         assert soa and soa[0].startswith("orig.com. "), f"expected orig.com SOA owner, got {soa!r}"
 
     def test_cname_memoized_target_respects_original_whitelist(self, monkeypatch: Any) -> None:
-        # Round-2 B1: orig is whitelisted, target already memoized as a block.
+        # orig is whitelisted, target already memoized as a block.
         # evaluate_domain's is_cname whitelist set is [target, original]; the
         # hoist must not copy the target memo onto orig. orig HTTPS+CNAME and a
         # later orig A (no CNAME) both WAIT_MODULE.

--- a/tests/test_pfb_unbound.py
+++ b/tests/test_pfb_unbound.py
@@ -1551,17 +1551,19 @@ class TestOperateDnsbl:
         assert qstate.return_rcode == RCODE_NOERROR, f"expected {RCODE_NOERROR!r}, got {qstate.return_rcode!r}"
         answers = DNSMessage.instances[-1].answer
         assert any(pfb_unbound.pfb["dnsbl_ipv4"] in a for a in answers), f"expected a match in {answers!r}"
+        assert DNSMessage.instances[-1].authority == [], (
+            f"A-block must not carry a NODATA SOA, got {DNSMessage.instances[-1].authority!r}"
+        )
 
-    @pytest.mark.parametrize("qtype", [64, 65])
-    def test_svcb_https_vip_block_is_empty_noerror(self, monkeypatch: Any, qtype: int) -> None:
-        # Issue #3222. Scenario: a VIP-list hit queried as SVCB (64) or HTTPS (65).
+    @pytest.mark.parametrize("qtype", [64, 65, 15, 16, 33])
+    def test_non_address_vip_block_is_nodata_soa(self, monkeypatch: Any, qtype: int) -> None:
+        # Issue #3222. Scenario: a VIP-list hit queried as a non-address type
+        # (SVCB/HTTPS/MX/TXT/SRV — the shared path, not a type-65 special case).
         #   Given evil.com on a VIP feed (log_type "1")
-        #   When operate() handles qtype 64/65 (both are in pfb["rr_types"])
-        #   Then it FINISHES with rcode NOERROR and a DNSMessage whose answer
-        #        list is empty — operate() only appends A/AAAA. No SOA is added
-        #        either (stub DNSMessage has no authority list). This is the
-        #        empty-NOERROR shape the reporter captured; a NODATA+SOA fix
-        #        must change this assertion, not silently keep it green.
+        #   When operate() intercepts that qtype
+        #   Then it FINISHES NOERROR with an empty ANSWER and exactly one SOA
+        #        in AUTHORITY (RFC 2308 Type-2 NODATA). Empty NOERROR without
+        #        SOA is the defect; NXDOMAIN would contradict the sinkhole A.
         self._enable(monkeypatch)
         add_data("evil.com", log="1", index=0)
         set_feed_group(0, "TestFeed", "TestGroup")
@@ -1575,8 +1577,13 @@ class TestOperateDnsbl:
             f"qtype {qtype} expected {RCODE_NOERROR!r}, got {qstate.return_rcode!r}"
         )
         assert qstate.return_msg is not None, f"qtype {qtype} expected a synthetic DNSMessage"
-        answers = DNSMessage.instances[-1].answer
-        assert answers == [], f"qtype {qtype} expected empty answer, got {answers!r}"
+        msg = DNSMessage.instances[-1]
+        assert msg.answer == [], f"qtype {qtype} expected empty answer, got {msg.answer!r}"
+        assert len(msg.authority) == 1, f"qtype {qtype} expected one SOA, got {msg.authority!r}"
+        soa = msg.authority[0]
+        assert " IN SOA " in soa, f"qtype {qtype} authority is not SOA: {soa!r}"
+        assert "pfb.invalid." in soa, f"qtype {qtype} SOA mname should be pfb.invalid: {soa!r}"
+        assert soa.startswith("evil.com. "), f"qtype {qtype} SOA owner should be the queried name: {soa!r}"
 
     def test_nxdomain_mode_returns_bare_nxdomain(self, monkeypatch: Any) -> None:
         # Issue #31. Scenario: a DNSBL hit in NXDOMAIN-logging mode ("3").

--- a/tests/test_pfb_unbound.py
+++ b/tests/test_pfb_unbound.py
@@ -1982,6 +1982,51 @@ class TestOperateDnsbl:
         soa = DNSMessage.instances[-1].authority
         assert soa and soa[0].startswith("orig.com. "), f"expected orig.com SOA owner, got {soa!r}"
 
+    def test_cname_memoized_target_https_soa_owner_without_prior_orig_a(self, monkeypatch: Any) -> None:
+        # Round-2 N1: target memo, then orig type 65 with a CNAME chain and no
+        # intervening orig A, so the new elif (not orig's own memo) sets the SOA owner.
+        self._enable(monkeypatch)
+        pfb_unbound.pfb["python_cname"] = True
+        monkeypatch.setattr(pfb_unbound, "convert_other", lambda b: "evil-cname.com")
+        monkeypatch.setattr(pfb_unbound, "get_details_dnsbl", lambda *a, **k: None)
+        add_data("evil-cname.com", log="1", index=0)
+        set_feed_group(0, "F", "G")
+        pfb_unbound.operate(0, MODULE_EVENT_NEW, make_qstate("evil-cname.com.", qtype=RR_A), None)
+
+        https = make_qstate("orig.com.", qtype=65, return_msg=self._cname_reply("orig.com."))
+        pfb_unbound.operate(0, MODULE_EVENT_NEW, https, None)
+        soa = DNSMessage.instances[-1].authority
+        assert soa and soa[0].startswith("orig.com. "), f"expected orig.com SOA owner, got {soa!r}"
+
+    def test_cname_memoized_target_respects_original_whitelist(self, monkeypatch: Any) -> None:
+        # Round-2 B1: orig is whitelisted, target already memoized as a block.
+        # evaluate_domain's is_cname whitelist set is [target, original]; the
+        # hoist must not copy the target memo onto orig. orig HTTPS+CNAME and a
+        # later orig A (no CNAME) both WAIT_MODULE.
+        self._enable(monkeypatch)
+        pfb_unbound.pfb["python_cname"] = True
+        monkeypatch.setattr(pfb_unbound, "convert_other", lambda b: "evil-cname.com")
+        monkeypatch.setattr(pfb_unbound, "get_details_dnsbl", lambda *a, **k: None)
+        add_data("evil-cname.com", log="1", index=0)
+        add_white("orig.com", wildcard=False)
+        set_feed_group(0, "F", "G")
+        pfb_unbound.operate(0, MODULE_EVENT_NEW, make_qstate("evil-cname.com.", qtype=RR_A), None)
+
+        https = make_qstate("orig.com.", qtype=65, return_msg=self._cname_reply("orig.com."))
+        pfb_unbound.operate(0, MODULE_EVENT_NEW, https, None)
+        assert https.ext_state[0] == MODULE_WAIT_MODULE, (
+            f"whitelisted orig HTTPS+CNAME must not block, got {https.ext_state[0]!r}"
+        )
+
+        follow = make_qstate("orig.com.", qtype=RR_A)
+        pfb_unbound.operate(0, MODULE_EVENT_NEW, follow, None)
+        assert follow.ext_state[0] == MODULE_WAIT_MODULE, (
+            f"follow-up orig A must not inherit the target memo, got {follow.ext_state[0]!r}"
+        )
+        orig = pfb_unbound.decisionDB.get("orig.com")
+        blocked = orig is not None and orig.dnsbl.is_found and not orig.dnsbl.in_whitelist
+        assert not blocked, f"orig.com must not be memoized as a block, got {orig!r}"
+
     def test_cname_target_with_long_interior_label_blocks_without_decoder_stub(self, monkeypatch: Any) -> None:
         # End-to-end proof that operate()'s CNAME walk feeds the REAL convert_other()
         # decoder -- unlike the sibling tests above, convert_other is NOT monkeypatched

--- a/tests/test_pfb_unbound.py
+++ b/tests/test_pfb_unbound.py
@@ -1552,6 +1552,32 @@ class TestOperateDnsbl:
         answers = DNSMessage.instances[-1].answer
         assert any(pfb_unbound.pfb["dnsbl_ipv4"] in a for a in answers), f"expected a match in {answers!r}"
 
+    @pytest.mark.parametrize("qtype", [64, 65])
+    def test_svcb_https_vip_block_is_empty_noerror(self, monkeypatch: Any, qtype: int) -> None:
+        # Issue #3222. Scenario: a VIP-list hit queried as SVCB (64) or HTTPS (65).
+        #   Given evil.com on a VIP feed (log_type "1")
+        #   When operate() handles qtype 64/65 (both are in pfb["rr_types"])
+        #   Then it FINISHES with rcode NOERROR and a DNSMessage whose answer
+        #        list is empty — operate() only appends A/AAAA. No SOA is added
+        #        either (stub DNSMessage has no authority list). This is the
+        #        empty-NOERROR shape the reporter captured; a NODATA+SOA fix
+        #        must change this assertion, not silently keep it green.
+        self._enable(monkeypatch)
+        add_data("evil.com", log="1", index=0)
+        set_feed_group(0, "TestFeed", "TestGroup")
+        qstate = make_qstate("evil.com.", qtype=qtype)
+        rcd = pfb_unbound.operate(0, MODULE_EVENT_NEW, qstate, None)
+        assert rcd is True, f"expected True, got {rcd!r}"
+        assert qstate.ext_state[0] == MODULE_FINISHED, (
+            f"qtype {qtype} expected intercept ({MODULE_FINISHED!r}), got {qstate.ext_state[0]!r}"
+        )
+        assert qstate.return_rcode == RCODE_NOERROR, (
+            f"qtype {qtype} expected {RCODE_NOERROR!r}, got {qstate.return_rcode!r}"
+        )
+        assert qstate.return_msg is not None, f"qtype {qtype} expected a synthetic DNSMessage"
+        answers = DNSMessage.instances[-1].answer
+        assert answers == [], f"qtype {qtype} expected empty answer, got {answers!r}"
+
     def test_nxdomain_mode_returns_bare_nxdomain(self, monkeypatch: Any) -> None:
         # Issue #31. Scenario: a DNSBL hit in NXDOMAIN-logging mode ("3").
         #   Given evil.com on a feed whose Logging/Blocking mode is NXDOMAIN ("3")

--- a/tests/test_pfb_unbound.py
+++ b/tests/test_pfb_unbound.py
@@ -1555,6 +1555,19 @@ class TestOperateDnsbl:
             f"A-block must not carry a NODATA SOA, got {DNSMessage.instances[-1].authority!r}"
         )
 
+    @pytest.mark.parametrize("qtype", [RR_A, RR_AAAA, 255])
+    def test_address_vip_block_has_no_nodata_soa(self, monkeypatch: Any, qtype: int) -> None:
+        # Issue #3222 criterion: A/AAAA/ANY keep sinkhole answers and must not
+        # grow a NODATA SOA.
+        self._enable(monkeypatch)
+        add_data("evil.com", log="1", index=0)
+        set_feed_group(0, "TestFeed", "TestGroup")
+        qstate = make_qstate("evil.com.", qtype=qtype)
+        pfb_unbound.operate(0, MODULE_EVENT_NEW, qstate, None)
+        msg = DNSMessage.instances[-1]
+        assert msg.authority == [], f"qtype {qtype} expected no SOA, got {msg.authority!r}"
+        assert msg.answer != [], f"qtype {qtype} expected sinkhole answers, got {msg.answer!r}"
+
     @pytest.mark.parametrize("qtype", [64, 65, 15, 16, 33])
     def test_non_address_vip_block_is_nodata_soa(self, monkeypatch: Any, qtype: int) -> None:
         # Issue #3222. Scenario: a VIP-list hit queried as a non-address type
@@ -1579,11 +1592,19 @@ class TestOperateDnsbl:
         assert qstate.return_msg is not None, f"qtype {qtype} expected a synthetic DNSMessage"
         msg = DNSMessage.instances[-1]
         assert msg.answer == [], f"qtype {qtype} expected empty answer, got {msg.answer!r}"
-        assert len(msg.authority) == 1, f"qtype {qtype} expected one SOA, got {msg.authority!r}"
-        soa = msg.authority[0]
-        assert " IN SOA " in soa, f"qtype {qtype} authority is not SOA: {soa!r}"
-        assert "pfb.invalid." in soa, f"qtype {qtype} SOA mname should be pfb.invalid: {soa!r}"
-        assert soa.startswith("evil.com. "), f"qtype {qtype} SOA owner should be the queried name: {soa!r}"
+        expected_soa = "{}. 3600 IN SOA {}".format("evil.com", pfb_unbound.DNSBL_NODATA_SOA_RDATA)
+        assert msg.authority == [expected_soa], f"qtype {qtype} expected {[expected_soa]!r}, got {msg.authority!r}"
+
+    def test_non_address_null_block_is_nodata_soa(self, monkeypatch: Any) -> None:
+        self._enable(monkeypatch)
+        add_data("evil.com", log="2", index=0)
+        set_feed_group(0, "TestFeed", "TestGroup")
+        qstate = make_qstate("evil.com.", qtype=65)
+        pfb_unbound.operate(0, MODULE_EVENT_NEW, qstate, None)
+        msg = DNSMessage.instances[-1]
+        assert msg.answer == [], f"expected [], got {msg.answer!r}"
+        expected_soa = "{}. 3600 IN SOA {}".format("evil.com", pfb_unbound.DNSBL_NODATA_SOA_RDATA)
+        assert msg.authority == [expected_soa], f"expected {[expected_soa]!r}, got {msg.authority!r}"
 
     def test_nxdomain_mode_returns_bare_nxdomain(self, monkeypatch: Any) -> None:
         # Issue #31. Scenario: a DNSBL hit in NXDOMAIN-logging mode ("3").
@@ -1932,6 +1953,34 @@ class TestOperateDnsbl:
         )
         answers = DNSMessage.instances[-1].answer
         assert any(a.startswith("orig.com. ") for a in answers), f"expected a match in {answers!r}"
+
+    def test_cname_memoized_target_block_uses_original_qname(self, monkeypatch: Any) -> None:
+        # Issue #3222 / review F3: when the CNAME *target* is already memoized,
+        # operate() used to keep q_name as the target, so A/SOA owners were
+        # out-of-bailiwick. Query the target first, then the original with a
+        # CNAME chain; both the A owner and a type-65 SOA owner must be orig.com.
+        self._enable(monkeypatch)
+        pfb_unbound.pfb["python_cname"] = True
+        monkeypatch.setattr(pfb_unbound, "convert_other", lambda b: "evil-cname.com")
+        monkeypatch.setattr(pfb_unbound, "get_details_dnsbl", lambda *a, **k: None)
+        add_data("evil-cname.com", log="1", index=0)
+        set_feed_group(0, "F", "G")
+
+        direct = make_qstate("evil-cname.com.", qtype=RR_A)
+        pfb_unbound.operate(0, MODULE_EVENT_NEW, direct, None)
+        assert pfb_unbound.decisionDB.get("evil-cname.com") is not None
+
+        qstate = make_qstate("orig.com.", qtype=RR_A, return_msg=self._cname_reply("orig.com."))
+        pfb_unbound.operate(0, MODULE_EVENT_NEW, qstate, None)
+        answers = DNSMessage.instances[-1].answer
+        assert any(a.startswith("orig.com. ") for a in answers), f"expected orig.com owner, got {answers!r}"
+        orig = pfb_unbound.decisionDB.get("orig.com")
+        assert orig is not None and orig.dnsbl.is_found, f"expected orig.com memoized as block, got {orig!r}"
+
+        https = make_qstate("orig.com.", qtype=65, return_msg=self._cname_reply("orig.com."))
+        pfb_unbound.operate(0, MODULE_EVENT_NEW, https, None)
+        soa = DNSMessage.instances[-1].authority
+        assert soa and soa[0].startswith("orig.com. "), f"expected orig.com SOA owner, got {soa!r}"
 
     def test_cname_target_with_long_interior_label_blocks_without_decoder_stub(self, monkeypatch: Any) -> None:
         # End-to-end proof that operate()'s CNAME walk feeds the REAL convert_other()


### PR DESCRIPTION
Fixes #3222.

VIP/null Python-mode DNSBL intercepted HTTPS/SVCB (and MX/NS/TXT/…) but only synthesised A/AAAA, so those queries returned empty NOERROR with no SOA. This PR keeps intercepting those types and returns RFC 2308 Type-2 NODATA (NOERROR + synthetic SOA in AUTHORITY). Address queries stay sinkholed. NXDOMAIN list mode is unchanged.

devel / v4 only — not for 3.2.x.

## Tests
- RED: `test_non_address_vip_block_is_nodata_soa` failed with `expected one SOA, got []` on untouched `operate()`.
- Frozen `tests/test_pfb_unbound.py` `git hash-object` at red: `b27b97483a67f684af63036e0b9b4531915207cd` (unchanged at green).
- GREEN: same tests, 31 `TestOperateDnsbl` cases passed.

## Out of scope
- No 3.2.x backport.
- CNAME-memo wrong-owner answer (review F3) is a separate pre-existing defect.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved DNSBL responses for HTTPS, SVCB, MX, and other non-address queries by returning standards-compliant NODATA responses with an SOA record.
  - Preserved correct blocking and whitelist behavior when DNS aliases or cached CNAME targets are involved.
  - Ensured blocked responses remain associated with the original queried domain.
- **Tests**
  - Added coverage for response sections, SOA records, query types, CNAME handling, and whitelist scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->