### PR TITLE
dnsbl: Add SOA to No-AAAA NODATA replies

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -7267,6 +7267,8 @@ def operate(id: int, event: int, qstate: module_qstate, qdata: Any) -> bool:
             # Create FQDN Reply Message (AAAA -> A)
             if dec.noaaaa:
                 msg = DNSMessage(qstate.qinfo.qname_str, RR_TYPE_A, RR_CLASS_IN, PKT_QR | PKT_RA)
+                # issue #3224: empty answer -> RFC 2308 Type-2 NODATA (SOA in AUTHORITY).
+                msg.authority.append("{}. 3600 IN SOA {}".format(q_name_original, DNSBL_NODATA_SOA_RDATA))
                 if msg is None or not msg.set_return_msg(qstate):
                     qstate.ext_state[id] = MODULE_ERROR
                     return True

--- a/tests/test_pfb_unbound.py
+++ b/tests/test_pfb_unbound.py
@@ -1477,6 +1477,11 @@ class TestOperateNoAAAA:
         # The synthesized AAAA -> A reply is unsigned; it must be stamped
         # non-bogus or the validator SERVFAILs it (issue #149 class).
         assert qstate.return_msg.rep.security == 2, f"expected 2, got {qstate.return_msg.rep.security!r}"
+        # issue #3224: empty answer -> RFC 2308 Type-2 NODATA (SOA in AUTHORITY).
+        msg = DNSMessage.instances[-1]
+        assert msg.answer == [], f"expected [], got {msg.answer!r}"
+        expected_soa = "{}. 3600 IN SOA {}".format("example.com", pfb_unbound.DNSBL_NODATA_SOA_RDATA)
+        assert msg.authority == [expected_soa], f"expected {[expected_soa]!r}, got {msg.authority!r}"
 
     def test_wildcard_blocks_subdomain_and_caches(self) -> None:
         add_noaaaa("example.com", wildcard=True)
@@ -1487,6 +1492,11 @@ class TestOperateNoAAAA:
         # The wildcard-path synthesized reply needs the same non-bogus stamp
         # as the exact-match one (issue #149 class).
         assert qstate.return_msg.rep.security == 2, f"expected 2, got {qstate.return_msg.rep.security!r}"
+        # issue #3224: same empty-answer NODATA SOA on the wildcard-match path.
+        msg = DNSMessage.instances[-1]
+        assert msg.answer == [], f"expected [], got {msg.answer!r}"
+        expected_soa = "{}. 3600 IN SOA {}".format("sub.example.com", pfb_unbound.DNSBL_NODATA_SOA_RDATA)
+        assert msg.authority == [expected_soa], f"expected {[expected_soa]!r}, got {msg.authority!r}"
         # The wildcard-parent hit is memoized as the child's noaaaa verdict on its
         # Decision, so a subsequent identical query short-circuits on the cache.
         assert pfb_unbound.decisionDB["sub.example.com"].noaaaa is True, (
@@ -1502,6 +1512,11 @@ class TestOperateNoAAAA:
         assert rcd2 is True, f"expected True, got {rcd2!r}"
         assert qstate2.ext_state[0] == MODULE_FINISHED, f"expected {MODULE_FINISHED!r}, got {qstate2.ext_state[0]!r}"
         assert qstate2.return_msg.rep.security == 2, f"expected 2, got {qstate2.return_msg.rep.security!r}"
+        # issue #3224: the memoized/fast-path reply carries the same SOA.
+        msg2 = DNSMessage.instances[-1]
+        assert msg2.answer == [], f"expected [], got {msg2.answer!r}"
+        expected_soa2 = "{}. 3600 IN SOA {}".format("sub.example.com", pfb_unbound.DNSBL_NODATA_SOA_RDATA)
+        assert msg2.authority == [expected_soa2], f"expected {[expected_soa2]!r}, got {msg2.authority!r}"
 
     def test_excluded_domain_not_blocked(self) -> None:
         add_noaaaa("example.com", wildcard=False)


### PR DESCRIPTION
Fixes #3224.

## Change
The Python No-AAAA block path now adds a QNAME-owned SOA to AUTHORITY before constructing the return message. Replies remain NOERROR with an empty answer, but are RFC 2308 Type-2 NODATA rather than empty Type-3 replies. This reuses the existing DNSBL SOA RDATA and 3600-second TTL.

Exact matches, wildcard matches, and memoized repeats are covered by extended existing tests. Non-AAAA queries, exclusions, the existing A-question constructor, and DNSBL/SafeSearch behavior remain unchanged.

## Verification
- Frozen test file: `tests/test_pfb_unbound.py`, blob `e85f51a659d5c9c122fc7aebcb1987563613d2ca`.
- RED before production edit: `python3 -m pytest tests/test_pfb_unbound.py -k TestOperateNoAAAA -q -n0` reported **2 failed, 3 passed** because authority was `[]` instead of the expected SOA.
- GREEN, byte-identical tests: **5 passed**.
- Independent private-archive reproduction: **2 failed, 3 passed** on base production; **5 passed** on fixed production.
- `uv run pytest tests/test_pfb_unbound.py -q -n0`: **346 passed**.
- `sh scripts/agent/run-gates.sh --diff ee827b71c894d2381487a1646774c67abdb9df89`: **GATES: PASS** (coverage pairing, graph freshness, full pytest, Ruff lint/format, mypy).
- Independent condensed four-lens review: no findings.

## Scope and limitations
Development branch only; no backport or configuration change. No live-appliance or iOS/Happy-Eyeballs run is claimed. The existing Unbound test double records message sections but does not serialize them; the SOA is appended before `set_return_msg`, matching the established DNSBL path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Blocked AAAA DNS responses now include the appropriate NODATA authority information when no answer is returned.
  * This behavior is consistent across exact matches, wildcard matches, and repeated queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->