### PR TITLE
dnsbl: unset www.apex on exact whitelist delete

### DIFF
--- a/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
@@ -1229,14 +1229,14 @@ if (isset($_POST) && !empty($_POST)) {
 			case 'delete_domain':
 				$savemsg = "The Domain [ {$entry} ] has been deleted from the DNSBL Whitelist!";
 				if (isset($clists['dnsblwhitelist']['data'][$entry]) ||
-				    isset($clists['dnsblwhitelist']['data']['www' . $entry])) {
+				    isset($clists['dnsblwhitelist']['data']['www.' . $entry])) {
 
 					if (isset($clists['dnsblwhitelist']['data'][$entry])) {
 						unset($clists['dnsblwhitelist']['data'][$entry]);
 					}
 
-					if (isset($clists['dnsblwhitelist']['data']['www' . $entry])) {
-						unset($clists['dnsblwhitelist']['data']['www' . $entry]);
+					if (isset($clists['dnsblwhitelist']['data']['www.' . $entry])) {
+						unset($clists['dnsblwhitelist']['data']['www.' . $entry]);
 					}
 
 					// ADR-06: re-blocking is driven by the whiteDB refresh below

--- a/tests/php/AlertsDeleteDomainWwwSiblingTest.php
+++ b/tests/php/AlertsDeleteDomainWwwSiblingTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Exact whitelist add writes apex and www.apex. delete_domain must unset both.
+ *
+ * The lookup concatenated 'www' and $entry with no dot, so the sibling key
+ * www.apex was never the key it unsets and stayed in dnsbl/whitelist.
+ */
+final class AlertsDeleteDomainWwwSiblingTest extends TestCase
+{
+	public function testDeleteDomainUnsetsDottedWwwSibling(): void
+	{
+		$src = php_strip_whitespace(
+			dirname(__DIR__, 2) . '/src/usr/local/www/pfblockerng/pfblockerng_alerts.php'
+		);
+		$this->assertNotSame('', $src, 'comment-free Alerts source must be readable');
+
+		$start = strpos($src, "case 'delete_domain':");
+		$end = strpos($src, "case 'delete_domainwildcard':", $start === FALSE ? 0 : $start);
+		$this->assertNotFalse($start, 'delete_domain case must exist');
+		$this->assertNotFalse($end, 'delete_domainwildcard must follow delete_domain');
+		$region = substr($src, $start, $end - $start);
+
+		$this->assertStringContainsString(
+			"isset(\$clists['dnsblwhitelist']['data']['www.' . \$entry])",
+			$region,
+			'delete_domain must look up the www.apex sibling that exact add writes'
+		);
+		$this->assertStringContainsString(
+			"unset(\$clists['dnsblwhitelist']['data']['www.' . \$entry])",
+			$region,
+			'delete_domain must unset the www.apex sibling that exact add writes'
+		);
+		$this->assertStringNotContainsString(
+			"['www' . \$entry]",
+			$region,
+			"delete_domain must not look up wwwapex; that is not the key exact add writes"
+		);
+	}
+}

--- a/tests/smoke/ui/test_alerts.py
+++ b/tests/smoke/ui/test_alerts.py
@@ -147,8 +147,7 @@ def _suppression_entries(vm: helpers.SmokeVM, cfg_path: str) -> set[str]:
     handler keys its in-memory store by the FIRST whitespace-delimited token of each
     line (``$clists[...]['data'][$line[0]]``), so an exact-token set is the faithful
     membership oracle -- a substring check would wrongly match ``example.com`` inside
-    the ``www.example.com`` entry the whitelist add also writes (and which
-    ``entry_delete=delete_domain`` deliberately leaves behind). An empty/absent node
+    the ``www.example.com`` sibling that exact whitelist add also writes. An empty/absent node
     is an empty set.
     """
     raw = helpers.config_get(vm, cfg_path)
@@ -358,13 +357,14 @@ def test_addwhitelistdom_writes_whitelist_and_entry_delete_removes_it(
 
     * BEFORE: ``domain`` is absent from the decoded ``suppression`` node.
     * ADD via the form (``addwhitelistdom`` + ``dnsbl_exclude`` not 'true'): the
-      handler appends ``domain`` (and ``www.domain``) and writes the base64 node.
-    * AFTER: ``domain`` is present in the decoded node.
+      handler appends ``domain`` and ``www.domain`` and writes the base64 node.
+    * AFTER: ``domain`` and ``www.domain`` are present in the decoded node.
     * WILDCARD while exact is still listed (issue #3198): ``.domain`` is appended
       and the exact line survives. Do not ``delete_domainwildcard`` here — that
       path also unsets the exact apex (unchanged ``entry_delete``).
     * RESTORE via ``entry_delete=delete_domain``: the handler removes the exact
-      line; leftover ``.domain`` is removed by the later wildcard-delete or ``finally``.
+      line and ``www.domain`` (issue #3201); leftover ``.domain`` is removed by
+      the later wildcard-delete or ``finally``.
     * Repeat with a wildcard entry and ``entry_delete=delete_domainwildcard`` so the
       broad allow→block cache-policy branch executes. Belt-and-suspenders config reset
       in ``finally``.
@@ -393,8 +393,12 @@ def test_addwhitelistdom_writes_whitelist_and_entry_delete_removes_it(
         )
         assert not looks_like_login_page(resp.text), "addwhitelistdom POST returned the login form (session lost)"
         assert "Alert Settings" in resp.text, "addwhitelistdom redirect did not render the Alerts page"
-        assert domain in _suppression_entries(vm, CFG_WHITELIST), (
+        entries_after_add = _suppression_entries(vm, CFG_WHITELIST)
+        assert domain in entries_after_add, (
             f"{domain} not written to the DNSBL whitelist config node after addwhitelistdom"
+        )
+        assert f"www.{domain}" in entries_after_add, (
+            f"www.{domain} not written with the exact apex after addwhitelistdom"
         )
 
         # issue #3198: exact apex already listed must still persist .apex; append, never replace.
@@ -418,8 +422,12 @@ def test_addwhitelistdom_writes_whitelist_and_entry_delete_removes_it(
         # RESTORE via entry_delete=delete_domain (reverse transition + entry_delete coverage).
         resp = _post_action(webui, {"entry_delete": "delete_domain", "domain": domain, "table": "DNSBL"})
         assert not looks_like_login_page(resp.text), "entry_delete POST returned the login form (session lost)"
-        assert domain not in _suppression_entries(vm, CFG_WHITELIST), (
+        entries_after_delete = _suppression_entries(vm, CFG_WHITELIST)
+        assert domain not in entries_after_delete, (
             f"{domain} still in the DNSBL Whitelist after entry_delete=delete_domain"
+        )
+        assert f"www.{domain}" not in entries_after_delete, (
+            f"www.{domain} still in the DNSBL Whitelist after entry_delete=delete_domain"
         )
 
         # Repeat through the wildcard branch. Removing this entry can re-block any


### PR DESCRIPTION
Fixes #3201

## Objective

`entry_delete=delete_domain` must remove the `www.{apex}` sibling that exact whitelist add writes.

## Symptom

Exact add writes `www.{$domain}` (dot). `delete_domain` looked up `'www' . $entry` (no dot), so `www.apex` was not the key it unsets and stayed in `dnsbl/whitelist`.

## Change

Three concatenations in `case 'delete_domain'` now use `'www.' . $entry` (outer isset gate, inner isset, unset). `dnsbl_add` already used `"www.{$wl_base}"`.

Untouched: `delete_domainwildcard` (still unsets both `.entry` and `$entry`), the #3198 save gate, Python matcher, TLD Exclusion.

## Frozen RED evidence

Production at red time was untouched `origin/devel`. Tests were added first; no production edit yet.

| Frozen RED test | git hash-object | RED run tail |
| --- | --- | --- |
| `tests/php/AlertsDeleteDomainWwwSiblingTest.php` | `dd77628447d2d3b8aba95340d8f7a281cc8953db` | Failed asserting the `delete_domain` region contains `isset($clists['dnsblwhitelist']['data']['www.' . $entry])`; actual region had `['www' . $entry]` |

GREEN (byte-identical): `git hash-object tests/php/AlertsDeleteDomainWwwSiblingTest.php` → `dd77628447d2d3b8aba95340d8f7a281cc8953db`

```text
vendor/bin/phpunit tests/php/AlertsDeleteDomainWwwSiblingTest.php
PHPUnit 12.5.31 / PHP 8.4.24
.                                                                   1 / 1 (100%)
OK (1 test, 6 assertions)
```

## UI coverage

POST-handler on an existing page. Tier A `ui_render` already GET-covers `/pfblockerng/pfblockerng_alerts.php`. GET cannot reproduce the leftover sibling. PR-gate is the PHPUnit region pin.

`tests/smoke/ui/test_alerts.py` already posted `entry_delete=delete_domain` and only asserted the apex token was gone. It now also asserts `www.{domain}` is written on exact add and gone after delete, and the oracle comment no longer calls leftover www "deliberate". No smoke seat this run; that row is not cited as executed evidence.

## Review

Condensed 4-in-1 at `28eead62`: SHIP, no findings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed DNSBL domain deletion so the corresponding `www.domain` whitelist entry is also removed correctly.

- **Tests**
  - Added coverage for removing `www.domain` sibling whitelist entries.
  - Updated smoke tests to verify both the domain and its `www` entry are added and removed as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->