### PR TITLE
tests: use kernel-assigned HTTP fixture ports

### DIFF
--- a/tests/php/DownloadExtractedPayloadSanityTest.php
+++ b/tests/php/DownloadExtractedPayloadSanityTest.php
@@ -358,11 +358,10 @@ PHP;
 		$failures = [];
 		$port = 0;
 		for ($try = 0; $try < 10 && $port === 0; $try++) {
-			$candidate = random_int(20000, 60000);
 			$nonce = bin2hex(random_bytes(16));
-			$stderr = "{$this->dir}/server-{$candidate}-{$try}.stderr";
+			$stderr = "{$this->dir}/server-{$try}-{$nonce}.stderr";
 			$proc = proc_open(
-				['php', '-S', "127.0.0.1:{$candidate}", $router],
+				['php', '-S', '127.0.0.1:0', $router],
 				[1 => ['file', '/dev/null', 'w'], 2 => ['file', $stderr, 'w']],
 				$pipes,
 				$this->dir,
@@ -372,9 +371,10 @@ PHP;
 				]
 			);
 			if (!is_resource($proc)) {
-				$failures[] = "port {$candidate}: process=proc_open failed stderr=(unavailable)";
+				$failures[] = 'port 0: process=proc_open failed stderr=(unavailable)';
 				continue;
 			}
+			$candidate = pfb_test_http_fixture_port($stderr);
 			for ($poll = 0; $poll < 40; $poll++) {
 				if (pfb_test_http_fixture_event_received($candidate, $nonce)) {
 					$this->server = $proc;

--- a/tests/php/DownloadRedirectCredentialScopeTest.php
+++ b/tests/php/DownloadRedirectCredentialScopeTest.php
@@ -182,11 +182,10 @@ PHP;
 	{
 		$failures = [];
 		for ($try = 0; $try < 10; $try++) {
-			$port   = random_int(20000, 60000);
 			$nonce  = bin2hex(random_bytes(16));
-			$stderr = "{$this->workdir}/server-{$port}-{$try}.stderr";
+			$stderr = "{$this->workdir}/server-{$try}-{$nonce}.stderr";
 			$proc   = proc_open(
-				['php', '-S', "127.0.0.1:{$port}", $router],
+				['php', '-S', '127.0.0.1:0', $router],
 				[1 => ['file', '/dev/null', 'w'], 2 => ['file', $stderr, 'w']],
 				$pipes,
 				$this->workdir,
@@ -199,9 +198,10 @@ PHP;
 				]
 			);
 			if (!is_resource($proc)) {
-				$failures[] = "port {$port}: process=proc_open failed stderr=(unavailable)";
+				$failures[] = 'port 0: process=proc_open failed stderr=(unavailable)';
 				continue;
 			}
+			$port = pfb_test_http_fixture_port($stderr);
 			for ($i = 0; $i < 40; $i++) {
 				if (pfb_test_http_fixture_event_received($port, $nonce)) {
 					$this->servers[$port] = $proc;

--- a/tests/php/DownloadRejectValidatorClearTest.php
+++ b/tests/php/DownloadRejectValidatorClearTest.php
@@ -757,20 +757,20 @@ final class DownloadRejectValidatorClearTest extends TestCase
 
 		$failures = [];
 		for ($try = 0; $try < 20 && $this->port === 0; $try++) {
-			$candidate = random_int(20000, 60000);
 			$nonce = bin2hex(random_bytes(16));
-			$stderr = "{$this->dir}/server-{$candidate}-{$try}.stderr";
+			$stderr = "{$this->dir}/server-{$try}-{$nonce}.stderr";
 			$proc = proc_open(
-				['php', '-S', "127.0.0.1:{$candidate}", $router],
+				['php', '-S', '127.0.0.1:0', $router],
 				[1 => ['file', '/dev/null', 'w'], 2 => ['file', $stderr, 'w']],
 				$pipes,
 				$this->dir,
 				['READY_TOKEN' => $nonce, 'PATH' => (string) getenv('PATH')]
 			);
 			if (!is_resource($proc)) {
-				$failures[] = "port {$candidate}: process=proc_open failed stderr=(unavailable)";
+				$failures[] = 'port 0: process=proc_open failed stderr=(unavailable)';
 				continue;
 			}
+			$candidate = pfb_test_http_fixture_port($stderr);
 			for ($poll = 0; $poll < 40; $poll++) {
 				if (pfb_test_http_fixture_event_received($candidate, $nonce)) {
 					$this->server = $proc;

--- a/tests/php/DownloadRetryBodyResetTest.php
+++ b/tests/php/DownloadRetryBodyResetTest.php
@@ -140,11 +140,10 @@ PHP;
 
 		$failures = [];
 		for ($try = 0; $try < 10; $try++) {
-			$port   = random_int(20000, 60000);
 			$nonce  = bin2hex(random_bytes(16));
-			$stderr = "{$this->workdir}/server-{$port}-{$try}.stderr";
+			$stderr = "{$this->workdir}/server-{$try}-{$nonce}.stderr";
 			$proc   = proc_open(
-				['php', '-S', "127.0.0.1:{$port}", $router],
+				['php', '-S', '127.0.0.1:0', $router],
 				[1 => ['file', '/dev/null', 'w'], 2 => ['file', $stderr, 'w']],
 				$pipes,
 				$this->workdir,
@@ -156,9 +155,10 @@ PHP;
 				]
 			);
 			if (!is_resource($proc)) {
-				$failures[] = "port {$port}: process=proc_open failed stderr=(unavailable)";
+				$failures[] = 'port 0: process=proc_open failed stderr=(unavailable)';
 				continue;
 			}
+			$port = pfb_test_http_fixture_port($stderr);
 			for ($i = 0; $i < 40; $i++) {
 				if (pfb_test_http_fixture_event_received($port, $nonce)) {
 					$this->server = $proc;

--- a/tests/php/DownloadSizeRefusalTest.php
+++ b/tests/php/DownloadSizeRefusalTest.php
@@ -158,11 +158,10 @@ PHP;
 
 		$failures = [];
 		for ($try = 0; $try < 10; $try++) {
-			$port = random_int(20000, 60000);
 			$nonce = bin2hex(random_bytes(16));
-			$stderr = "{$this->workdir}/server-{$port}-{$try}.stderr";
+			$stderr = "{$this->workdir}/server-{$try}-{$nonce}.stderr";
 			$proc = proc_open(
-				['php', '-S', "127.0.0.1:{$port}", $router],
+				['php', '-S', '127.0.0.1:0', $router],
 				[1 => ['file', '/dev/null', 'w'], 2 => ['file', $stderr, 'w']],
 				$pipes,
 				$this->workdir,
@@ -173,9 +172,10 @@ PHP;
 				]
 			);
 			if (!is_resource($proc)) {
-				$failures[] = "port {$port}: process=proc_open failed stderr=(unavailable)";
+				$failures[] = 'port 0: process=proc_open failed stderr=(unavailable)';
 				continue;
 			}
+			$port = pfb_test_http_fixture_port($stderr);
 			for ($i = 0; $i < 40; $i++) {
 				if (pfb_test_http_fixture_event_received($port, $nonce)) {
 					$this->server = $proc;

--- a/tests/php/GeoipZipPublicationTest.php
+++ b/tests/php/GeoipZipPublicationTest.php
@@ -127,11 +127,10 @@ PHP;
 		$failures = [];
 		$port = 0;
 		for ($try = 0; $try < 10 && $port === 0; $try++) {
-			$candidate = random_int(20000, 60000);
 			$nonce = bin2hex(random_bytes(16));
-			$stderr = "{$this->dir}/server-{$candidate}-{$try}.stderr";
+			$stderr = "{$this->dir}/server-{$try}-{$nonce}.stderr";
 			$proc = proc_open(
-				['php', '-S', "127.0.0.1:{$candidate}", $router],
+				['php', '-S', '127.0.0.1:0', $router],
 				[1 => ['file', '/dev/null', 'w'], 2 => ['file', $stderr, 'w']],
 				$pipes,
 				$this->dir,
@@ -141,9 +140,10 @@ PHP;
 				]
 			);
 			if (!is_resource($proc)) {
-				$failures[] = "port {$candidate}: process=proc_open failed stderr=(unavailable)";
+				$failures[] = 'port 0: process=proc_open failed stderr=(unavailable)';
 				continue;
 			}
+			$candidate = pfb_test_http_fixture_port($stderr);
 			for ($poll = 0; $poll < 40; $poll++) {
 				if (pfb_test_http_fixture_event_received($candidate, $nonce)) {
 					$this->server = $proc;

--- a/tests/php/HttpFixtureReadinessBehaviorTest.php
+++ b/tests/php/HttpFixtureReadinessBehaviorTest.php
@@ -6,7 +6,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\SkippedTest;
 use PHPUnit\Framework\TestCase;
 
-/** Issue #2904: occupied-port retries keep nonce, bound, and bind diagnostics observable. */
+/** Issue #2904/#3218: occupied-port retries keep nonce, bound, and bind diagnostics observable. */
 final class HttpFixtureReadinessBehaviorTest extends TestCase
 {
 	/** @var resource|null */
@@ -19,6 +19,8 @@ final class HttpFixtureReadinessBehaviorTest extends TestCase
 	private static array $pollPauses = [];
 	/** @var list<string> */
 	private static array $stderrPaths = [];
+	/** @var list<list<string>> */
+	private static array $fixtureCommands = [];
 	/** @var list<resource> */
 	private static array $fixtureProcesses = [];
 	/** @var list<resource> */
@@ -34,6 +36,7 @@ final class HttpFixtureReadinessBehaviorTest extends TestCase
 		self::$probeNonces = [];
 		self::$pollPauses = [];
 		self::$stderrPaths = [];
+		self::$fixtureCommands = [];
 		self::$fixtureProcesses = [];
 		self::$terminatedFixtureProcesses = [];
 		self::$foreignPort = $this->startForeignServer();
@@ -112,7 +115,7 @@ final class HttpFixtureReadinessBehaviorTest extends TestCase
 			$this->restoreFixtureGlobals($savedGlobals);
 		}
 
-		$this->assertNotNull($failure, "{$file}::{$method} adopted the planted foreign listener");
+		$this->assertNotNull($failure, "{$file}::{$method} must not settle on the planted foreign listener's port");
 		$this->assertNotSame(
 			[],
 			self::$probeNonces,
@@ -129,17 +132,24 @@ final class HttpFixtureReadinessBehaviorTest extends TestCase
 		$this->assertStringContainsString('exit=', $message);
 		$this->assertStringContainsString('close=', $message);
 		$this->assertStringContainsString('stderr=', $message);
-		$this->assertStringContainsString('Failed to listen', $message);
 		$this->assertCount($tries, self::$stderrPaths, "{$file}::{$method} changed the stderr file count");
 		$this->assertCount($tries, array_unique(self::$stderrPaths), "{$file}::{$method} must use a fresh stderr file per attempt");
+		$this->assertCount($tries, self::$fixtureCommands, "{$file}::{$method} changed the child-process count");
+		foreach (self::$fixtureCommands as $command) {
+			$this->assertSame(
+				'127.0.0.1:0',
+				$command[2] ?? NULL,
+				"{$file}::{$method} must let the kernel assign the fixture port instead of guessing one"
+			);
+		}
 		$this->assertCount($tries, self::$fixtureProcesses, "{$file}::{$method} changed the child-process count");
 		foreach (self::$fixtureProcesses as $process) {
 			$this->assertFalse(is_resource($process), "{$file}::{$method} left a failed fixture child open");
 		}
-		$this->assertSame(
-			[],
+		$this->assertCount(
+			$tries,
 			self::$terminatedFixtureProcesses,
-			"{$file}::{$method} tried to terminate an already-exited fixture child"
+			"{$file}::{$method} must terminate the still-running kernel-assigned child once its attempt is exhausted"
 		);
 
 		$expectedPolls = $tries * 40;
@@ -158,14 +168,6 @@ final class HttpFixtureReadinessBehaviorTest extends TestCase
 		$this->assertCount($tries, array_unique($attemptNonces), "{$file}::{$method} must generate a fresh nonce per attempt");
 	}
 
-	public static function candidatePort(int $minimum, int $maximum): int
-	{
-		if (self::$foreignPort < $minimum || self::$foreignPort > $maximum) {
-			throw new RuntimeException('planted foreign port is outside the fixture candidate range');
-		}
-		return self::$foreignPort;
-	}
-
 	public static function observeProbe(int $port, string $nonce): bool
 	{
 		if (self::$probeNonces === [] || self::$probeNonces[array_key_last(self::$probeNonces)] !== $nonce) {
@@ -180,6 +182,12 @@ final class HttpFixtureReadinessBehaviorTest extends TestCase
 		self::$pollPauses[] = $microseconds;
 	}
 
+	/** Plants the foreign port as the "learned" port for every attempt, forcing a nonce mismatch. */
+	public static function learnFixturePort(string $stderrPath): int
+	{
+		return self::$foreignPort;
+	}
+
 	/** @return resource|false */
 	public static function openFixtureProcess(
 		array $command,
@@ -189,6 +197,7 @@ final class HttpFixtureReadinessBehaviorTest extends TestCase
 		?array $environment,
 		?array $options = NULL
 	) {
+		self::$fixtureCommands[] = $command;
 		$stderr = $descriptorSpec[2][1] ?? NULL;
 		if (is_string($stderr)) {
 			self::$stderrPaths[] = $stderr;
@@ -216,11 +225,6 @@ final class HttpFixtureReadinessBehaviorTest extends TestCase
 
 namespace {$namespace};
 
-function random_int(int \$minimum, int \$maximum): int
-{
-	return \\HttpFixtureReadinessBehaviorTest::candidatePort(\$minimum, \$maximum);
-}
-
 function usleep(int \$microseconds): void
 {
 	\\HttpFixtureReadinessBehaviorTest::recordPollPause(\$microseconds);
@@ -229,6 +233,11 @@ function usleep(int \$microseconds): void
 function pfb_test_http_fixture_event_received(int \$port, string \$nonce): bool
 {
 	return \\HttpFixtureReadinessBehaviorTest::observeProbe(\$port, \$nonce);
+}
+
+function pfb_test_http_fixture_port(string \$stderrPath): int
+{
+	return \\HttpFixtureReadinessBehaviorTest::learnFixturePort(\$stderrPath);
 }
 
 function proc_open(

--- a/tests/php/HttpFixtureReadinessBehaviorTest.php
+++ b/tests/php/HttpFixtureReadinessBehaviorTest.php
@@ -19,6 +19,8 @@ final class HttpFixtureReadinessBehaviorTest extends TestCase
 	private static array $pollPauses = [];
 	/** @var list<string> */
 	private static array $stderrPaths = [];
+	/** @var list<string> */
+	private static array $learnedStderrPaths = [];
 	/** @var list<list<string>> */
 	private static array $fixtureCommands = [];
 	/** @var list<resource> */
@@ -36,6 +38,7 @@ final class HttpFixtureReadinessBehaviorTest extends TestCase
 		self::$probeNonces = [];
 		self::$pollPauses = [];
 		self::$stderrPaths = [];
+		self::$learnedStderrPaths = [];
 		self::$fixtureCommands = [];
 		self::$fixtureProcesses = [];
 		self::$terminatedFixtureProcesses = [];
@@ -134,6 +137,11 @@ final class HttpFixtureReadinessBehaviorTest extends TestCase
 		$this->assertStringContainsString('stderr=', $message);
 		$this->assertCount($tries, self::$stderrPaths, "{$file}::{$method} changed the stderr file count");
 		$this->assertCount($tries, array_unique(self::$stderrPaths), "{$file}::{$method} must use a fresh stderr file per attempt");
+		$this->assertSame(
+			self::$stderrPaths,
+			self::$learnedStderrPaths,
+			"{$file}::{$method} must learn the port from its own per-attempt stderr path"
+		);
 		$this->assertCount($tries, self::$fixtureCommands, "{$file}::{$method} changed the child-process count");
 		foreach (self::$fixtureCommands as $command) {
 			$this->assertSame(
@@ -185,6 +193,7 @@ final class HttpFixtureReadinessBehaviorTest extends TestCase
 	/** Plants the foreign port as the "learned" port for every attempt, forcing a nonce mismatch. */
 	public static function learnFixturePort(string $stderrPath): int
 	{
+		self::$learnedStderrPaths[] = $stderrPath;
 		return self::$foreignPort;
 	}
 

--- a/tests/php/HttpFixtureReadinessTest.php
+++ b/tests/php/HttpFixtureReadinessTest.php
@@ -48,6 +48,31 @@ final class HttpFixtureReadinessStreamSpy
 	}
 }
 
+final class HttpFixtureReadinessPortPollSpy
+{
+	/** @var list<string> */
+	public static array $reads = [];
+	/** @var list<int> */
+	public static array $pauses = [];
+
+	public static function reset(): void
+	{
+		self::$reads = [];
+		self::$pauses = [];
+	}
+
+	public static function read(string $path): string
+	{
+		self::$reads[] = $path;
+		return 'unmatched stderr';
+	}
+
+	public static function pause(int $microseconds): void
+	{
+		self::$pauses[] = $microseconds;
+	}
+}
+
 /** Issue #2065: HTTP fixture readiness proves which process owns the selected port. */
 final class HttpFixtureReadinessTest extends TestCase
 {
@@ -237,6 +262,41 @@ final class HttpFixtureReadinessTest extends TestCase
 	{
 		$this->requireReadinessHelper();
 		$this->assertSame(0, pfb_test_http_fixture_port("{$this->workdir}/does-not-exist.stderr"));
+	}
+
+	public function testFixturePortParserKeepsExactFortyReadAndPauseBound(): void
+	{
+		$source = file_get_contents(__DIR__ . '/support/HttpFixtureReadiness.php');
+		$this->assertIsString($source);
+		$namespace = 'PfbIssue3218\\PortPoll' . bin2hex(random_bytes(6));
+		$instrumentation = <<<PHP
+
+namespace {$namespace};
+
+function file_get_contents(string \$path): string
+{
+	return \HttpFixtureReadinessPortPollSpy::read(\$path);
+}
+
+function usleep(int \$microseconds): void
+{
+	\HttpFixtureReadinessPortPollSpy::pause(\$microseconds);
+}
+PHP;
+		$source = str_replace(
+			"declare(strict_types=1);\n",
+			"declare(strict_types=1);{$instrumentation}\n",
+			$source
+		);
+		$mirror = "{$this->workdir}/poll-helper.php";
+		$this->assertNotFalse(file_put_contents($mirror, $source));
+		HttpFixtureReadinessPortPollSpy::reset();
+		require $mirror;
+
+		$learner = "{$namespace}\\pfb_test_http_fixture_port";
+		$this->assertSame(0, $learner('/fixture.stderr'));
+		$this->assertSame(array_fill(0, 40, '/fixture.stderr'), HttpFixtureReadinessPortPollSpy::$reads);
+		$this->assertSame(array_fill(0, 40, 50000), HttpFixtureReadinessPortPollSpy::$pauses);
 	}
 
 	private function requireReadinessHelper(): void

--- a/tests/php/HttpFixtureReadinessTest.php
+++ b/tests/php/HttpFixtureReadinessTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class HttpFixtureReadinessStreamSpy
@@ -173,6 +174,69 @@ final class HttpFixtureReadinessTest extends TestCase
 			pfb_test_http_fixture_event_received($port, $token),
 			'the fixture router must count as ready after it returns the child-owned secret'
 		);
+	}
+
+	/** @return array<string,array{string,int}> */
+	public static function bannerParserRows(): array
+	{
+		return [
+			'php 8.4 banner' => [
+				"[Mon Sep  7 12:13:20 2026] PHP 8.4.24 Development Server (http://127.0.0.1:38413) started\n",
+				38413,
+			],
+			'pre-8.4 surrounding wording' => [
+				"PHP 7.4.33 Development Server (http://127.0.0.1:8000) started\n",
+				8000,
+			],
+			'unrelated stderr around the token' => [
+				"Deprecated: some notice on line 3\n[Mon Sep  7 12:13:20 2026] PHP 8.4.24 Development Server (http://127.0.0.1:9001) started\nPHP Warning: trailing noise\n",
+				9001,
+			],
+			'wrong host localhost' => ["PHP 8.4.24 Development Server (http://localhost:9001) started\n", 0],
+			'wrong host 0.0.0.0' => ["PHP 8.4.24 Development Server (http://0.0.0.0:9001) started\n", 0],
+			'wrong scheme https' => ["PHP 8.4.24 Development Server (https://127.0.0.1:9001) started\n", 0],
+			'empty stderr' => ['', 0],
+			'partial banner missing digits' => ["PHP 8.4.24 Development Server (http://127.0.0.1:", 0],
+			'partial banner missing closing paren' => ["PHP 8.4.24 Development Server (http://127.0.0.1:38413", 0],
+		];
+	}
+
+	/** Issue #3218: the port learner tolerates version-specific wording but never a truncated token. */
+	#[DataProvider('bannerParserRows')]
+	public function testFixturePortParserHandlesHostileBannerContent(string $stderrContent, int $expectedPort): void
+	{
+		$this->requireReadinessHelper();
+		$stderr = "{$this->workdir}/banner-" . bin2hex(random_bytes(4)) . '.stderr';
+		$this->assertNotFalse(file_put_contents($stderr, $stderrContent));
+		$this->assertSame($expectedPort, pfb_test_http_fixture_port($stderr));
+	}
+
+	public function testFixturePortParserWaitsForAsynchronousBannerWrite(): void
+	{
+		$this->requireReadinessHelper();
+		$stderr = "{$this->workdir}/async.stderr";
+		$this->assertNotFalse(file_put_contents($stderr, ''));
+		$code = sprintf(
+			'usleep(200000); file_put_contents(%s, "[date] PHP 8.4.24 Development Server (http://127.0.0.1:24680) started\n");',
+			var_export($stderr, TRUE)
+		);
+		$writer = proc_open(['php', '-r', $code], [1 => ['file', '/dev/null', 'w'], 2 => ['file', '/dev/null', 'w']], $pipes);
+		$this->assertIsResource($writer);
+		try {
+			$this->assertSame(
+				24680,
+				pfb_test_http_fixture_port($stderr),
+				'a banner written after the poll begins must still be learned within the bound'
+			);
+		} finally {
+			proc_close($writer);
+		}
+	}
+
+	public function testFixturePortParserReturnsZeroWhenStderrNeverAppears(): void
+	{
+		$this->requireReadinessHelper();
+		$this->assertSame(0, pfb_test_http_fixture_port("{$this->workdir}/does-not-exist.stderr"));
 	}
 
 	private function requireReadinessHelper(): void

--- a/tests/php/Top1mDccDetectorTest.php
+++ b/tests/php/Top1mDccDetectorTest.php
@@ -222,20 +222,20 @@ PHP;
 		$this->assertNotFalse(file_put_contents($router, sprintf($routerSource, var_export($body, TRUE))));
 		$failures = [];
 		for ($try = 0; $try < 10; $try++) {
-			$port = random_int(20000, 60000);
 			$nonce = bin2hex(random_bytes(16));
-			$stderr = "{$this->dir}/server-{$port}-{$try}-{$nonce}.stderr";
+			$stderr = "{$this->dir}/server-{$try}-{$nonce}.stderr";
 			$proc = proc_open(
-				['php', '-S', "127.0.0.1:{$port}", $router],
+				['php', '-S', '127.0.0.1:0', $router],
 				[1 => ['file', '/dev/null', 'w'], 2 => ['file', $stderr, 'w']],
 				$pipes,
 				$this->dir,
 				['PATH' => (string) getenv('PATH'), 'READY_TOKEN' => $nonce]
 			);
 			if (!is_resource($proc)) {
-				$failures[] = "port {$port}: process=proc_open failed stderr=(unavailable)";
+				$failures[] = 'port 0: process=proc_open failed stderr=(unavailable)';
 				continue;
 			}
+			$port = pfb_test_http_fixture_port($stderr);
 			for ($poll = 0; $poll < 40; $poll++) {
 				if (pfb_test_http_fixture_event_received($port, $nonce)) {
 					$this->server = $proc;
@@ -510,20 +510,20 @@ PHP;
 		$failures = [];
 		$port = 0;
 		for ($try = 0; $try < 10 && $port === 0; $try++) {
-			$candidate = random_int(20000, 60000);
 			$nonce = bin2hex(random_bytes(16));
-			$stderr = "{$this->dir}/server-{$candidate}-{$try}-{$nonce}.stderr";
+			$stderr = "{$this->dir}/server-{$try}-{$nonce}.stderr";
 			$proc = proc_open(
-				['php', '-S', "127.0.0.1:{$candidate}", $router],
+				['php', '-S', '127.0.0.1:0', $router],
 				[1 => ['file', '/dev/null', 'w'], 2 => ['file', $stderr, 'w']],
 				$pipes,
 				$this->dir,
 				['PATH' => (string) getenv('PATH'), 'READY_TOKEN' => $nonce]
 			);
 			if (!is_resource($proc)) {
-				$failures[] = "port {$candidate}: process=proc_open failed stderr=(unavailable)";
+				$failures[] = 'port 0: process=proc_open failed stderr=(unavailable)';
 				continue;
 			}
+			$candidate = pfb_test_http_fixture_port($stderr);
 			for ($poll = 0; $poll < 40; $poll++) {
 				if (pfb_test_http_fixture_event_received($candidate, $nonce)) {
 					$this->server = $proc;

--- a/tests/php/Top1mDownloadSemanticValidationTest.php
+++ b/tests/php/Top1mDownloadSemanticValidationTest.php
@@ -179,20 +179,20 @@ PHP;
 		$port = 0;
 		$failures = [];
 		for ($try = 0; $try < 10 && $port === 0; $try++) {
-			$candidate = random_int(20000, 60000);
 			$nonce = bin2hex(random_bytes(16));
-			$stderr = "{$this->dir}/server-{$candidate}-{$try}.stderr";
+			$stderr = "{$this->dir}/server-{$try}-{$nonce}.stderr";
 			$proc = proc_open(
-				['php', '-S', "127.0.0.1:{$candidate}", $router],
+				['php', '-S', '127.0.0.1:0', $router],
 				[1 => ['file', '/dev/null', 'w'], 2 => ['file', $stderr, 'w']],
 				$pipes,
 				$this->dir,
 				['READY_TOKEN' => $nonce, 'PATH' => (string) getenv('PATH')]
 			);
 			if (!is_resource($proc)) {
-				$failures[] = "port {$candidate}: process=proc_open failed stderr=(unavailable)";
+				$failures[] = 'port 0: process=proc_open failed stderr=(unavailable)';
 				continue;
 			}
+			$candidate = pfb_test_http_fixture_port($stderr);
 			for ($poll = 0; $poll < 40; $poll++) {
 				if (pfb_test_http_fixture_event_received($candidate, $nonce)) {
 					$this->server = $proc;

--- a/tests/php/Top1mSemanticMatrixTest.php
+++ b/tests/php/Top1mSemanticMatrixTest.php
@@ -300,20 +300,20 @@ PHP;
 		$port = 0;
 		$failures = [];
 		for ($try = 0; $try < 10 && $port === 0; $try++) {
-			$candidate = random_int(20000, 60000);
 			$nonce = bin2hex(random_bytes(16));
-			$stderr = "{$this->dir}/server-{$candidate}-{$try}.stderr";
+			$stderr = "{$this->dir}/server-{$try}-{$nonce}.stderr";
 			$proc = proc_open(
-				['php', '-S', "127.0.0.1:{$candidate}", $router],
+				['php', '-S', '127.0.0.1:0', $router],
 				[1 => ['file', '/dev/null', 'w'], 2 => ['file', $stderr, 'w']],
 				$pipes,
 				$this->dir,
 				['READY_TOKEN' => $nonce, 'PATH' => (string) getenv('PATH')]
 			);
 			if (!is_resource($proc)) {
-				$failures[] = "port {$candidate}: process=proc_open failed stderr=(unavailable)";
+				$failures[] = 'port 0: process=proc_open failed stderr=(unavailable)';
 				continue;
 			}
+			$candidate = pfb_test_http_fixture_port($stderr);
 			for ($poll = 0; $poll < 40; $poll++) {
 				if (pfb_test_http_fixture_event_received($candidate, $nonce)) {
 					$this->server = $proc;

--- a/tests/php/support/HttpFixtureReadiness.php
+++ b/tests/php/support/HttpFixtureReadiness.php
@@ -14,7 +14,7 @@ function pfb_test_http_fixture_event_received(int $port, string $secret): bool
 
 /**
  * Bounded-polls $stderrPath (40 x 50ms) for the async `php -S 127.0.0.1:0`
- * banner; parses only `http://127.0.0.1:(\d+)`, tolerant of banner wording.
+ * banner; parses only `http://127.0.0.1:(\d+)\)`, tolerant of banner wording.
  * Returns 0 if no complete match lands within the bound.
  */
 function pfb_test_http_fixture_port(string $stderrPath): int

--- a/tests/php/support/HttpFixtureReadiness.php
+++ b/tests/php/support/HttpFixtureReadiness.php
@@ -11,3 +11,20 @@ function pfb_test_http_fixture_event_received(int $port, string $secret): bool
 
 	return is_string($body) && hash_equals($secret, $body);
 }
+
+/**
+ * Bounded-polls $stderrPath (40 x 50ms) for the async `php -S 127.0.0.1:0`
+ * banner; parses only `http://127.0.0.1:(\d+)`, tolerant of banner wording.
+ * Returns 0 if no complete match lands within the bound.
+ */
+function pfb_test_http_fixture_port(string $stderrPath): int
+{
+	for ($poll = 0; $poll < 40; $poll++) {
+		$banner = @file_get_contents($stderrPath);
+		if (is_string($banner) && preg_match('#http://127\.0\.0\.1:(\d+)\)#', $banner, $matches) === 1) {
+			return (int) $matches[1];
+		}
+		usleep(50000);
+	}
+	return 0;
+}


### PR DESCRIPTION
## Summary

- launch the ten HTTP fixtures on `127.0.0.1:0` and learn the kernel-assigned port from the PHP server banner
- retain the nonce-bound readiness probe and existing retry, cleanup, diagnostic, and fail/skip contracts
- make the readiness meta-test deterministic and add hostile/asynchronous parser coverage

## Evidence

Under concurrent PHPUnit load, the pre-change readiness meta-test failed on moving provider rows because a child had not completed its occupied-port bind failure before the instrumented poll loop inspected it. The final frozen regression tests failed against the base implementation with 11 missing-helper errors and 10 unmigrated-site failures. They pass on this branch: `OK (26 tests, 5115 assertions)`.

`sh scripts/agent/check-graph-fresh.sh` passes after rebasing onto current `devel`. The canonical PHP gate's nonzero local rows reproduce identically on the exact base under this Debian/PHP 8.4 host and are tracked by #3103; CI's PHP 8.3/8.5 matrix remains authoritative.

A condensed adversarial review found two test-honesty gaps. The follow-up commit pins the exact 40 × 50 ms learner budget without wall-clock assertions and verifies that every fixture passes its own stderr path. Scoped mutation re-review is clean.

Fixes #3218