### PR TITLE
perf: avoid Python DNS-label charset scans

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfb_unbound.py
+++ b/src/usr/local/pkg/pfblockerng/pfb_unbound.py
@@ -164,6 +164,7 @@ _PSL_ICANN_BEGIN = "// ===BEGIN ICANN DOMAINS==="
 _PSL_ICANN_END = "// ===END ICANN DOMAINS==="
 _PSL_PRIVATE_BEGIN = "// ===BEGIN PRIVATE DOMAINS==="
 _PSL_PRIVATE_END = "// ===END PRIVATE DOMAINS==="
+_PSL_LABEL_CHARS = frozenset("abcdefghijklmnopqrstuvwxyz0123456789-")
 
 
 def _psl_normalize_name(name: str) -> str:
@@ -172,7 +173,7 @@ def _psl_normalize_name(name: str) -> str:
         raise ValueError("invalid DNS name")
     normalized: list[str] = []
     for label in labels:
-        if any(char in label for char in "*!"):
+        if "*" in label or "!" in label:
             raise ValueError("invalid DNS label")
         if label.isascii() and not label.lower().startswith("xn--"):
             # Plain-ASCII fast path (the overwhelming hot-path case): the idna
@@ -195,7 +196,7 @@ def _psl_normalize_name(name: str) -> str:
             or len(encoded.encode("ascii")) > 63
             or encoded[0] == "-"
             or encoded[-1] == "-"
-            or any(char not in "abcdefghijklmnopqrstuvwxyz0123456789-" for char in encoded)
+            or not _PSL_LABEL_CHARS.issuperset(encoded)
         ):
             raise ValueError("invalid DNS label")
         normalized.append(encoded)
@@ -4651,7 +4652,7 @@ def _normalise_verdict(value: str) -> tuple[str | None, str | None]:
     for label in host.split("."):
         if not label or label[0] == "-" or label[-1] == "-":
             return None, "shape"
-        if any(c not in _DNSBL_LABEL_CHARS for c in label):
+        if not _DNSBL_LABEL_CHARS.issuperset(label):
             return None, "shape"
     return host, None
 

--- a/tests/test_issue3056_label_charset.py
+++ b/tests/test_issue3056_label_charset.py
@@ -1,0 +1,56 @@
+"""DNS-label validation preserves both alphabets without per-character Python work."""
+
+from __future__ import annotations
+
+import cProfile
+from collections.abc import Callable
+
+import pytest
+
+import pfb_unbound as P
+
+
+@pytest.mark.parametrize("normalize", [P._psl_normalize_name, P.normalise])
+def test_ascii_validation_python_work_does_not_scale_with_label_length(normalize: Callable[[str], str | None]) -> None:
+    calls = []
+    for width in (1, 63):
+        name = f"{'a' * width}.com"
+        profile = cProfile.Profile()
+        assert profile.runcall(normalize, name) == name
+        calls.append(sum(row.callcount for row in profile.getstats() if not isinstance(row.code, str)))
+    assert calls[1] == calls[0], f"Python calls grew with label length: short={calls[0]}, long={calls[1]}"
+
+
+@pytest.mark.parametrize("name", ["", ".", "a..com"])
+def test_empty_names_and_labels_are_rejected(name: str) -> None:
+    with pytest.raises(ValueError):
+        P._psl_normalize_name(name)
+    assert P.normalise(name) is None
+    assert P._normalise_verdict(name) == (None, "shape")
+
+
+def test_ascii_alphabets_remain_distinct() -> None:
+    for codepoint in range(128):
+        char = chr(codepoint)
+        name = f"a{char}b.com"
+        allowed = char.lower() in "abcdefghijklmnopqrstuvwxyz0123456789-" or char == "."
+        if allowed:
+            assert P._psl_normalize_name(name) == name.lower()
+        else:
+            with pytest.raises(ValueError):
+                P._psl_normalize_name(name)
+        assert P.normalise(name) == (name.lower() if allowed or char == "_" else None), repr(char)
+
+
+@pytest.mark.parametrize(
+    ("name", "expected"),
+    [("BÜCHER.de", "xn--bcher-kva.de"), ("xn--bcher-kva.de", "xn--bcher-kva.de")],
+)
+def test_idna_normalization_is_preserved(name: str, expected: str) -> None:
+    assert P._psl_normalize_name(name) == expected
+
+
+@pytest.mark.parametrize("name", ["a\u200bb.com", "a\x00b.com", "a\t b.com", "xn--bad.com", "-bad.com", "bad-.com"])
+def test_hostile_labels_are_rejected(name: str) -> None:
+    with pytest.raises(ValueError):
+        P._psl_normalize_name(name)

--- a/tests/test_psl_resolver.py
+++ b/tests/test_psl_resolver.py
@@ -188,3 +188,13 @@ def test_resolver_throughput_is_indexed_not_linear_scan() -> None:
     # Coarse salvage cap only (issue #3051): catches an outright linear matcher,
     # ~7 s here. The two assertions above are what prove the property.
     assert elapsed < 2.0, f"2000 resolves took {elapsed:.2f}s; matcher is scanning rules per lookup"
+
+
+def test_ascii_psl_validation_avoids_per_label_any_scans() -> None:
+    import cProfile
+
+    profile = cProfile.Profile()
+    assert profile.runcall(pfb_unbound._psl_normalize_name, "example.com") == "example.com"
+    any_calls = sum(row.callcount for row in profile.getstats() if row.code == "<built-in method builtins.any>")
+    # Only the whole-name empty-label guard needs any(); marker checks must not add calls per label.
+    assert any_calls <= 1, f"ASCII PSL validation called any() {any_calls} times; per-label scans regressed"

--- a/tests/test_psl_resolver.py
+++ b/tests/test_psl_resolver.py
@@ -195,6 +195,8 @@ def test_ascii_psl_validation_avoids_per_label_any_scans() -> None:
 
     profile = cProfile.Profile()
     assert profile.runcall(pfb_unbound._psl_normalize_name, "example.com") == "example.com"
-    any_calls = sum(row.callcount for row in profile.getstats() if row.code == "<built-in method builtins.any>")
+    any_calls = sum(
+        row.callcount for row in profile.getstats() if isinstance(row.code, str) and "builtins.any" in row.code
+    )
     # Only the whole-name empty-label guard needs any(); marker checks must not add calls per label.
     assert any_calls <= 1, f"ASCII PSL validation called any() {any_calls} times; per-label scans regressed"


### PR DESCRIPTION
## Summary

- Replace the two per-character Python charset scans with `frozenset.issuperset` and the PSL star/bang scan with direct membership checks.
- Keep the two alphabets distinct: PSL accepts LDH; DNSBL also accepts underscores. IDNA, empty-label, length, hyphen, and rejection-bucket behavior is unchanged.
- Add executable performance regression coverage based on Python call growth rather than elapsed-time thresholds, plus ASCII-alphabet, empty-input, IDNA, and hostile-label coverage.

Fixes #3056

## Test-first evidence

Frozen test: `tests/test_issue3056_label_charset.py`

| Test file Git blob | Before production edit | After production edit |
| --- | --- | --- |
| `f0f4d98476ead7b9b858d4d6be110cf0354d3361` | 2 failed, 12 passed | 14 passed |

Command: `uv run pytest -q -o addopts= tests/test_issue3056_label_charset.py`.
The two failures measure Python calls at label widths 1 and 63: PSL normalization grew from 16 to 78 calls; DNSBL normalization grew from 12 to 74. The unchanged assertions pass after the optimization.

`uv run pytest -q -o addopts= tests/test_issue3056_label_charset.py tests/test_psl_resolver.py tests/test_psl_runtime_integration.py tests/test_adr06_build_module.py`: **146 passed**, including all **132 unchanged** tests.

## Real-corpus parity and alternatives

The currently accessible firewall snapshot contains **147,499 rows across four actual feeds** (DandelionSprouts, EasyList, EasyPrivacy, PhishTank). This is not the historical 1,219,390-row/29-feed snapshot reported in the issue. No rows were fabricated or duplicated to inflate the corpus.

The pure `build()` function was run five times on the baseline and five times on the optimized source, using the same in-memory feed rows, manifest configuration, and parsed PSL. Every `BuildResult` field was serialized, preserving mapping order and normalizing unordered sets and compiled regex objects. The two serialized output files compare byte-identically with `cmp`:

- SHA-256: `c4092d6146bc44605aec6485489d3b4494b4895fbb2d99dea0a7d982440be093`
- Data entries: **12,746**, unchanged.
- Zone entries: **115,420**, unchanged.
- Classifier calls: **39,110**, unchanged.

On 200,000 labels taken from those same raw feeds, five-run median charset checks produced identical verdicts:

| Predicate | Median |
| --- | --- |
| Python `any()` | 92.61 ms |
| `frozenset.issuperset` | 20.61 ms |
| Precompiled regex `fullmatch` | 42.66 ms |

Option A wins this control and remains the simpler change. Full-build measurements on this shared Linux host were noisy; this PR does not claim to reproduce the issue's 14.5% appliance result. No production appliance code or configuration was changed.

## Local gates

`sh scripts/agent/run-gates.sh --diff origin/devel`: **GATES: PASS**.

- Coverage pairing
- Deterministic graph freshness
- Full locked pytest suite
- Ruff check and format check
- Mypy `tests/`

## Independent review

One condensed four-lens review covered contract, correctness/hostile inputs, test honesty, and over-engineering. Its sole finding—missing isolated regression protection for the fixed-size star/bang scan—was addressed with the reviewer's concrete runtime assertion. Restoring only that old scan now fails (`any()` called 3 times instead of at most 1). Original frozen tests remain unchanged.

Review and resolution evidence: https://github.com/pfBlockerNG/pfBlockerNG/issues/3056#issuecomment-5572037615 and https://github.com/pfBlockerNG/pfBlockerNG/issues/3056#issuecomment-5572069739.

Final focused suite: **147 passed**. Canonical gates passed again after the review correction. A subsequent rebase incorporated unrelated PHP test-fixture changes; the graph was regenerated, pre-push freshness passed, and the focused suite passed again.
