### PR TITLE
config: Complete wrapped gateway reads

### DIFF
--- a/.agents/policy/testing.md
+++ b/.agents/policy/testing.md
@@ -18,6 +18,21 @@ Tests = how change proves itself. **Five non-negotiable principles govern every 
 4. **Front-end changes REQUIRE front-end tests.** Change touching `www/` must carry UI tests (ADR-14). webConfigurator-reachable surface requires **Tier A (`ui_render`)**. Surface recorded in `test_render_smoke.py`'s `EXCLUDED_FROM_TIER_A` because Tier A cannot reach it requires live tier named by that exclusion plus focused hermetic coverage; never relabel unreachable Tier-B flow as Tier A. **Tier B (`ui_e2e`/`ui_browser`) also REQUIRED IFF change observable *only* in Tier B** — explicitly includes **new page**, **multi-step flow** (anything spanning more than one request/interaction), and **visual/structural** changes (element positioning/addition/removal, layout). When in doubt, add Tier B.
 5. **Tests express change's INTENT — documentation, not just coverage.** Name and comments state intended outcome being pinned, never mechanics of how it coded.
 
+### Production proof and test maintenance
+
+Red→green proves a change to existing production behaviour; it does not recursively
+apply to tests themselves. Test maintenance, test deletions and fixture/golden refreshes
+do not require tests-of-tests or a historical RED for each changed test-side file.
+In the Frozen RED table, record these as **N/A — test maintenance** with the reason,
+current file hash and relevant verification, rather than inventing a failing run.
+
+Test honesty still requires assertions that catch real regressions. Realistic
+production mutations in an isolated scratch tree, with the tests unchanged, are
+permitted evidence: run green, apply the production mutant, observe the relevant
+assertion fail, then restore production and confirm green. This does not replace
+test-first proof for an actual production behaviour change or required live/UI
+coverage; mark unexecuted live checks pending, never passed.
+
 ## Satisfying the principles
 
 - **Branch coverage — test every condition, not one side.** Boolean gets off *and* on (plus any third state); every `if`/`switch`/match branch and documented input class gets own assertion (exemplar pair: `test_dnsbl_hsts_override_forces_null` / `test_dnsbl_hsts_disabled_keeps_vip`).

--- a/docs/misc/config-gateway.md
+++ b/docs/misc/config-gateway.md
@@ -126,10 +126,13 @@ Authorization = property of **write**, not call site (generalises
     `Off = 'off'` backing value remains its internal/render identity. Runtime `$pfb[]`
     toggle mirrors carry
     enum itself (never `->value`), so consumers compare `=== PfbToggle::On`.
-    Registered checkbox fields still on `NULL`/`NULL` adapters (e.g. `pfb_regex`,
-    `pfb_noaaaa`, `pfb_gp`, `pfb_py_nolog`, `tld_wildcard`, `top1m_enable`)
-    keep raw `{'on', ''}` storage until they adopt pair — field joining
-    adapter set moves all its consumers in same commit (see below).
+    The seven `dnsbl/{top1m_enable,pfb_regex,pfb_cname,tld_allow,pfb_py_nolog,`
+    `pfb_noaaaa,pfb_gp}` fields also use this adapter pair (issue #3137).
+    Page checkbox rendering accepts either the enum from GET or raw POST redisplay
+    through the same adapter; TOP1M comparison snapshots use `toStored()` to keep
+    both sides scalar (`''`, not the enum's backing `'off'`).
+    Registered checkbox fields still on `NULL`/`NULL` adapters, such as
+    `tld_wildcard`, keep raw storage until all their consumers adopt the pair.
   - **The seventeen #2123 relocations.** `PFB_FILTER_ON_OFF` save sites whose default,
     stored vocabulary and render comparison were still declared in the page (the 3.2
     arrangement) now read through the registry: `ip/{enable_dup,enable_agg,enable_log,`
@@ -178,12 +181,13 @@ Authorization = property of **write**, not call site (generalises
     `pfb_alias_delta_batch` (plain string, `NULL`/`NULL` adapters) = batch-size companion
     field; stored value is decimal integer string, clamped to `[64, 4096]` at read time by
     `pfb_alias_delta_batch_clamp()`.
-  - **`pfb_reentry_timeout`** (issue #2851, plain string — `NULL`/`NULL` adapters): the ONE
+  - **`pfb_reentry_timeout`** (issue #2851, normalized string): the ONE
     global budget (whole seconds) for every nested `pfblockerng.php` re-entry an update pass
     launches — GeoIP, blacklist, TOP1M, ASN alike, no per-subsystem override. Default
     `'1800'` = the budget issue #2016 hardcoded, so an absent key preserves an upgrader's
-    wait exactly (hence `no_grandfather`). Normalized at read time by
-    `pfb_reentry_timeout()` (`pfblockerng.inc`): whole seconds in `[60, 7200]` pass
+    wait exactly (hence `no_grandfather`). Both adapters use
+    `pfb_cfg_reentry_timeout_adapter()`, which calls the shared
+    `pfb_reentry_timeout()` before scalar coercion: whole seconds in `[60, 7200]` pass
     through, everything else — absent, `''`, non-integral, signed, padded, zero, negative,
     out-of-range, 64-bit-overflowing, non-scalar — resolves to `1800`, never to no timeout.
     `pfblockerng_general.php` canonicalizes the POST through the same function, so the
@@ -255,9 +259,11 @@ pages. Wired into `.github/workflows/test.yml`, `.githooks/pre-commit` and
 - **RULE 1** — a `$pfb['<mirror>']['<key>'] = … PFB_FILTER_ON_OFF …` save into a section
   that `PFB_SECTIONS` knows MUST name a registered key. So a new settings checkbox
   cannot land without a registry entry.
-- **RULE 2** — a registered field's default MUST NOT be restated by the page: no
-  `$pconfig[…] = $pfb['<mirror>']['<key>'] ?: '<literal>'` and no
-  `isset($pfb['<mirror>']['<key>']) ? … : '<literal>'`. Read it with `PfbConfig::read()`.
+- **RULE 2** — a registered field's default MUST NOT be restated by the page:
+  `$pfb['<mirror>']['<key>'] ?? ...`, `?: ...`, or an `isset(...) ? ... : ...`
+  read must use `PfbConfig::read()`, including call-wrapped, parenthesized, returned,
+  array-value, and comparison expressions (issue #3137). Coalescing/Elvis reads cover
+  literal single/double-quoted keys and whitespace in `? :`; save-side `??=` stays a write.
   issue #2994 widened this from toggles to every registered key after aligning the
   six page/registry scalar divergences (`pfb_dnsport`/`pfb_dnsport_ssl`/`aliaslog`
   follow the page, and a fresh install now seeds those values; `pfb_dnsbl_rule` keeps
@@ -274,8 +280,8 @@ pages. Wired into `.github/workflows/test.yml`, `.githooks/pre-commit` and
 - **Hyphenated keys** (issue #3136): the key group now includes `-`, so the widget's
   `global/widget-*` saves reach the rules; they are classified foreign via
   `FOREIGN_KEY_PREFIXES` (the `rep` arrangement above), not registered.
-- **Matcher ceilings** — recorded in the checker's docstring: a call-wrapped RULE 2 read
-  (issue #3137), comment/heredoc skip heuristics.
+- **Matcher ceilings** — the checker's docstring records the existing leading-token
+  comment and heredoc skip heuristics.
 - Fails CLOSED: an unreadable registry, an unparseable `PFB_SECTIONS`, or fewer than 100
   parsed keys exits 2 rather than reporting clean.
 - `--self-test` is the red canary — a synthetic violating page must trip BOTH rules — and
@@ -283,11 +289,11 @@ pages. Wired into `.github/workflows/test.yml`, `.githooks/pre-commit` and
 - Exemptions live in the checker's `EXEMPT` table, each with a reason;
   `test_every_exempt_row_still_names_a_live_site` fails on a stale row.
 
-`tld_allow_sort` and `tld_allow_{gtld,cctld,itld,bgtld}` = plain registered scalars (`NULL`/
-`NULL` adapters) since issue #1921 — previously on foreign-key exclusion list
-below. They still stay legal on `pfblockerng_dnsbl.php`'s direct section-blob read/write (gateway
-does not require every registered field to move its consumers in same step); registration
-exists for `old_name` parity with rest of `pfb_pytld*` rename family.
+`tld_allow_sort` and `tld_allow_{gtld,cctld,itld,bgtld}` remain plain registered scalars
+(`NULL`/`NULL` adapters) since issue #1921. The DNSBL page reads each through the
+gateway, then converts the CSV buckets to display lists, retaining the local-domain
+TLD suggestions for an empty generic-TLD bucket. Section saves still preserve the
+stored CSV representation.
 
 ## Forward-upgrade contract
 

--- a/scripts/check_toggle_registry.py
+++ b/scripts/check_toggle_registry.py
@@ -110,7 +110,10 @@ _READ_COALESCE_RE = re.compile(
     r"\s*\[\s*(?=(?:'[\w-]+'|\"[\w-]+\"))['\"]([\w-]+)['\"]\s*\]\s*"
     r"(?:\?\?(?!=)|\?\s*:)"
 )
-_READ_ISSET_RE = re.compile(r"isset\(\s*\$pfb\s*\[\s*'(\w+)'\s*\]\s*\[\s*'([\w-]+)'\s*\]\s*\)\s*\?[^?:]*:")
+_READ_ISSET_RE = re.compile(
+    r"isset\(\s*\$pfb\s*\[\s*(?=(?:'\w+'|\"\w+\"))['\"](\w+)['\"]\s*\]"
+    r"\s*\[\s*(?=(?:'[\w-]+'|\"[\w-]+\"))['\"]([\w-]+)['\"]\s*\]\s*\)\s*\?[^?:]*:"
+)
 
 # Sanity floor: the registry has had >100 entries since issue #1920's audit. A parse
 # that finds fewer has broken, and a broken parse must fail the gate rather than

--- a/scripts/check_toggle_registry.py
+++ b/scripts/check_toggle_registry.py
@@ -7,21 +7,21 @@ comparison written inline at the render -- and onto `pfb_cfg_registry()`. Withou
 mechanical gate that sweep is a one-off: the next settings checkbox someone adds gets
 its own page-level `?: ''` and the drift is back.
 
-Two rules, both scoped to a SECTION-MIRROR save (`$pfb['<mirror>']['<key>'] = ...`),
-which is the shape a registered scalar takes:
+Two rules, both scoped to a literal section-mirror expression
+(`$pfb['<mirror>']['<key>']`), which is the shape a registered scalar takes:
 
-  RULE 1 -- REGISTERED. A `PFB_FILTER_ON_OFF` save into a section mirror must name a key
+  RULE 1 -- REGISTERED. A `PFB_FILTER_ON_OFF` SAVE into a section mirror must name a key
   that `pfb_cfg_registry()` knows, under the alias the mirror's own section resolves to.
 
   RULE 2 -- NO PAGE DEFAULT. Once a key IS registered (toggle or plain scalar), the page
   must not restate its default: a READ of `$pfb['<mirror>']['<key>']` may not carry a
-  `?:` fallback or sit inside an `isset(...) ? ... : <literal>`. The default belongs
-  to the registry entry. issue #2994 widened this off toggles after aligning the six
-  page/registry divergences. Reads are distinguished from saves by side: a save has
-  the mirror expression on the LEFT of `=`, a read has it on the right. The save
-  site's own `?: ''` is left alone on purpose -- it is transport normalisation of an
-  absent checkbox, not a default, and `PfbConfig::writeSection()` re-normalises it
-  through the registered adapter anyway.
+  `??` / `?:` fallback or sit inside an `isset(...) ? ... : <literal>`. The default
+  belongs to the registry entry. issue #2994 widened this off toggles after aligning
+  the six page/registry divergences. A read is recognised wherever it appears in an
+  expression, including inside a call, return, array value, or comparison. The save
+  site's own `?: ''` and `??=` assignments are left alone on purpose -- they write the
+  mirror rather than default a read, and `PfbConfig::writeSection()` re-normalises
+  stored values through the registered adapter.
 
 The mirror -> section mapping is DERIVED, never listed: each page declares it itself
 with `$pfb['<mirror>'] = PfbConfig::readSection('<section path>')`, and the section path
@@ -48,14 +48,11 @@ section (the widget marks each foreign in-code), so RULE 1 classifies them forei
 `FOREIGN_KEY_PREFIXES` -- the owner decided (2026-09-03) to recognise them, not register
 them -- while a hyphenated key ANYWHERE ELSE still fires normally.
 
-Two matcher ceilings remain, neither load-bearing on today's tree but both real:
-
-  * RULE 2's read matcher anchors on the assignment operator, so a mirror read wrapped
-    in a call (`pfb_b64_text($pfb['dconfig']['k'] ?? NULL)`) is not seen -- issue #3137.
-  * Comments are skipped by LEADING token only, so a read quoted after code on the
-    same line, or inside a `/* */` block whose line lacks a `*`, is a false positive.
-    A heredoc body is matched as code, which is correct for the generated-page nowdocs
-    in `pfblockerng_geoip.inc` and wrong only for a heredoc carrying prose.
+One matcher ceiling remains, not load-bearing on today's tree but real: comments are
+skipped by LEADING token only, so a read quoted after code on the same line, or inside
+a `/* */` block whose line lacks a `*`, is a false positive. A heredoc body is matched
+as code, which is correct for the generated-page nowdocs in `pfblockerng_geoip.inc`
+and wrong only for a heredoc carrying prose.
 
 `--self-test` is the red canary the testing policy requires for a newly wired blocking
 gate: it feeds a known-violating synthetic page through the same matchers and exits 0
@@ -90,8 +87,12 @@ _REGISTRY_ENTRY_RE = re.compile(
 _SECTIONS_BLOCK_RE = re.compile(r"const PFB_SECTIONS\s*=\s*\[(.*?)^\];", re.DOTALL | re.MULTILINE)
 _SECTIONS_ROW_RE = re.compile(r"'([a-z]+)'\s*=>\s*'([^']+)'")
 
-# A page's own mirror declaration: `$pfb['iconfig'] = PfbConfig::readSection('...');`.
-_MIRROR_RE = re.compile(r"\$pfb\s*\[\s*'(\w+)'\s*\]\s*=\s*PfbConfig::readSection\(\s*'([^']+)'")
+# A page's own mirror declaration; paired single or double quotes are equivalent:
+# `$pfb["iconfig"] = PfbConfig::readSection("...");`.
+_MIRROR_RE = re.compile(
+    r"\$pfb\s*\[\s*(?=(?:'\w+'|\"\w+\"))['\"](\w+)['\"]\s*\]\s*=\s*"
+    r"PfbConfig::readSection\(\s*(?=(?:'[^']+'|\"[^\"]+\"))['\"]([^'\"]+)['\"]"
+)
 
 # A save into a section mirror through the on/off form filter. Matched over the whole
 # file, not line by line: `[^;]*?` cannot cross a statement terminator, so a save
@@ -102,10 +103,13 @@ _SAVE_RE = re.compile(
     re.DOTALL,
 )
 
-# A read of a section mirror carrying its own default. Two spellings:
-#   $x = $pfb['iconfig']['enable_dup'] ?: '';
-#   $x = isset($pfb['aglobal']['alertrefresh']) ? $pfb['aglobal']['alertrefresh'] : 'on';
-_READ_COALESCE_RE = re.compile(r"=\s*\$pfb\s*\[\s*'(\w+)'\s*\]\s*\[\s*'([\w-]+)'\s*\]\s*\?[:?]")
+# A section-mirror read carrying `??`, `?:`, or spaced `? :`. The paired-quote
+# lookaheads keep mirror/key in groups 1/2 without accepting mismatched PHP literals.
+_READ_COALESCE_RE = re.compile(
+    r"\$pfb\s*\[\s*(?=(?:'\w+'|\"\w+\"))['\"](\w+)['\"]\s*\]"
+    r"\s*\[\s*(?=(?:'[\w-]+'|\"[\w-]+\"))['\"]([\w-]+)['\"]\s*\]\s*"
+    r"(?:\?\?(?!=)|\?\s*:)"
+)
 _READ_ISSET_RE = re.compile(r"isset\(\s*\$pfb\s*\[\s*'(\w+)'\s*\]\s*\[\s*'([\w-]+)'\s*\]\s*\)\s*\?[^?:]*:")
 
 # Sanity floor: the registry has had >100 entries since issue #1920's audit. A parse
@@ -245,7 +249,7 @@ def _git_tracked_pages(root: Path) -> list[str]:
 
 _SELF_TEST_PAGE = """<?php
 $pfb['iconfig'] = PfbConfig::readSection('installedpackages/pfblockerngipsettings/config/0');
-$pconfig['suppression'] = $pfb['iconfig']['suppression'] ?: 'on';
+$pconfig['suppression'] = trim($pfb['iconfig']['suppression'] ?? '');
 if ($_POST) {
     $pfb['iconfig']['pfb_brand_new_toggle'] = pfb_filter(
         $_POST['pfb_brand_new_toggle'] ?? '', PFB_FILTER_ON_OFF, 'ip') ?: '';
@@ -255,13 +259,13 @@ if ($_POST) {
 
 
 def _self_test(sections_by_path: dict[str, str], registry_keys: set[tuple[str, str]]) -> int:
-    """Red canary: prove both rules fire on a known-violating synthetic page."""
+    """Red canary: prove both rules fire at their exact known-violating sites."""
     found = find_violations(_SELF_TEST_PAGE, "self-test/pfblockerng_ip.php", sections_by_path, registry_keys)
-    rules = {v.rule for v in found}
-    missing = {"unregistered-toggle", "page-level-default"} - rules
+    expected_sites = {("page-level-default", 3), ("unregistered-toggle", 5)}
+    missing = expected_sites - {(v.rule, v.line) for v in found}
     if missing:
         print(
-            f"check_toggle_registry --self-test: rule(s) did not fire: {sorted(missing)}. "
+            f"check_toggle_registry --self-test: canary site(s) did not fire: {sorted(missing)}. "
             "The gate cannot detect the drift it exists to detect.",
             file=sys.stderr,
         )
@@ -269,8 +273,8 @@ def _self_test(sections_by_path: dict[str, str], registry_keys: set[tuple[str, s
             print(f"    fired: {v.rule} at line {v.line}", file=sys.stderr)
         return 1
     print(
-        "check_toggle_registry --self-test: both rules fired on the violating page "
-        f"({len(found)} finding(s)) -- gate wiring proven.",
+        "check_toggle_registry --self-test: both rules fired at their exact canary sites "
+        f"(including the wrapped read; {len(found)} finding(s)) -- gate wiring proven.",
     )
     return 0
 

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -3367,7 +3367,7 @@ function pfb_global() {
 
 	$pfb['dnsbl_port']	= $pfb['dnsblconfig']['pfb_dnsport'];									// Lighttpd web server http port setting
 	$pfb['dnsbl_port_ssl']	= $pfb['dnsblconfig']['pfb_dnsport_ssl'];								// Lighttpd web server https port setting
-	$pfb['dnsbl_top1m']	= pfb_cfg_toggle_read($pfb['dnsblconfig']['top1m_enable'] ?? '');							// TOP1M whitelist
+	$pfb['dnsbl_top1m']	= PfbConfig::read('dnsbl/top1m_enable');							// TOP1M whitelist
 	$pfb['dnsbl_top1m_type']	= PfbConfig::read('dnsbl/top1m_source');						// TOP1M type (PfbTop1mSource enum; legacy 'alexa' coalesces to Tranco, #877) (default Tranco)
 	$pfb['dnsbl_res_cache']	= PfbConfig::read('dnsbl/pfb_cache');							// DNSBL Option to backup/restore Resolver cache (default on, issue #1907)
 	$pfb['dnsbl_cache_flush']	= PfbConfig::read('dnsbl/pfb_cache_flush');						// Opt-in full cache flush after DNSBL data swaps
@@ -3387,20 +3387,20 @@ function pfb_global() {
 	$pfb['dnsbl_idn']	= PfbConfig::read('dnsbl/pfb_idn');				// DNSBL Resolver python IDN mode (PfbIdnMode enum)
 	$pfb['dnsbl_idn_block_malicious']	= PfbConfig::read('dnsbl/pfb_idn_block_malicious');		// Confusable: block malicious homoglyphs (default 'on')
 	$pfb['dnsbl_idn_escalate_suspicious']	= PfbConfig::read('dnsbl/pfb_idn_escalate_suspicious');	// Confusable: escalate suspicious mixed-script to block (opt-in)
-	$pfb['dnsbl_regex']	= pfb_cfg_toggle_read($pfb['dnsblconfig']['pfb_regex'] ?? '');			// DNSBL Resolver python regex
+	$pfb['dnsbl_regex']	= PfbConfig::read('dnsbl/pfb_regex');			// DNSBL Resolver python regex
 	$pfb['dnsbl_regex_list']= PfbConfig::read('dnsbl/pfb_regex_list');	// DNSBL Resolver python regex list
 	$pfb['dnsbl_regex_cap']	= PfbConfig::read('dnsbl/pfb_regex_cap');			// DNSBL Resolver Python opt-in regex length cap
-	$pfb['dnsbl_cname']	= pfb_cfg_toggle_read($pfb['dnsblconfig']['pfb_cname'] ?? '');			// DNSBL Resolver python CNAME Validation
-	$pfb['dnsbl_tld_allow']	= pfb_cfg_toggle_read($pfb['dnsblconfig']['tld_allow'] ?? '');			// DNSBL Resolver TLD Allow option
+	$pfb['dnsbl_cname']	= PfbConfig::read('dnsbl/pfb_cname');			// DNSBL Resolver python CNAME Validation
+	$pfb['dnsbl_tld_allow']	= PfbConfig::read('dnsbl/tld_allow');			// DNSBL Resolver TLD Allow option
 	$pfb['dnsbl_psl_include_private'] = PfbConfig::read('dnsbl/pfb_psl_include_private');			// PSL PRIVATE recognition (default On)
 	$pfb['dnsbl_psl_allow_private'] = PfbConfig::read('dnsbl/pfb_psl_allow_private');			// PSL PRIVATE TLD-Allow precision (default Off)
 	$pfb['dnsbl_psl_feed_private_policy'] = PfbConfig::read('dnsbl/pfb_psl_feed_private_policy');	// issue #2371: feed-at-suffix PSL PRIVATE policy (PfbFeedSuffixPolicy enum; absent -> Honor)
 	$pfb['dnsbl_psl_feed_icann_policy'] = PfbConfig::read('dnsbl/pfb_psl_feed_icann_policy');		// issue #2371: feed-at-suffix PSL ICANN policy (PfbFeedSuffixPolicy enum; absent -> Honor)
-	$pfb['dnsbl_py_nolog']	= pfb_cfg_toggle_read($pfb['dnsblconfig']['pfb_py_nolog'] ?? '');			// DNSBL Resolver python - Log events via DNSBL Webserver vs python
-	$pfb['dnsbl_noaaaa']	= pfb_cfg_toggle_read($pfb['dnsblconfig']['pfb_noaaaa'] ?? '');			// DNSBL Resolver python no AAAA
+	$pfb['dnsbl_py_nolog']	= PfbConfig::read('dnsbl/pfb_py_nolog');			// DNSBL Resolver python - Log events via DNSBL Webserver vs python
+	$pfb['dnsbl_noaaaa']	= PfbConfig::read('dnsbl/pfb_noaaaa');			// DNSBL Resolver python no AAAA
 	$pfb['dnsbl_noaaaa_list']=PfbConfig::read('dnsbl/pfb_noaaaa_list');	// DNSBL Resolver python no AAAA list
 
-	$pfb['dnsbl_gp']		= pfb_cfg_toggle_read($pfb['dnsblconfig']['pfb_gp'] ?? '');		// DNSBL Resolver python - DNSBL Bypass
+	$pfb['dnsbl_gp']		= PfbConfig::read('dnsbl/pfb_gp');		// DNSBL Resolver python - DNSBL Bypass
 	$pfb['dnsbl_gp_bypass_list']	= PfbConfig::read('dnsbl/pfb_gp_bypass_list');	// DNSBL Resolver python - List of Local IPs to bypass DNSBL
 
 	// SafeSearch — read via gateway (ADR-29).
@@ -5205,9 +5205,7 @@ function pfb_reentry_budget($budget): int {
 	if (is_string($budget) && ctype_digit($budget) && (int) $budget > 0) {
 		return (int) $budget;
 	}
-	global $pfb;
-	// The gen-section mirror pfb_global() populates through PfbConfig::readSection().
-	return pfb_reentry_timeout($pfb['config']['pfb_reentry_timeout'] ?? NULL);
+	return (int) PfbConfig::read('gen/pfb_reentry_timeout');
 }
 
 /*
@@ -9526,7 +9524,7 @@ function pfb_unbound_python_whitelist($mode='') {
 	pfb_global();
 
 	$dnsbl_whitelist = '';
-	$dnsbl_white = pfb_text_area_decode($pfb['dnsblconfig']['whitelist'] ?? '', TRUE, FALSE, TRUE);
+	$dnsbl_white = pfb_text_area_decode(PfbConfig::read('dnsbl/whitelist'), TRUE, FALSE, TRUE);
 	if (!empty($dnsbl_white)) {
 		foreach ($dnsbl_white as $key => $line) {
 			if (!empty($line)) {
@@ -9562,9 +9560,7 @@ function pfb_unbound_python_whitelist($mode='') {
 // leading-dot wildcard form — before it reaches the manifest and query-time whiteDB; a failing
 // line is SKIPPED + logged, never silently dropped.
 function pfb_dnsbl_whitelist_lines() {
-	global $pfb;
-
-	$lines = pfb_text_area_decode($pfb['dnsblconfig']['whitelist'] ?? '', TRUE, FALSE, TRUE);
+	$lines = pfb_text_area_decode(PfbConfig::read('dnsbl/whitelist'), TRUE, FALSE, TRUE);
 	$out = array();
 	if (!empty($lines)) {
 		foreach ($lines as $line) {

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -828,6 +828,12 @@ function pfb_cfg_top1m_source_write(PfbTop1mSource|string $source): string
 	return ($source instanceof PfbTop1mSource ? $source : PfbTop1mSource::fromStored($source))->toStored();
 }
 
+/** Normalize the timeout before scalar coercion, retaining the gateway's string API. */
+function pfb_cfg_reentry_timeout_adapter(mixed $stored): string
+{
+	return (string) pfb_reentry_timeout($stored);
+}
+
 // ---------------------------------------------------------------------------
 // ADR-29 — PfbConfig gateway: the single sanctioned gateway for config.xml reads/writes of
 // registered installedpackages/pfblockerng* keys, wrapping config_get/set/del_path with the
@@ -1080,8 +1086,8 @@ function pfb_cfg_registry(): array
 		// resolves anything else back to 1800, so no stored value can weaken the bound.
 		'gen/pfb_reentry_timeout' => [
 			'default'       => '1800',
-			'read_adapter'  => NULL,
-			'write_adapter' => NULL,
+			'read_adapter'  => 'pfb_cfg_reentry_timeout_adapter',
+			'write_adapter' => 'pfb_cfg_reentry_timeout_adapter',
 			'no_grandfather' => '#2851 exposes #2016\'s hardcoded 1800s budget; the absent default IS that budget, so an upgrade\'s wait is unchanged',
 		],
 
@@ -1255,8 +1261,8 @@ function pfb_cfg_registry(): array
 		// TOP1M whitelist enable. Default ''.
 		'dnsbl/top1m_enable' => [
 			'default'       => '',
-			'read_adapter'  => NULL,
-			'write_adapter' => NULL,
+			'read_adapter'  => 'pfb_cfg_toggle_read',
+			'write_adapter' => 'pfb_cfg_toggle_write',
 			'old_name'      => 'alexa_enable',
 			'no_grandfather' => 'v3.2.16 absent-key fallback equals current default (as alexa_enable)',
 		],
@@ -1397,8 +1403,8 @@ function pfb_cfg_registry(): array
 		// Python regex: 'on' | ''. Default ''.
 		'dnsbl/pfb_regex' => [
 			'default'       => '',
-			'read_adapter'  => NULL,
-			'write_adapter' => NULL,
+			'read_adapter'  => 'pfb_cfg_toggle_read',
+			'write_adapter' => 'pfb_cfg_toggle_write',
 			'no_grandfather' => 'v3.2.16 absent-key fallback equals current default',
 		],
 
@@ -1421,16 +1427,16 @@ function pfb_cfg_registry(): array
 		// CNAME validation. Default ''.
 		'dnsbl/pfb_cname' => [
 			'default'       => '',
-			'read_adapter'  => NULL,
-			'write_adapter' => NULL,
+			'read_adapter'  => 'pfb_cfg_toggle_read',
+			'write_adapter' => 'pfb_cfg_toggle_write',
 			'no_grandfather' => 'v3.2.16 absent-key fallback equals current default',
 		],
 
 		// TLD Allow option. Default ''.
 		'dnsbl/tld_allow' => [
 			'default'       => '',
-			'read_adapter'  => NULL,
-			'write_adapter' => NULL,
+			'read_adapter'  => 'pfb_cfg_toggle_read',
+			'write_adapter' => 'pfb_cfg_toggle_write',
 			'old_name'      => 'pfb_pytld',
 			'no_grandfather' => 'v3.2.16 absent-key fallback equals current default (as pfb_pytld)',
 		],
@@ -1476,11 +1482,9 @@ function pfb_cfg_registry(): array
 			'no_grandfather' => 'new FEED-suffix policy (#2371); absent/empty reads Honor (current pre-#2371 behaviour) on every upgrade -- the fresh-install apex/apex seed is a one-time install-time write (pfb_psl_feed_policy_is_fresh_install()), deliberately NOT a registry grandfather map, since issue #1921\'s ABSENT map is OLDCFG-only and would wrongly also apply to a genuinely-fresh install',
 		],
 
-		// issue #1921: TLD Allow sort order for the python list emit. Default ''.
-		// Consumed via the dnsbl section blob (pfblockerng_dnsbl.php), not a per-key read --
-		// stored '' is legal (config-gateway.md's foreign-key exclusion list previously
-		// carried this and its 4 siblings below as "unregistered"; registered here for
-		// old_name parity, no consumer change).
+		// issue #1921/#3137: TLD Allow sort plus the four CSV buckets below read through
+		// their per-key gateways. They remain plain strings; the page applies pfb_csv_list()
+		// to each bucket after the registered default has been resolved.
 		'dnsbl/tld_allow_sort' => [
 			'default'        => '',
 			'read_adapter'   => NULL,
@@ -1528,16 +1532,16 @@ function pfb_cfg_registry(): array
 		// Log events via DNSBL Webserver vs python. Default ''.
 		'dnsbl/pfb_py_nolog' => [
 			'default'       => '',
-			'read_adapter'  => NULL,
-			'write_adapter' => NULL,
+			'read_adapter'  => 'pfb_cfg_toggle_read',
+			'write_adapter' => 'pfb_cfg_toggle_write',
 			'no_grandfather' => 'v3.2.16 absent-key fallback equals current default',
 		],
 
 		// No AAAA blocking: 'on' | ''. Default ''.
 		'dnsbl/pfb_noaaaa' => [
 			'default'       => '',
-			'read_adapter'  => NULL,
-			'write_adapter' => NULL,
+			'read_adapter'  => 'pfb_cfg_toggle_read',
+			'write_adapter' => 'pfb_cfg_toggle_write',
 			'no_grandfather' => 'v3.2.16 absent-key fallback equals current default',
 		],
 
@@ -1552,8 +1556,8 @@ function pfb_cfg_registry(): array
 		// DNSBL bypass enable: 'on' | ''. Default ''.
 		'dnsbl/pfb_gp' => [
 			'default'       => '',
-			'read_adapter'  => NULL,
-			'write_adapter' => NULL,
+			'read_adapter'  => 'pfb_cfg_toggle_read',
+			'write_adapter' => 'pfb_cfg_toggle_write',
 			'no_grandfather' => 'v3.2.16 absent-key fallback equals current default',
 		],
 

--- a/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
@@ -62,7 +62,7 @@ $pconfig['pfb_dnsport']		= PfbConfig::read('dnsbl/pfb_dnsport');
 $pconfig['pfb_dnsport_ssl']	= PfbConfig::read('dnsbl/pfb_dnsport_ssl');
 $pconfig['dnsbl_interface']	= PfbConfig::read('dnsbl/dnsbl_interface');
 $pconfig['pfb_dnsbl_rule']	= PfbConfig::read('dnsbl/pfb_dnsbl_rule');
-$pconfig['dnsbl_allow_int']	= pfb_csv_list($pfb['dconfig']['dnsbl_allow_int'] ?? NULL);
+$pconfig['dnsbl_allow_int']	= pfb_csv_list(PfbConfig::read('dnsbl/dnsbl_allow_int'));
 $pconfig['global_log']		= PfbConfig::read('dnsbl/global_log');
 $pconfig['dnsbl_webpage']	= $pfb['dconfig']['dnsbl_webpage']			?: 'dnsbl_default.php';
 // Default 'on' owned by the registry (ADR-29, issue #1907); PfbConfig::read applies it
@@ -98,14 +98,14 @@ $pconfig['pfb_noaaaa']		= PfbConfig::read('dnsbl/pfb_noaaaa');
 $pconfig['pfb_gp']		= PfbConfig::read('dnsbl/pfb_gp');
 $pconfig['tld_allow']		= PfbConfig::read('dnsbl/tld_allow');
 $pconfig['tld_allow_sort']	= PfbConfig::read('dnsbl/tld_allow_sort');
-$pconfig['tld_allow_gtld']	= pfb_csv_list($pfb['dconfig']['tld_allow_gtld'] ?? NULL, $default_tlds);
-$pconfig['tld_allow_cctld']	= pfb_csv_list($pfb['dconfig']['tld_allow_cctld'] ?? NULL);
-$pconfig['tld_allow_itld']	= pfb_csv_list($pfb['dconfig']['tld_allow_itld'] ?? NULL);
-$pconfig['tld_allow_bgtld']	= pfb_csv_list($pfb['dconfig']['tld_allow_bgtld'] ?? NULL);
+$pconfig['tld_allow_gtld']	= pfb_csv_list(PfbConfig::read('dnsbl/tld_allow_gtld'), $default_tlds);
+$pconfig['tld_allow_cctld']	= pfb_csv_list(PfbConfig::read('dnsbl/tld_allow_cctld'));
+$pconfig['tld_allow_itld']	= pfb_csv_list(PfbConfig::read('dnsbl/tld_allow_itld'));
+$pconfig['tld_allow_bgtld']	= pfb_csv_list(PfbConfig::read('dnsbl/tld_allow_bgtld'));
 $pconfig['pfb_py_nolog']	= PfbConfig::read('dnsbl/pfb_py_nolog');
-$pconfig['pfb_regex_list']	= pfb_b64_text($pfb['dconfig']['pfb_regex_list'] ?? NULL);
-$pconfig['pfb_noaaaa_list']	= pfb_b64_text($pfb['dconfig']['pfb_noaaaa_list'] ?? NULL);
-$pconfig['pfb_gp_bypass_list']	= pfb_b64_text($pfb['dconfig']['pfb_gp_bypass_list'] ?? NULL);
+$pconfig['pfb_regex_list']	= pfb_b64_text(PfbConfig::read('dnsbl/pfb_regex_list'));
+$pconfig['pfb_noaaaa_list']	= pfb_b64_text(PfbConfig::read('dnsbl/pfb_noaaaa_list'));
+$pconfig['pfb_gp_bypass_list']	= pfb_b64_text(PfbConfig::read('dnsbl/pfb_gp_bypass_list'));
 $pconfig['action']		= PfbConfig::read('dnsbl/action');
 $pconfig['aliaslog']		= PfbConfig::read('dnsbl/aliaslog');
 
@@ -131,7 +131,7 @@ $pconfig['aliasaddr_out']	= $pfb['dconfig']['aliasaddr_out']			?: '';
 $pconfig['autoproto_out']	= $pfb['dconfig']['autoproto_out']			?: 'any';
 $pconfig['agateway_out']	= $pfb['dconfig']['agateway_out']			?: 'default';
 
-$pconfig['whitelist']		= pfb_b64_text($pfb['dconfig']['whitelist'] ?? NULL);
+$pconfig['whitelist']		= pfb_b64_text(PfbConfig::read('dnsbl/whitelist'));
 
 $pconfig['top1m_enable']	= PfbConfig::read('dnsbl/top1m_enable');
 // Routed via the gateway (not the section array) so a stored legacy 'alexa'
@@ -142,10 +142,10 @@ $pconfig['top1m_source']		= PfbConfig::read('dnsbl/top1m_source')->toStored();
 $pconfig['top1m_count']		= PfbConfig::read('dnsbl/top1m_count');
 // 0 (unlimited) is meaningful, so don't use the ?: idiom (0 is falsy -> would reset to default).
 $pconfig['pfb_py_cache_max']	= (isset($pfb['dconfig']['pfb_py_cache_max']) && $pfb['dconfig']['pfb_py_cache_max'] !== '') ? $pfb['dconfig']['pfb_py_cache_max'] : '10000';
-$pconfig['top1m_inclusion']	= pfb_csv_list($pfb['dconfig']['top1m_inclusion'] ?? NULL, array('com','net','org','ca','co','io'));
+$pconfig['top1m_inclusion']	= pfb_csv_list(PfbConfig::read('dnsbl/top1m_inclusion'), array('com','net','org','ca','co','io'));
 
-$pconfig['tld_wildcard_exclusion']	= pfb_b64_text($pfb['dconfig']['tld_wildcard_exclusion'] ?? NULL);
-$pconfig['tld_wildcard_blacklist']	= pfb_b64_text($pfb['dconfig']['tld_wildcard_blacklist'] ?? NULL);
+$pconfig['tld_wildcard_exclusion']	= pfb_b64_text(PfbConfig::read('dnsbl/tld_wildcard_exclusion'));
+$pconfig['tld_wildcard_blacklist']	= pfb_b64_text(PfbConfig::read('dnsbl/tld_wildcard_blacklist'));
 
 // DoH/DoT/DoQ blocking — stored in pfblockerngsafesearch; read via gateway (registered keys)
 $pconfig['safesearch_doh']		= PfbConfig::read('ss/safesearch_doh');
@@ -837,10 +837,10 @@ if ($_POST) {
 
 		if (!$input_errors) {
 			$pfb_top1m_settings_before = array(
-				'enable'   => $pfb['dconfig']['top1m_enable'] ?? '',
-				'count'    => $pfb['dconfig']['top1m_count'] ?? '',
-				'tld'      => $pfb['dconfig']['top1m_inclusion'] ?? '',
-				'provider' => $pfb['dconfig']['top1m_source'] ?? '',
+				'enable'   => PfbConfig::read('dnsbl/top1m_enable')->toStored(),
+				'count'    => PfbConfig::read('dnsbl/top1m_count'),
+				'tld'      => PfbConfig::read('dnsbl/top1m_inclusion'),
+				'provider' => PfbConfig::read('dnsbl/top1m_source')->toStored(),
 			);
 
 			$pfb['dconfig']['pfb_dnsbl']		= pfb_filter($_POST['pfb_dnsbl'], PFB_FILTER_ON_OFF, 'dnsbl')		?: '';
@@ -948,9 +948,9 @@ if ($_POST) {
 			// the replacement download has been validated and published.
 			$pfb_top1m_provider = $_POST['top1m_source'] ?: 'tranco';
 			$pfb_top1m_identity_changed =
-				(($pfb['dconfig']['top1m_source'] ?? '') !== $pfb_top1m_provider) ||
+				(PfbConfig::read('dnsbl/top1m_source')->toStored() !== $pfb_top1m_provider) ||
 				($pfb_top1m_token_post !== '' &&
-					($pfb['dconfig']['top1m_token'] ?? '') !== $pfb_top1m_token_post);
+					PfbConfig::read('dnsbl/top1m_token') !== $pfb_top1m_token_post);
 			$pfb['dconfig']['top1m_source'] = $pfb_top1m_provider;
 
 			// top1m_token: masked/write-only -- blank means "keep the existing stored

--- a/src/usr/local/www/pfblockerng/pfblockerng_general.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_general.php
@@ -59,7 +59,7 @@ $pconfig['pfb_feed_internal_filter']	= PfbConfig::read('gen/pfb_feed_internal_fi
 
 // Exemptions from the internal-address feed-host check: IP addresses / CIDR ranges
 // (one per line) whose feeds are allowed even when they resolve internally.
-$pconfig['pfb_feed_internal_allowlist']	= (string) base64_decode($pfb['gconfig']['pfb_feed_internal_allowlist'] ?? '');
+$pconfig['pfb_feed_internal_allowlist']	= (string) base64_decode(PfbConfig::read('gen/pfb_feed_internal_allowlist'));
 
 $pconfig['pfb_scheduled_feed_updates'] = PfbConfig::read('gen/pfb_scheduled_feed_updates')->value;
 $pconfig['pfb_schedule_weekday'] = PfbConfig::read('gen/pfb_schedule_weekday');
@@ -101,11 +101,8 @@ $pconfig['log_syslog']			= PfbConfig::read('gen/log_syslog')->value;
 // the registered default ('0') applies when the key is absent (new install / upgrade).
 $pconfig['pfb_log_trim_margin_pct']	= PfbConfig::read('gen/pfb_log_trim_margin_pct');
 
-// issue #2851: the one global nested-pass timeout (seconds). Render the EFFECTIVE
-// budget from PfbConfig::readSection()'s raw gen-section mirror, then through the same
-// mixed-safe resolver both language seams use. A field-level read has no adapter and
-// would cast hostile arrays/floats before validation.
-$pconfig['pfb_reentry_timeout']		= (string) pfb_reentry_timeout($pfb['gconfig']['pfb_reentry_timeout'] ?? NULL);
+// The gateway normalizes before scalar coercion, using the shared timeout resolver.
+$pconfig['pfb_reentry_timeout']		= PfbConfig::read('gen/pfb_reentry_timeout');
 
 // issue #1669 slice C / #1888: client-side editor toggle (default on). Read via
 // PfbConfig::read so the registered default applies; pfb_syntax_highlight is a

--- a/src/usr/local/www/pfblockerng/pfblockerng_ip.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_ip.php
@@ -83,11 +83,10 @@ $pconfig['enable_float']	= PfbConfig::read('ip/enable_float');
 $pconfig['pass_order']		= $pfb['iconfig']['pass_order']				?: 'order_0';
 $pconfig['autorule_suffix']	= $pfb['iconfig']['autorule_suffix']			?: 'autorule';
 $pconfig['killstates']		= PfbConfig::read('ip/killstates');
-$pconfig['v4suppression']	= pfb_b64_text($pfb['iconfig']['v4suppression'] ?? NULL);
-// ADR-53 review finding B: '?? ""' on the array read -- v6suppression (unlike
-// v4suppression) is NEVER install-migrated, so it is absent from config.xml
-// on every install until this page's first post-upgrade save.
-$pconfig['v6suppression']	= pfb_b64_text($pfb['iconfig']['v6suppression'] ?? NULL);
+$pconfig['v4suppression']	= pfb_b64_text(PfbConfig::read('ip/v4suppression'));
+// v6suppression may remain absent until the first post-upgrade save; the registered
+// empty default reaches the same decoder fallback as the former guarded section read.
+$pconfig['v6suppression']	= pfb_b64_text(PfbConfig::read('ip/v6suppression'));
 
 // Select array options
 $options_asn_reporting 		= [	'disabled'	=> 'Disabled',

--- a/tests/php/Adr62DnsblCorpusManifestTest.php
+++ b/tests/php/Adr62DnsblCorpusManifestTest.php
@@ -33,6 +33,8 @@ final class Adr62DnsblCorpusManifestTest extends TestCase
 	private string $tmp;
 	private bool $hadPfb = false;
 	private array $originalPfb = [];
+	private bool $hadConfig;
+	private mixed $originalConfig;
 
 	/** @var list<array<string, string>> */
 	private array $feeds;
@@ -41,6 +43,9 @@ final class Adr62DnsblCorpusManifestTest extends TestCase
 	{
 		$this->hadPfb = array_key_exists('pfb', $GLOBALS);
 		$this->originalPfb = $GLOBALS['pfb'] ?? [];
+		$this->hadConfig = array_key_exists('config', $GLOBALS);
+		$this->originalConfig = $GLOBALS['config'] ?? NULL;
+		$GLOBALS['config'] = [];
 
 		$this->tmp = sys_get_temp_dir() . '/adr62_corpus_' . uniqid('', true);
 		mkdir("{$this->tmp}/dnsbl", 0777, true);
@@ -64,9 +69,9 @@ final class Adr62DnsblCorpusManifestTest extends TestCase
 			'dnsblconfig'        => [
 				'tld_wildcard_blacklist' => base64_encode("zip"),
 				'tld_wildcard_exclusion' => base64_encode("excluded.com"),
-				'whitelist'  => base64_encode("www.adblock.com\r\n.wildwhite.org\r\nphishing.net"),
 			],
 		]);
+		PfbConfig::writeSystem('dnsbl/whitelist', base64_encode("www.adblock.com\r\n.wildwhite.org\r\nphishing.net"));
 		file_put_contents("{$this->tmp}/db/pfbalexawhitelist.txt", "popularcdn.com\n");
 
 		$json = file_get_contents(self::CORPUS_DIR . '/feeds.json');
@@ -82,6 +87,11 @@ final class Adr62DnsblCorpusManifestTest extends TestCase
 			$GLOBALS['pfb'] = $this->originalPfb;
 		} else {
 			unset($GLOBALS['pfb']);
+		}
+		if ($this->hadConfig) {
+			$GLOBALS['config'] = $this->originalConfig;
+		} else {
+			unset($GLOBALS['config']);
 		}
 		rmdir_recursive($this->tmp);
 	}

--- a/tests/php/CfgGatewayTest.php
+++ b/tests/php/CfgGatewayTest.php
@@ -3012,12 +3012,9 @@ final class CfgGatewayTest extends TestCase
 	// -----------------------------------------------------------------------
 
 	/**
-	 * Parity oracle: every fixture entry (bare key -> {section, default,
-	 * read_adapter, write_adapter, write_priv?}), captured from the pre-#1931
-	 * registry, must still resolve identically once its section is flipped to
-	 * an alias via PFB_SECTIONS and joined onto the bare key. Iterates the
-	 * FIXTURE, never the live registry -- additions to the registry stay
-	 * legal; only a removal or a changed field on an existing entry fails.
+	 * Parity oracle: the pre-#1931 fixture's paths, defaults and write privileges
+	 * survive section re-keying. Iterate the historical fixture so additions stay
+	 * legal; adapter behaviour is covered by the gateway input/output tests.
 	 *
 	 * issue #1907: the fixture pins the #1931 re-key TRANSITION (that flipping bare
 	 * keys to alias/bare paths changed nothing else), not future default-value

--- a/tests/php/CfgGatewayTest.php
+++ b/tests/php/CfgGatewayTest.php
@@ -36,6 +36,18 @@ require_once __DIR__ . '/LogTypesFixture.php';
  */
 final class CfgGatewayTest extends TestCase
 {
+
+	private const ISSUE_3137_TOGGLES = [
+		'dnsbl/top1m_enable' => 'top1m_enable',
+		'dnsbl/pfb_regex'    => 'pfb_regex',
+		'dnsbl/pfb_cname'    => 'pfb_cname',
+		'dnsbl/tld_allow'    => 'tld_allow',
+		'dnsbl/pfb_py_nolog' => 'pfb_py_nolog',
+		'dnsbl/pfb_noaaaa'   => 'pfb_noaaaa',
+		'dnsbl/pfb_gp'       => 'pfb_gp',
+	];
+
+	private const DNSBL_SECTION = 'installedpackages/pfblockerngdnsblsettings/config/0';
 	// -----------------------------------------------------------------------
 	// Test fixture helpers
 	// -----------------------------------------------------------------------
@@ -52,6 +64,71 @@ final class CfgGatewayTest extends TestCase
 	private function seedConfig(string $path, mixed $value): void
 	{
 		config_set_path($path, $value);
+	}
+
+	/** @return iterable<string,array{0:string,1:string,2:bool,3:mixed,4:PfbToggle}> */
+	public static function issue3137ToggleStates(): iterable
+	{
+		$states = [
+			'absent'     => [FALSE, NULL, PfbToggle::Off],
+			'null'       => [TRUE, NULL, PfbToggle::Off],
+			'empty'      => [TRUE, '', PfbToggle::Off],
+			'on'         => [TRUE, 'on', PfbToggle::On],
+			'mixed On'   => [TRUE, 'On', PfbToggle::On],
+			'mixed oN'   => [TRUE, 'oN', PfbToggle::On],
+			'legacy off' => [TRUE, 'off', PfbToggle::Off],
+			'junk'       => [TRUE, 'yes', PfbToggle::Off],
+			'non-scalar' => [TRUE, ['on'], PfbToggle::Off],
+		];
+
+		foreach (self::ISSUE_3137_TOGGLES as $key => $bare) {
+			foreach ($states as $state => [$seed, $raw, $expected]) {
+				yield "{$key} [{$state}]" => [$key, $bare, $seed, $raw, $expected];
+			}
+		}
+	}
+
+	#[DataProvider('issue3137ToggleStates')]
+	public function testIssue3137TogglesAdaptAtTheGateway(
+		string $key,
+		string $bare,
+		bool $seed,
+		mixed $raw,
+		PfbToggle $expected
+	): void {
+		$path = self::DNSBL_SECTION . "/{$bare}";
+		if ($seed) {
+			$this->seedConfig($path, $raw);
+		}
+
+		$actual = PfbConfig::read($key);
+		$this->assertSame($expected, $actual,
+			"{$key} must expose PfbToggle; only case-insensitive 'on' may enable it");
+
+		PfbConfig::write($key, $actual);
+		$this->assertSame($expected->toStored(), config_get_path($path),
+			"{$key} write(read()) must emit canonical on/empty storage");
+	}
+
+	public function testIssue3137SectionReadsStayRawAndSectionWritesLeaveForeignSiblingsUntouched(): void
+	{
+		$raw = ['foreign' => ['nested' => 'keep']];
+		foreach (self::ISSUE_3137_TOGGLES as $bare) {
+			$raw[$bare] = 'On';
+		}
+		$this->seedConfig(self::DNSBL_SECTION, $raw);
+
+		$this->assertSame($raw, PfbConfig::readSection(self::DNSBL_SECTION),
+			'readSection is the raw storage boundary even when fields have adapters');
+
+		PfbConfig::writeSection(self::DNSBL_SECTION, $raw);
+		$stored = config_get_path(self::DNSBL_SECTION);
+		$this->assertSame(['nested' => 'keep'], $stored['foreign'],
+			'a section save must not alter an unregistered sibling');
+		foreach (self::ISSUE_3137_TOGGLES as $bare) {
+			$this->assertSame('on', $stored[$bare],
+				"section writes must apply the adopted toggle adapter to {$bare}");
+		}
 	}
 
 	// -----------------------------------------------------------------------
@@ -1033,7 +1110,7 @@ final class CfgGatewayTest extends TestCase
 	 * exactly the wait it ran before.
 	 *
 	 * Scenario:
-	 *   Background: pfb_reentry_timeout is a plain-string field; default = '1800'.
+	 *   Background: pfb_reentry_timeout returns normalized seconds as a string.
 	 *     Given no stored value.
 	 *     When PfbConfig::read('gen/pfb_reentry_timeout').
 	 *     Then '1800' is returned.
@@ -1054,7 +1131,7 @@ final class CfgGatewayTest extends TestCase
 	 * Both accepted bounds round-trip losslessly (write(read(v)) == v).
 	 *
 	 * Scenario:
-	 *   Background: pfb_reentry_timeout is a plain-string field (no adapter); the owner
+	 *   Background: pfb_reentry_timeout normalizes before scalar coercion; the owner
 	 *     ruling accepts whole seconds 60 through 7200 inclusive.
 	 *     Given stored = '60' / '7200'.
 	 *     When read then write back.
@@ -2489,6 +2566,7 @@ final class CfgGatewayTest extends TestCase
 			'pfb_cfg_idn_mode_read'         => ['on', 'confusable', 'off', 'all', 'junk'],
 			'pfb_cfg_top1m_source_read'     => ['tranco', 'cisco', 'openpagerank', 'majestic', 'cloudflare', 'alexa', 'domcop', 'junk'],
 			'pfb_cfg_alias_delta_mode_read' => ['auto', 'delta', 'replace', '', 'junk'],
+			'pfb_cfg_reentry_timeout_adapter' => ['60', '7200', '5', 'junk'],
 			'pfb_cfg_feed_suffix_policy_read' => ['ignore', 'apex', 'honor', '', 'junk'],
 		];
 
@@ -2989,8 +3067,6 @@ final class CfgGatewayTest extends TestCase
 			} else {
 				$this->assertSame($expected['default'], $actual['default'], "{$path_key}: default must match the fixture");
 			}
-			$this->assertSame($expected['read_adapter'], $actual['read_adapter'], "{$path_key}: read_adapter must match the fixture");
-			$this->assertSame($expected['write_adapter'], $actual['write_adapter'], "{$path_key}: write_adapter must match the fixture");
 			$this->assertSame(
 				array_key_exists('write_priv', $expected),
 				array_key_exists('write_priv', $actual),

--- a/tests/php/DnsblFreshPconfigTest.php
+++ b/tests/php/DnsblFreshPconfigTest.php
@@ -5,36 +5,26 @@ declare(strict_types=1);
 use PHPUnit\Framework\TestCase;
 
 /**
- * Fresh DNSBL-page $pconfig assembly guard (issue #1768).
+ * DNSBL-page $pconfig consumer guard (issues #1768 and #3137).
  *
- * A fresh install / first page load runs pfblockerng_dnsbl.php's $pconfig
- * assembly (:49-132) against an EMPTY installedpackages/pfblockerngdnsblsettings
- * section ($pfb['dconfig'] = [] -- the shape PfbConfig::readSection() returns
- * when the section has never been saved). Every explode()/base64_decode()
- * call in that block reads its $pfb['dconfig'][...] operand directly; on an
- * absent key that operand is NULL, and PHP 8.1+ deprecates passing NULL to
- * explode()'s/base64_decode()'s non-nullable string parameter -- these are
- * the "Passing null" deprecations issue #1768 reports blocking the release
- * functional-UI gate.
+ * The page carries top-level execution and cannot be require()d off-appliance, so its
+ * real $pconfig assembly block is eval-extracted as an executable function. Tests seed
+ * authoritative config.xml state separately from a deliberately stale $pfb['dconfig']
+ * mirror: consumer assertions therefore fail while registered fields still bypass
+ * PfbConfig::read(), without asserting on source text.
  *
- * Scope: the assertions below check only the "Passing null" deprecation
- * class. The SAME block also has ~20 untouched bare
- * `$pfb['dconfig']['key'] ?: default` reads that still emit "Undefined array
- * key" warnings on an absent key -- those are the pre-existing, explicitly
- * out-of-scope "3e bare-read class" (#1768 brief); asserting the FULL
- * diagnostics list empty would conflate the two and this test would never
- * go green.
+ * The original #1768 contract remains: fresh and populated CSV/base64 inputs emit no
+ * "Passing null" deprecations. Issue #3137 additionally pins empty/default, stored "0",
+ * populated/multiline, malformed, missing, and decode-exactly-once behavior while those
+ * fields move to the gateway. Other pre-existing diagnostics remain outside this class.
  *
- * The page carries top-level execution and cannot be require()d
- * off-appliance, so the $pconfig block is eval-extracted verbatim from the
- * REAL source (CategoryEditFreshRowPconfigTest's pattern, issue #1211),
- * anchored on the unique `$pconfig = array();` line through the trailing
- * `tld_wildcard_blacklist` assignment -- non-greedy, so the regex matches whatever the
- * RHS guard state is (pre-fix bare read or post-fix `?? ''`-guarded) and
- * survives the fix -- and run as a pure function of ($dconfig, $default_tlds).
+ * Extraction is anchored on the unique `$pconfig = array();` line through the trailing
+ * `tld_wildcard_blacklist` assignment and runs as a function of the raw section mirror,
+ * registered config state, and local-domain-derived default TLD list.
  */
 final class DnsblFreshPconfigTest extends TestCase
 {
+	private const DNSBL_SECTION = 'installedpackages/pfblockerngdnsblsettings/config/0';
 	public static function setUpBeforeClass(): void
 	{
 		$src = file_get_contents(
@@ -64,8 +54,13 @@ final class DnsblFreshPconfigTest extends TestCase
 	}
 
 	/** @return array{0: array, 1: string[]} [$pconfig, $diagnostics] */
-	private function runCapturingDiagnostics(array $dconfig, array $default_tlds): array
-	{
+	private function runCapturingDiagnostics(
+		array $dconfig,
+		array $default_tlds,
+		?array $stored = NULL
+	): array {
+		$GLOBALS['config'] = [];
+		config_set_path(self::DNSBL_SECTION, $stored ?? $dconfig);
 		$diagnostics = [];
 		set_error_handler(static function (int $errno, string $errstr) use (&$diagnostics): bool {
 			$diagnostics[] = $errstr;
@@ -141,5 +136,54 @@ final class DnsblFreshPconfigTest extends TestCase
 		$this->assertSame(['com', 'net', 'org'], $pconfig['top1m_inclusion']);
 		$this->assertSame('example.test', $pconfig['tld_wildcard_exclusion']);
 		$this->assertSame('bad.example', $pconfig['tld_wildcard_blacklist']);
+	}
+
+	public function testListAndTextareaConsumersUseAuthoritativeGatewayValuesWithoutChangingFallbacks(): void
+	{
+		$mirror = [
+			'dnsbl_allow_int'        => 'mirror',
+			'tld_allow_gtld'         => 'mirror',
+			'tld_allow_cctld'        => 'mirror',
+			'tld_allow_itld'         => 'mirror',
+			'tld_allow_bgtld'        => 'mirror',
+			'pfb_regex_list'         => base64_encode('mirror'),
+			'pfb_noaaaa_list'        => base64_encode('mirror'),
+			'pfb_gp_bypass_list'     => base64_encode('mirror'),
+			'whitelist'              => base64_encode('mirror'),
+			'top1m_inclusion'        => 'mirror',
+			'tld_wildcard_exclusion' => base64_encode('mirror'),
+			'tld_wildcard_blacklist' => base64_encode('mirror'),
+		];
+		$stored = [
+			'dnsbl_allow_int'        => '0',
+			'tld_allow_gtld'         => '',
+			'tld_allow_cctld'        => 'uk,de',
+			'tld_allow_bgtld'        => 'app,dev',
+			'pfb_regex_list'         => base64_encode("foo\nbar"),
+			'pfb_noaaaa_list'        => '%%%',
+			'pfb_gp_bypass_list'     => base64_encode('0'),
+			'whitelist'              => base64_encode(base64_encode('once')),
+			'top1m_inclusion'        => '',
+			'tld_wildcard_exclusion' => base64_encode("one\ntwo"),
+		];
+		$default_tlds = ['arpa', 'corp', 'com', 'net'];
+
+		[$pconfig, $diagnostics] = $this->runCapturingDiagnostics($mirror, $default_tlds, $stored);
+
+		$this->assertSame([], self::nullDeprecationsOnly($diagnostics));
+		$this->assertSame(['0'], $pconfig['dnsbl_allow_int'], "stored CSV '0' is one entry");
+		$this->assertSame($default_tlds, $pconfig['tld_allow_gtld'],
+			'an empty stored gTLD list keeps the local-domain-derived display fallback');
+		$this->assertSame(['uk', 'de'], $pconfig['tld_allow_cctld']);
+		$this->assertSame([], $pconfig['tld_allow_itld'], 'a missing CSV field remains an empty list');
+		$this->assertSame(['app', 'dev'], $pconfig['tld_allow_bgtld']);
+		$this->assertSame("foo\nbar", $pconfig['pfb_regex_list']);
+		$this->assertSame('', $pconfig['pfb_noaaaa_list'], 'malformed base64 keeps the current empty fallback');
+		$this->assertSame('0', $pconfig['pfb_gp_bypass_list'], "decoded textarea '0' must survive");
+		$this->assertSame(base64_encode('once'), $pconfig['whitelist'],
+			'a gateway-backed textarea must be decoded exactly once');
+		$this->assertSame(['com', 'net', 'org', 'ca', 'co', 'io'], $pconfig['top1m_inclusion']);
+		$this->assertSame("one\ntwo", $pconfig['tld_wildcard_exclusion']);
+		$this->assertSame('', $pconfig['tld_wildcard_blacklist'], 'a missing textarea remains empty');
 	}
 }

--- a/tests/php/DnsblFreshPconfigTest.php
+++ b/tests/php/DnsblFreshPconfigTest.php
@@ -59,17 +59,24 @@ final class DnsblFreshPconfigTest extends TestCase
 		array $default_tlds,
 		?array $stored = NULL
 	): array {
-		$GLOBALS['config'] = [];
-		config_set_path(self::DNSBL_SECTION, $stored ?? $dconfig);
+		$hadConfig = array_key_exists('config', $GLOBALS);
+		$previousConfig = $GLOBALS['config'] ?? NULL;
 		$diagnostics = [];
 		set_error_handler(static function (int $errno, string $errstr) use (&$diagnostics): bool {
 			$diagnostics[] = $errstr;
 			return TRUE;
 		});
 		try {
+			$GLOBALS['config'] = [];
+			config_set_path(self::DNSBL_SECTION, $stored ?? $dconfig);
 			$pconfig = pfb_dnsbl_oracle_fresh_pconfig($dconfig, $default_tlds);
 		} finally {
 			restore_error_handler();
+			if ($hadConfig) {
+				$GLOBALS['config'] = $previousConfig;
+			} else {
+				unset($GLOBALS['config']);
+			}
 		}
 		return [$pconfig, $diagnostics];
 	}
@@ -159,7 +166,7 @@ final class DnsblFreshPconfigTest extends TestCase
 			'tld_allow_gtld'         => '',
 			'tld_allow_cctld'        => 'uk,de',
 			'tld_allow_bgtld'        => 'app,dev',
-			'pfb_regex_list'         => base64_encode("foo\nbar"),
+			'pfb_regex_list'         => base64_encode(" foo\nbar "),
 			'pfb_noaaaa_list'        => '%%%',
 			'pfb_gp_bypass_list'     => base64_encode('0'),
 			'whitelist'              => base64_encode(base64_encode('once')),
@@ -177,7 +184,7 @@ final class DnsblFreshPconfigTest extends TestCase
 		$this->assertSame(['uk', 'de'], $pconfig['tld_allow_cctld']);
 		$this->assertSame([], $pconfig['tld_allow_itld'], 'a missing CSV field remains an empty list');
 		$this->assertSame(['app', 'dev'], $pconfig['tld_allow_bgtld']);
-		$this->assertSame("foo\nbar", $pconfig['pfb_regex_list']);
+		$this->assertSame(" foo\nbar ", $pconfig['pfb_regex_list']);
 		$this->assertSame('', $pconfig['pfb_noaaaa_list'], 'malformed base64 keeps the current empty fallback');
 		$this->assertSame('0', $pconfig['pfb_gp_bypass_list'], "decoded textarea '0' must survive");
 		$this->assertSame(base64_encode('once'), $pconfig['whitelist'],

--- a/tests/php/GeneralAdvancedTimeoutUiTest.php
+++ b/tests/php/GeneralAdvancedTimeoutUiTest.php
@@ -31,19 +31,6 @@ final class GeneralAdvancedTimeoutUiTest extends TestCase
 		return $source;
 	}
 
-	public function testTheFieldRendersTheRawSectionValueThroughTheSharedResolver(): void
-	{
-		$source = self::source();
-
-		$this->assertMatchesRegularExpression(
-			"/\\\$pconfig\['pfb_reentry_timeout'\]\s*=\s*\(string\) pfb_reentry_timeout\(\\\$pfb\['gconfig'\]\['pfb_reentry_timeout'\] \?\? NULL\)/",
-			$source,
-			'the page must resolve the raw section value before any gateway scalar cast can alter hostile stored input'
-		);
-		$this->assertStringNotContainsString("PfbConfig::read('gen/pfb_reentry_timeout')", $source,
-			'an adapter-less field read would cast hostile stored arrays and floats before validation');
-	}
-
 	public function testTheSaveCanonicalizesThroughTheSharedResolverBeforePersisting(): void
 	{
 		$source = self::source();

--- a/tests/php/Issue1792SweepSitesTest.php
+++ b/tests/php/Issue1792SweepSitesTest.php
@@ -31,6 +31,24 @@ final class Issue1792SweepSitesTest extends TestCase
 	private const IP_PAGE = 'src/usr/local/www/pfblockerng/pfblockerng_ip.php';
 	private const ALERTS_PAGE = 'src/usr/local/www/pfblockerng/pfblockerng_alerts.php';
 	private const BLACKLIST_PAGE = 'src/usr/local/www/pfblockerng/pfblockerng_blacklist.php';
+	private bool $hadConfig;
+	private mixed $originalConfig;
+
+	protected function setUp(): void
+	{
+		$this->hadConfig = array_key_exists('config', $GLOBALS);
+		$this->originalConfig = $GLOBALS['config'] ?? NULL;
+		$GLOBALS['config'] = [];
+	}
+
+	protected function tearDown(): void
+	{
+		if ($this->hadConfig) {
+			$GLOBALS['config'] = $this->originalConfig;
+		} else {
+			unset($GLOBALS['config']);
+		}
+	}
 
 	public static function setUpBeforeClass(): void
 	{
@@ -43,7 +61,6 @@ final class Issue1792SweepSitesTest extends TestCase
 	{
 		$default_tlds = ['com', 'net', 'org'];
 		$out = pfb_test_1792_eval_site(self::DNSBL_PAGE, "\$pconfig['tld_allow_gtld']", [
-			'pfb'          => ['dconfig' => []],
 			'pconfig'      => [],
 			'default_tlds' => $default_tlds,
 		]);
@@ -53,8 +70,8 @@ final class Issue1792SweepSitesTest extends TestCase
 
 	public function testEmptyAlexaInclusionYieldsItsInlineDefault(): void
 	{
+		PfbConfig::writeSystem('dnsbl/top1m_inclusion', '');
 		$out = pfb_test_1792_eval_site(self::DNSBL_PAGE, "\$pconfig['top1m_inclusion']", [
-			'pfb'     => ['dconfig' => ['top1m_inclusion' => '']],
 			'pconfig' => [],
 		]);
 		$this->assertSame(['com', 'net', 'org', 'ca', 'co', 'io'], $out['pconfig']['top1m_inclusion'],
@@ -86,8 +103,8 @@ final class Issue1792SweepSitesTest extends TestCase
 
 	public function testStoredZeroWhitelistSurvivesToTheForm(): void
 	{
+		PfbConfig::writeSystem('dnsbl/whitelist', base64_encode('0'));
 		$out = pfb_test_1792_eval_site(self::DNSBL_PAGE, "\$pconfig['whitelist']", [
-			'pfb'     => ['dconfig' => ['whitelist' => base64_encode('0')]],
 			'pconfig' => [],
 		]);
 		$this->assertSame('0', $out['pconfig']['whitelist'],
@@ -97,7 +114,6 @@ final class Issue1792SweepSitesTest extends TestCase
 	public function testAbsentWhitelistStillRendersEmpty(): void
 	{
 		$out = pfb_test_1792_eval_site(self::DNSBL_PAGE, "\$pconfig['whitelist']", [
-			'pfb'     => ['dconfig' => []],
 			'pconfig' => [],
 		]);
 		$this->assertSame('', $out['pconfig']['whitelist']);

--- a/tests/php/ReentryTimeoutSettingTest.php
+++ b/tests/php/ReentryTimeoutSettingTest.php
@@ -35,11 +35,15 @@ final class ReentryTimeoutSettingTest extends TestCase
 
 	/** The stored key the one global budget lives under (gen section). */
 	private const KEY = 'pfb_reentry_timeout';
+	private const PATH = 'installedpackages/pfblockerng/config/0/pfb_reentry_timeout';
 
 	private string $tmp;
 	/** @var array<string, mixed> */
 	private array $originalPfb;
 	private bool $hadPfb;
+	/** @var array<string, mixed> */
+	private array $originalConfig;
+	private bool $hadConfig;
 
 	protected function setUp(): void
 	{
@@ -47,6 +51,9 @@ final class ReentryTimeoutSettingTest extends TestCase
 		$this->assertTrue(mkdir($this->tmp, 0700, TRUE));
 		$this->hadPfb      = array_key_exists('pfb', $GLOBALS);
 		$this->originalPfb = $GLOBALS['pfb'] ?? [];
+		$this->hadConfig      = array_key_exists('config', $GLOBALS);
+		$this->originalConfig = $GLOBALS['config'] ?? [];
+		$GLOBALS['config']    = [];
 		// A pristine mirror: no stored setting at all, which is the upgrade/new-install case.
 		$GLOBALS['pfb'] = [
 			'log'    => "{$this->tmp}/pfblockerng.log",
@@ -62,16 +69,21 @@ final class ReentryTimeoutSettingTest extends TestCase
 		} else {
 			unset($GLOBALS['pfb']);
 		}
+		if ($this->hadConfig) {
+			$GLOBALS['config'] = $this->originalConfig;
+		} else {
+			unset($GLOBALS['config']);
+		}
 		foreach (glob("{$this->tmp}/*") ?: [] as $file) {
 			@unlink($file);
 		}
 		@rmdir($this->tmp);
 	}
 
-	/** Seed the gen-section mirror pfb_global() populates, exactly as a stored value would. */
+	/** Seed authoritative config.xml state; the runtime mirror may be absent or stale. */
 	private function store(mixed $raw): void
 	{
-		$GLOBALS['pfb']['config'][self::KEY] = $raw;
+		config_set_path(self::PATH, $raw);
 	}
 
 	/**
@@ -194,7 +206,7 @@ final class ReentryTimeoutSettingTest extends TestCase
 	public function testAnAbsentSettingKeepsTheFiniteDefaultOnTheSeam(): void
 	{
 		// Before: nothing stored -- the upgrade case the issue names first.
-		$this->assertArrayNotHasKey(self::KEY, $GLOBALS['pfb']['config']);
+		$this->assertNull(config_get_path(self::PATH));
 
 		$this->assertSame(1800, pfb_reentry_budget(NULL), 'an absent setting must resolve to the finite default');
 		$this->assertSame('1800', $this->durationToken(pfb_reentry_cmd('al', ['scheduled'], "{$this->tmp}/out")),
@@ -213,6 +225,7 @@ final class ReentryTimeoutSettingTest extends TestCase
 			'negative'   => ['-1'],
 			'overflow'   => ['99999999999999999999'],
 			'array'      => [['5']],
+			'float'      => [900.0],
 		];
 	}
 
@@ -221,7 +234,14 @@ final class ReentryTimeoutSettingTest extends TestCase
 	{
 		$this->store($raw);
 
-		$secs = $this->durationToken(pfb_reentry_cmd('bls', ['scheduled', 'x'], "{$this->tmp}/out"));
+		set_error_handler(static function (int $severity, string $message, string $file, int $line): never {
+			throw new ErrorException($message, 0, $severity, $file, $line);
+		});
+		try {
+			$secs = $this->durationToken(pfb_reentry_cmd('bls', ['scheduled', 'x'], "{$this->tmp}/out"));
+		} finally {
+			restore_error_handler();
+		}
 
 		$this->assertSame((string) PFB_REENTRY_TIMEOUT, $secs,
 			"a hostile stored budget must fall back to the finite default; got [{$secs}]");
@@ -260,6 +280,15 @@ final class ReentryTimeoutSettingTest extends TestCase
 		$this->assertSame(900, pfb_reentry_budget(''), 'a degraded caller budget must fall through to the stored setting');
 		$this->assertSame(900, pfb_reentry_budget(0), 'a zero caller budget must fall through to the stored setting');
 		$this->assertSame(900, pfb_reentry_budget(-1), 'a negative caller budget must fall through to the stored setting');
+	}
+
+	public function testAStaleSectionMirrorCannotOverrideTheGatewaySetting(): void
+	{
+		$this->store('900');
+		$GLOBALS['pfb']['config'][self::KEY] = '60';
+
+		$this->assertSame(900, pfb_reentry_budget(NULL),
+			'the authoritative field gateway must win over a stale pfb_global section mirror');
 	}
 
 	public function testTheReaperModeAndTheFileCaptureSurviveAConfiguredBudget(): void

--- a/tests/php/ToggleSectionMirrorTypeTest.php
+++ b/tests/php/ToggleSectionMirrorTypeTest.php
@@ -6,43 +6,21 @@ use PHPUnit\Framework\Attributes\CoversFunction;
 use PHPUnit\Framework\TestCase;
 
 /**
- * issue #1887 — on/off mirrors read straight from a raw section blob carry PfbToggle too.
+ * Runtime identity coverage for DNSBL toggle mirrors initialized by pfb_global().
  *
- * ToggleMirrorTypeTest covers the mirrors sourced through PfbConfig::read(). These are the
- * other half: pfb_global() also publishes toggle mirrors by reaching directly into the raw
- * $pfb['dnsblconfig'] / $pfb['ipconfig'] section arrays, e.g.
+ * These fields historically came from the raw dnsbl section and were adapted at each
+ * assignment. Issue #3137 moves the remaining seven registered toggles to field-level
+ * PfbConfig::read() calls, so the runtime mirror must be the exact PfbToggle returned by
+ * the gateway. pfb_regex_cap already used that route and stays in the matrix as the
+ * established sibling.
  *
- *     $pfb['dnsbl_regex'] = $pfb['dnsblconfig']['pfb_regex'];
- *
- * Those bypass the gateway entirely, so they arrived as raw stored tokens and every
- * consumer compared them against 'on' by hand — the same untyped pattern, just reached by
- * a different route. Typing them at the single assignment site converts every downstream
- * comparison at once.
- *
- * The raw section arrays themselves stay strings: they are the storage boundary, and
- * $pfb['config'] / ['ipconfig'] / ['dnsblconfig'] are consumed by code that legitimately
- * wants the stored form (the py_unbound.ini writer, section write-back). Only the named
- * per-feature mirrors are typed.
- *
- * Scope note: mirrors assigned inside sync_package_pfblockerng() rather than pfb_global()
- * (float, dup, agg, global_log, dnsbl_control, dnsbl_control_legacy) are converted in the
- * same pass but are not asserted here — invoking that function off-box is not viable, so
- * their coverage rides the existing apply-path suites.
- *
- * issue #1907 (#1921 S3): dnsbl_res_cache, dnsbl_py_reply and supp moved OUT of this
- * file -- pfb_global() now sources all three through PfbConfig::read() (registered,
- * default 'on'), so their absent-key polarity is no longer PfbToggle::Off; they belong
- * to ToggleMirrorTypeTest now, alongside dnsbl_hsts.
- *
- * Seeding mirrors DnsblVipDisableNoticeTest::seedGlobalPrereqs().
+ * The raw section itself remains strings for storage-boundary consumers; only the named
+ * runtime mirrors are enums.
  */
 #[CoversFunction('pfb_global')]
 final class ToggleSectionMirrorTypeTest extends TestCase
 {
-	/**
-	 * Toggle mirrors pfb_global() publishes from a raw section blob, with the DNSBL
-	 * settings key each one reads.
-	 */
+	/** Runtime mirror => registered DNSBL key. */
 	private const SECTION_MIRRORS = [
 		'dnsbl_top1m'     => 'top1m_enable',
 		'dnsbl_regex'     => 'pfb_regex',
@@ -109,9 +87,7 @@ final class ToggleSectionMirrorTypeTest extends TestCase
 		}
 	}
 
-	/**
-	 * Every section-blob toggle mirror is a PfbToggle after pfb_global().
-	 */
+	/** Every DNSBL toggle mirror is a PfbToggle after pfb_global(). */
 	public function testEverySectionMirrorIsAPfbToggleInstance(): void
 	{
 		$this->seedAll('on');
@@ -123,7 +99,7 @@ final class ToggleSectionMirrorTypeTest extends TestCase
 			$this->assertInstanceOf(
 				PfbToggle::class,
 				$GLOBALS['pfb'][$mirror],
-				"\$pfb['{$mirror}'] reads a raw section token and must be typed at its assignment"
+				"\$pfb['{$mirror}'] must carry the gateway's PfbToggle runtime identity"
 			);
 		}
 	}
@@ -146,14 +122,7 @@ final class ToggleSectionMirrorTypeTest extends TestCase
 		}
 	}
 
-	/**
-	 * An unset key surfaces as Off — not NULL, not ''.
-	 *
-	 * The polarity pair for the test above: without it, a mirror hard-wired to On would
-	 * satisfy the On case. Unset rather than 'off' because these keys reach pfb_global()
-	 * straight from the section array, so absent is the state a fresh install actually
-	 * presents, and the untyped code relied on NULL/'' being falsy.
-	 */
+	/** An absent registered key surfaces as Off — not NULL, not ''. */
 	public function testAbsentSectionKeySurfacesAsOff(): void
 	{
 		pfb_global();
@@ -167,20 +136,4 @@ final class ToggleSectionMirrorTypeTest extends TestCase
 		}
 	}
 
-	/**
-	 * No section mirror holds a raw string in any polarity.
-	 */
-	public function testNoSectionMirrorHoldsARawToken(): void
-	{
-		$this->seedAll('off');
-
-		pfb_global();
-
-		foreach (array_keys(self::SECTION_MIRRORS) as $mirror) {
-			$this->assertIsNotString(
-				$GLOBALS['pfb'][$mirror] ?? NULL,
-				"\$pfb['{$mirror}'] still holds a raw token"
-			);
-		}
-	}
 }

--- a/tests/php/UnboundPythonSourcesTest.php
+++ b/tests/php/UnboundPythonSourcesTest.php
@@ -39,6 +39,8 @@ final class UnboundPythonSourcesTest extends TestCase
 	private string $tmp;
 	private bool $hadPfb = FALSE;
 	private array $originalPfb = [];
+	private bool $hadConfig;
+	private mixed $originalConfig;
 
 	protected function setUp(): void
 	{
@@ -46,6 +48,9 @@ final class UnboundPythonSourcesTest extends TestCase
 		// replaced dnsblconfig subtree) don't leak into later test classes.
 		$this->hadPfb = array_key_exists('pfb', $GLOBALS);
 		$this->originalPfb = $GLOBALS['pfb'] ?? [];
+		$this->hadConfig = array_key_exists('config', $GLOBALS);
+		$this->originalConfig = $GLOBALS['config'] ?? NULL;
+		$GLOBALS['config'] = [];
 
 		$this->tmp = sys_get_temp_dir() . '/pfb_sources_' . uniqid('', TRUE);
 		mkdir("{$this->tmp}/dnsbl", 0777, TRUE);
@@ -66,7 +71,6 @@ final class UnboundPythonSourcesTest extends TestCase
 			'dnsblconfig'        => [
 				'tld_wildcard_blacklist' => '',
 				'tld_wildcard_exclusion' => '',
-				'whitelist'              => '',
 			],
 		]);
 
@@ -88,6 +92,11 @@ final class UnboundPythonSourcesTest extends TestCase
 			$GLOBALS['pfb'] = $this->originalPfb;
 		} else {
 			unset($GLOBALS['pfb']);
+		}
+		if ($this->hadConfig) {
+			$GLOBALS['config'] = $this->originalConfig;
+		} else {
+			unset($GLOBALS['config']);
 		}
 
 		rmdir_recursive($this->tmp);
@@ -618,8 +627,7 @@ final class UnboundPythonSourcesTest extends TestCase
 	public function testWhitelistKeepsValidDomainAndWildcardLinesUnchanged(): void
 	{
 		// Plain domain + leading-dot wildcard both pass through unchanged, no log.
-		$GLOBALS['pfb']['dnsblconfig']['whitelist'] =
-			base64_encode("good.example.com\r\n.wild.example.com");
+		PfbConfig::writeSystem('dnsbl/whitelist', base64_encode("good.example.com\r\n.wild.example.com"));
 
 		$this->assertSame(['good.example.com', '.wild.example.com'], pfb_dnsbl_whitelist_lines());
 		$this->assertSame('', $this->logContents(), 'valid lines must not be logged');
@@ -628,8 +636,7 @@ final class UnboundPythonSourcesTest extends TestCase
 	public function testWhitelistSkipsAndLogsNonDomainLine(): void
 	{
 		// Given one failing line among valid ones, and an empty log
-		$GLOBALS['pfb']['dnsblconfig']['whitelist'] =
-			base64_encode("good.example.com\r\nbad domain;ls\r\n.wild.example.com");
+		PfbConfig::writeSystem('dnsbl/whitelist', base64_encode("good.example.com\r\nbad domain;ls\r\n.wild.example.com"));
 		$this->assertSame('', $this->logContents(), 'log must start empty');
 
 		// When the manifest whitelist is collected

--- a/tests/php/fixtures/function_inventory.json
+++ b/tests/php/fixtures/function_inventory.json
@@ -1168,6 +1168,19 @@
             }
         ]
     },
+    "pfb_cfg_reentry_timeout_adapter": {
+        "returnsRef": false,
+        "returnType": "string",
+        "params": [
+            {
+                "name": "stored",
+                "byRef": false,
+                "variadic": false,
+                "type": "mixed",
+                "default": null
+            }
+        ]
+    },
     "pfb_cfg_registry": {
         "returnsRef": false,
         "returnType": "array",

--- a/tests/smoke/ui/test_dnsbl_top1m_auth_retention.py
+++ b/tests/smoke/ui/test_dnsbl_top1m_auth_retention.py
@@ -13,6 +13,7 @@ from .test_dnsbl_top1m_retention import (
     TOP1M_BASE,
     TOP1M_FILES,
     TOP1M_PROVIDER_CFG,
+    _detector_fixture,
     _restore_guest_files,
     _snapshot_guest_files,
     _write_guest_file,
@@ -71,6 +72,34 @@ def test_dnsbl_top1m_token_save_retains_active_files_and_invalidates_baseline(
         for path in TOP1M_FILES[2:]:
             assert vm.ssh("test", "-e", path).returncode != 0, (
                 f"TOP1M detector sidecar {path} survived auth identity change"
+            )
+    finally:
+        _restore_guest_files(vm, original)
+
+
+def test_dnsbl_top1m_same_nonblank_token_keeps_detector_baseline(webui: WebUI, smoke_vm: helpers.SmokeVM) -> None:
+    """Re-submitting the same token is not an auth identity transition."""
+    vm = smoke_vm
+    original = _snapshot_guest_files(vm)
+    token = "issue3137SameToken"
+    seeded = _detector_fixture("cloudflare")
+
+    try:
+        response = webui.post(
+            DNSBL_PAGE,
+            {"top1m_source": "cloudflare", "top1m_token": token},
+            timeout=300.0,
+        )
+        assert not looks_like_login_page(response.text), "TOP1M auth setup POST returned the login form"
+        for path, content in seeded.items():
+            _write_guest_file(vm, path, content)
+
+        response = webui.post(DNSBL_PAGE, {"top1m_token": token}, timeout=300.0)
+        assert not looks_like_login_page(response.text), "same-token TOP1M POST returned the login form"
+        assert helpers.config_get(vm, TOP1M_TOKEN_CFG) == token
+        for path, content in seeded.items():
+            assert helpers.read_log_file(vm, path) == content, (
+                f"{path} changed although the submitted TOP1M auth token was unchanged"
             )
     finally:
         _restore_guest_files(vm, original)

--- a/tests/smoke/ui/test_dnsbl_top1m_retention.py
+++ b/tests/smoke/ui/test_dnsbl_top1m_retention.py
@@ -49,6 +49,19 @@ def _restore_guest_files(vm: helpers.SmokeVM, snapshot: dict[str, str | None]) -
             _write_guest_file(vm, path, content)
 
 
+def _detector_fixture(provider: str) -> dict[str, str]:
+    return {
+        f"{helpers.PFB_DBDIR}/top-1m.csv": "1,active.example\n",
+        f"{helpers.PFB_DBDIR}/pfbalexawhitelist.txt": "active.example\n",
+        f"{TOP1M_BASE}.orig": "1,active.example\n",
+        f"{TOP1M_BASE}.xxhash128": "0123456789abcdef0123456789abcdef\n",
+        f"{TOP1M_BASE}.md5": "fedcba9876543210fedcba9876543210\n",
+        f"{TOP1M_BASE}.source": f'{{"provider":"{provider}"}}\n',
+        f"{TOP1M_BASE}.orig.etag": f'"top1m-{provider}"\n',
+        f"{TOP1M_BASE}.orig.lastmod": "1700000000\n",
+    }
+
+
 def test_dnsbl_top1m_provider_save_retains_active_files_and_invalidates_baseline(
     webui: WebUI, smoke_vm: helpers.SmokeVM
 ) -> None:
@@ -62,16 +75,7 @@ def test_dnsbl_top1m_provider_save_retains_active_files_and_invalidates_baseline
         "TOP1M provider must start at Tranco so the POST proves a provider transition"
     )
 
-    seeded = {
-        f"{helpers.PFB_DBDIR}/top-1m.csv": "1,active.example\n",
-        f"{helpers.PFB_DBDIR}/pfbalexawhitelist.txt": "active.example\n",
-        f"{TOP1M_BASE}.orig": "1,active.example\n",
-        f"{TOP1M_BASE}.xxhash128": "0123456789abcdef0123456789abcdef\n",
-        f"{TOP1M_BASE}.md5": "fedcba9876543210fedcba9876543210\n",
-        f"{TOP1M_BASE}.source": '{"provider":"tranco"}\n',
-        f"{TOP1M_BASE}.orig.etag": '"top1m-tranco"\n',
-        f"{TOP1M_BASE}.orig.lastmod": "1700000000\n",
-    }
+    seeded = _detector_fixture("tranco")
 
     try:
         for path, content in seeded.items():
@@ -96,3 +100,65 @@ def test_dnsbl_top1m_provider_save_retains_active_files_and_invalidates_baseline
             )
     finally:
         _restore_guest_files(vm, original)
+
+
+@pytest.mark.parametrize(("legacy", "canonical"), [("alexa", "tranco"), ("domcop", "openpagerank")])
+def test_legacy_provider_canonicalization_keeps_equivalent_detector_baseline(
+    webui: WebUI, smoke_vm: helpers.SmokeVM, legacy: str, canonical: str
+) -> None:
+    """A legacy provider token canonicalizes on save without becoming an identity change."""
+    vm = smoke_vm
+    original = _snapshot_guest_files(vm)
+    seeded = _detector_fixture(canonical)
+
+    try:
+        result = helpers.php_eval(
+            vm,
+            f"config_set_path('{TOP1M_PROVIDER_CFG}', '{legacy}');\n"
+            "write_config('pfBlockerNG smoke #3137: seed legacy TOP1M provider');\n"
+            "echo 'SEED-OK';\n",
+        )
+        assert result.returncode == 0 and "SEED-OK" in result.stdout
+        for path, content in seeded.items():
+            _write_guest_file(vm, path, content)
+
+        response = webui.post(DNSBL_PAGE, {}, timeout=300.0)
+        assert not looks_like_login_page(response.text), "legacy TOP1M canonicalization POST returned the login form"
+        assert helpers.config_get(vm, TOP1M_PROVIDER_CFG) == canonical
+        for path, content in seeded.items():
+            assert helpers.read_log_file(vm, path) == content, (
+                f"{path} changed although legacy {legacy!r} and {canonical!r} are one provider identity"
+            )
+    finally:
+        _restore_guest_files(vm, original)
+
+
+@pytest.mark.parametrize(
+    ("before", "after"),
+    [
+        ({"top1m_count": "1000"}, {"top1m_count": "2000"}),
+        ({"top1m_enable": ""}, {"top1m_enable": "on"}),
+        ({"top1m_inclusion[]": "com"}, {"top1m_inclusion[]": "net"}),
+    ],
+)
+def test_real_top1m_filter_setting_change_marks_reprocess(
+    webui: WebUI, smoke_vm: helpers.SmokeVM, before: dict[str, str], after: dict[str, str]
+) -> None:
+    marker = f"{helpers.PFB_DBDIR}/top-1m.update"
+    existed = smoke_vm.ssh("test", "-f", marker).returncode == 0
+    prior = helpers.read_log_file(smoke_vm, marker) if existed else None
+
+    try:
+        response = webui.post(DNSBL_PAGE, before, timeout=300.0)
+        assert not looks_like_login_page(response.text), "TOP1M setup POST returned the login form"
+        smoke_vm.ssh("rm", "-f", marker)
+
+        response = webui.post(DNSBL_PAGE, after, timeout=300.0)
+        assert not looks_like_login_page(response.text), "TOP1M change POST returned the login form"
+        assert smoke_vm.ssh("test", "-f", marker).returncode == 0, (
+            f"TOP1M change {after} did not mark the cached source for local reprocessing"
+        )
+    finally:
+        smoke_vm.ssh("rm", "-f", marker)
+        if prior is not None:
+            _write_guest_file(smoke_vm, marker, prior)

--- a/tests/smoke/ui/test_toggle_registry_default_render.py
+++ b/tests/smoke/ui/test_toggle_registry_default_render.py
@@ -84,7 +84,7 @@ def _textarea_value(html: str, name: str) -> str:
         re.DOTALL,
     )
     assert match is not None, f'textarea name="{name}" not found in the rendered page'
-    return match.group(1).strip()
+    return match.group(1)
 
 
 def _select_selected_values(html: str, name: str) -> set[str]:
@@ -415,8 +415,8 @@ def test_absent_dnsbl_vips_render_the_none_sentinel(
             IP_PAGE,
             "pfBlockerNG",
             "v6suppression",
-            "b25lCnR3bw==",
-            "one\ntwo",
+            "IG9uZQp0d28g",
+            " one\ntwo ",
         ),
     ],
 )

--- a/tests/smoke/ui/test_toggle_registry_default_render.py
+++ b/tests/smoke/ui/test_toggle_registry_default_render.py
@@ -77,6 +77,32 @@ def _input_value(html: str, name: str) -> str:
     return val.group(1) if val else ""
 
 
+def _textarea_value(html: str, name: str) -> str:
+    match = re.search(
+        rf'<textarea[^>]*\bname="{re.escape(name)}"[^>]*>(.*?)</textarea>',
+        html,
+        re.DOTALL,
+    )
+    assert match is not None, f'textarea name="{name}" not found in the rendered page'
+    return match.group(1).strip()
+
+
+def _select_selected_values(html: str, name: str) -> set[str]:
+    match = re.search(
+        rf'<select[^>]*\bname="{re.escape(name)}(?:\[\])?"[^>]*>(.*?)</select>',
+        html,
+        re.DOTALL,
+    )
+    assert match is not None, f'select name="{name}" not found in the rendered page'
+    values: set[str] = set()
+    for tag in re.findall(r"<option[^>]*>", match.group(1)):
+        if re.search(r"\bselected\b", tag):
+            value = re.search(r'\bvalue="([^"]*)"', tag)
+            if value:
+                values.add(value.group(1))
+    return values
+
+
 def _select_selected(html: str, name: str) -> str:
     """The selected option value of the named ``<select>``."""
     match = re.search(
@@ -241,6 +267,13 @@ _SWEPT_DNSBL_TOGGLES = {
     "pfb_idn_escalate_suspicious": "installedpackages/pfblockerngdnsblsettings/config/0/pfb_idn_escalate_suspicious",
     "pfb_regex_cap": "installedpackages/pfblockerngdnsblsettings/config/0/pfb_regex_cap",
     "pfb_dnsbl_lenient": "installedpackages/pfblockerngdnsblsettings/config/0/pfb_dnsbl_lenient",
+    "top1m_enable": "installedpackages/pfblockerngdnsblsettings/config/0/top1m_enable",
+    "pfb_regex": "installedpackages/pfblockerngdnsblsettings/config/0/pfb_regex",
+    "pfb_cname": "installedpackages/pfblockerngdnsblsettings/config/0/pfb_cname",
+    "tld_allow": "installedpackages/pfblockerngdnsblsettings/config/0/tld_allow",
+    "pfb_py_nolog": "installedpackages/pfblockerngdnsblsettings/config/0/pfb_py_nolog",
+    "pfb_noaaaa": "installedpackages/pfblockerngdnsblsettings/config/0/pfb_noaaaa",
+    "pfb_gp": "installedpackages/pfblockerngdnsblsettings/config/0/pfb_gp",
 }
 CFG_ENABLE_CB = "installedpackages/pfblockerng/config/0/enable_cb"
 
@@ -250,12 +283,11 @@ CFG_ENABLE_CB = "installedpackages/pfblockerng/config/0/enable_cb"
 def test_swept_dnsbl_toggle_renders_on_when_stored_and_off_when_absent(
     smoke_vm: SmokeVM, webui: WebUI, node_state: Callable[[str, str | None], None], name: str
 ) -> None:
-    """issue #2812: each swept DNSBL toggle's checked state comes from the registry.
+    """Each gateway-backed DNSBL toggle renders checked only for stored ``on``.
 
-    Given the key stored as 'on', the checkbox renders CHECKED -- the control that
-    the page can render this box checked at all. Given the key absent, it renders
-    UNCHECKED: the registered '' (or, for the lenient key, legacy-'off') default
-    that replaced the page literal #2812 deleted.
+    This includes issue #3137's seven final toggle-adapter adoptions. The stored-on
+    control and absent-Off assertion defend the real form boundary after the gateway
+    begins returning PfbToggle instances.
     """
     path = _SWEPT_DNSBL_TOGGLES[name]
     node_state(path, "on")
@@ -355,3 +387,74 @@ def test_absent_dnsbl_vips_render_the_none_sentinel(
     html = _render(smoke_vm, webui, _DNSBL_SETTINGS_PAGE, "DNSBL Webserver Configuration")
     assert _select_selected(html, "pfb_dnsvip4") == "none"
     assert _select_selected(html, "pfb_dnsvip6") == "none"
+
+
+@pytest.mark.ui_e2e
+@pytest.mark.parametrize(
+    ("path", "page", "title", "field", "stored", "expected"),
+    [
+        (f"{_CFG_DNSBL}/whitelist", _DNSBL_SETTINGS_PAGE, "DNSBL Webserver Configuration", "whitelist", "MA==", "0"),
+        (
+            "installedpackages/pfblockerng/config/0/pfb_feed_internal_allowlist",
+            _GENERAL_SETTINGS_PAGE,
+            "General Settings",
+            "pfb_feed_internal_allowlist",
+            "b25lCnR3bw==",
+            "one\ntwo",
+        ),
+        (
+            "installedpackages/pfblockerngipsettings/config/0/v4suppression",
+            IP_PAGE,
+            "pfBlockerNG",
+            "v4suppression",
+            "MA==",
+            "0",
+        ),
+        (
+            "installedpackages/pfblockerngipsettings/config/0/v6suppression",
+            IP_PAGE,
+            "pfBlockerNG",
+            "v6suppression",
+            "b25lCnR3bw==",
+            "one\ntwo",
+        ),
+    ],
+)
+def test_gateway_backed_textareas_keep_decoded_content(
+    smoke_vm: SmokeVM,
+    webui: WebUI,
+    node_state: Callable[[str, str | None], None],
+    path: str,
+    page: str,
+    title: str,
+    field: str,
+    stored: str,
+    expected: str,
+) -> None:
+    node_state(path, stored)
+
+    html = _render(smoke_vm, webui, page, title)
+
+    assert _textarea_value(html, field) == expected
+
+
+@pytest.mark.ui_e2e
+def test_gateway_backed_dnsbl_csv_list_keeps_selected_entries(
+    smoke_vm: SmokeVM, webui: WebUI, node_state: Callable[[str, str | None], None]
+) -> None:
+    node_state(f"{_CFG_DNSBL}/top1m_inclusion", "com,net")
+
+    html = _render(smoke_vm, webui, _DNSBL_SETTINGS_PAGE, "DNSBL Webserver Configuration")
+
+    assert _select_selected_values(html, "top1m_inclusion") == {"com", "net"}
+
+
+@pytest.mark.ui_e2e
+def test_gateway_backed_timeout_renders_the_effective_configured_value(
+    smoke_vm: SmokeVM, webui: WebUI, node_state: Callable[[str, str | None], None]
+) -> None:
+    node_state("installedpackages/pfblockerng/config/0/pfb_reentry_timeout", "900")
+
+    html = _render(smoke_vm, webui, _GENERAL_SETTINGS_PAGE, "General Settings")
+
+    assert _input_value(html, "pfb_reentry_timeout") == "900"

--- a/tests/test_toggle_registry_check.py
+++ b/tests/test_toggle_registry_check.py
@@ -20,6 +20,7 @@ importable directly by path via importlib.
 from __future__ import annotations
 
 import importlib.util
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -41,6 +42,7 @@ GLOBAL_SECTION = "installedpackages/pfblockerngglobal"
 # A minimal stand-in for the parsed registry: registered (alias, bare key) pairs.
 FAKE_KEYS: set[tuple[str, str]] = {
     ("ip", "enable_dup"),
+    ("ip", "enable-dup"),
     ("ip", "maxmind_locale"),
     ("global", "alertrefresh"),
 }
@@ -539,3 +541,170 @@ def test_foreign_prefix_is_keyed_to_its_section_not_applied_globally() -> None:
     violations = _find(text)
     assert [v.rule for v in violations] == ["unregistered-toggle"]
     assert "ip/widget-popup" in violations[0].detail
+
+
+# --------------------------------------------------------------------------- #
+# Issue #3137 -- wrapped reads cannot evade RULE 2
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    "source_line",
+    (
+        "$x = $pfb['iconfig']['enable_dup'] ?? '';",
+        "$x = trim($pfb['iconfig']['enable_dup'] ?? '');",
+        "$x = ($pfb['iconfig']['enable_dup'] ?? '');",
+        "return $pfb['iconfig']['enable_dup'] ?? '';",
+        "$x = ['k' => $pfb['iconfig']['enable_dup'] ?? ''];",
+        "if (($pfb['iconfig']['enable_dup'] ?? '') !== $x) {}",
+    ),
+)
+def test_registered_read_shapes_are_flagged_with_stable_diagnostics(source_line: str) -> None:
+    """RULE 2 follows a registered read regardless of its enclosing expression."""
+    source = "matrix.php"
+    violations = _find(MIRROR + source_line + "\n", source)
+    assert len(violations) == 1
+    violation = violations[0]
+    assert (violation.source, violation.line, violation.rule, violation.snippet) == (
+        source,
+        2,
+        "page-level-default",
+        source_line,
+    )
+    assert "'ip/enable_dup'" in violation.detail
+
+
+@pytest.mark.parametrize(
+    ("mirror", "source_line", "key"),
+    (
+        (MIRROR, "$x = $pfb['iconfig']['enable_dup'] ?: '';", "enable_dup"),
+        (MIRROR, "$x = $pfb['iconfig']['enable_dup'] ? : '';", "enable_dup"),
+        (MIRROR, "$x = $pfb['iconfig']['enable_dup'] ?\t:\t'';", "enable_dup"),
+        (
+            f'$pfb["iconfig"] = PfbConfig::readSection("{IP_SECTION}");\n',
+            '$x = $pfb["iconfig"]["enable_dup"] ?? "";',
+            "enable_dup",
+        ),
+        (MIRROR, '$x = $pfb["iconfig"][\'enable-dup\'] ?? "";', "enable-dup"),
+    ),
+)
+def test_registered_read_operators_and_paired_quotes_are_flagged(
+    mirror: str,
+    source_line: str,
+    key: str,
+) -> None:
+    """PHP's supported literal quoting and fallback spellings share one contract."""
+    violations = _find(mirror + source_line + "\n")
+    assert [v.rule for v in violations] == ["page-level-default"]
+    assert violations[0].line == 2
+    assert violations[0].detail.startswith(f"'ip/{key}' is a registered field")
+    assert violations[0].snippet == source_line
+
+
+@pytest.mark.parametrize(
+    "text",
+    (
+        MIRROR + "$x = trim($pfb['iconfig']['unknown_key'] ?? '');\n",
+        (
+            "$pfb['foreign'] = PfbConfig::readSection('installedpackages/foreign/config/0');\n"
+            "$x = trim($pfb['foreign']['enable_dup'] ?? '');\n"
+        ),
+        MIRROR + "$key = 'enable_dup';\n$x = trim($pfb['iconfig'][$key] ?? '');\n",
+    ),
+)
+def test_wrapped_read_does_not_claim_unknown_foreign_or_dynamic_keys(text: str) -> None:
+    """RULE 2 only owns literal registered keys in a mapped section mirror."""
+    assert _find(text) == []
+
+
+@pytest.mark.parametrize(
+    "text",
+    (
+        (
+            f"$pfb['iconfig\"] = PfbConfig::readSection('{IP_SECTION}');\n"
+            "$x = trim($pfb['iconfig']['enable_dup'] ?? '');\n"
+        ),
+        MIRROR + "$x = trim($pfb['iconfig\"][\"enable_dup\"] ?? '');\n",
+    ),
+)
+def test_php_invalid_mismatched_quote_literals_are_out_of_scope(text: str) -> None:
+    """Malformed PHP literals are not broadened into a second parser contract."""
+    assert _find(text) == []
+
+
+def test_null_coalescing_assignment_is_a_save_not_a_defaulted_read() -> None:
+    """A registered `??=` assignment writes the mirror and must stay clean."""
+    assert _find(MIRROR + "$pfb['iconfig']['enable_dup'] ??= '';\n") == []
+
+
+def test_save_with_a_wrapped_registered_read_on_its_rhs_flags_the_read() -> None:
+    """A clean registered save must not mask another registered field read on its RHS."""
+    source_line = (
+        "$pfb['iconfig']['enable_dup'] = "
+        "pfb_filter($pfb['iconfig']['maxmind_locale'] ?? '', PFB_FILTER_ON_OFF, 'ip') ?: '';"
+    )
+    violations = _find(MIRROR + source_line + "\n")
+    assert [v.rule for v in violations] == ["page-level-default"]
+    assert "ip/maxmind_locale" in violations[0].detail
+    assert violations[0].snippet == source_line
+
+
+@pytest.mark.parametrize(
+    ("prefix", "suffix"),
+    (("// ", "php"), ("* ", "inc"), ("/* ", "xml"), ("# ", "php")),
+)
+def test_leading_comment_prefixes_keep_wrapped_reads_out_of_scope(prefix: str, suffix: str) -> None:
+    """The existing leading-token comment heuristic applies across the scan surface."""
+    wrapped = "trim($pfb['iconfig']['enable_dup'] ?? '');"
+    assert _find(MIRROR + prefix + wrapped + "\n", f"matrix.{suffix}") == []
+
+
+@pytest.mark.parametrize(
+    ("source_line", "suffix"),
+    (
+        ("$x = 1; // trim($pfb['iconfig']['enable_dup'] ?? '');", "php"),
+        ("trim($pfb['iconfig']['enable_dup'] ?? '');", "inc"),
+        ("trim($pfb['iconfig']['enable_dup'] ?? '');", "xml"),
+    ),
+)
+def test_nonleading_or_generated_wrapped_reads_keep_the_existing_code_heuristic(
+    source_line: str,
+    suffix: str,
+) -> None:
+    """Only a leading comment token suppresses a match; generated PHP remains scanned."""
+    assert _rules(MIRROR + source_line + "\n", f"matrix.{suffix}") == ["page-level-default"]
+
+
+def test_cli_reports_a_double_quoted_wrapped_read(tmp_path: Path) -> None:
+    """The real CLI exposes wrapped findings with the established diagnostic contract."""
+    page = tmp_path / "wrapped.php"
+    source_line = '$x = trim($pfb["iconfig"]["enable_dup"] ?? "");'
+    page.write_text(
+        f'$pfb["iconfig"] = PfbConfig::readSection("{IP_SECTION}");\n{source_line}\n',
+        encoding="utf-8",
+    )
+
+    result = subprocess.run(
+        [sys.executable, str(_TOOL), str(page)],
+        cwd=_REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 1, result.stderr
+    assert f"{page}:2: [page-level-default]" in result.stderr
+    assert "'ip/enable_dup' is a registered field" in result.stderr
+    assert source_line in result.stderr
+
+
+def test_self_test_rejects_the_assignment_anchored_read_matcher(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The canary fails when direct reads work but its wrapped read becomes invisible."""
+    assignment_anchored = re.compile(r"=\s*\$pfb\s*\[\s*'(\w+)'\s*\]\s*\[\s*'([\w-]+)'\s*\]\s*\?[:?]")
+    monkeypatch.setattr(ctr, "_READ_COALESCE_RE", assignment_anchored)
+
+    assert ctr._self_test(FAKE_SECTIONS, FAKE_KEYS | {("ip", "suppression")}) == 1
+    assert "page-level-default" in capsys.readouterr().err

--- a/tests/test_toggle_registry_check.py
+++ b/tests/test_toggle_registry_check.py
@@ -124,12 +124,13 @@ def test_page_level_default_for_a_registered_toggle_is_flagged() -> None:
     assert "ip/enable_dup" in violations[0].detail
 
 
-def test_isset_style_page_level_default_is_flagged() -> None:
-    """The other spelling: the 3.2 `isset(...) ? ... : 'on'` fallback."""
-    text = (
-        f"$pfb['aglobal'] = PfbConfig::readSection('{GLOBAL_SECTION}');\n"
-        "$alertrefresh = isset($pfb['aglobal']['alertrefresh']) ? $pfb['aglobal']['alertrefresh'] : 'on';\n"
-    )
+@pytest.mark.parametrize("mirror_quote", ["'", '"'])
+@pytest.mark.parametrize("key_quote", ["'", '"'])
+def test_isset_style_page_level_default_is_flagged(mirror_quote: str, key_quote: str) -> None:
+    """Each supported literal quote pair preserves the isset fallback contract."""
+    mirror = f"$pfb[{mirror_quote}aglobal{mirror_quote}]"
+    field = f"{mirror}[{key_quote}alertrefresh{key_quote}]"
+    text = f"{mirror} = PfbConfig::readSection('{GLOBAL_SECTION}');\n$alertrefresh = isset({field}) ? {field} : 'on';\n"
     assert _rules(text, "pfblockerng_alerts.php") == ["page-level-default"]
 
 
@@ -610,6 +611,12 @@ def test_registered_read_operators_and_paired_quotes_are_flagged(
             "$x = trim($pfb['foreign']['enable_dup'] ?? '');\n"
         ),
         MIRROR + "$key = 'enable_dup';\n$x = trim($pfb['iconfig'][$key] ?? '');\n",
+        MIRROR + '$x = isset($pfb["iconfig"]["unknown_key"]) ? "yes" : "no";\n',
+        (
+            '$pfb["foreign"] = PfbConfig::readSection("installedpackages/foreign/config/0");\n'
+            '$x = isset($pfb["foreign"]["enable_dup"]) ? "yes" : "no";\n'
+        ),
+        MIRROR + '$x = isset($pfb["iconfig"][$key]) ? "yes" : "no";\n',
     ),
 )
 def test_wrapped_read_does_not_claim_unknown_foreign_or_dynamic_keys(text: str) -> None:
@@ -625,6 +632,8 @@ def test_wrapped_read_does_not_claim_unknown_foreign_or_dynamic_keys(text: str) 
             "$x = trim($pfb['iconfig']['enable_dup'] ?? '');\n"
         ),
         MIRROR + "$x = trim($pfb['iconfig\"][\"enable_dup\"] ?? '');\n",
+        MIRROR + '$x = isset($pfb[\'iconfig"]["enable_dup"]) ? "yes" : "no";\n',
+        MIRROR + '$x = isset($pfb["iconfig"][\'enable_dup"]) ? "yes" : "no";\n',
     ),
 )
 def test_php_invalid_mismatched_quote_literals_are_out_of_scope(text: str) -> None:


### PR DESCRIPTION
Fixes #3137

## Changes

- Detect registered coalescing/Elvis mirror reads in calls, parentheses, returns, array values, and comparisons, including double-quoted keys and spaced `? :`. Preserve saves, foreign keys, and existing comment heuristics. The self-test specifically detects the original assignment-anchor regression.
- Migrate all 32 live-enumerated reads through `PfbConfig`; adopt seven toggle adapter pairs while preserving runtime enum identities and scalar TOP1M comparison snapshots.
- Normalize the nested-pass timeout before scalar coercion through a narrow symmetric adapter, retain textarea/CSV behavior, migrate affected consumer fixtures, and reconcile the existing gateway documentation.

## Final status and review

**Landed by signed fast-forward** at `00ec452356469b366ee1f50bf5ece4bbf64a7c8a` over `4ba093cbd478167600bca348c9920bf3fcece7c8`; PR MERGED and issue closed as completed. All four outgoing commits are locally signed; final-head CI and real authorized live gates passed. Both Copilot and CodeRabbit reviews finished; every finding was triaged and replied to.

The original single condensed independent review covered contract, correctness/hostile input, test honesty and over-engineering. Its F1/F2/F3/F5 fixes were verified. One subsequent **focused advisory-fix verifier**, not a second full review, checked the five-file delta and final formatter-normalized bytes, with no new findings.

### Advisory ledger

- **A — APPLY:** both reviewers' paired-quote isset matcher finding, fixed in `00ec452356469b366ee1f50bf5ece4bbf64a7c8a`. Frozen final checker blob `5a1dea431c3fa07b0080272d1761af4bd88c65bf`: pre-fix07c28 production **3 failed,1 passed,69 deselected**; current complete file **73 passed**. Unknown/foreign/dynamic keys and invalid quotes remain clean; tree/self-test pass. CodeRabbit acknowledged and resolved its thread.
- **B — APPLY:** both reviewers' config-fixture leak finding, fixed in `00ec452356469b366ee1f50bf5ece4bbf64a7c8a`. Real helper probe preserves present/null/absent states after previously leaking all three; cleanup is in finally. CodeRabbit acknowledged and resolved its thread.
- **C — APPLY:** Copilot's textarea observer finding, fixed in `00ec452356469b366ee1f50bf5ece4bbf64a7c8a`. Exact inner text and significant whitespace fixture now pass on the actual UI. A realistic production-only `pfb_b64_text` trim mutation was killed by the unchanged PHP consumer assertion; restored production passed.
- **D — SKIP:** CodeRabbit's outside-diff request to restore adapter-callable-name pins. Names are internal implementation, not an external gateway contract; semantic input/output assertions and independently killed missing-adapter mutation remain. Stale parity documentation corrected, no exception list or identity pin added.
- **E — SKIP:** default80% docstring percentage is not a configured canonical requirement. Actual contract/comment/Markdown/style gates pass; no padding or blanket exemption added.

Each inline thread has an evidence reply; D/E are recorded in the [disposition audit](https://github.com/pfBlockerNG/pfBlockerNG/pull/3236#issuecomment-5577688603). No second bot ask was spent on mechanical application of the reviewers' own concrete suggestions.

## Executed proof

- Historical implementation proof against `e374c6b07c55e0799175c25f540cf110e25c4f49`: review-time frozen eight-file PHP set **325tests/74failures RED → 325tests/2887assertions GREEN, zero warnings**; checker **15failed/12passed RED →65passed GREEN**. These are historical file versions, not a claim that later test-maintenance bytes share those old hashes.
- Final frozen checker reproduction:
  ```sh
  .venv/bin/python -m pytest -n 0 tests/test_toggle_registry_check.py -k isset_style
  .venv/bin/python -m pytest -n 0 tests/test_toggle_registry_check.py
  ```
  First command used the final unchanged test file with pre-fix07c28 checker in a private archive: **3failed/1passed/69deselected**. Current whole file: **73passed**. The original pre-production-edit test run was **3failed/70passed**; after canonical formatting the independent final-byte replay above confirmed the same cases.
- Current focused PHP: `vendor/bin/phpunit tests/php/DnsblFreshPconfigTest.php tests/php/CfgGatewayTest.php` → **206tests/2241assertions PASS**. Private production trim mutation: DnsblFresh **3tests/22assertions/1whitespace failure**; restored production, unchanged tests: **3tests/28assertions PASS**. Original anchor, missing toggle adapter, whitelist bypass and finite-timeout mutations were also independently killed in the completed implementation review.
- Canonical `.agents/policy/testing.md` now explicitly says production changes require test-first red→green; test maintenance/deletion/golden refreshes do not require recursive tests-of-tests; realistic production mutations with unchanged tests may prove test honesty. No failure was fabricated, checker exemption introduced, or required live coverage waived.

## Per-file evidence

The table distinguishes actual reproduction/mutation RED, N/A maintenance and executed live GREEN. Current hashes are exact `git hash-object` values; historical hashes are named explicitly where a base-owned or maintenance change moved file bytes.

| Frozen RED test | git hash-object | RED run tail |
| --- | --- | --- |
| `tests/php/Adr62DnsblCorpusManifestTest.php` | `d4449aae8954bb68042e17f10876a1a533ae2320` | PHP-R: `testPublishedManifestMatchesV1Fixture` failed: expected populated user_whitelist, actual empty array. |
| `tests/php/CfgGatewayTest.php` | `cdeb25feca24ae22d5c6484263acd6daa8cd9afe` | Historical PHP-R, blob `5bc265a4c1056382861152ca9dbd992121459361`: 64 gateway/type/normalization failures. Current base adds unrelated #3243 sample maintenance; #3137 cases unchanged. Current file green with inventory oracle: 204 tests / 2219 assertions; no false current-file historical freeze claim. |
| `tests/php/DnsblFreshPconfigTest.php` | `a2cab3a5b8ec68c2a2d5e2ca577b7bfae943d2e5` | Realistic production trim mutation with unchanged final tests: 3 tests / 22 assertions / 1 whitespace failure; restored GREEN 3 tests / 28 assertions. Config-helper maintenance preserves present/null/absent state; no recursive tests-of-tests claim. |
| `tests/php/GeneralAdvancedTimeoutUiTest.php` | `def1dff11140365c773c2c9541fc6d2a584afa60` | N/A — test maintenance: obsolete source-text assertion removed, not a behavior change requiring its own RED. Timeout behavior is covered by ReentryTimeoutSettingTest and the production direct-cast mutation. Current-base help-text maintenance is incorporated; focused current run passes. |
| `tests/php/Issue1792SweepSitesTest.php` | `64698d7d52722bf94c6387b565bc8ad8a52b931a` | PHP-R: `testStoredZeroWhitelistSurvivesToTheForm` failed: expected 0, actual empty string. |
| `tests/php/ReentryTimeoutSettingTest.php` | `e8bf9aeb6ab4625b06bc0fead953e89a332726cd` | PHP-R: five gateway-authority failures, including `Failed asserting that 60 is identical to 900.` Separate pre-adapter F1 run: 56 tests, 1 array-conversion error, 1 float-default failure. |
| `tests/php/ToggleSectionMirrorTypeTest.php` | `02c738163392985e0e70c7dff4c80320941fd076` | N/A — test maintenance/preservation: redundant assertions removed; final cases passed on both baseline and fix. The realistic dropped-toggle-adapter production mutation is killed by all nine gateway state rows; no per-file RED claimed. |
| `tests/php/UnboundPythonSourcesTest.php` | `83888e0dd567488493f5d3b794355f08e1439cb4` | PHP-R: two whitelist failures: expected good.example.com and .wild.example.com, actual empty array. |
| `tests/php/fixtures/function_inventory.json` | `326959c28871c92ebb1e7214a3b8020d16c2271f` | N/A — golden inventory maintenance, not a tests-of-tests behavior change. The unchanged oracle failed in prior CI on the missing adapter and passes with the corrected inventory; this is not claimed as frozen-final-fixture RED. |
| `tests/smoke/ui/test_dnsbl_top1m_auth_retention.py` | `f0ee48f309116b2083304f8ae0b200156c4d3ea2` | Live GREEN on `00ec452356469b366ee1f50bf5ece4bbf64a7c8a`: ui_e2e33passed/677deselected; zero selected skips/failures. Preservation/transition verification, not a historical live RED claim. |
| `tests/smoke/ui/test_dnsbl_top1m_retention.py` | `a613dcc1283af628fada14397704c4a005627557` | Live GREEN on `00ec452356469b366ee1f50bf5ece4bbf64a7c8a`: ui_e2e33passed/677deselected; zero selected skips/failures. Preservation/transition verification, not a historical live RED claim. |
| `tests/smoke/ui/test_toggle_registry_default_render.py` | `7eb6176e941fa453a568ee573d99eff526ff687b` | Live GREEN on `00ec452356469b366ee1f50bf5ece4bbf64a7c8a`: ui_render28passed/682deselected and ui_e2e33passed/677deselected; zero selected skips/failures. Preservation/transition verification, not a historical live RED claim. |
| `tests/test_toggle_registry_check.py` | `5a1dea431c3fa07b0080272d1761af4bd88c65bf` | Final-byte isset RED against 07c28: 3 failed, 1 passed, 69 deselected; unchanged current file GREEN 73 passed. Historical wrapped-read RED/green remains recorded above. |

## Final exact-head CI and actual live gates

- **[Tests run34176614124](https://github.com/pfBlockerNG/pfBlockerNG/actions/runs/34176614124): SUCCESS** on `00ec452356469b366ee1f50bf5ece4bbf64a7c8a`. Coverage pairing, all PHP8.3/8.4/8.5 unit/syntax/static jobs, Python, Ruff, mypy, shellspec, ShellCheck, actionlint, Markdown, JS/webassets, graph and aggregate passed. Canonical SHA-pinned waiter: **PASS**.
- [Agent config34176613849](https://github.com/pfBlockerNG/pfBlockerNG/actions/runs/34176613849) and [Context budget34176613835](https://github.com/pfBlockerNG/pfBlockerNG/actions/runs/34176613835): **SUCCESS**.
- Actual harness-leased live commands, with the authorized pool supplied only in environment:
  ```sh
  sh scripts/local-smoke.sh --ref 00ec452356469b366ee1f50bf5ece4bbf64a7c8a --marker ui_render --filter 'test_toggle_registry_default_render or test_dnsbl_top1m_retention or test_dnsbl_top1m_auth_retention'
  sh scripts/local-smoke.sh --ref 00ec452356469b366ee1f50bf5ece4bbf64a7c8a --marker ui_e2e --filter 'test_toggle_registry_default_render or test_dnsbl_top1m_retention or test_dnsbl_top1m_auth_retention'
  ```
  **ui_render28passed/682deselected; ui_e2e33passed/677deselected; both exit0, zero selected skips/failures.** Both leases released. This includes final whitespace bytes, seven toggle states, text/list/timeout fields, legacy provider equivalence, token/provider detector transitions, active-file retention and count/enable/inclusion reprocessing. The CI UI fan-out skip is not being treated as a live pass: these are separate actual runs.
- Full final live logs: `/var/tmp/agents/issue3137-finish/final-ui-render.log` and `final-ui-e2e.log`; independent focused report and formatter addendum: `bot-fix-verifier-report.txt`; exact-head CI: `final-ci.json` in the same artifact directory.
- All required hooks ran without bypass; final Ruff check reports554files formatted, PHP syntax/PHPCS passed, graph refreshed/fresh, and the policy Markdown gate checked94files with0issues. Old local host-dependent failures tracked#3103 remain distinguished from final authoritative CI, not used as waivers.

Landed execution evidence: https://github.com/pfBlockerNG/pfBlockerNG/issues/3137#issuecomment-5577812315
