### PR TITLE
ci: exercise live nightly downgrade

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -127,8 +127,6 @@ jobs:
             --ref "$MATRIX_SHA" --print-build)"
           ROUTE_MATRIX="$(cd "$TRUSTED_DIR" && sh scripts/read-version-matrix.sh \
             --ref "$MATRIX_SHA" --print-route)"
-          CI_MATRIX="$(cd "$TRUSTED_DIR" && sh scripts/read-version-matrix.sh \
-            --ref "$MATRIX_SHA" --print-ci)"
           if ! matrix_gate "$BUILD_MATRIX" "$ROUTE_MATRIX"; then
             echo "::error::missing live BUILD/ROUTE matrix rows"
             exit 1
@@ -144,7 +142,6 @@ jobs:
           PKG_VERSION="$(sh "$TRUSTED_DIR/scripts/nightly-pkgversion.sh" "$SOURCE_SHA")"
           python3 "$TRUSTED_DIR/scripts/build-dep-pkg-portable.py" --print-toolchain \
             > plan/dependency-builder.json
-          printf '%s\n' "$CI_MATRIX" > plan/ci-matrix.json
           printf '%s\n' "$BUILD_MATRIX" > plan/build-matrix.json
           printf '%s\n' "$ROUTE_MATRIX" > plan/route-matrix.json
           printf '%s\n' "$SOURCE_SHA" > plan/source-sha
@@ -167,9 +164,13 @@ jobs:
 
       - name: Select live downgrade runtime
         id: live-downgrade
+        env:
+          TRUSTED_DIR: ${{ github.workspace }}/trusted
+          MATRIX_SHA: ${{ steps.inputs.outputs.matrix_sha }}
         run: |
           set -eu
-          [ -n "${CI_MATRIX:-}" ] || CI_MATRIX="$(cat plan/ci-matrix.json)"
+          CI_MATRIX="$(cd "$TRUSTED_DIR" && sh scripts/read-version-matrix.sh \
+            --ref "$MATRIX_SHA" --print-ci)"
           ROW="$(printf '%s\n' "$CI_MATRIX" | jq -c \
             '[.[] | select(.channel == "CE")] | sort_by(.pfsense_version | split("-")[0] | split(".") | map(tonumber)) | .[0] // null')"
           [ "$ROW" != null ] || { echo "::error::no ci:true CE row for the live downgrade" >&2; exit 1; }
@@ -519,9 +520,9 @@ jobs:
     needs: [prepare, ingest-pkg]
     runs-on: ubuntu-latest
     outputs:
-      source_sha: ${{ steps.identity.outputs.smoke_repo_expected_source_sha }}
-      version: ${{ steps.identity.outputs.smoke_repo_expected_version }}
-      channel: ${{ steps.identity.outputs.smoke_repo_expected_channel }}
+      source_sha: ${{ steps.identity.outputs.source_sha }}
+      version: ${{ steps.identity.outputs.version }}
+      channel: ${{ steps.identity.outputs.channel }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -568,7 +569,6 @@ jobs:
               PkgError,
               load_build_record,
               pkg_version_sort_key,
-              validate_build_record,
               zstd_decompress,
           )
 
@@ -599,19 +599,13 @@ jobs:
           if not isinstance(annotation, str):
               raise SystemExit("canonical package has no build record")
           try:
-              unvalidated_record = json.loads(annotation)
-          except (TypeError, ValueError) as exc:
-              raise SystemExit(f"build record is invalid: {exc}") from None
-          if not isinstance(unvalidated_record, dict):
-              raise SystemExit("build record is invalid: expected an object")
-          if unvalidated_record.get("canonical_package_version") != version:
-              raise SystemExit("catalogue version does not match the build record version")
-          if unvalidated_record.get("channel") != "stable":
-              raise SystemExit("stable catalogue selected a non-stable build record")
-          try:
               record = load_build_record(annotation)
           except PkgError as exc:
               raise SystemExit(f"build record is invalid: {exc}") from None
+          if record["canonical_package_version"] != version:
+              raise SystemExit("catalogue version does not match the build record version")
+          if record["channel"] != "stable":
+              raise SystemExit("stable catalogue selected a non-stable build record")
 
           live_row = json.loads(os.environ["LIVE_DOWNGRADE_ROW"])
           if not isinstance(live_row, dict):
@@ -619,33 +613,27 @@ jobs:
           for field in ("pfsense_version", "variant", "freebsd_major", "php_version", "py_flavor"):
               if not isinstance(live_row.get(field), str) or not live_row[field]:
                   raise SystemExit(f"selected runtime {field} is malformed")
-          validate_build_record(
-              record,
-              abi=f"FreeBSD:{live_row['freebsd_major']}:amd64",
-              php_version=live_row["php_version"],
-              py_flavor=live_row["py_flavor"],
-          )
           record_row = record["matrix_row"]
+          for field in ("freebsd_major", "php_version", "py_flavor"):
+              if record_row[field] != live_row[field]:
+                  raise SystemExit(
+                      f"build record {field} {record_row[field]!r} does not match selected runtime {live_row[field]!r}"
+                  )
           record_varver = catalog_name_from_version(record_row["pfsense_version"], record_row["variant"])
           if record_varver != os.environ["VARVER"]:
               raise SystemExit(f"build record runtime maps to {record_varver}, expected {os.environ['VARVER']}")
           if selected.get("abi") != f"FreeBSD:{live_row['freebsd_major']}:*":
               raise SystemExit("catalogue ABI does not match the selected runtime")
 
+          print(
+              f"resolved Stable {version} from {os.environ['VARVER']} at pkg commit {os.environ['PKG_SHA']}"
+          )
           with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
-              output.write(f"smoke_repo_expected_source_sha={record['source_sha']}\n")
-              output.write(f"smoke_repo_expected_version={version}\n")
-              output.write("smoke_repo_expected_channel=stable\n")
-              output.write(f"varver={os.environ['VARVER']}\n")
-              output.write(f"pkg_repo_sha={os.environ['PKG_SHA']}\n")
+              output.write(f"source_sha={record['source_sha']}\n")
+              output.write(f"version={version}\n")
+              output.write("channel=stable\n")
           PY
 
-      - name: Confirm pinned Stable identity
-        env:
-          SOURCE_SHA: ${{ steps.identity.outputs.smoke_repo_expected_source_sha }}
-          VERSION: ${{ steps.identity.outputs.smoke_repo_expected_version }}
-          CHANNEL: ${{ steps.identity.outputs.smoke_repo_expected_channel }}
-        run: test -n "$SOURCE_SHA" && test -n "$VERSION" && test "$CHANNEL" = stable
 
   validate-live-pages-install:
     name: Live Pages pkg install

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -48,6 +48,7 @@ jobs:
       matrix_sha: ${{ steps.plan.outputs.matrix_sha }}
       matrix_digest: ${{ steps.plan.outputs.matrix_digest }}
       source_date_epoch: ${{ steps.plan.outputs.source_date_epoch }}
+      live_downgrade_row: ${{ steps.live-downgrade.outputs.row }}
     steps:
       - name: Checkout trusted workflow tools
         uses: actions/checkout@v7
@@ -126,6 +127,8 @@ jobs:
             --ref "$MATRIX_SHA" --print-build)"
           ROUTE_MATRIX="$(cd "$TRUSTED_DIR" && sh scripts/read-version-matrix.sh \
             --ref "$MATRIX_SHA" --print-route)"
+          CI_MATRIX="$(cd "$TRUSTED_DIR" && sh scripts/read-version-matrix.sh \
+            --ref "$MATRIX_SHA" --print-ci)"
           if ! matrix_gate "$BUILD_MATRIX" "$ROUTE_MATRIX"; then
             echo "::error::missing live BUILD/ROUTE matrix rows"
             exit 1
@@ -141,6 +144,7 @@ jobs:
           PKG_VERSION="$(sh "$TRUSTED_DIR/scripts/nightly-pkgversion.sh" "$SOURCE_SHA")"
           python3 "$TRUSTED_DIR/scripts/build-dep-pkg-portable.py" --print-toolchain \
             > plan/dependency-builder.json
+          printf '%s\n' "$CI_MATRIX" > plan/ci-matrix.json
           printf '%s\n' "$BUILD_MATRIX" > plan/build-matrix.json
           printf '%s\n' "$ROUTE_MATRIX" > plan/route-matrix.json
           printf '%s\n' "$SOURCE_SHA" > plan/source-sha
@@ -160,6 +164,16 @@ jobs:
             echo "source_date_epoch=$SOURCE_DATE_EPOCH"
             echo "pkg_version=$PKG_VERSION"
           } >> "$GITHUB_OUTPUT"
+
+      - name: Select live downgrade runtime
+        id: live-downgrade
+        run: |
+          set -eu
+          [ -n "${CI_MATRIX:-}" ] || CI_MATRIX="$(cat plan/ci-matrix.json)"
+          ROW="$(printf '%s\n' "$CI_MATRIX" | jq -c \
+            '[.[] | select(.channel == "CE")] | sort_by(.pfsense_version | split("-")[0] | split(".") | map(tonumber)) | .[0] // null')"
+          [ "$ROW" != null ] || { echo "::error::no ci:true CE row for the live downgrade" >&2; exit 1; }
+          printf 'row=%s\n' "$ROW" >> "$GITHUB_OUTPUT"
 
       - name: Expose pinned plan
         id: plan
@@ -500,6 +514,139 @@ jobs:
           export PKG_OPERATION=nightly # operation=nightly
           sh scripts/dispatch-pkg-publication.sh
 
+  resolve-live-stable-identity:
+    name: Pin deployed Stable identity
+    needs: [prepare, ingest-pkg]
+    runs-on: ubuntu-latest
+    outputs:
+      source_sha: ${{ steps.identity.outputs.smoke_repo_expected_source_sha }}
+      version: ${{ steps.identity.outputs.smoke_repo_expected_version }}
+      channel: ${{ steps.identity.outputs.smoke_repo_expected_channel }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.prepare.outputs.tools_sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - uses: astral-sh/setup-uv@v10.0.1
+        with:
+          version: "0.12.6"
+          activate-environment: true
+
+      - name: Install the pinned catalogue decoder
+        run: uv sync --locked --only-group dep-pkg-build
+
+      - name: Resolve exact published Stable identity
+        id: identity
+        env:
+          GH_TOKEN: ${{ github.token }}
+          LIVE_DOWNGRADE_ROW: ${{ needs.prepare.outputs.live_downgrade_row }}
+        run: |
+          set -eu
+          PKG_SHA="$(gh api repos/pfBlockerNG/pkg/commits/main --jq .sha)"
+          case "$PKG_SHA" in
+            *[!0-9a-f]*|'') echo "::error::pkg main did not resolve to a full SHA" >&2; exit 1 ;;
+          esac
+          [ "${#PKG_SHA}" -eq 40 ] || { echo "::error::pkg main did not resolve to a full SHA" >&2; exit 1; }
+          VARVER="$(python3 -c 'import json, os; from scripts.live_gate_matrix import catalog_name_from_version; row=json.loads(os.environ["LIVE_DOWNGRADE_ROW"]); print(catalog_name_from_version(row["pfsense_version"], row["variant"]))')"
+          CATALOGUE="$(mktemp)"
+          trap 'rm -f "$CATALOGUE"' EXIT
+          gh api -H "Accept: application/vnd.github.raw" \
+            "repos/pfBlockerNG/pkg/contents/docs/stable/${VARVER}/packagesite.pkg?ref=${PKG_SHA}" > "$CATALOGUE"
+          export CATALOGUE PKG_SHA VARVER
+          python3 - <<'PY'
+          import io
+          import json
+          import os
+          import tarfile
+
+          from scripts.live_gate_matrix import catalog_name_from_version
+          from scripts.pfb_pkg import (
+              CANONICAL_EMITTED_IDENTITY,
+              PFB_BUILD_RECORD_KEY,
+              PkgError,
+              load_build_record,
+              pkg_version_sort_key,
+              validate_build_record,
+              zstd_decompress,
+          )
+
+          try:
+              raw = zstd_decompress(open(os.environ["CATALOGUE"], "rb").read())
+              with tarfile.open(fileobj=io.BytesIO(raw)) as archive:
+                  member = archive.extractfile("packagesite.yaml")
+                  if member is None:
+                      raise ValueError("packagesite.yaml is missing")
+                  entries = [json.loads(line) for line in member if line.strip()]
+          except (OSError, PkgError, tarfile.TarError, UnicodeError, ValueError) as exc:
+              raise SystemExit(f"catalogue is invalid: {exc}") from None
+
+          candidates = [
+              entry
+              for entry in entries
+              if isinstance(entry, dict) and entry.get("name") == CANONICAL_EMITTED_IDENTITY
+          ]
+          if not candidates:
+              raise SystemExit("catalogue has no canonical package candidate")
+          for candidate in candidates:
+              if not isinstance(candidate.get("version"), str) or not candidate["version"]:
+                  raise SystemExit("canonical catalogue version is malformed")
+          selected = max(candidates, key=lambda entry: pkg_version_sort_key(entry["version"]))
+          version = selected["version"]
+          annotations = selected.get("annotations")
+          annotation = annotations.get(PFB_BUILD_RECORD_KEY) if isinstance(annotations, dict) else None
+          if not isinstance(annotation, str):
+              raise SystemExit("canonical package has no build record")
+          try:
+              unvalidated_record = json.loads(annotation)
+          except (TypeError, ValueError) as exc:
+              raise SystemExit(f"build record is invalid: {exc}") from None
+          if not isinstance(unvalidated_record, dict):
+              raise SystemExit("build record is invalid: expected an object")
+          if unvalidated_record.get("canonical_package_version") != version:
+              raise SystemExit("catalogue version does not match the build record version")
+          if unvalidated_record.get("channel") != "stable":
+              raise SystemExit("stable catalogue selected a non-stable build record")
+          try:
+              record = load_build_record(annotation)
+          except PkgError as exc:
+              raise SystemExit(f"build record is invalid: {exc}") from None
+
+          live_row = json.loads(os.environ["LIVE_DOWNGRADE_ROW"])
+          if not isinstance(live_row, dict):
+              raise SystemExit("selected runtime row is not an object")
+          for field in ("pfsense_version", "variant", "freebsd_major", "php_version", "py_flavor"):
+              if not isinstance(live_row.get(field), str) or not live_row[field]:
+                  raise SystemExit(f"selected runtime {field} is malformed")
+          validate_build_record(
+              record,
+              abi=f"FreeBSD:{live_row['freebsd_major']}:amd64",
+              php_version=live_row["php_version"],
+              py_flavor=live_row["py_flavor"],
+          )
+          record_row = record["matrix_row"]
+          record_varver = catalog_name_from_version(record_row["pfsense_version"], record_row["variant"])
+          if record_varver != os.environ["VARVER"]:
+              raise SystemExit(f"build record runtime maps to {record_varver}, expected {os.environ['VARVER']}")
+          if selected.get("abi") != f"FreeBSD:{live_row['freebsd_major']}:*":
+              raise SystemExit("catalogue ABI does not match the selected runtime")
+
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
+              output.write(f"smoke_repo_expected_source_sha={record['source_sha']}\n")
+              output.write(f"smoke_repo_expected_version={version}\n")
+              output.write("smoke_repo_expected_channel=stable\n")
+              output.write(f"varver={os.environ['VARVER']}\n")
+              output.write(f"pkg_repo_sha={os.environ['PKG_SHA']}\n")
+          PY
+
+      - name: Confirm pinned Stable identity
+        env:
+          SOURCE_SHA: ${{ steps.identity.outputs.smoke_repo_expected_source_sha }}
+          VERSION: ${{ steps.identity.outputs.smoke_repo_expected_version }}
+          CHANNEL: ${{ steps.identity.outputs.smoke_repo_expected_channel }}
+        run: test -n "$SOURCE_SHA" && test -n "$VERSION" && test "$CHANNEL" = stable
+
   validate-live-pages-install:
     name: Live Pages pkg install
     needs: [prepare, ingest-pkg]
@@ -513,9 +660,34 @@ jobs:
       smoke_nightly_expected_version: ${{ needs.prepare.outputs.pkg_version }}
     secrets: inherit
 
+  validate-live-downgrade:
+    name: Live Nightly to Stable downgrade
+    needs: [prepare, resolve-live-stable-identity]
+    uses: ./.github/workflows/smoke-single.yml
+    with:
+      pfsense_version: ${{ fromJson(needs.prepare.outputs.live_downgrade_row).pfsense_version }}
+      image_name: ${{ fromJson(needs.prepare.outputs.live_downgrade_row).image_name }}
+      mac: ${{ fromJson(needs.prepare.outputs.live_downgrade_row).mac }}
+      abi: FreeBSD:${{ fromJson(needs.prepare.outputs.live_downgrade_row).freebsd_major }}:amd64
+      php_version: ${{ fromJson(needs.prepare.outputs.live_downgrade_row).php_version }}
+      py_flavor: ${{ fromJson(needs.prepare.outputs.live_downgrade_row).py_flavor }}
+      extra_pkgs: ${{ toJson(fromJson(needs.prepare.outputs.live_downgrade_row).extra_pkgs) }}
+      pytest_marker: repo
+      pytest_filter: test_live_nightly_downgrade_requires_selected_semantic_repo
+      concurrency_key: nightly-to-stable
+      smoke_repo_live_url: http://pkg.pfblockerng.com/stable
+      smoke_repo_expected_source_sha: ${{ needs.resolve-live-stable-identity.outputs.source_sha }}
+      smoke_repo_expected_version: ${{ needs.resolve-live-stable-identity.outputs.version }}
+      smoke_repo_expected_channel: ${{ needs.resolve-live-stable-identity.outputs.channel }}
+      smoke_nightly_live_url: http://pkg.pfblockerng.com/nightly
+      smoke_nightly_expected_source_sha: ${{ needs.prepare.outputs.source_sha }}
+      smoke_nightly_expected_version: ${{ needs.prepare.outputs.pkg_version }}
+      checkout_ref: ${{ needs.prepare.outputs.tools_sha }}
+    secrets: inherit
+
   cleanup-nightly-oci:
     name: Delete successfully validated Nightly OCI handoff
-    needs: [prepare, publish-nightly-oci, validate-live-pages-install]
+    needs: [prepare, publish-nightly-oci, validate-live-pages-install, validate-live-downgrade]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/tests/test_issue2456_pkg_ownership.py
+++ b/tests/test_issue2456_pkg_ownership.py
@@ -1,12 +1,17 @@
 from __future__ import annotations
 
 import ast
+import io
+import json
 import os
 import subprocess
+import tarfile
 import textwrap
 import unittest
 from pathlib import Path
 
+import pfb_pkg
+import pytest
 import yaml
 
 from tests._workflow_steps import extract_after, extract_before, extract_job, extract_step
@@ -133,7 +138,10 @@ class SourcePublicationBoundaryTests(unittest.TestCase):
             publish,
         )
         self.assertNotIn("sha256:[0-9a-f][0-9a-f]*", publish)
-        self.assertIn("needs: [prepare, publish-nightly-oci, validate-live-pages-install]", cleanup)
+        self.assertEqual(
+            yaml.safe_load(NIGHTLY)["jobs"]["cleanup-nightly-oci"]["needs"],
+            ["prepare", "publish-nightly-oci", "validate-live-pages-install", "validate-live-downgrade"],
+        )
         self.assertIn(digest, cleanup)
         self.assertNotRegex(ingest, r"artifact_ref:\s*ghcr\.io/.+:(?:latest|nightly)")
         self.assertLess(NIGHTLY.index("operation=nightly"), NIGHTLY.index("test_install_from_live_nightly_url"))
@@ -460,6 +468,313 @@ def test_dispatch_helper_rejects_invalid_bounds_before_gh(tmp_path: Path) -> Non
         assert "dispatch bounds must be positive integers" in proc.stderr
         assert calls == ""
         assert not result.exists()
+
+
+def _live_build_record(
+    version: str,
+    *,
+    source: str = "a",
+    channel: str = "stable",
+    record_version: str | None = None,
+    freebsd_major: str = "15",
+    php_version: str = "8.3",
+    py_flavor: str = "py311",
+) -> dict[str, object]:
+    canonical_version = record_version or version
+    record: dict[str, object] = {
+        "schema": 1,
+        "channel": channel,
+        "release_line": "release/4.1",
+        "classification": "final",
+        "source_tag": f"v{canonical_version}",
+        "source_sha": source * 40,
+        "canonical_package_version": canonical_version,
+        "native_recipe_identity": pfb_pkg.CANONICAL_EMITTED_IDENTITY,
+        "emitted_identity": pfb_pkg.CANONICAL_EMITTED_IDENTITY,
+        "matrix_row": {
+            "variant": "CE",
+            "pfsense_version": "2.10.1",
+            "channel": "CE",
+            "freebsd_version": f"{freebsd_major}.0-RELEASE",
+            "freebsd_major": freebsd_major,
+            "php_version": php_version,
+            "py_flavor": py_flavor,
+            "status": "active",
+            "extra_pkgs": [],
+            "upgrade": {"available": False},
+        },
+        "freebsd_ports_sha": "b" * 40,
+        "route": f"{channel}/ce-2.10",
+        "source_date_epoch": 0,
+        "build_input_digest": "",
+    }
+    record["build_input_digest"] = pfb_pkg.build_input_digest(record)
+    return record
+
+
+def _catalogue(entries: list[dict[str, object]]) -> bytes:
+    payload = b"".join(json.dumps(entry, separators=(",", ":")).encode() + b"\n" for entry in entries)
+    raw = io.BytesIO()
+    with tarfile.open(fileobj=raw, mode="w") as archive:
+        member = tarfile.TarInfo("packagesite.yaml")
+        member.size = len(payload)
+        archive.addfile(member, io.BytesIO(payload))
+    return pfb_pkg.zstd_compress(raw.getvalue(), RuntimeError, "zstd unavailable")
+
+
+def _catalogue_entry(
+    name: str,
+    version: str,
+    *,
+    record: dict[str, object] | None = None,
+) -> dict[str, object]:
+    annotations = (
+        {pfb_pkg.PFB_BUILD_RECORD_KEY: json.dumps(record, separators=(",", ":"), sort_keys=True)}
+        if record is not None
+        else {}
+    )
+    return {
+        "name": name,
+        "version": version,
+        "abi": "FreeBSD:15:*",
+        "annotations": annotations,
+    }
+
+
+def _run_live_identity_resolver(
+    tmp_path: Path,
+    catalogue: bytes | None,
+    *,
+    row: dict[str, object] | None = None,
+) -> tuple[subprocess.CompletedProcess[str], str]:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir(parents=True)
+    archive = tmp_path / "packagesite.pkg"
+    if catalogue is not None:
+        archive.write_bytes(catalogue)
+    gh = bin_dir / "gh"
+    gh.write_text(
+        """#!/bin/sh
+case "$*" in
+  *"repos/pfBlockerNG/pkg/commits/main"*) printf '%s\n' "$FAKE_PKG_SHA" ;;
+  *"repos/pfBlockerNG/pkg/contents/"*)
+    [ -f "$FAKE_CATALOGUE" ] || exit 1
+    cat "$FAKE_CATALOGUE"
+    ;;
+  *) printf 'unexpected gh call: %s\n' "$*" >&2; exit 64 ;;
+esac
+""",
+        encoding="utf-8",
+    )
+    gh.chmod(0o755)
+    output = tmp_path / "github-output"
+    live_row = row or {
+        "pfsense_version": "2.10",
+        "channel": "CE",
+        "variant": "CE",
+        "image_name": "pfsense-ce",
+        "mac": "00:11:22:33:44:55",
+        "freebsd_major": "15",
+        "php_version": "8.3",
+        "py_flavor": "py311",
+        "extra_pkgs": ["textproc/py-charset-normalizer"],
+    }
+    step = extract_step(NIGHTLY, "Resolve exact published Stable identity")
+    script = textwrap.dedent(extract_after(step, "        run: |\n"))
+    completed = subprocess.run(
+        ["sh", "-c", script],
+        cwd=ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+        env={
+            **os.environ,
+            "PATH": f"{bin_dir}:{os.environ['PATH']}",
+            "GH_TOKEN": "test-token",
+            "FAKE_PKG_SHA": "d" * 40,
+            "FAKE_CATALOGUE": str(archive),
+            "GITHUB_OUTPUT": str(output),
+            "LIVE_DOWNGRADE_ROW": json.dumps(live_row, separators=(",", ":")),
+        },
+    )
+    return completed, output.read_text(encoding="utf-8") if output.exists() else ""
+
+
+def test_nightly_live_downgrade_resolver_selects_exact_compatible_catalogue_identity(tmp_path: Path) -> None:
+    selected = _live_build_record("4.1.0", source="c")
+    catalogue = _catalogue(
+        [
+            _catalogue_entry(pfb_pkg.CANONICAL_EMITTED_IDENTITY, "4.1.0", record=selected),
+            _catalogue_entry("py311-charset-normalizer", "99.0.0"),
+            _catalogue_entry(
+                pfb_pkg.CANONICAL_EMITTED_IDENTITY,
+                "4.0.0",
+                record=_live_build_record("4.0.0"),
+            ),
+        ]
+    )
+
+    completed, output = _run_live_identity_resolver(tmp_path, catalogue)
+
+    assert completed.returncode == 0, completed.stderr
+    assert "smoke_repo_expected_version=4.1.0" in output
+    assert f"smoke_repo_expected_source_sha={'c' * 40}" in output
+    assert "smoke_repo_expected_channel=stable" in output
+    assert "varver=ce-2.10" in output
+    assert f"pkg_repo_sha={'d' * 40}" in output
+
+
+@pytest.mark.parametrize(
+    ("case", "catalogue", "error"),
+    [
+        ("missing", None, ""),
+        ("corrupt", b"not-a-zstd-catalogue", "catalogue"),
+        (
+            "absent-canonical",
+            _catalogue([_catalogue_entry("py311-charset-normalizer", "99.0.0")]),
+            "canonical",
+        ),
+        (
+            "digest-invalid",
+            _catalogue(
+                [
+                    _catalogue_entry(
+                        pfb_pkg.CANONICAL_EMITTED_IDENTITY,
+                        "4.1.0",
+                        record={**_live_build_record("4.1.0"), "source_sha": "f" * 40},
+                    )
+                ]
+            ),
+            "build record",
+        ),
+        (
+            "wrong-channel",
+            _catalogue(
+                [
+                    _catalogue_entry(
+                        pfb_pkg.CANONICAL_EMITTED_IDENTITY,
+                        "4.1.0",
+                        record=_live_build_record("4.1.0", channel="testing"),
+                    )
+                ]
+            ),
+            "stable",
+        ),
+        (
+            "record-version",
+            _catalogue(
+                [
+                    _catalogue_entry(
+                        pfb_pkg.CANONICAL_EMITTED_IDENTITY,
+                        "4.1.0",
+                        record=_live_build_record("4.1.0", record_version="4.0.0"),
+                    )
+                ]
+            ),
+            "version",
+        ),
+        (
+            "runtime",
+            _catalogue(
+                [
+                    _catalogue_entry(
+                        pfb_pkg.CANONICAL_EMITTED_IDENTITY,
+                        "4.1.0",
+                        record=_live_build_record("4.1.0", php_version="8.5"),
+                    )
+                ]
+            ),
+            "php_version",
+        ),
+    ],
+)
+def test_nightly_live_downgrade_resolver_fails_closed(
+    tmp_path: Path,
+    case: str,
+    catalogue: bytes | None,
+    error: str,
+) -> None:
+    completed, output = _run_live_identity_resolver(tmp_path / case, catalogue)
+
+    assert completed.returncode != 0
+    assert error in completed.stderr
+    assert output == ""
+
+
+def test_nightly_selects_minimum_ci_true_ce_runtime_and_fails_without_one(tmp_path: Path) -> None:
+    step = extract_step(NIGHTLY, "Select live downgrade runtime")
+    script = textwrap.dedent(extract_after(step, "        run: |\n"))
+    rows = [
+        {"channel": "CE", "pfsense_version": "2.10"},
+        {"channel": "Plus", "pfsense_version": "1.0"},
+        {"channel": "CE", "pfsense_version": "2.9"},
+    ]
+
+    output = tmp_path / "selected"
+    selected = subprocess.run(
+        ["sh", "-c", script],
+        cwd=tmp_path,
+        check=False,
+        capture_output=True,
+        text=True,
+        env={
+            **os.environ,
+            "CI_MATRIX": json.dumps(rows),
+            "GITHUB_OUTPUT": str(output),
+        },
+    )
+    assert selected.returncode == 0, selected.stderr
+    assert json.loads(output.read_text(encoding="utf-8").removeprefix("row="))["pfsense_version"] == "2.9"
+
+    output.unlink()
+    rejected = subprocess.run(
+        ["sh", "-c", script],
+        cwd=tmp_path,
+        check=False,
+        capture_output=True,
+        text=True,
+        env={
+            **os.environ,
+            "CI_MATRIX": '[{"channel":"Plus","pfsense_version":"1.0"}]',
+            "GITHUB_OUTPUT": str(output),
+        },
+    )
+    assert rejected.returncode != 0
+    assert "no ci:true CE row" in rejected.stderr
+    assert not output.exists()
+
+
+def test_nightly_wires_real_live_downgrade_with_both_exact_identities() -> None:
+    workflow = yaml.safe_load(NIGHTLY)
+    jobs = workflow["jobs"]
+    direct = jobs["validate-live-pages-install"]
+    resolver = jobs["resolve-live-stable-identity"]
+    downgrade = jobs["validate-live-downgrade"]
+    inputs = downgrade["with"]
+
+    assert direct["with"]["pytest_filter"] == "test_install_from_live_nightly_url"
+    assert resolver["needs"] == ["prepare", "ingest-pkg"]
+    assert downgrade["needs"] == ["prepare", "resolve-live-stable-identity"]
+    assert inputs == {
+        "pfsense_version": "${{ fromJson(needs.prepare.outputs.live_downgrade_row).pfsense_version }}",
+        "image_name": "${{ fromJson(needs.prepare.outputs.live_downgrade_row).image_name }}",
+        "mac": "${{ fromJson(needs.prepare.outputs.live_downgrade_row).mac }}",
+        "abi": "FreeBSD:${{ fromJson(needs.prepare.outputs.live_downgrade_row).freebsd_major }}:amd64",
+        "php_version": "${{ fromJson(needs.prepare.outputs.live_downgrade_row).php_version }}",
+        "py_flavor": "${{ fromJson(needs.prepare.outputs.live_downgrade_row).py_flavor }}",
+        "extra_pkgs": "${{ toJson(fromJson(needs.prepare.outputs.live_downgrade_row).extra_pkgs) }}",
+        "pytest_marker": "repo",
+        "pytest_filter": "test_live_nightly_downgrade_requires_selected_semantic_repo",
+        "concurrency_key": "nightly-to-stable",
+        "smoke_repo_live_url": "http://pkg.pfblockerng.com/stable",
+        "smoke_repo_expected_source_sha": "${{ needs.resolve-live-stable-identity.outputs.source_sha }}",
+        "smoke_repo_expected_version": "${{ needs.resolve-live-stable-identity.outputs.version }}",
+        "smoke_repo_expected_channel": "${{ needs.resolve-live-stable-identity.outputs.channel }}",
+        "smoke_nightly_live_url": "http://pkg.pfblockerng.com/nightly",
+        "smoke_nightly_expected_source_sha": "${{ needs.prepare.outputs.source_sha }}",
+        "smoke_nightly_expected_version": "${{ needs.prepare.outputs.pkg_version }}",
+        "checkout_ref": "${{ needs.prepare.outputs.tools_sha }}",
+    }
 
 
 if __name__ == "__main__":

--- a/tests/test_issue2456_pkg_ownership.py
+++ b/tests/test_issue2456_pkg_ownership.py
@@ -15,6 +15,7 @@ import pytest
 import yaml
 
 from tests._workflow_steps import extract_after, extract_before, extract_job, extract_step
+from tests.gitenv import scrubbed_git_env
 
 ROOT = Path(__file__).resolve().parents[1]
 WORKFLOWS = ROOT / ".github" / "workflows"
@@ -481,15 +482,23 @@ def _live_build_record(
     py_flavor: str = "py311",
 ) -> dict[str, object]:
     canonical_version = record_version or version
+    release_line = ".".join(canonical_version.split(".")[:2])
+    classification = "final"
+    if channel != "stable":
+        classification = {"a": "alpha", "b": "beta", "r": "rc"}[canonical_version.rsplit(".", 1)[-1][0]]
     record: dict[str, object] = {
         "schema": 1,
         "channel": channel,
-        "release_line": "release/4.1",
-        "classification": "final",
+        "release_line": f"release/{release_line}",
+        "classification": classification,
         "source_tag": f"v{canonical_version}",
         "source_sha": source * 40,
         "canonical_package_version": canonical_version,
-        "native_recipe_identity": pfb_pkg.CANONICAL_EMITTED_IDENTITY,
+        "native_recipe_identity": (
+            pfb_pkg.CANONICAL_EMITTED_IDENTITY
+            if channel == "stable"
+            else f"{pfb_pkg.CANONICAL_EMITTED_IDENTITY}-{channel}"
+        ),
         "emitted_identity": pfb_pkg.CANONICAL_EMITTED_IDENTITY,
         "matrix_row": {
             "variant": "CE",
@@ -527,18 +536,16 @@ def _catalogue_entry(
     version: str,
     *,
     record: dict[str, object] | None = None,
+    annotation: str | None = None,
+    abi: str = "FreeBSD:15:*",
 ) -> dict[str, object]:
-    annotations = (
-        {pfb_pkg.PFB_BUILD_RECORD_KEY: json.dumps(record, separators=(",", ":"), sort_keys=True)}
-        if record is not None
-        else {}
-    )
-    return {
-        "name": name,
-        "version": version,
-        "abi": "FreeBSD:15:*",
-        "annotations": annotations,
-    }
+    if annotation is not None:
+        annotations = {pfb_pkg.PFB_BUILD_RECORD_KEY: annotation}
+    elif record is not None:
+        annotations = {pfb_pkg.PFB_BUILD_RECORD_KEY: json.dumps(record, separators=(",", ":"), sort_keys=True)}
+    else:
+        annotations = {}
+    return {"name": name, "version": version, "abi": abi, "annotations": annotations}
 
 
 def _run_live_identity_resolver(
@@ -580,7 +587,9 @@ esac
         "extra_pkgs": ["textproc/py-charset-normalizer"],
     }
     step = extract_step(NIGHTLY, "Resolve exact published Stable identity")
-    script = textwrap.dedent(extract_after(step, "        run: |\n"))
+    script = textwrap.dedent(
+        extract_before(extract_after(step, "        run: |\n"), "\n          PY") + "\n          PY\n"
+    )
     completed = subprocess.run(
         ["sh", "-c", script],
         cwd=ROOT,
@@ -604,24 +613,22 @@ def test_nightly_live_downgrade_resolver_selects_exact_compatible_catalogue_iden
     selected = _live_build_record("4.1.0", source="c")
     catalogue = _catalogue(
         [
-            _catalogue_entry(pfb_pkg.CANONICAL_EMITTED_IDENTITY, "4.1.0", record=selected),
-            _catalogue_entry("py311-charset-normalizer", "99.0.0"),
             _catalogue_entry(
                 pfb_pkg.CANONICAL_EMITTED_IDENTITY,
                 "4.0.0",
                 record=_live_build_record("4.0.0"),
             ),
+            _catalogue_entry("py311-charset-normalizer", "99.0.0"),
+            _catalogue_entry(pfb_pkg.CANONICAL_EMITTED_IDENTITY, "4.1.0", record=selected),
         ]
     )
 
     completed, output = _run_live_identity_resolver(tmp_path, catalogue)
 
     assert completed.returncode == 0, completed.stderr
-    assert "smoke_repo_expected_version=4.1.0" in output
-    assert f"smoke_repo_expected_source_sha={'c' * 40}" in output
-    assert "smoke_repo_expected_channel=stable" in output
-    assert "varver=ce-2.10" in output
-    assert f"pkg_repo_sha={'d' * 40}" in output
+    assert "version=4.1.0" in output
+    assert f"source_sha={'c' * 40}" in output
+    assert "channel=stable" in output
 
 
 @pytest.mark.parametrize(
@@ -633,6 +640,33 @@ def test_nightly_live_downgrade_resolver_selects_exact_compatible_catalogue_iden
             "absent-canonical",
             _catalogue([_catalogue_entry("py311-charset-normalizer", "99.0.0")]),
             "canonical",
+        ),
+        (
+            "missing-provenance",
+            _catalogue([_catalogue_entry(pfb_pkg.CANONICAL_EMITTED_IDENTITY, "4.1.0")]),
+            "build record",
+        ),
+        (
+            "malformed-provenance",
+            _catalogue([_catalogue_entry(pfb_pkg.CANONICAL_EMITTED_IDENTITY, "4.1.0", annotation="{")]),
+            "build record",
+        ),
+        (
+            "missing-digest",
+            _catalogue(
+                [
+                    _catalogue_entry(
+                        pfb_pkg.CANONICAL_EMITTED_IDENTITY,
+                        "4.1.0",
+                        record={
+                            key: value
+                            for key, value in _live_build_record("4.1.0").items()
+                            if key != "build_input_digest"
+                        },
+                    )
+                ]
+            ),
+            "build record",
         ),
         (
             "digest-invalid",
@@ -653,8 +687,8 @@ def test_nightly_live_downgrade_resolver_selects_exact_compatible_catalogue_iden
                 [
                     _catalogue_entry(
                         pfb_pkg.CANONICAL_EMITTED_IDENTITY,
-                        "4.1.0",
-                        record=_live_build_record("4.1.0", channel="testing"),
+                        "4.1.1.a1",
+                        record=_live_build_record("4.1.1.a1", channel="testing"),
                     )
                 ]
             ),
@@ -674,7 +708,20 @@ def test_nightly_live_downgrade_resolver_selects_exact_compatible_catalogue_iden
             "version",
         ),
         (
-            "runtime",
+            "record-abi",
+            _catalogue(
+                [
+                    _catalogue_entry(
+                        pfb_pkg.CANONICAL_EMITTED_IDENTITY,
+                        "4.1.0",
+                        record=_live_build_record("4.1.0", freebsd_major="16"),
+                    )
+                ]
+            ),
+            "freebsd_major",
+        ),
+        (
+            "record-php",
             _catalogue(
                 [
                     _catalogue_entry(
@@ -685,6 +732,33 @@ def test_nightly_live_downgrade_resolver_selects_exact_compatible_catalogue_iden
                 ]
             ),
             "php_version",
+        ),
+        (
+            "record-python",
+            _catalogue(
+                [
+                    _catalogue_entry(
+                        pfb_pkg.CANONICAL_EMITTED_IDENTITY,
+                        "4.1.0",
+                        record=_live_build_record("4.1.0", py_flavor="py312"),
+                    )
+                ]
+            ),
+            "py_flavor",
+        ),
+        (
+            "catalogue-abi",
+            _catalogue(
+                [
+                    _catalogue_entry(
+                        pfb_pkg.CANONICAL_EMITTED_IDENTITY,
+                        "4.1.0",
+                        record=_live_build_record("4.1.0"),
+                        abi="FreeBSD:16:*",
+                    )
+                ]
+            ),
+            "catalogue ABI",
         ),
     ],
 )
@@ -701,41 +775,96 @@ def test_nightly_live_downgrade_resolver_fails_closed(
     assert output == ""
 
 
-def test_nightly_selects_minimum_ci_true_ce_runtime_and_fails_without_one(tmp_path: Path) -> None:
+def _matrix_row(version: str, *, channel: str = "CE", ci: bool = True) -> dict[str, object]:
+    return {
+        "pfsense_version": version,
+        "channel": channel,
+        "freebsd_version": "15.0-RELEASE",
+        "freebsd_major": "15",
+        "php_version": "8.3",
+        "py_flavor": "py311",
+        "variant": channel,
+        "status": "active",
+        "ci": ci,
+        "extra_pkgs": [],
+    }
+
+
+def _commit_matrix(repo: Path, rows: list[dict[str, object]], message: str) -> str:
+    (repo / "supported-versions.json").write_text(
+        json.dumps({"description": "live downgrade fixture", "versions": rows}),
+        encoding="utf-8",
+    )
+    env = scrubbed_git_env(drop_git_vars=True)
+    subprocess.run(["git", "add", "supported-versions.json"], cwd=repo, env=env, check=True)
+    subprocess.run(
+        ["git", "-c", "commit.gpgsign=false", "commit", "-qm", message],
+        cwd=repo,
+        env=env,
+        check=True,
+    )
+    return subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=repo,
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+
+def test_nightly_selects_minimum_pinned_ci_true_ce_runtime_and_fails_without_one(tmp_path: Path) -> None:
+    repo = tmp_path / "trusted"
+    repo.mkdir()
+    env = scrubbed_git_env(drop_git_vars=True)
+    subprocess.run(["git", "init", "-q", "-b", "main"], cwd=repo, env=env, check=True)
+    subprocess.run(["git", "config", "user.name", "test"], cwd=repo, env=env, check=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=repo, env=env, check=True)
+    scripts = repo / "scripts"
+    scripts.mkdir()
+    (scripts / "read-version-matrix.sh").symlink_to(ROOT / "scripts" / "read-version-matrix.sh")
+    pinned_sha = _commit_matrix(
+        repo,
+        [
+            _matrix_row("2.7", ci=False),
+            _matrix_row("2.10"),
+            _matrix_row("2.9"),
+            _matrix_row("26.03", channel="Plus"),
+        ],
+        "pinned",
+    )
+    no_ce_sha = _commit_matrix(repo, [_matrix_row("26.07", channel="Plus")], "no CE")
+
     step = extract_step(NIGHTLY, "Select live downgrade runtime")
     script = textwrap.dedent(extract_after(step, "        run: |\n"))
-    rows = [
-        {"channel": "CE", "pfsense_version": "2.10"},
-        {"channel": "Plus", "pfsense_version": "1.0"},
-        {"channel": "CE", "pfsense_version": "2.9"},
-    ]
-
     output = tmp_path / "selected"
     selected = subprocess.run(
         ["sh", "-c", script],
-        cwd=tmp_path,
         check=False,
         capture_output=True,
         text=True,
         env={
             **os.environ,
-            "CI_MATRIX": json.dumps(rows),
+            "TRUSTED_DIR": str(repo),
+            "MATRIX_SHA": pinned_sha,
             "GITHUB_OUTPUT": str(output),
         },
     )
     assert selected.returncode == 0, selected.stderr
-    assert json.loads(output.read_text(encoding="utf-8").removeprefix("row="))["pfsense_version"] == "2.9"
+    row = json.loads(output.read_text(encoding="utf-8").removeprefix("row="))
+    assert row["pfsense_version"] == "2.9"
+    assert row["ci"] is True
 
     output.unlink()
     rejected = subprocess.run(
         ["sh", "-c", script],
-        cwd=tmp_path,
         check=False,
         capture_output=True,
         text=True,
         env={
             **os.environ,
-            "CI_MATRIX": '[{"channel":"Plus","pfsense_version":"1.0"}]',
+            "TRUSTED_DIR": str(repo),
+            "MATRIX_SHA": no_ce_sha,
             "GITHUB_OUTPUT": str(output),
         },
     )
@@ -754,6 +883,11 @@ def test_nightly_wires_real_live_downgrade_with_both_exact_identities() -> None:
 
     assert direct["with"]["pytest_filter"] == "test_install_from_live_nightly_url"
     assert resolver["needs"] == ["prepare", "ingest-pkg"]
+    assert resolver["outputs"] == {
+        "source_sha": "${{ steps.identity.outputs.source_sha }}",
+        "version": "${{ steps.identity.outputs.version }}",
+        "channel": "${{ steps.identity.outputs.channel }}",
+    }
     assert downgrade["needs"] == ["prepare", "resolve-live-stable-identity"]
     assert inputs == {
         "pfsense_version": "${{ fromJson(needs.prepare.outputs.live_downgrade_row).pfsense_version }}",

--- a/tests/test_issue2456_pkg_ownership.py
+++ b/tests/test_issue2456_pkg_ownership.py
@@ -783,6 +783,8 @@ def _matrix_row(version: str, *, channel: str = "CE", ci: bool = True) -> dict[s
         "freebsd_major": "15",
         "php_version": "8.3",
         "py_flavor": "py311",
+        "image_name": "pfsense-ce" if channel == "CE" else "pfsense-plus",
+        "mac": "00:11:22:33:44:55",
         "variant": channel,
         "status": "active",
         "ci": ci,
@@ -854,6 +856,8 @@ def test_nightly_selects_minimum_pinned_ci_true_ce_runtime_and_fails_without_one
     row = json.loads(output.read_text(encoding="utf-8").removeprefix("row="))
     assert row["pfsense_version"] == "2.9"
     assert row["ci"] is True
+    assert row["image_name"] == "pfsense-ce"
+    assert row["mac"] == "00:11:22:33:44:55"
 
     output.unlink()
     rejected = subprocess.run(


### PR DESCRIPTION
## Why

The live Nightly-to-selected-semantic-repository downgrade test required both repository roots, but no automated CI caller supplied both. Its scheduled skip could therefore remain silent indefinitely.

## How

- Select the minimum numeric `ci:true` CE runtime from the pinned version matrix.
- Resolve and pin the exact currently published Stable catalogue/build identity.
- Run only `test_live_nightly_downgrade_requires_selected_semantic_repo` after Nightly publication with both shared-root URLs, the exact Stable and Nightly identities, and the selected CE/FreeBSD/PHP/Python runtime.
- Keep the direct tagged install, direct Nightly install, and scheduled non-live repository install unchanged.

## Executed evidence

| Frozen RED test | git hash-object | RED run tail |
| --- | --- | --- |
| `tests/test_issue2456_pkg_ownership.py` | `71cf307920cd6ccbc46d85a1b4f3c299a29869bf` | `2 failed, 15 passed` |

- Test-first RED: `uv run pytest -q tests/test_issue2456_pkg_ownership.py -k nightly` → 11 failed before the caller existed; frozen test hash `f9cca19f15ececc2d9c794a147e5d08e71e96549`.
- Initial GREEN: `uv run pytest -q tests/test_issue2456_pkg_ownership.py` → 24 passed.
- Correction RED/GREEN with frozen hash `a41630ed994e92f211099284fe32c3d635fb650e`: old workflow → 2 failed, 15 passed; corrected workflow → 17 passed.
- Focused file: `uv run pytest -q tests/test_issue2456_pkg_ownership.py` → 30 passed.
- Canonical gate: `sh scripts/agent/run-gates.sh --diff 969c8c4977ee6c7f8ead4507f9375865ec7fbb8b` → graph fresh, locked pytest, Ruff check/format, mypy, and coverage pairing all PASS (5,980 passed, 7 skipped in pytest).
- Independent correction gate re-executed RED (2 failed, 15 passed), GREEN (17 passed), the SHA hygiene test (1 passed), and four mutations; all four mutations were killed.
- Rebased onto live `devel`; source/test diff remained byte-identical by SHA-256 (`e9852b306d202b7b481d27ead7da5c1f3969c3ef1417bfe0e13a9c374fabfafc`), generated graph refreshed, and both rebased commits verify with good signatures.

Fixes #3112
