### PR TITLE
ci: activate hooks in remaining commit writers

### DIFF
--- a/.github/workflows/image-refresh.yml
+++ b/.github/workflows/image-refresh.yml
@@ -239,6 +239,10 @@ jobs:
       - name: Install the Graphify merge driver
         run: sh scripts/agent/ensure-graphify-merge-driver.sh .
 
+      # Automated commits must hit the same local gates as a human commit.
+      - name: Activate git hooks
+        run: sh scripts/setup-hooks.sh
+
       - name: Enable KVM access for the runner user
         # GH-hosted ubuntu-latest ships /dev/kvm but the unprivileged `runner` user is
         # not in the `kvm` group, so qemu -enable-kvm gets EPERM. A udev rule making

--- a/.github/workflows/module-durations.yml
+++ b/.github/workflows/module-durations.yml
@@ -67,6 +67,10 @@ jobs:
       - name: Install the Graphify merge driver
         run: sh scripts/agent/ensure-graphify-merge-driver.sh .
 
+      # Automated commits must hit the same local gates as a human commit.
+      - name: Activate git hooks
+        run: sh scripts/setup-hooks.sh
+
       - name: Verify the source smoke run finished green
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -278,6 +278,10 @@ jobs:
       - name: Install the Graphify merge driver
         run: sh "${GITHUB_WORKSPACE}/pfblockerng-src/scripts/agent/ensure-graphify-merge-driver.sh" .
 
+      # Automated commits must hit the same local gates as a human commit.
+      - name: Activate git hooks
+        run: sh "${GITHUB_WORKSPACE}/pfblockerng-src/scripts/setup-hooks.sh"
+
       - name: Configure pfblockerng-bot signing
         env:
           PFB_BOT_SIGNING_KEY: ${{ secrets.PFB_BOT_SIGNING_KEY }}

--- a/.github/workflows/version-tracker.yml
+++ b/.github/workflows/version-tracker.yml
@@ -281,6 +281,10 @@ jobs:
       - name: Install the Graphify merge driver
         run: sh scripts/agent/ensure-graphify-merge-driver.sh .
 
+      # Automated commits must hit the same local gates as a human commit.
+      - name: Activate git hooks
+        run: sh scripts/setup-hooks.sh
+
       # The reconcile needs EVERY family, one row per version: build_matrix is
       # deduped to one row per runtime tuple (issue #2926), which hides the
       # SIBLING VERSIONS of a merged same-tuple group (26.03 vs 26.07 share a

--- a/scripts/setup-hooks.sh
+++ b/scripts/setup-hooks.sh
@@ -14,15 +14,25 @@ set -eu
 
 root=$(git rev-parse --show-toplevel)
 script_dir=$(CDPATH='' cd "$(dirname "$0")" && pwd -P)
-sh "$script_dir/agent/ensure-graphify.sh" "$root" >/dev/null
+# Graphify/CodeGraph need pyproject.toml. A scripts-only helper checkout
+# (release-published.yml) still activates hooksPath on the writer repo.
+if [ -f "$root/pyproject.toml" ] || [ -f "$script_dir/../pyproject.toml" ]; then
+	has_project=1
+else
+	has_project=0
+fi
+if [ "$has_project" -eq 1 ]; then
+	sh "$script_dir/agent/ensure-graphify.sh" "$root" >/dev/null
+fi
 git -C "$root" config core.hooksPath .githooks
 
-if command -v codegraph >/dev/null 2>&1; then
+if [ "$has_project" -eq 1 ] && command -v codegraph >/dev/null 2>&1; then
 	sh "$script_dir/agent/ensure-codegraph.sh" "$root"
 fi
 
 printf 'core.hooksPath set to: %s\n' "$(git -C "$root" config core.hooksPath)"
 printf 'Active hooks:\n'
 for hook in "$root"/.githooks/*; do
-	[ -f "$hook" ] && printf '  %s\n' "$(basename "$hook")"
+	[ -f "$hook" ] || continue
+	printf '  %s\n' "$(basename "$hook")"
 done

--- a/tests/shell/setup_hooks_spec.sh
+++ b/tests/shell/setup_hooks_spec.sh
@@ -105,4 +105,22 @@ CODEGRAPH
     The value "$(git_fixture -C "$primary" config --get core.hooksPath 2>/dev/null || true)" should equal ''
     The file "$install_log" should not be exist
   End
+
+  It 'still activates Git hooks when the git root and helper checkout have no pyproject.toml'
+    # release-published.yml runs setup-hooks.sh from a scripts-only sparse
+    # checkout of pfBlockerNG while CWD is the FreeBSD-ports fork. Graphify
+    # cannot install without pyproject.toml; hook activation still must.
+    foreign="$fixture/ports"
+    helper="$foreign/pfblockerng-src"
+    git_fixture init -q "$foreign" || return 1
+    mkdir -p "$helper/scripts/agent" "$helper/scripts/lib"
+    cp "$script_abs" "$helper/scripts/setup-hooks.sh"
+    cp "${SHELLSPEC_PROJECT_ROOT:-$PWD}/scripts/agent/"*.sh "$helper/scripts/agent/"
+    cp "${SHELLSPEC_PROJECT_ROOT:-$PWD}/scripts/lib/"*.sh "$helper/scripts/lib/"
+    When run sh -c 'cd "$1" && exec sh "$2"' _ "$foreign" "$helper/scripts/setup-hooks.sh"
+    The status should equal 0
+    The output should include 'core.hooksPath set to: .githooks'
+    The value "$(git_fixture -C "$foreign" config --get core.hooksPath)" should equal '.githooks'
+    The file "$install_log" should not be exist
+  End
 End

--- a/tests/test_workflow_writer_hooks.py
+++ b/tests/test_workflow_writer_hooks.py
@@ -1,0 +1,158 @@
+"""GitHub Actions jobs that create commits activate repository hooks first.
+
+Issue #3045: git.md requires every Actions workflow that commits code to run
+``scripts/setup-hooks.sh`` after checkout. HSTS/PSL/TLD refresh already do;
+the remaining writers must pair hook activation with the commit step.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+WORKFLOWS = Path(__file__).resolve().parents[1] / ".github" / "workflows"
+_COMMIT = re.compile(r"\bgit(?:\s+-C\s+\S+)?\s+commit\b")
+_HOOKS = re.compile(r"scripts/setup-hooks\.sh|core\.hooksPath")
+
+
+def _active_script(step: dict[str, Any]) -> str:
+    """A step's ``run`` body with whole-line comments blanked.
+
+    A documented ``git commit`` or ``setup-hooks.sh`` is prose; only real
+    invocations are judged.
+    """
+    script = step.get("run", "")
+    if not isinstance(script, str) or not script:
+        return ""
+    return "\n".join("" if line.lstrip().startswith("#") else line for line in script.splitlines())
+
+
+def _writer_jobs(text: str) -> list[tuple[str, list[dict[str, Any]]]]:
+    workflow = yaml.safe_load(text)
+    writers: list[tuple[str, list[dict[str, Any]]]] = []
+    for job_name, job in workflow.get("jobs", {}).items():
+        steps = job.get("steps", [])
+        if any(_COMMIT.search(_active_script(step)) for step in steps):
+            writers.append((job_name, steps))
+    return writers
+
+
+def _offenders(name: str, text: str) -> tuple[list[str], list[str]]:
+    """(offending job descriptions, inspected job labels) for one workflow."""
+    offenders: list[str] = []
+    inspected: list[str] = []
+    for job, steps in _writer_jobs(text):
+        inspected.append(f"{name}:{job}")
+        hook_indexes = [index for index, step in enumerate(steps) if _HOOKS.search(_active_script(step))]
+        writer_indexes = [index for index, step in enumerate(steps) if _COMMIT.search(_active_script(step))]
+        if not hook_indexes:
+            offenders.append(f"{name}: job `{job}` commits without activating repository hooks")
+            continue
+        if min(hook_indexes) >= min(writer_indexes):
+            offenders.append(f"{name}: job `{job}` activates hooks after writing a commit")
+    return offenders, inspected
+
+
+def test_git_commit_writer_jobs_activate_hooks_before_committing() -> None:
+    """Every job that can create a commit activates .githooks first.
+
+    Given a job whose steps include ``git commit``,
+    when the inventory runs,
+    then ``scripts/setup-hooks.sh`` (or ``core.hooksPath``) appears in an
+    earlier step of that same job.
+    """
+    offenders: list[str] = []
+    inspected: list[str] = []
+    for path in sorted(WORKFLOWS.glob("*.yml")):
+        job_offenders, job_inspected = _offenders(path.name, path.read_text(encoding="utf-8"))
+        offenders.extend(job_offenders)
+        inspected.extend(job_inspected)
+    assert inspected, "no Git-commit writer jobs discovered"
+    assert not offenders, "\n".join(offenders)
+
+
+def test_guard_flags_a_writer_without_hooks() -> None:
+    """The guard's own red path: a commit job with no hook activation."""
+    offenders, inspected = _offenders(
+        "synthetic.yml",
+        "jobs:\n"
+        "  refresh:\n"
+        "    steps:\n"
+        "      - run: |\n"
+        "          git add tests/smoke/module-durations.txt\n"
+        "          git commit -m 'refresh'\n",
+    )
+    assert inspected == ["synthetic.yml:refresh"]
+    assert offenders == ["synthetic.yml: job `refresh` commits without activating repository hooks"]
+
+
+def test_guard_flags_hooks_activated_after_the_commit() -> None:
+    """Ordering matters: hooks after ``git commit`` are too late."""
+    offenders, _inspected = _offenders(
+        "synthetic.yml",
+        "jobs:\n  refresh:\n    steps:\n      - run: git commit -m 'x'\n      - run: sh scripts/setup-hooks.sh\n",
+    )
+    assert offenders == ["synthetic.yml: job `refresh` activates hooks after writing a commit"]
+
+
+def test_guard_passes_hooks_before_the_commit() -> None:
+    """The fixed shape: activate hooks, then commit."""
+    offenders, inspected = _offenders(
+        "synthetic.yml",
+        "jobs:\n"
+        "  refresh:\n"
+        "    steps:\n"
+        "      - run: sh scripts/setup-hooks.sh\n"
+        "      - run: |\n"
+        "          git add tests/smoke/module-durations.txt\n"
+        "          git commit -m 'refresh'\n",
+    )
+    assert inspected == ["synthetic.yml:refresh"]
+    assert offenders == []
+
+
+def test_guard_sees_git_c_commit_and_helper_checkout_hook_path() -> None:
+    """``git -C`` commits and a helper-checkout setup-hooks path still count."""
+    offenders, inspected = _offenders(
+        "synthetic.yml",
+        "jobs:\n"
+        "  refresh:\n"
+        "    steps:\n"
+        '      - run: sh "${GITHUB_WORKSPACE}/pfblockerng-src/scripts/setup-hooks.sh"\n'
+        '      - run: git -C "$WT" commit -m activate\n',
+    )
+    assert inspected == ["synthetic.yml:refresh"]
+    assert offenders == []
+
+
+def test_guard_ignores_a_git_commit_that_is_only_a_comment() -> None:
+    """A documented ``git commit`` is prose; only real invocations are judged."""
+    offenders, inspected = _offenders(
+        "synthetic.yml",
+        "jobs:\n"
+        "  react:\n"
+        "    steps:\n"
+        "      - run: |\n"
+        "          # No git commit on channel branches appears in this job.\n"
+        "          echo ok\n",
+    )
+    assert inspected == []
+    assert offenders == []
+
+
+def test_guard_ignores_a_hook_activation_that_is_only_a_comment() -> None:
+    """A commented ``setup-hooks.sh`` does not pair a writer."""
+    offenders, inspected = _offenders(
+        "synthetic.yml",
+        "jobs:\n"
+        "  refresh:\n"
+        "    steps:\n"
+        "      - run: |\n"
+        "          # sh scripts/setup-hooks.sh\n"
+        "          git commit -m 'x'\n",
+    )
+    assert inspected == ["synthetic.yml:refresh"]
+    assert offenders == ["synthetic.yml: job `refresh` commits without activating repository hooks"]


### PR DESCRIPTION
## Summary

- run `scripts/setup-hooks.sh` after checkout in the four Git-object writers that still committed without `.githooks`: `module-durations.yml`, `image-refresh.yml`, `version-tracker.yml`, and `release-published.yml`
- keep Graphify merge-driver ordering, writer `if` / `continue-on-error` guards, and the ports-fork sparse checkout layout
- skip Graphify/CodeGraph in `setup-hooks.sh` when neither the git root nor the helper checkout has `pyproject.toml`, so the ports-fork writer can still set `core.hooksPath`

## Verification

| Frozen RED test | git hash-object | RED run tail |
| --- | --- | --- |
| `tests/test_workflow_writer_hooks.py` | `7ecdd12b64c0dc59326ec1e7f9c405d32badfdab` | `1 failed, 6 passed`: the four named writers committed without hook activation |
| `tests/shell/setup_hooks_spec.sh` | `890869a8baf18551922d7983ca1558ed7b001573` | status 1: `required project configuration '.../pyproject.toml' is missing` |

- GREEN: inventory file → `7 passed`; setup-hooks spec → `5 examples, 0 failures`
- sibling writer/signing/composer/graphify contracts → `43 passed`
- actionlint 1.7.12 over the four changed workflows → exit 0
- ShellCheck on `scripts/setup-hooks.sh` → exit 0

Fixes #3045

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Automated repository updates and release synchronization now apply the same validation checks as manual commits.
  - Git hooks can be activated reliably in repositories that do not contain project-specific configuration.
  - Non-file entries in the hooks directory are safely ignored during setup.

- **Tests**
  - Added coverage to verify hook activation across automated workflows and non-project repositories.
  - Added safeguards ensuring automated commits configure hooks before committing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->