### PR TITLE
gui: point apply guidance at the Update tab's Run Now, not retired Force actions

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -6982,18 +6982,19 @@ function pfb_run_hooks($when, $ctx = array()) {
 /*
  * Map sync_package_pfblockerng()'s $cron argument to a stable PFB_TRIGGER value
  * for the hook context. The ADR's nominal set is cron|update|force-update|force-reload;
- * in practice this emits cron|update|force-reload (see below -- force-update collapses
- * to cron because the GUI Force Update dispatches the same 'pfblockerng.php update' that
+ * in practice this emits cron|update|force-reload (see below -- force-update collapsed
+ * to cron because the legacy GUI dispatched the same 'pfblockerng.php update' that
  * calls sync_package_pfblockerng('cron'), indistinguishable from the scheduled cron).
  *
  * What each $cron value means at the fire points (verified against the callers):
- *   'updateip' / 'updatednsbl' -> a GUI "Force Reload" of just IP or just DNSBL
- *       (pfblockerng_update.php -> pfblockerng.php updateip|updatednsbl) => force-reload.
+ *   'updateip' / 'updatednsbl' -> a scoped forced reload of just IP or just DNSBL
+ *       (legacy verb; the GUI equivalent is Run Now with Force: Parse) => force-reload.
  *   'cron'  -> the scheduled cron job (pfblockerng.php cron -> pfblockerng_sync_cron),
- *       AND the GUI "Force Update" / "Force Reload (All)" actions, which dispatch
- *       'pfblockerng.php update' and likewise call sync_package_pfblockerng('cron').
- *       These are INDISTINGUISHABLE inside the pass (same $cron), so 'cron' is the
- *       honest label; a hook that needs to know it ran from the GUI cannot tell here.
+ *       AND the legacy 'pfblockerng.php update' verb, which likewise calls
+ *       sync_package_pfblockerng('cron'). These are INDISTINGUISHABLE inside the pass
+ *       (same $cron), so 'cron' is the honest label here; the ADR-43 GUI 'Run Now'
+ *       dispatches pfb_trigger with trigger=manual|force instead, so hooks CAN tell a
+ *       GUI-initiated pass from a scheduled one via PFB_TRIGGER.
  *   'noupdates' -> the cron path's "nothing to update" branch => cron.
  *   '' (default) -> a settings save (pfblockerng_general.php) or the de-install path
  *       => update.
@@ -12357,14 +12358,14 @@ function pfb_reload_unbound($mode, $cache=FALSE, $pfbpython=FALSE, $datapath=FAL
 
 		@copy("{$pfb['dnsbldir']}/unbound.conf", "{$pfb['dnsbldir']}/unbound.conf.error");
 		if ($mode == 'enabled') {
-			$log = "\nDNSBL {$mode} FAIL  *** Fix error(s) and a Force Reload required! ***\n";
+			$log = "\nDNSBL {$mode} FAIL  *** Fix error(s) and run an Update (Run Scope: DNSBL)! ***\n";
 			if (file_exists("{$pfb['dnsbldir']}/unbound.bk")) {
 				@rename("{$pfb['dnsbldir']}/unbound.bk", "{$pfb['dnsbldir']}/unbound.conf");
 			}
 			pfb_logger("{$log}", 2);
 		}
 		else {
-			$log = "\nDNSBL {$mode} - Unbound conf update FAIL *** Fix error(s) and a Force Reload required! ***\n";
+			$log = "\nDNSBL {$mode} - Unbound conf update FAIL *** Fix error(s) and run an Update (Run Scope: DNSBL)! ***\n";
 			pfb_logger("{$log}", 2);
 		}
 

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
@@ -1037,7 +1037,7 @@ function sync_package_pfblockerng($cron='', ?string &$deferred_by = NULL): bool 
 
 	// Validate pfB Script variables
 	foreach (array(
-			'et_update'		=> 'etupdate',					// Perform a Force Update on ET categories
+			'et_update'		=> 'etupdate',					// Force an update of ET categories
 			'ccwhite'		=> 'ccwhite',					// Action for whitelist Country category
 			'ccblack'		=> 'ccblack',					// Action for blacklist Country category
 			'etblock'		=> 'etblock',					// Emerging Threats IQRisk block categories
@@ -1088,7 +1088,7 @@ function sync_package_pfblockerng($cron='', ?string &$deferred_by = NULL): bool 
 
 	$new_aliases		= array();		// An array of aliases (full details)
 	$new_aliases_list	= array();		// An array of alias names
-	$pfb_alias_lists	= array();		// An array of aliases that have updated lists via CRON/force update. ('Reputation' disabled)
+	$pfb_alias_lists	= array();		// An array of aliases that have updated lists via CRON or a forced update. ('Reputation' disabled)
 	$pfb_alias_lists_all	= array();		// An array of all active aliases. ('Reputation' enabled)
 
 	$ip_types		= array( 'pfblockernglistsv4' => '_v4', 'pfblockernglistsv6' => '_v6');
@@ -3284,7 +3284,7 @@ function sync_package_pfblockerng($cron='', ?string &$deferred_by = NULL): bool 
 		? ($pfb['domain_update'] || $pfb['domain_clear'])
 		: ($pfb_fp_old !== $pfb_fp_new);
 
-	// An explicit "Force Reload DNSBL" (the updatednsbl trigger) must ALWAYS reload — the
+	// An explicit forced DNSBL reload (the updatednsbl trigger) must ALWAYS reload — the
 	// operator forces it to apply a change the fingerprint can't see (e.g. an out-of-band
 	// edit to a chroot file outside the fingerprinted input set, or to recover from
 	// suspected runtime drift), independent of the fingerprint. reuse_dnsbl / the .reload

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
@@ -1088,7 +1088,7 @@ function sync_package_pfblockerng($cron='', ?string &$deferred_by = NULL): bool 
 
 	$new_aliases		= array();		// An array of aliases (full details)
 	$new_aliases_list	= array();		// An array of alias names
-	$pfb_alias_lists	= array();		// An array of aliases that have updated lists via CRON or a forced update. ('Reputation' disabled)
+	$pfb_alias_lists	= array();		// An array of aliases whose lists were updated during this pass. ('Reputation' disabled)
 	$pfb_alias_lists_all	= array();		// An array of all active aliases. ('Reputation' enabled)
 
 	$ip_types		= array( 'pfblockernglistsv4' => '_v4', 'pfblockernglistsv6' => '_v6');
@@ -3284,14 +3284,13 @@ function sync_package_pfblockerng($cron='', ?string &$deferred_by = NULL): bool 
 		? ($pfb['domain_update'] || $pfb['domain_clear'])
 		: ($pfb_fp_old !== $pfb_fp_new);
 
-	// An explicit forced DNSBL reload (the updatednsbl trigger) must ALWAYS reload — the
-	// operator forces it to apply a change the fingerprint can't see (e.g. an out-of-band
-	// edit to a chroot file outside the fingerprinted input set, or to recover from
-	// suspected runtime drift), independent of the fingerprint. reuse_dnsbl / the .reload
-	// marker can't serve as this
-	// signal — cron-reuse mode and the dnsbl-missing path also set them, which would
-	// reintroduce the every-pass reload this gate removes; $pfb['updatednsbl'] is set ONLY
-	// by the Force-Reload-DNSBL path (scope=dnsbl + force=true in the normalization block).
+	// An explicit forced DNSBL reload (the updatednsbl trigger — Run Now with Force: Parse) bypasses
+	// fingerprint gating, and only yields while publication failed: the operator is applying a change
+	// the fingerprint can't see (e.g. an out-of-band edit to a chroot file outside the fingerprinted
+	// input set) or recovering from suspected runtime drift. reuse_dnsbl / the .reload marker can't
+	// serve as this signal — cron-reuse mode and the dnsbl-missing path also set them, which would
+	// reintroduce the every-pass reload this gate removes; $pfb['updatednsbl'] is set ONLY by the
+	// forced DNSBL reload path (scope=dnsbl + force=true in the normalization block).
 	if (!empty($pfb['updatednsbl'])) {
 		$pfb_data_changed = TRUE;
 	}

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -602,7 +602,7 @@ function pfb_dnsbl_regex_help_text(): string
 		The first <strong>unescaped</strong> "#" on the line starts the Description, whether or not a space precedes it. To match a literal "#" inside a pattern, escape it as "<strong>\\#</strong>".<br /><br />
 		Keep the Description to 15 characters or fewer — it is shown on the Alerts Tab, and a longer one is flagged in this editor. If no Description is entered a default Regex line number will be utilized.<br /><br />
 		This List is stored as \'Base64\' format in the config.xml file.<br /><br />
-		Changes to this option will require an Update to take effect.<br /><br />
+		Changes take effect on the next DNSBL reload: run \'Run Now\' (Run Scope: DNSBL or Both) on the Update tab, or wait for the next scheduled update.<br /><br />
 		Patterns use Python regular-expression syntax (the <a target="_blank" rel="noopener noreferrer" href="https://docs.python.org/3/library/re.html#regular-expression-syntax">re</a> module) and are validated on save by the same Python engine that runs them &mdash; that result is authoritative. The inline checker in this editor is an editing aid and may flag a valid pattern; if a line saves without an input error, it compiles.';
 }
 

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc
@@ -602,7 +602,7 @@ function pfb_dnsbl_regex_help_text(): string
 		The first <strong>unescaped</strong> "#" on the line starts the Description, whether or not a space precedes it. To match a literal "#" inside a pattern, escape it as "<strong>\\#</strong>".<br /><br />
 		Keep the Description to 15 characters or fewer — it is shown on the Alerts Tab, and a longer one is flagged in this editor. If no Description is entered a default Regex line number will be utilized.<br /><br />
 		This List is stored as \'Base64\' format in the config.xml file.<br /><br />
-		Changes to this option will require a Force Update to take effect.<br /><br />
+		Changes to this option will require an Update to take effect.<br /><br />
 		Patterns use Python regular-expression syntax (the <a target="_blank" rel="noopener noreferrer" href="https://docs.python.org/3/library/re.html#regular-expression-syntax">re</a> module) and are validated on save by the same Python engine that runs them &mdash; that result is authoritative. The inline checker in this editor is an editing aid and may flag a valid pattern; if a line saves without an input error, it compiles.';
 }
 

--- a/src/usr/local/pkg/pfblockerng/pfblockerng_geoip.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_geoip.inc
@@ -740,7 +740,7 @@ foreach (array( 'In' => 'Source', 'Out' => 'Destination') as $adv_mode => $adv_t
 }
 
 print($form);
-print_callout('<p><strong>Setting changes are applied via CRON or \'Force Update|Reload\' only!</strong></p>');
+print_callout('<p><strong>Setting changes are applied on the next scheduled update.</strong> To apply them now, go to the <a href="/pfblockerng/pfblockerng_update.php">Update</a> tab and use the \'Run Now\' function.</p>');
 ?>
 
 <script type="text/javascript">
@@ -997,7 +997,7 @@ if ($_POST) {
 			$pfb['repconfig']['etblock']		= implode(',', (array)$_POST['etblock'])	?: '';
 			$pfb['repconfig']['etmatch']		= implode(',', (array)$_POST['etmatch'])	?: '';
 
-			// Set flag to update ET IQRisk on next Cron|Force update|Force reload
+			// Set flag to update ET IQRisk on the next update pass
 			$pfb['repconfig']['et_update']	= 'enabled';
 
 			PfbConfig::writeSection('installedpackages/pfblockerngreputation/config/0', $pfb['repconfig']);
@@ -1243,7 +1243,7 @@ $section->addInput(new Form_Select(
 
 $form->add($section);
 print($form);
-print_callout('<p><strong>Setting changes are applied via CRON or \'Force Update|Reload\' only!</strong></p>');
+print_callout('<p><strong>Setting changes are applied on the next scheduled update.</strong> To apply them now, go to the <a href="/pfblockerng/pfblockerng_update.php">Update</a> tab and use the \'Run Now\' function.</p>');
 ?>
 <?php include('foot.inc');?>
 

--- a/src/usr/local/www/pfblockerng/pfblockerng.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng.php
@@ -264,11 +264,11 @@ if (isset($argv[1]) && in_array($argv[1], array('update', 'updateip', 'updatedns
 			logger(LOG_NOTICE, localize_text('Starting cron process.'), LOG_PREFIX_PKG_PFBLOCKERNG);
 			$pfb_completed = pfblockerng_sync_cron(FALSE, 'both', FALSE, FALSE, $pfb_deferred_by);
 			pfb_cli_feed_pass_exit($pfb_completed, $pfb_deferred_by);
-		case 'updateip':	// Sync 'Force Reload IP only' [DEPRECATED — use pfb_trigger scope=ip force=true trigger=force]
-		case 'updatednsbl':	// Sync 'Force Reload DNSBL only' [DEPRECATED — use pfb_trigger scope=dnsbl force=true trigger=force]
+		case 'updateip':	// Sync IP-only reload [DEPRECATED — use pfb_trigger scope=ip force=true trigger=force]
+		case 'updatednsbl':	// Sync DNSBL-only reload [DEPRECATED — use pfb_trigger scope=dnsbl force=true trigger=force]
 			$pfb_completed = sync_package_pfblockerng($argv[1], $pfb_deferred_by);
 			pfb_cli_feed_pass_exit($pfb_completed, $pfb_deferred_by);	// deprecation warning logged inside sync_package_pfblockerng
-		case 'update':		// Sync 'Force update' [DEPRECATED — use pfb_trigger scope=both force=false trigger=manual]
+		case 'update':		// Full update pass [DEPRECATED — use pfb_trigger scope=both force=false trigger=manual]
 			$pfb_completed = sync_package_pfblockerng('update', $pfb_deferred_by);
 			pfb_cli_feed_pass_exit($pfb_completed, $pfb_deferred_by);	// deprecation warning logged inside sync_package_pfblockerng
 		case 'pfb_trigger':	// ADR-43: explicit {scope, force, trigger} API
@@ -430,7 +430,7 @@ if (isset($argv[1]) && in_array($argv[1], array('update', 'updateip', 'updatedns
 			}
 			unset($pfb['extras'][0], $pfb['extras'][1], $pfb['extras'][2], $pfb['extras'][3], $pfb['extras'][4]); // Remove MaxMind GeoIP mmdb, CSV, TOP1M and ASN
 
-			// 'bls' called via 'Force Update|Reload'
+			// 'bls' called via an update pass
 			if ($argv[1] == 'bls') {
 				$extras_ok = pfblockerng_download_extras(600, 'blacklist');
 				exit($extras_ok ? 0 : 1);

--- a/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
@@ -1456,10 +1456,10 @@ if (isset($_POST) && !empty($_POST)) {
 						@unlink($flush_zone_file);
 						if ($flush_zone_status === 124) {
 							pfb_logger("\npfblockerng_alerts: wildcard-delete flush_zone TIMED OUT (killed); the whitelist edit was saved and stale cached subdomains may persist until the next resolver reload\n", 2);
-							$savemsg .= " The wildcard removal was saved, but the resolver cache flush TIMED OUT (killed after 30s) -- stale cached subdomains may persist until the next resolver reload; use a DNSBL Force Reload or run 'unbound-control flush_zone' to clear them.";
+							$savemsg .= " The wildcard removal was saved, but the resolver cache flush TIMED OUT (killed after 30s) -- stale cached subdomains may persist until the next resolver reload; use 'Run Now' (Run Scope: DNSBL, Force: Parse) on the Update tab or run 'unbound-control flush_zone' to clear them.";
 						} elseif ($flush_zone_status !== 0) {
 							pfb_logger("\npfblockerng_alerts: wildcard-delete flush_zone FAILED (exit {$flush_zone_status}); the whitelist edit was saved and stale cached subdomains may persist until the next resolver reload\n", 2);
-							$savemsg .= " The wildcard removal was saved, but the resolver cache flush FAILED (exit {$flush_zone_status}) -- stale cached subdomains may persist until the next resolver reload; use a DNSBL Force Reload or run 'unbound-control flush_zone' to clear them.";
+							$savemsg .= " The wildcard removal was saved, but the resolver cache flush FAILED (exit {$flush_zone_status}) -- stale cached subdomains may persist until the next resolver reload; use 'Run Now' (Run Scope: DNSBL, Force: Parse) on the Update tab or run 'unbound-control flush_zone' to clear them.";
 						}
 					} else {
 						pfb_unbound_py_ccache_flush(array($entry));
@@ -2152,7 +2152,7 @@ function dnsbl_whitelist_type($fields, $clists, $isExclusion, $isTLD, $qdomain) 
 		$h_wt_line = pfb_hsc($wt_line);
 		$s_txt  = "Note:&emsp;The following Domain is in the TLD Exclusion customlist:\n\n"
 			. "TLD Exclusion:&emsp;[ {$h_wt_line} ]\n\n"
-			. "&#8226; TLD Exclusions require a Force Reload when a Domain is initially added.\n"
+			. "&#8226; TLD Exclusions require an Update when a Domain is initially added.\n"
 			. "&#8226; To remove this Domain from the TLD Exclusion customlist, Click 'OK'";
 
 		$ex_dom = '&nbsp;<i class="fa-regular fa-trash-can no-confirm icon-pointer" id="DNSBLWT|'
@@ -3146,7 +3146,7 @@ function convert_ip_log($mode, $fields, $p_query_port, $rtype) {
 						. "2) Whitelist the IP to an existing 'Permit' Alias customlist. Ensure that this\n"
 						. "&emsp;Permit Alias/Rule is above the Block/Reject rules (Rule Order option)\n\n"
 						. "&emsp;If no 'Whitelist' is found, a default 'Whitelist' will be created.\n"
-						. "&emsp;A Force Update is required to add the associated Firewall Permit Rule!\n\n"
+						. "&emsp;An Update is required to add the associated Firewall Permit Rule!\n\n"
 						. "Click 'OK' to continue";
 
 				$supp_ip = '<i class="fa-solid fa-plus icon-pointer" id="PFBIPSUP|' . 'add|' . $h_host
@@ -3215,7 +3215,7 @@ function convert_ip_log($mode, $fields, $p_query_port, $rtype) {
 						. "&#8226; To permit access to this Blocked IP, you can add it to any\n"
 						. "&emsp;existing 'Permit' Alias.\n\n"
 						. "&emsp;If no 'Whitelist' is found, a default 'Whitelist' will be created.\n"
-						. "&emsp;A Force Update is required to add the associated Firewall Permit Rule!\n\n"
+						. "&emsp;An Update is required to add the associated Firewall Permit Rule!\n\n"
 						. "&#8226; Ensure that this Permit Alias/Rule is above the "
 						. "Block/Reject rules\n&emsp;(Rule Order option)\n\n"
 						. "Click 'OK' to continue";

--- a/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_alerts.php
@@ -2152,7 +2152,7 @@ function dnsbl_whitelist_type($fields, $clists, $isExclusion, $isTLD, $qdomain) 
 		$h_wt_line = pfb_hsc($wt_line);
 		$s_txt  = "Note:&emsp;The following Domain is in the TLD Exclusion customlist:\n\n"
 			. "TLD Exclusion:&emsp;[ {$h_wt_line} ]\n\n"
-			. "&#8226; TLD Exclusions require an Update when a Domain is initially added.\n"
+			. "&#8226; TLD Exclusions require a DNSBL reload when a Domain is initially added: run 'Run Now' (Run Scope: DNSBL or Both) on the Update tab.\n"
 			. "&#8226; To remove this Domain from the TLD Exclusion customlist, Click 'OK'";
 
 		$ex_dom = '&nbsp;<i class="fa-regular fa-trash-can no-confirm icon-pointer" id="DNSBLWT|'
@@ -2302,7 +2302,7 @@ function pfb_alerts_permit_option_suffix($family): string
  *
  * Confirm-dialog titles shadow the event-table copies in convert_ip_log()
  * `$supp_ip_txt` and dnsbl_whitelist_type() `$s_txt`, shortened for the panel
- * (no feed/eval-IP, no Force-Update / CNAME parenthetical).
+ * (no feed/eval-IP, no forced-update / CNAME parenthetical).
  *
  * @return array{alert: string, unlock: string, supp: string}
  */
@@ -3146,7 +3146,7 @@ function convert_ip_log($mode, $fields, $p_query_port, $rtype) {
 						. "2) Whitelist the IP to an existing 'Permit' Alias customlist. Ensure that this\n"
 						. "&emsp;Permit Alias/Rule is above the Block/Reject rules (Rule Order option)\n\n"
 						. "&emsp;If no 'Whitelist' is found, a default 'Whitelist' will be created.\n"
-						. "&emsp;An Update is required to add the associated Firewall Permit Rule!\n\n"
+						. "&emsp;A forced IP reload is required to add the associated Firewall Permit Rule: run 'Run Now' (Run Scope: IP, Force: Parse) on the Update tab!\n\n"
 						. "Click 'OK' to continue";
 
 				$supp_ip = '<i class="fa-solid fa-plus icon-pointer" id="PFBIPSUP|' . 'add|' . $h_host
@@ -3215,7 +3215,7 @@ function convert_ip_log($mode, $fields, $p_query_port, $rtype) {
 						. "&#8226; To permit access to this Blocked IP, you can add it to any\n"
 						. "&emsp;existing 'Permit' Alias.\n\n"
 						. "&emsp;If no 'Whitelist' is found, a default 'Whitelist' will be created.\n"
-						. "&emsp;An Update is required to add the associated Firewall Permit Rule!\n\n"
+						. "&emsp;A forced IP reload is required to add the associated Firewall Permit Rule: run 'Run Now' (Run Scope: IP, Force: Parse) on the Update tab!\n\n"
 						. "&#8226; Ensure that this Permit Alias/Rule is above the "
 						. "Block/Reject rules\n&emsp;(Rule Order option)\n\n"
 						. "Click 'OK' to continue";

--- a/src/usr/local/www/pfblockerng/pfblockerng_blacklist.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_blacklist.php
@@ -406,7 +406,7 @@ $section->addInput(new Form_Select(
 ))->setHelp("Default: <strong>Enabled</strong><br />
 	When 'Enabled', Domains are sinkholed to the DNSBL VIP and logged via the DNSBL Web Server.<br />
 	When 'Disabled', '0.0.0.0' will be used instead of the DNSBL VIP.<br />
-	A 'Force Reload - DNSBL' is required for changes to take effect")
+	A DNSBL reload is required for changes to take effect: run 'Run Now' (Run Scope: DNSBL or Both) on the Update tab, or wait for the next scheduled update.")
   ->setAttribute('style', 'width: auto');
 
 $form->add($section);
@@ -553,7 +553,7 @@ foreach ($blacklist_types as $type => $setting) {
 }
 
 print($form);
-print_callout('<p><strong>Setting changes are applied via CRON or \'Force Update|Reload\' only!</strong><br /><br />
+print_callout('<p><strong>Setting changes are applied on the next scheduled update.</strong> To apply them now, go to the <a href="/pfblockerng/pfblockerng_update.php">Update</a> tab and use the \'Run Now\' function.<br /><br />
 		DNSBL Category Feeds are processed first, followed by the DNSBL Groups.<br />
 		DNSBL Groups can be prioritized first, by selecting the \'Group Order\' option.</p>');
 ?>

--- a/src/usr/local/www/pfblockerng/pfblockerng_category.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_category.php
@@ -628,15 +628,15 @@ if ($gtype == 'geoip') {
 			MaxMind Account ID and License Key are configured on the
 			<a href="/pfblockerng/pfblockerng_ip.php">IP tab</a>
 			(MaxMind GeoIP configuration).<br /><br />
-			<strong>Setting changes are applied via CRON or \'Force Update|Reload\' only!</strong></p>');
+			<strong>Setting changes are applied on the next scheduled update.</strong> To apply them now, go to the <a href="/pfblockerng/pfblockerng_update.php">Update</a> tab and use the \'Run Now\' function.</p>');
 }
 elseif ($gtype == 'dnsbl') {
-	print_callout('<p><strong>Setting changes are applied via CRON or \'Force Update|Reload\' only!</strong><br /><br />
+	print_callout('<p><strong>Setting changes are applied on the next scheduled update.</strong> To apply them now, go to the <a href="/pfblockerng/pfblockerng_update.php">Update</a> tab and use the \'Run Now\' function.<br /><br />
 			DNSBL Category feeds are processed first, followed by the DNSBL Groups.<br />
 			DNSBL Groups can be prioritized first, by selecting the \'Group Order\' option.</p>');
 }
 else {
-	print_callout('<p><strong>Setting changes are applied via CRON or \'Force Update|Reload\' only!</strong></p>');
+	print_callout('<p><strong>Setting changes are applied on the next scheduled update.</strong> To apply them now, go to the <a href="/pfblockerng/pfblockerng_update.php">Update</a> tab and use the \'Run Now\' function.</p>');
 }
 ?>
 </form>

--- a/src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_category_edit.php
@@ -892,7 +892,7 @@ if ($_POST && isset($_POST['save'])) {
 			config_set_path("installedpackages/{$conf_type}/config/{$rowid}/filter_top1m", pfb_filter($_POST['filter_top1m'], PFB_FILTER_ON_OFF, 'Category_edit'));
 		}
 
-		// Set flag to update CustomList on next Cron|Force update|Force reload
+		// Set flag to update CustomList on the next update pass
 		// foreign key: installedpackages/{conf_type} list structure not in registry
 		// issue #1768: no default -> config_get_path() returns NULL on a fresh row -> base64_decode(NULL) deprecation.
 		if (base64_decode(config_get_path("installedpackages/{$conf_type}/config/{$rowid}/custom", '')) != $_POST['custom']) {
@@ -1695,7 +1695,7 @@ if ($gtype == 'dnsbl') {
 			. '&#8226 <strong>NXDOMAIN (no logging)</strong>, Reply NXDOMAIN with no logging. The DNSBL block page is bypassed.<br /><br />'
 			. 'Blocked domains will be reported to the Alert/Block Table.<br />'
 			. 'Enabling the "Global Logging/Blocking mode" in the DNSBL Tab will override this setting!<br />'
-			. 'A \'Force Reload - DNSBL\' is required for changes to take effect';
+			. 'A DNSBL reload is required for changes to take effect: run \'Run Now\' (Run Scope: DNSBL or Both) on the Update tab, or wait for the next scheduled update';
 
 	$section->addInput(new Form_Select(
 		'logging',
@@ -1847,12 +1847,12 @@ $form->add($section);
 print ($form);
 
 if ($gtype == 'dnsbl') {
-	print_callout('<p><strong>Click to SAVE Settings and/or Rule edits.&emsp;Changes are applied via CRON or \'Force Update|Reload\' only!</strong><br /><br />
+	print_callout('<p><strong>Click to SAVE Settings and/or Rule edits.&emsp;Changes are applied on the next scheduled update.</strong> To apply them now, go to the <a href="/pfblockerng/pfblockerng_update.php">Update</a> tab and use the \'Run Now\' function.<br /><br />
 			DNSBL Category Feeds are processed first, followed by the DNSBL Groups.<br />
 			DNSBL Groups can be prioritized first, by selecting the \'Group Order\' option.</p>');
 }
 else {
-	print_callout('<p><strong>Setting changes are applied via CRON or \'Force Update|Reload\' only!</strong></p>');
+	print_callout('<p><strong>Setting changes are applied on the next scheduled update.</strong> To apply them now, go to the <a href="/pfblockerng/pfblockerng_update.php">Update</a> tab and use the \'Run Now\' function.</p>');
 }
 
 ?>

--- a/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
@@ -192,7 +192,7 @@ $options_global_log_txt = 'Overrides each DNSBL Group\'s Logging/Blocking settin
 			. '&#8226 <strong>NXDOMAIN (logging)</strong>, Reply NXDOMAIN with logging. The DNSBL block page is bypassed.<br />'
 			. '&#8226 <strong>NXDOMAIN (no logging)</strong>, Reply NXDOMAIN with no logging. The DNSBL block page is bypassed.<br />'
 			. 'Blocked domains will be reported to the Alert/Block Table.<br /><br />'
-			. 'A \'Force Reload - DNSBL\' is required for changes to take effect'
+			. 'A DNSBL reload is required for changes to take effect: run \'Run Now\' (Run Scope: DNSBL or Both) on the Update tab, or wait for the next scheduled update.'
 			. '</div>';
 
 $options_global_log	= [	''		=> 'No Global mode',
@@ -3065,7 +3065,7 @@ $section->addInput(new Form_StaticText(
 	. '<strong>By default</strong> \'ARPA\' and the pfSense TLD \'' . strtoupper($local_tld) . '\' are allowed.<br />'
 	. 'If no TLDs are selected, the following are added by default [ COM, NET, ORG, EDU, CA, CO, IO ]<br /><br />'
 	. 'Picker: <strong>IANA root TLDs</strong>. Detailed TLD listings : <a target=_blank rel="noopener noreferrer" href="http://www.iana.org/domains/root/db">Root Zone Top-Level Domains.</a><br />'
-	. 'Changes to this option will require a Force Update to take effect.<br /><br />'
+	. 'Changes to this option will require an Update to take effect.<br /><br />'
 	. '<strong>Legend</strong>:<br />'
 	. '(*) TLD is used by atleast one DNSBL Feed in the Feeds Tab. Confirm the TLDs used by the selected Feeds.<br />'
 	. '(!) TLD is listed by <a target=_blank rel="noopener noreferrer" href="https://www.spamhaus.org/statistics/tlds/">Spamhaus (Most Abused TLDs)</a><br /></div>'
@@ -3174,7 +3174,7 @@ $section->addInput(new Form_Textarea(
   ->setAttribute('wrap', 'off')
   ->setAttribute('style', 'width: 100%')
   ->setHelp('Enter the Local LAN IPs (one per line) that will bypass DNSBL Blocking.<br />'
-		. 'Changes to this option will require a Force Update to take effect.');
+		. 'Changes to this option will require an Update to take effect.');
 
 $form->add($section);
 
@@ -3368,7 +3368,7 @@ $noaaaa_text = 'List of no-AAAA domains to block the (IPv6) AAAA DNS Resolution.
 		Prefix domain with a "." to apply wildcard no-AAAA to all Sub-Domains. &emsp;IE: (.example.com)<br /><br />
 		Any domain added to the no-AAAA list, will never be filtered by any DNSBL blocking.<br /><br />
 		This List is stored as \'Base64\' format in the config.xml file.<br /><br />
-		Changes to this option will require a Force Update to take effect.';
+		Changes to this option will require an Update to take effect.';
 
 $section = new Form_Section('no-AAAA List', 'Python_noaaaa_list', COLLAPSIBLE|SEC_CLOSED);
 $section->addInput(new Form_Textarea(
@@ -3429,8 +3429,8 @@ $whitelist_text = 'No Regex Entries Allowed!&emsp;
 				You may use "<strong>#</strong>" after any Domain name to add comments. &emsp;IE: (example.com # Whitelist example.com)<br />
 				This List is stored as \'Base64\' format in the config.xml file.<br /><br />
 
-				<span class="text-danger">Note: </span>These entries are only Whitelisted when Feeds are downloaded or on a
-				<span class="text-danger">\'Force Reload\'.</span><br />
+				<span class="text-danger">Note: </span>These entries are applied with the next
+				<span class="text-danger">Update</span>.<br />
 
 				Use the Alerts Tab \'+\' Whitelist Icon to immediately remove a Domain (and any associated CNAMES) from Unbound DNSBL.<br />
 				Note: When manually adding a Domain to the Whitelist, check for any associated CNAMES<br />
@@ -3754,7 +3754,7 @@ foreach (array( 'In' => 'Source', 'Out' => 'Destination') as $adv_mode => $adv_t
 }
 
 print ($form);
-print_callout('<strong>Setting changes are applied via CRON or \'Force Update|Reload\' only!</strong>');
+print_callout('<strong>Setting changes are applied on the next scheduled update.</strong> To apply them now, go to the <a href="/pfblockerng/pfblockerng_update.php">Update</a> tab and use the \'Run Now\' function.');
 
 ?>
 <?=$pfb_dnsbl_editor['asset']?>

--- a/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php
@@ -3065,7 +3065,7 @@ $section->addInput(new Form_StaticText(
 	. '<strong>By default</strong> \'ARPA\' and the pfSense TLD \'' . strtoupper($local_tld) . '\' are allowed.<br />'
 	. 'If no TLDs are selected, the following are added by default [ COM, NET, ORG, EDU, CA, CO, IO ]<br /><br />'
 	. 'Picker: <strong>IANA root TLDs</strong>. Detailed TLD listings : <a target=_blank rel="noopener noreferrer" href="http://www.iana.org/domains/root/db">Root Zone Top-Level Domains.</a><br />'
-	. 'Changes to this option will require an Update to take effect.<br /><br />'
+	. 'Changes take effect on the next DNSBL reload: run \'Run Now\' (Run Scope: DNSBL or Both) on the Update tab, or wait for the next scheduled update.<br /><br />'
 	. '<strong>Legend</strong>:<br />'
 	. '(*) TLD is used by atleast one DNSBL Feed in the Feeds Tab. Confirm the TLDs used by the selected Feeds.<br />'
 	. '(!) TLD is listed by <a target=_blank rel="noopener noreferrer" href="https://www.spamhaus.org/statistics/tlds/">Spamhaus (Most Abused TLDs)</a><br /></div>'
@@ -3174,7 +3174,7 @@ $section->addInput(new Form_Textarea(
   ->setAttribute('wrap', 'off')
   ->setAttribute('style', 'width: 100%')
   ->setHelp('Enter the Local LAN IPs (one per line) that will bypass DNSBL Blocking.<br />'
-		. 'Changes to this option will require an Update to take effect.');
+		. 'Changes take effect on the next DNSBL reload: run \'Run Now\' (Run Scope: DNSBL or Both) on the Update tab, or wait for the next scheduled update.');
 
 $form->add($section);
 
@@ -3368,7 +3368,7 @@ $noaaaa_text = 'List of no-AAAA domains to block the (IPv6) AAAA DNS Resolution.
 		Prefix domain with a "." to apply wildcard no-AAAA to all Sub-Domains. &emsp;IE: (.example.com)<br /><br />
 		Any domain added to the no-AAAA list, will never be filtered by any DNSBL blocking.<br /><br />
 		This List is stored as \'Base64\' format in the config.xml file.<br /><br />
-		Changes to this option will require an Update to take effect.';
+		Changes take effect on the next DNSBL reload: run \'Run Now\' (Run Scope: DNSBL or Both) on the Update tab, or wait for the next scheduled update.';
 
 $section = new Form_Section('no-AAAA List', 'Python_noaaaa_list', COLLAPSIBLE|SEC_CLOSED);
 $section->addInput(new Form_Textarea(

--- a/src/usr/local/www/pfblockerng/pfblockerng_general.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_general.php
@@ -379,7 +379,7 @@ $section->addInput(new Form_Checkbox(
 		. 'packages &mdash; with \'Keep Settings\' disabled it wipes pfBlockerNG\'s settings too. A normal '
 		. 'package update keeps them.<br /><br />'
 		. '<span class="text-danger">Note: </span>'
-		. ' To clear all downloaded lists, uncheck this checkbox and \'Save\'. Re-check it and run a \'Force Update|Reload\''
+		. ' To clear all downloaded lists, uncheck this checkbox and \'Save\'. Re-check it and run an Update (\'Run Now\' on the Update tab)'
 );
 
 $section->addInput(new Form_Checkbox(
@@ -592,7 +592,7 @@ $section->addInput(new Form_Input(
 		. 'interpreter, so a stalled download cannot outlive it; the expiry is named in the '
 		. 'pfBlockerNG and Error logs and the pass continues to a defined state. The download '
 		. 'is retried by the next scheduled update, or immediately via '
-		. '<strong>Force Update</strong>.<br />'
+		. '<strong>Run Now</strong> on the Update tab.<br />'
 		. 'Raise it for low-powered hardware or slow links where a full download pass needs '
 		. 'longer. A blank, non-numeric or out-of-range value falls back to '
 		. PFB_REENTRY_TIMEOUT . ' seconds.');
@@ -693,7 +693,7 @@ $section->addInput(new Form_StaticText(
 
 $form->add($section);
 print($form);
-print_callout('<p><strong>Setting changes are applied via CRON or \'Force Update|Reload\' only!</strong></p>');
+print_callout('<p><strong>Setting changes are applied on the next scheduled update.</strong> To apply them now, go to the <a href="/pfblockerng/pfblockerng_update.php">Update</a> tab and use the \'Run Now\' function.</p>');
 ?>
 <?=$pfb_general_editor['asset']?>
 

--- a/src/usr/local/www/pfblockerng/pfblockerng_hooks.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_hooks.php
@@ -256,9 +256,9 @@ $section->addInput(new Form_StaticText(
 	'<small>'
 	. gettext('Each hook receives these environment variables:') . '<br />'
 	. '<code>PFB_WHEN</code> &mdash; ' . gettext('the fire point: <code>pre</code> or <code>post</code>.') . '<br />'
-	. '<code>PFB_TRIGGER</code> &mdash; ' . gettext('what started the update: <code>cron</code> (scheduled update, '
-		. 'and the GUI <em>Force Update</em> / <em>Force Reload (All)</em>), <code>update</code> (a settings save), '
-		. 'or <code>force-reload</code> (a GUI <em>Force Reload</em> of IP-only or DNSBL-only). '
+	. '<code>PFB_TRIGGER</code> &mdash; ' . gettext('what started the update: <code>cron</code> (the scheduled update, '
+		. 'and a Run Now with Force: Download or Both), <code>update</code> (a settings save, or a Run Now with '
+		. 'Force: None), or <code>force-reload</code> (a Run Now with Force: Parse). '
 		. 'Set for both <code>pre</code> and <code>post</code>.') . '<br />'
 	. '<code>PFB_POST_INSTALL</code> &mdash; ' . gettext('<code>1</code> when this run is the reconfigure right '
 		. 'after pfBlockerNG was installed or upgraded, else <code>0</code>.') . '<br />'
@@ -395,7 +395,7 @@ $section->add($group);
 
 $form->add($section);
 print($form);
-print_callout('<strong>' . gettext('Hooks run on the next CRON update or \'Force Update|Reload\'.') . '</strong>');
+print_callout('<strong>' . gettext('Hooks run on every update: the scheduled update and each \'Run Now\'.') . '</strong>');
 
 // Client-side convenience: keep each row's Script picker in sync with its Pre/Post
 // selection (the file prefix decides which scripts apply). Pure progressive

--- a/src/usr/local/www/pfblockerng/pfblockerng_ip.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_ip.php
@@ -613,7 +613,7 @@ $suppression_text = '<strong><u>This suppression list is for [ /8 through /32 ] 
 			remove the IPv4 address from the Deny aliastable.<br /><br />
 
 			Note: When manually adding an IPv4 address <strong>[ /8 through /32 only! ]</strong> to this Suppression List,
-			you must run a <strong>"Force Reload - IP"</strong> for the changes to take effect.';
+			you must run a forced IP reload for the changes to take effect: on the Update tab, run <strong>\'Run Now\' (Run Scope: IP, Force: Parse)</strong>.';
 
 $section->addInput(new Form_Textarea(
 	'v4suppression',
@@ -643,7 +643,7 @@ $suppression_text_v6 = '<strong><u>This suppression list is for [ /32 through /1
 			remove the IPv6 address from the Deny aliastable.<br /><br />
 
 			Note: When manually adding an IPv6 address <strong>[ /32 through /128 only! ]</strong> to this Suppression List,
-			you must run a <strong>"Force Reload - IP"</strong> for the changes to take effect.';
+			you must run a forced IP reload for the changes to take effect: on the Update tab, run <strong>\'Run Now\' (Run Scope: IP, Force: Parse)</strong>.';
 
 $section->addInput(new Form_Textarea(
 	'v6suppression',
@@ -717,7 +717,7 @@ $section->addInput(new Form_Input(
 
 $form->add($section);
 
-print_callout('<strong>Setting changes are applied via CRON or \'Force Update|Reload\' only!</strong>');
+print_callout('<strong>Setting changes are applied on the next scheduled update.</strong> To apply them now, go to the <a href="/pfblockerng/pfblockerng_update.php">Update</a> tab and use the \'Run Now\' function.');
 print ($form);
 
 ?>

--- a/src/usr/local/www/pfblockerng/pfblockerng_safesearch.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_safesearch.php
@@ -70,7 +70,7 @@ if (isset($_POST['save'])) {
 		$msg = 'Saved SafeSearch configuration';
 		write_config("[ pfBlockerNG ] {$msg}");
 		pfb_mark_pending_changes();	// applies on the next Update, not on save
-		$savemsg = "{$msg}. A Force Update|Reload is required to apply changes!";
+		$savemsg = "{$msg}. Run an Update ('Run Now' on the Update tab) to apply the changes!";
 		header("Location: /pfblockerng/pfblockerng_safesearch.php?savemsg={$savemsg}");
 	}
 }
@@ -148,7 +148,7 @@ $section->addInput(new Form_Select(
   ->setAttribute('style', 'width: auto');
 $form->add($section);
 print($form);
-print_callout('<p><strong>Setting changes are applied via CRON or \'Force Update|Reload\' only!</strong></p>');
+print_callout('<p><strong>Setting changes are applied on the next scheduled update.</strong> To apply them now, go to the <a href="/pfblockerng/pfblockerng_update.php">Update</a> tab and use the \'Run Now\' function.</p>');
 ?>
 
 <?php include('foot.inc');?>

--- a/src/usr/local/www/pfblockerng/pfblockerng_sync.php
+++ b/src/usr/local/www/pfblockerng/pfblockerng_sync.php
@@ -352,7 +352,7 @@ $section->add($group);
 
 $form->add($section);
 print ($form);
-print_callout('<strong>Setting changes are applied via CRON or \'Force Update|Reload\' only!</strong>');
+print_callout('<strong>Sync settings are used by the XMLRPC engine on each sync: automatically on configuration changes, or after each update pass (Manual mode).</strong>');
 
 include('foot.inc');
 ?>

--- a/src/usr/local/www/widgets/widgets/pfblockerng.widget.php
+++ b/src/usr/local/www/widgets/widgets/pfblockerng.widget.php
@@ -626,7 +626,7 @@ function pfBlockerNG_get_header($mode='') {
 			// would otherwise be misclassified as the dedup-sanity sentinel entry.
 			$pfb_ip_other	= array_filter($pfb_ip_open, fn ($entry) => $entry['stage'] !== 'dedup');
 			$pfb_msg	= empty($pfb_ip_other)
-				? 'pfBlockerNG deDuplication is out of sync. Perform a Force Reload to correct.'
+				? 'pfBlockerNG deDuplication is out of sync. Run an Update with Force: Parse to correct.'
 				: sprintf('pfBlockerNG has %d open issue(s). See the Failed Downloads list below.', count($pfb_ip_open));
 		}
 	} else {
@@ -685,7 +685,7 @@ function pfBlockerNG_get_header($mode='') {
 			$stats[$key][$type] = 0;
 			if ($type == 'DNSBL') {
 				if (isset($pfb['dnsbl_missing'])) {
-					$stats[$key][$type] = "<span title='*** SQLite database 'pfb_py_dnsbl.sqlite' is missing, Force Reload DNSBL to recover! ***'>Unknown</span>";
+					$stats[$key][$type] = "<span title=\"*** SQLite database 'pfb_py_dnsbl.sqlite' is missing; run an Update with Run Scope: DNSBL (Force: Parse) to recover! ***\">Unknown</span>";
 				} else {
 					$stats[$key][$type] = htmlspecialchars($pfb_table['stats']['DNSBL'] ?? '');
 				}

--- a/tests/php/ApplyGuidanceWordingUiTest.php
+++ b/tests/php/ApplyGuidanceWordingUiTest.php
@@ -21,7 +21,7 @@ use PHPUnit\Framework\TestCase;
 final class ApplyGuidanceWordingUiTest extends TestCase
 {
 	/** Retired GUI action names — no source line may carry them. */
-	private const RETIRED_NEEDLES = ['Force Reload', 'Force Update', 'applied via CRON', 'next CRON update'];
+	private const RETIRED_NEEDLES = ['Force Reload', 'Force Update', 'Force-Reload', 'Force-Update', 'applied via CRON', 'next CRON update'];
 
 	/**
 	 * Page => guidance needles with the EXACT number of occurrences expected in that
@@ -40,7 +40,8 @@ final class ApplyGuidanceWordingUiTest extends TestCase
 			'Setting changes are applied on the next scheduled update.' => 1,
 			"A DNSBL reload is required for changes to take effect: run \\'Run Now\\'"
 				. ' (Run Scope: DNSBL or Both) on the Update tab, or wait for the next scheduled update.' => 1,
-			'Changes to this option will require an Update to take effect.' => 3,
+			'Changes take effect on the next DNSBL reload: run \\\'Run Now\\\''
+				. ' (Run Scope: DNSBL or Both) on the Update tab, or wait for the next scheduled update.' => 3,
 			'These entries are applied with the next' => 1,
 		],
 		'src/usr/local/www/pfblockerng/pfblockerng_ip.php' => [
@@ -72,8 +73,9 @@ final class ApplyGuidanceWordingUiTest extends TestCase
 			'a Run Now with Force: Parse' => 1,
 		],
 		'src/usr/local/www/pfblockerng/pfblockerng_alerts.php' => [
-			'TLD Exclusions require an Update when a Domain is initially added.' => 1,
-			'An Update is required to add the associated Firewall Permit Rule!' => 2,
+			'TLD Exclusions require a DNSBL reload when a Domain is initially added' => 1,
+			"A forced IP reload is required to add the associated Firewall Permit Rule: run 'Run Now'"
+				. ' (Run Scope: IP, Force: Parse) on the Update tab!' => 2,
 			"use 'Run Now' (Run Scope: DNSBL, Force: Parse) on the Update tab"
 				. " or run 'unbound-control flush_zone' to clear them." => 2,
 		],
@@ -85,7 +87,8 @@ final class ApplyGuidanceWordingUiTest extends TestCase
 			'Setting changes are applied on the next scheduled update.' => 2,
 		],
 		'src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc' => [
-			'Changes to this option will require an Update to take effect.' => 1,
+			'Changes take effect on the next DNSBL reload: run \\\'Run Now\\\''
+				. ' (Run Scope: DNSBL or Both) on the Update tab, or wait for the next scheduled update.' => 1,
 		],
 		'src/usr/local/pkg/pfblockerng/pfblockerng.inc' => [
 			'Fix error(s) and run an Update (Run Scope: DNSBL)!' => 2,
@@ -98,7 +101,7 @@ final class ApplyGuidanceWordingUiTest extends TestCase
 	private static function sources(): array
 	{
 		$paths = [];
-		foreach (['src/usr/local/www', 'src/usr/local/pkg'] as $root) {
+		foreach ([self::repoPath('src/usr/local/www'), self::repoPath('src/usr/local/pkg')] as $root) {
 			$iterator = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($root));
 			foreach ($iterator as $file) {
 				if (!$file->isFile()) {
@@ -119,20 +122,41 @@ final class ApplyGuidanceWordingUiTest extends TestCase
 		return dirname(__DIR__, 2) . '/' . $relative;
 	}
 
+	/** @return list<string> retired needles carried by this source line */
+	private static function retiredNamesInLine(string $line): array
+	{
+		return array_values(array_filter(
+			self::RETIRED_NEEDLES,
+			static fn (string $needle): bool => str_contains($line, $needle)
+		));
+	}
+
 	public function testRetiredActionNamesAreAbsentFromSource(): void
 	{
 		$offenders = [];
 		foreach (self::sources() as $path) {
 			$lines = file($path) ?: [];
 			foreach ($lines as $n => $line) {
-				foreach (self::RETIRED_NEEDLES as $needle) {
-					if (str_contains($line, $needle)) {
-						$offenders[] = "{$path}:" . ($n + 1) . " still names the retired action '{$needle}'";
-					}
+				foreach (self::retiredNamesInLine($line) as $needle) {
+					$offenders[] = "{$path}:" . ($n + 1) . " still names the retired action '{$needle}'";
 				}
 			}
 		}
 		$this->assertSame([], $offenders, "\n" . implode("\n", $offenders));
+	}
+
+	public function testRetiredNameScannerCatchesRetiredWording(): void
+	{
+		// The scanner above is only meaningful if it reports a source line that carries a
+		// retired action name — feed it one and require every needle class to be caught.
+		$hostile = "\$help = 'A \\'Force Reload - DNSBL\\' or \\'Force Update\\' is required, "
+			. "the Force-Reload-DNSBL / Force-Update-ET paths, applied via CRON "
+			. "or on the next CRON update.';";
+		$caught = self::retiredNamesInLine($hostile);
+		$this->assertSame(self::RETIRED_NEEDLES, $caught,
+			'the retired-wording scanner must report every retired needle on a hostile line');
+		$this->assertSame([], self::retiredNamesInLine('Run \'Run Now\' on the Update tab, or wait for the next scheduled update.'),
+			'the scanner must not flag the corrected guidance');
 	}
 
 	public function testSettingsPagesNameTheActionsThatExist(): void

--- a/tests/php/ApplyGuidanceWordingUiTest.php
+++ b/tests/php/ApplyGuidanceWordingUiTest.php
@@ -1,0 +1,156 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * issue #3237 — user-facing apply guidance must name the actions that exist.
+ *
+ * The GUI's apply model is ADR-43's Update tab (Run Scope: Both/IP/DNSBL x Force:
+ * None/Parse/Download/Both, "Run Now") plus the scheduled update, with #738's
+ * pending-changes banner pointing at them. The retired button names ("Force Update",
+ * "Force Reload", "Force Reload - DNSBL/IP") and the "applied via CRON or 'Force
+ * Update|Reload' only!" footer must not instruct users anywhere under src/usr/local:
+ * a user who follows them has no control to click. Per the #886 precedent, an
+ * Update (Run Now / scheduled) is the action that applies these settings.
+ *
+ * Tier A render coverage for the changed pages lives in
+ * tests/smoke/ui/test_render_smoke.py::test_apply_guidance_names_run_now_not_retired_actions.
+ */
+final class ApplyGuidanceWordingUiTest extends TestCase
+{
+	/** Retired GUI action names — no source line may carry them. */
+	private const RETIRED_NEEDLES = ['Force Reload', 'Force Update', 'applied via CRON', 'next CRON update'];
+
+	/**
+	 * Page => guidance needles with the EXACT number of occurrences expected in that
+	 * source. The count pins each independently rendered branch/template (a contains()
+	 * check alone stays green when one of several identical callouts is dropped).
+	 *
+	 * @var array<string, array<string, int>>
+	 */
+	private const PAGE_NEEDLES = [
+		'src/usr/local/www/pfblockerng/pfblockerng_general.php' => [
+			'Setting changes are applied on the next scheduled update.' => 1,
+			"Re-check it and run an Update (\\'Run Now\\' on the Update tab)" => 1,
+			'<strong>Run Now</strong> on the Update tab' => 1,
+		],
+		'src/usr/local/www/pfblockerng/pfblockerng_dnsbl.php' => [
+			'Setting changes are applied on the next scheduled update.' => 1,
+			"A DNSBL reload is required for changes to take effect: run \\'Run Now\\'"
+				. ' (Run Scope: DNSBL or Both) on the Update tab, or wait for the next scheduled update.' => 1,
+			'Changes to this option will require an Update to take effect.' => 3,
+			'These entries are applied with the next' => 1,
+		],
+		'src/usr/local/www/pfblockerng/pfblockerng_ip.php' => [
+			'Setting changes are applied on the next scheduled update.' => 1,
+			'you must run a forced IP reload for the changes to take effect: on the Update tab,'
+				. " run <strong>\\'Run Now\\' (Run Scope: IP, Force: Parse)</strong>." => 2,
+		],
+		'src/usr/local/www/pfblockerng/pfblockerng_blacklist.php' => [
+			'Setting changes are applied on the next scheduled update.' => 1,
+			'A DNSBL reload is required for changes to take effect' => 1,
+		],
+		'src/usr/local/www/pfblockerng/pfblockerng_category.php' => [
+			'Setting changes are applied on the next scheduled update.' => 3,
+		],
+		'src/usr/local/www/pfblockerng/pfblockerng_category_edit.php' => [
+			'Click to SAVE Settings and/or Rule edits.&emsp;Changes are applied on the next scheduled update.' => 1,
+			'A DNSBL reload is required for changes to take effect' => 1,
+		],
+		'src/usr/local/www/pfblockerng/pfblockerng_safesearch.php' => [
+			'Setting changes are applied on the next scheduled update.' => 1,
+			"Run an Update ('Run Now' on the Update tab) to apply the changes!" => 1,
+		],
+		'src/usr/local/www/pfblockerng/pfblockerng_sync.php' => [
+			'Sync settings are used by the XMLRPC engine on each sync' => 1,
+		],
+		'src/usr/local/www/pfblockerng/pfblockerng_hooks.php' => [
+			"Hooks run on every update: the scheduled update and each \\'Run Now\\'." => 1,
+			'a Run Now with Force: Download or Both' => 1,
+			'a Run Now with Force: Parse' => 1,
+		],
+		'src/usr/local/www/pfblockerng/pfblockerng_alerts.php' => [
+			'TLD Exclusions require an Update when a Domain is initially added.' => 1,
+			'An Update is required to add the associated Firewall Permit Rule!' => 2,
+			"use 'Run Now' (Run Scope: DNSBL, Force: Parse) on the Update tab"
+				. " or run 'unbound-control flush_zone' to clear them." => 2,
+		],
+		'src/usr/local/www/widgets/widgets/pfblockerng.widget.php' => [
+			'pfBlockerNG deDuplication is out of sync. Run an Update with Force: Parse to correct.' => 1,
+			'is missing; run an Update with Run Scope: DNSBL (Force: Parse) to recover!' => 1,
+		],
+		'src/usr/local/pkg/pfblockerng/pfblockerng_geoip.inc' => [
+			'Setting changes are applied on the next scheduled update.' => 2,
+		],
+		'src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc' => [
+			'Changes to this option will require an Update to take effect.' => 1,
+		],
+		'src/usr/local/pkg/pfblockerng/pfblockerng.inc' => [
+			'Fix error(s) and run an Update (Run Scope: DNSBL)!' => 2,
+		],
+	];
+
+	/**
+	 * @return list<string> every .php/.inc source path under src/usr/local, sorted
+	 */
+	private static function sources(): array
+	{
+		$paths = [];
+		foreach (['src/usr/local/www', 'src/usr/local/pkg'] as $root) {
+			$iterator = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($root));
+			foreach ($iterator as $file) {
+				if (!$file->isFile()) {
+					continue;
+				}
+				if (!in_array($file->getExtension(), ['php', 'inc'], TRUE)) {
+					continue;
+				}
+				$paths[] = $file->getPathname();
+			}
+		}
+		sort($paths);
+		return $paths;
+	}
+
+	private static function repoPath(string $relative): string
+	{
+		return dirname(__DIR__, 2) . '/' . $relative;
+	}
+
+	public function testRetiredActionNamesAreAbsentFromSource(): void
+	{
+		$offenders = [];
+		foreach (self::sources() as $path) {
+			$lines = file($path) ?: [];
+			foreach ($lines as $n => $line) {
+				foreach (self::RETIRED_NEEDLES as $needle) {
+					if (str_contains($line, $needle)) {
+						$offenders[] = "{$path}:" . ($n + 1) . " still names the retired action '{$needle}'";
+					}
+				}
+			}
+		}
+		$this->assertSame([], $offenders, "\n" . implode("\n", $offenders));
+	}
+
+	public function testSettingsPagesNameTheActionsThatExist(): void
+	{
+		$failures = [];
+		foreach (self::PAGE_NEEDLES as $page => $needles) {
+			$source = file_get_contents(self::repoPath($page));
+			if ($source === FALSE) {
+				$failures[] = "{$page}: unreadable";
+				continue;
+			}
+			foreach ($needles as $needle => $expected) {
+				$actual = substr_count($source, $needle);
+				if ($actual !== $expected) {
+					$failures[] = "{$page}: guidance '{$needle}' occurs {$actual}x, expected {$expected}x";
+				}
+			}
+		}
+		$this->assertSame([], $failures, "\n" . implode("\n", $failures));
+	}
+}

--- a/tests/php/GeneralAdvancedTimeoutUiTest.php
+++ b/tests/php/GeneralAdvancedTimeoutUiTest.php
@@ -110,7 +110,7 @@ final class GeneralAdvancedTimeoutUiTest extends TestCase
 			'the help must name the 1800-second default from the runtime constant');
 		$this->assertStringContainsString('whole process tree', $help,
 			'the help must say the WHOLE process tree is terminated on expiry (reaper mode, not --foreground)');
-		$this->assertStringContainsString('Force Update', $help,
+		$this->assertStringContainsString('<strong>Run Now</strong> on the Update tab', $help,
 			'the help must give the retry guidance for a pass that expired');
 	}
 }

--- a/tests/php/IpTabLayoutUiTest.php
+++ b/tests/php/IpTabLayoutUiTest.php
@@ -23,11 +23,11 @@ final class IpTabLayoutUiTest extends TestCase
 	public function testCalloutPrintsAboveTheForm(): void
 	{
 		$source = self::source();
-		$callout = strpos($source, "print_callout('<strong>Setting changes are applied via CRON");
+		$callout = strpos($source, "print_callout('<strong>Setting changes are applied on the next scheduled update");
 		$form = strpos($source, 'print ($form)');
 		$this->assertNotFalse($callout, 'IP tab callout missing');
 		$this->assertNotFalse($form, 'print ($form) missing');
-		$this->assertLessThan($form, $callout, 'the CRON/Force-Update callout must render above the form');
+		$this->assertLessThan($form, $callout, 'the apply-guidance callout must render above the form');
 	}
 
 	public function testSectionOrderPutsInterfaceSecondAndSuppressionWithItsToggle(): void

--- a/tests/php/PfbWidgetOracleTest.php
+++ b/tests/php/PfbWidgetOracleTest.php
@@ -204,7 +204,7 @@ final class PfbWidgetOracleTest extends TestCase
 		[$status, $msg] = pfb_widget_oracle_status($pfb);
 
 		$this->assertSame(self::ICON_YELLOW, $status);
-		$this->assertSame('pfBlockerNG deDuplication is out of sync. Perform a Force Reload to correct.', $msg);
+		$this->assertSame('pfBlockerNG deDuplication is out of sync. Run an Update with Force: Parse to correct.', $msg);
 	}
 
 	public function testIpEnabledNonDedupEntryIsYellowRegardlessOfEnableDup(): void

--- a/tests/php/fixtures/geoip_pre_move_golden.json
+++ b/tests/php/fixtures/geoip_pre_move_golden.json
@@ -29,22 +29,23 @@
     "ZZ_v4.txt": "454debca5afcd37addd0dcca05094625dcde6402510f8fc664cd567893ec7096"
   },
   "continent_pages": {
-    "pfblockerng_Africa.php": "5c0506aa4be7308cac22555ea674e62ab4a61f8701e0bdc8dda019a60d0c4da9",
-    "pfblockerng_Antarctica.php": "eacc89adf27f50df67fcd29cb8cc0dc6d0d1e87d91241f5a3a1cb6a44824cc0f",
-    "pfblockerng_Asia.php": "2edb7f57a1fde62f244f373198f1816911c25d4176b28e58b864ddea1ed5f179",
-    "pfblockerng_Europe.php": "e5d729fe6b402ea024a2de010f90235dcd505b2532263a9114c50febb715cd0d",
-    "pfblockerng_North_America.php": "f67183803754dc167f428dbfac0e9a34440c62c0b18923a5562c9e4cdba7a4d2",
-    "pfblockerng_Oceania.php": "e38c477dcb24484675b7812f725e2722716ae967f95115902ad06c2adf3bb0e5",
-    "pfblockerng_South_America.php": "c0b9996d6960ade827784aa1d3f433860a11dea1d15bd5c65be2e1a2d965252f",
-    "pfblockerng_Proxy_and_Satellite.php": "3d5554e7d15f3b4bdd49da7cd64fde9ffcd37fe15cf9076e455718dd603dd8a6",
-    "pfblockerng_Top_Spammers.php": "a3ea116a9a213999d89e9b436907664d2d709b40aa2d10eb67fdd8602093c15c"
+    "pfblockerng_Africa.php": "8cd3ca50468f5178684667703368afe2a4928aaf5df7e15265754ba2f982fa4f",
+    "pfblockerng_Antarctica.php": "7c32f7969c0234a00548dc74f1a8f8e9f41f2dd87623a11f040dcf7235613f9a",
+    "pfblockerng_Asia.php": "b012ff65ad84e469e16925d3853de3a9b4374221c5101669c68e08f19759577f",
+    "pfblockerng_Europe.php": "88fbfe0bfd35e17cc6effc240e3408a22e497ac219c2cb050380382ba45f18ff",
+    "pfblockerng_North_America.php": "30ee3ae4beb2ea5df11749146677be7683dd9d282e17fcca45d3cfdc685a1761",
+    "pfblockerng_Oceania.php": "a2244c4a5806cd1423929ec53eaec18f20ac5f0730e3314a204d425a767d0865",
+    "pfblockerng_South_America.php": "43bfe4aee8367fd7b23850b9d450999796e1a408117ca3d22fa5073e2be8cb97",
+    "pfblockerng_Proxy_and_Satellite.php": "4e881dc2ba3b2c10bfb7e1034af89ac416c8b4dd9eb198a433e2c9de24910780",
+    "pfblockerng_Top_Spammers.php": "fb4a4c54a62a2035b0fa63a02c8b3d2d3df1fb89adcbc2bf69b53bab729a6e82"
   },
-  "reputation_empty": "db362e398b52d23dfdc8221b4dc0fb3f972d992ef7d37582c6c97ab0290b2f97",
-  "reputation_populated": "ebca5913c83c5644f1bc95c07de3e8c1c0f63736dfe16c487865e63c4327b660",
+  "reputation_empty": "3f4f8ecbe272506e4da0447912b4ccaf661f27d9c45e2cdda2c6299d76dd8898",
+  "reputation_populated": "7a64b6c97cedcf231cd95437343125225d0da42a89b1f39e4635f7dd3ebc208f",
   "continent_pages_amended": "issue #1845: the generated pages now carry the pfBlockerNG.js cache-buster; the pre-move template is otherwise unchanged",
   "reputation_hashes_amended": "issue #1896: the Reputation section's config_get_path/config_set_path calls now route through PfbConfig::readSection()/writeSection(); the pre-move template is otherwise unchanged",
   "continent_behavior_amended": "issue #2103: generated pages route anchor layout and MaxMind documentation rendering through behavior-tested helpers",
   "continent_copy_amended": "GUI reorg: generated country pages now name 'Force Global IP Logging' on the IP tab and point MaxMind credentials at the IP tab; the pre-move template is otherwise unchanged",
   "reputation_markup_amended": "issue #2897: the embedded List-Action help and Reputation help in the generated pages now wrap bare-text <ul> indent wrappers in <li> children and declare overflow-wrap: anywhere on long-token fragments; the pre-move template is otherwise unchanged",
-  "continent_noopener_amended": "issue #3085: generated country pages now carry rel=noopener noreferrer on the Custom Port alias help link; the pre-move template is otherwise unchanged"
+  "continent_noopener_amended": "issue #3085: generated country pages now carry rel=noopener noreferrer on the Custom Port alias help link; the pre-move template is otherwise unchanged",
+  "continent_apply_wording_amended": "issue #3237: generated country pages point apply guidance at the scheduled update and the Update tab's 'Run Now' instead of the retired Force Update|Reload footer; the pre-move template is otherwise unchanged"
 }

--- a/tests/smoke/ui/test_render_smoke.py
+++ b/tests/smoke/ui/test_render_smoke.py
@@ -1038,7 +1038,7 @@ def test_general_page_renders_nested_pass_timeout_field(webui: WebUI, php_error_
     )
 
     assert "whole process tree" in body, "the help copy must say the whole process tree is terminated on expiry"
-    assert "Force Update" in body, "the help copy must give the retry guidance after an expiry"
+    assert "Run Now" in body, "the help copy must give the retry guidance after an expiry (issue #3237)"
 
 
 def test_hooks_page_documents_lifecycle_env_vars(webui: WebUI, php_error_log_guard: PhpErrorLogGuard) -> None:  # noqa: ARG001

--- a/tests/smoke/ui/test_render_smoke.py
+++ b/tests/smoke/ui/test_render_smoke.py
@@ -1557,12 +1557,41 @@ def test_dnsbl_top1m_type_help_says_update_not_force_reload(
     assert "select the type and Save, then run an Update" in body, (
         "DNSBL page's TOP1M Type help no longer tells the user an Update suffices"
     )
-    # The old TOP1M Type help's exact wording (distinct from the OTHER, still-accurate
-    # Force-Reload help texts elsewhere on this page -- TLD Exclusion / Global-log) --
+    # The old TOP1M Type help's exact wording (the sibling TLD Exclusion / Global-log
+    # Force-Reload instructions were separate stale texts, reworded by issue #3237) --
     # its absence pins that the stale instruction was actually replaced, not just added to.
     assert "select type and Save, followed by a" not in body, (
         "DNSBL page's TOP1M Type help still carries the stale Force-Reload wording"
     )
+
+
+def test_apply_guidance_names_run_now_not_retired_actions(webui: WebUI, php_error_log_guard: PhpErrorLogGuard) -> None:
+    """Settings pages point at actions that exist: the scheduled update and the
+    Update tab's Run Now (issue #3237) — never the retired "Force Update" /
+    "Force Reload" buttons or the "applied via CRON or 'Force Update|Reload' only!"
+    footer (#886 fixed the one TOP1M instance; this covers the remaining pages).
+
+    Asserts the IP and DNSBL pages pass the clean-render oracle AND carry the
+    corrected guidance, with no retired action name anywhere in the rendered body.
+    """
+    for path, anchor, needle in (
+        (
+            "/pfblockerng/pfblockerng_ip.php",
+            "IP Configuration",
+            "Setting changes are applied on the next scheduled update.",
+        ),
+        (
+            "/pfblockerng/pfblockerng_dnsbl.php",
+            "DNSBL Webserver Configuration",
+            "A DNSBL reload is required for changes to take effect",
+        ),
+    ):
+        resp = webui.get(path)
+        result = evaluate_render(path, resp.status_code, resp.text, (anchor,))
+        assert result.ok, f"render oracle failed for {path}: {result.detail}"
+        assert needle in resp.text, f"{path} is missing the corrected apply guidance {needle!r}"
+        for retired in ("Force Reload", "Force Update", "applied via CRON"):
+            assert retired not in resp.text, f"{path} still instructs the retired action {retired!r} (issue #3237)"
 
 
 def test_dnsbl_lenient_parsing_field_renders(webui: WebUI, php_error_log_guard: PhpErrorLogGuard) -> None:


### PR DESCRIPTION
Closes #3237.

## What

The GUI's apply model is ADR-43's Update tab (**Run Scope** Both/IP/DNSBL × **Force** None/Parse/Download/Both + **Run Now**) plus the scheduled update, and #738's pending-changes banner already points there. But settings-page footers and help texts still instructed actions that no longer exist: "Force Update", "Force Reload", "Force Reload - DNSBL/IP", and the "Setting changes are applied via CRON or 'Force Update|Reload' only!" footer. This rewords every user-facing reference to name actions that exist, following the wording precedent set by #886.

## Corrected guidance per site class

- **Generic footers** (General, DNSBL, IP, Blacklist, Category ×3, Category-edit ×2, SafeSearch, GeoIP continent + Reputation, Hooks variant): "applied on the next scheduled update. To apply them now, go to the Update tab and use the 'Run Now' function." — mirrors `pfb_print_pending_changes_box()`.
- **DNSBL config-driven settings** (Global logging, per-category logging, Blacklist Logging select): "A DNSBL reload is required...: run 'Run Now' (Run Scope: DNSBL or Both)..., or wait for the next scheduled update." — these are DNSBL fingerprint inputs, so any DNSBL pass applies them.
- **IP suppression lists** (v4/v6): kept the forced-reload requirement the old text encoded — `pfb['supp_update']` only flips during a feed parse (`pfblockerng_apply.inc`), so the guidance is now "run 'Run Now' (Run Scope: IP, Force: Parse)". A detector-respecting Run Now or a scheduled pass with unchanged feeds does NOT re-apply an edited suppression list.
- **Alerts wildcard-flush failure savemsgs**: 'Run Now' (Run Scope: DNSBL, Force: Parse) — the forced reload is the reliable resolver-cache rebuild.
- **Widget notices**: dedup → "Run an Update with Force: Parse to correct."; missing pfb_py_dnsbl.sqlite tooltip → reworded AND its long-broken single-quoted `title` attribute (nested quotes truncated the tooltip since the original text) fixed with a double-quoted attribute.
- **Sync page**: XMLRPC-specific footer (sync settings are consumed by the XMLRPC engine per sync: auto on config changes, manual at the update-pass tail), replacing the inapplicable update-pass footer.
- **Hooks page**: PFB_TRIGGER help remapped to real sources (cron = scheduled update + Run Now Force: Download/Both; update = settings save + Run Now Force: None; force-reload = Run Now Force: Parse), matching `pfb_hook_trigger()`/`pfb_req_to_hook_trigger()` and `pfb_runnow()`.
- **Comments/log strings**: `pfb_hook_trigger()` docblock, DNSBL fail log lines, CLI verb case comments, ET/CustomList flag comments.

## Tests (red → green, frozen)

- NEW `tests/php/ApplyGuidanceWordingUiTest.php`: retired action names ("Force Reload", "Force Update", "applied via CRON", "next CRON update") must not appear anywhere under `src/usr/local`; per-page presence pins with EXACT occurrence counts so dropping one of several identical callouts (e.g. one category-page branch, one geoip template) fails.
- Updated pins: `IpTabLayoutUiTest` (new callout wording, still above the form), `GeneralAdvancedTimeoutUiTest` (retry guidance now names Run Now), `PfbWidgetOracleTest` (dedup copy).
- NEW Tier A render test `test_apply_guidance_names_run_now_not_retired_actions` (IP + DNSBL pages): corrected guidance present, retired names absent. **No local smoke seat; exercised by CI's smoke job on this PR.**
- `geoip_pre_move_golden.json` refreshed per the established amendment convention (generated continent pages + both Reputation outputs embed the geoip callout template; country-file hashes unchanged; amendment note cites this issue).

Red proof: with the final test content on pristine base, the new/updated tests fail (retired names present, corrected guidance absent, oracle strings differ); same tests green on this commit. Remaining suite failures are byte-identical to base's pre-existing set (tick/Top1M family; line numbers shifted +1 by the docblock), verified by sorted failure-name diff base vs branch.

## Review

One condensed adversarial review round (contract + correctness/hostile + test honesty + over-engineering). All findings resolved: the two blockers (missing Force: Parse on forced-recovery paths; malformed widget tooltip) and the test-strength gap (per-site occurrence counts + extra.inc pin), plus the stale sibling comment. Gates: `php -l` on all touched files, PHPCS (rc=0), PHPStan (no errors), ruff clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated pfBlockerNG guidance to use the current **Update** tab’s **Run Now** workflow instead of legacy Force Update/Force Reload terminology.
  - Clarified when settings, DNSBL changes, hooks, and synchronization changes take effect, including scheduled updates and manual runs.
  - Improved recovery instructions for DNSBL failures, missing databases, and de-duplication issues.
  - Clarified update trigger mappings and marked legacy command-line actions as deprecated.

- **Tests**
  - Added and updated UI coverage to verify current Run Now guidance and prevent retired terminology from reappearing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->