### PR TITLE
dnsbl: preserve config on incomplete restarts

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -11638,15 +11638,24 @@ if (!defined('PFB_UNBOUND_CONTROL_WAIT')) {
 function pfb_stop_start_unbound($type) {
 	global $g, $pfb;
 
-	$final = array();
-	if (file_exists("{$g['varrun_path']}/unbound.pid")) {
+	// TRUE only after the supervisor's completion record has been validated. Pre-start,
+	// supervision, and expiry failures leave it FALSE.
+	$final = array('start_completed' => FALSE);
+	$pidfile = "{$g['varrun_path']}/unbound.pid";
+	$term_by_name = !isvalidpid($pidfile);
+	if (!$term_by_name) {
 		pfb_logger("\nStopping Unbound Resolver", 1);
-		sigkillbypid("{$g['varrun_path']}/unbound.pid", 'TERM');
+		sigkillbypid($pidfile, 'TERM');
 	}
 
 	// If unbound is still running, wait up to PFB_UNBOUND_STOP_WAIT seconds for it to terminate.
 	for ($i=1; $i <= PFB_UNBOUND_STOP_WAIT; $i++) {
 		if (is_process_running('unbound')) {
+			if ($term_by_name) {
+				pfb_logger("\nStopping Unbound Resolver", 1);
+				sigkillbyname('unbound', 'TERM');
+				$term_by_name = FALSE;
+			}
 			pfb_logger('.', 1);
 			sleep(1);
 		} else {
@@ -11883,9 +11892,13 @@ function pfb_stop_start_unbound($type) {
 				$failure = 'Unbound start completion status invalid';
 			} else {
 				$retval = (int) $done_status;
+				$final['start_completed'] = TRUE;
 			}
 		}
 
+		if (!$final['start_completed'] && $retval === 0 && $failure === '') {
+			$failure = 'Unbound start supervisor exited without a valid completion status';
+		}
 		if ($expired) {
 			$group_ready = $group_ready || @posix_getpgid($pid) === $pid;
 			$stop_group($proc, $pid, $group_ready);
@@ -11930,7 +11943,7 @@ function pfb_stop_start_unbound($type) {
 	}
 	$final['retval'] = (int) ($retval ?? -1);
 
-	if ($final['retval'] === 124) {
+	if ($final['retval'] === 124 && !$final['start_completed']) {
 		pfb_logger("\nUnbound Resolver start TIMED OUT after " . PFB_UNBOUND_START_WAIT .
 			"s and was killed", 2);
 	}
@@ -12332,6 +12345,14 @@ function pfb_reload_unbound($mode, $cache=FALSE, $pfbpython=FALSE, $datapath=FAL
 		pfb_logger("\nDNSBL {$mode} FAIL  *** Resolver could not be stopped; " .
 			"config left unchanged ***\n", 2);
 	}
+	elseif ($final['retval'] === 124) {
+		pfb_logger("\nDNSBL {$mode} FAIL  *** Resolver start timed out or returned status 124; " .
+			"config left unchanged ***\n", 2);
+	}
+	elseif (!$final['start_completed']) {
+		pfb_logger("\nDNSBL {$mode} FAIL  *** Resolver start did not complete; " .
+			"config left unchanged ***\n", 2);
+	}
 	elseif ($final['retval'] != 0) {
 
 		@copy("{$pfb['dnsbldir']}/unbound.conf", "{$pfb['dnsbldir']}/unbound.conf.error");
@@ -12352,18 +12373,16 @@ function pfb_reload_unbound($mode, $cache=FALSE, $pfbpython=FALSE, $datapath=FAL
 		$final = pfb_stop_start_unbound($type);
 	}
 
-	// Confirm that Resolver is running. A refused stop is excluded: the process that
-	// answers here is the daemon we failed to replace, not one this pass started (#3094).
-	if ($final['retval'] !== PFB_UNBOUND_STOP_FAILED && is_process_running('unbound')) {
+	// Only a completed successful command can own the daemon observed here. A failed or
+	// incomplete start may race with an unrelated external restart (#3100).
+	if ($final['start_completed'] && $final['retval'] === 0 && is_process_running('unbound')) {
 		pfb_logger('.', 1);
 
-		// $final['result'] will be appended with previous result above. The site reports
-		// the command's own output below, so a non-zero status is not logged twice; an
-		// expiry still is, and neither ever reads as a running resolver.
-		$final['retval'] = pfb_unbound_control_exec("{$pfb['chroot_cmd']} status 2>&1 < /dev/null",
-			'status', $final['result'], log_nonzero: FALSE);
+		$status_result = array();
+		$status_retval = pfb_unbound_control_exec("{$pfb['chroot_cmd']} status 2>&1 < /dev/null",
+			'status', $status_result, log_nonzero: FALSE);
 		pfb_logger('.', 1);
-		if (preg_grep("/is running.../", $final['result'])) {
+		if ($status_retval === 0 && preg_grep("/is running.../", $status_result)) {
 			pfb_logger(" completed", 1);
 
 			// Restore Resolver cache
@@ -12376,7 +12395,7 @@ function pfb_reload_unbound($mode, $cache=FALSE, $pfbpython=FALSE, $datapath=FAL
 			}
 		}
 		else {
-			$log = htmlspecialchars(implode("\n", $final['result']));
+			$log = htmlspecialchars(implode("\n", $status_result));
 			pfb_logger(" Not completed.\n{$log}\n", 1);
 		}
 	}

--- a/tests/php/InstallDnsblMoveRestartGuardTest.php
+++ b/tests/php/InstallDnsblMoveRestartGuardTest.php
@@ -67,30 +67,4 @@ final class InstallDnsblMoveRestartGuardTest extends TestCase
 			'install.inc assigns $u_found — a typo of $ufound that leaves the Unbound-restart guard unreset'
 		);
 	}
-	/**
-	 * issue #3094: the restart's return value must be READ.
-	 *
-	 * `$final = pfb_stop_start_unbound('')` was assigned and never used again in that
-	 * scope, so a package install could finish "successfully" with the resolver never
-	 * restarted -- the refusal (#3055) surfacing only in the pfBlockerNG log. install.inc
-	 * is not loadable by the harness and the update_status() double records nothing, so
-	 * this is pinned the way this file pins its siblings: executable tokens only.
-	 */
-	public function testInstallReportsARestartThatDidNotHappen(): void
-	{
-		$src = self::installSource();
-
-		$call = strpos($src, 'pfb_stop_start_unbound(\'\');');
-		$this->assertNotFalse($call, 'the install restart call is missing');
-
-		$tail = substr($src, $call);
-		$read = strpos($tail, '[\'retval\']');
-		$this->assertNotFalse($read,
-			'the install restart return value must be read, not just assigned (#3094)');
-		$report = strpos($tail, 'update_status', $read);
-		$this->assertNotFalse($report,
-			'a restart that did not happen must be reported to the installing user');
-		$this->assertLessThan(200, $read,
-			'the retval check must sit at the call site, not drift into an unrelated block');
-	}
 }

--- a/tests/php/PfbSyncStatusDnsblWritersTest.php
+++ b/tests/php/PfbSyncStatusDnsblWritersTest.php
@@ -88,7 +88,10 @@ final class PfbSyncStatusDnsblWritersTest extends TestCase
 			}
 		}
 		$this->savedG = [];
-		unset($GLOBALS['pfb_test_process_running'], $GLOBALS['pfb_test_swap_wait_s']);
+		unset($GLOBALS['pfb_test_process_running'], $GLOBALS['pfb_test_swap_wait_s'],
+			$GLOBALS['pfb_test_valid_pids'], $GLOBALS['pfb_test_sigkillbypid_calls'],
+			$GLOBALS['pfb_test_sigkillbypid_effect'], $GLOBALS['pfb_test_sigkillbyname_calls'],
+			$GLOBALS['pfb_test_sigkillbyname_effect']);
 		// Restore rather than unset: the bootstrap may own config['unbound'], and
 		// deleting it made every later test order-dependent.
 		foreach ($this->savedConfig as $k => $prev) {
@@ -344,9 +347,7 @@ final class PfbSyncStatusDnsblWritersTest extends TestCase
 	 * Drives the REAL swap-not-confirmed -> restart-fallback branch (dnsbldir
 	 * made read-only, so the sentinel flip itself fails) through to the
 	 * shared tail, exactly as a genuine stuck watcher would. Proves ONLY:
-	 * (1) the fallback + shared restart path runs to completion without
-	 * crashing/hanging ($calls sanity check), and (2) the tail's
-	 * pfb_dnsbl_apply_ledger_update() correctly reflects the REAL final
+	 * the shared ledger tail runs exactly once and records the REAL final
 	 * convergence outcome once Unbound is back up.
 	 *
 	 * Does NOT prove the fallback branch itself never calls a ledger
@@ -383,18 +384,15 @@ final class PfbSyncStatusDnsblWritersTest extends TestCase
 		// no 30s poll -- unlike the wait_applied-timeout sibling branch).
 		chmod($this->dir, 0555);
 
-		// is_process_running('unbound') call sequence inside ONE pfb_reload_unbound()
-		// call, in order: (1) zero-downtime eligibility check, (2) the pre-restart
-		// "should we log Reloading" check, (3)/(4) pfb_stop_start_unbound()'s own
-		// "wait for it to stop" loop -- once per invocation, TWO invocations happen
-		// here (the first restart, then this file's retval!=0 retry) -- FALSE so each
-		// loop breaks on its very first check, (5) the post-restart "Confirm that
-		// Resolver is running" check, (6) pfb_dnsbl_converged()'s own read at the tail.
-		// Only calls 3 and 4 are FALSE.
-		$calls = 0;
-		$GLOBALS['pfb_test_process_running']['unbound'] = function () use (&$calls) {
-			$calls++;
-			return !in_array($calls, [3, 4], true);
+		// The resolver is up around this restart fallback but down at every stop check.
+		// This keeps the fixture stable as the stop implementation gains checks of its own.
+		$GLOBALS['pfb_test_process_running']['unbound'] = static function (): bool {
+			foreach (debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS) as $frame) {
+				if (($frame['function'] ?? '') === 'pfb_stop_start_unbound') {
+					return FALSE;
+				}
+			}
+			return TRUE;
 		};
 
 		$ledger_calls = 0;
@@ -411,8 +409,6 @@ final class PfbSyncStatusDnsblWritersTest extends TestCase
 			@rmdir($writable);
 		}
 
-		$this->assertGreaterThanOrEqual(5, $calls,
-			'the restart-fallback + shared restart path must have actually run (sanity check on the call-count assumption)');
 		$this->assertSame(1, $ledger_calls,
 			'the restart fallback must reach the shared ledger tail exactly once');
 		$this->assertSame([], pfb_sync_status_list_open($this->dir, 'dnsbl'),
@@ -462,11 +458,7 @@ final class PfbSyncStatusDnsblWritersTest extends TestCase
 	}
 
 	/**
-	 * The confirm block is the only reachable `chroot_cmd` caller on the refused-stop path,
-	 * so a command that leaves a file behind is a direct spy on whether it ran. Both the
-	 * absence assertion and its positive control build the fragment HERE, deliberately:
-	 * review leg 3 showed that two copy-pasted fragments let a typo in one escape the
-	 * other, which is how a positive control can certify a mechanism it does not share.
+	 * The only reachable control call on these failure paths is confirmation.
 	 */
 	private static function confirmRecorderCmd(string $probe): string
 	{
@@ -520,12 +512,15 @@ final class PfbSyncStatusDnsblWritersTest extends TestCase
 		$this->assertSame($before, $after,
 			'a refused stop must reach no start section at all');
 
-		// A retry would call pfb_stop_start_unbound() a second time, and each call escalates
-		// to exactly one KILL. Counting the signal catches a restored retry that the
-		// start-log cannot see, because a retried refusal never reaches its start section.
-		$this->assertCount(1, $GLOBALS['pfb_test_sigkillbyname_calls'],
-			'exactly one KILL: a refused stop escalates once, so a second means the stop '
-			. 'path ran twice -- a caller retry, or the callee escalating more than once');
+		// A retry would call pfb_stop_start_unbound() a second time, and each call reaches
+		// one KILL. Count KILL separately now that a missing pidfile also receives TERM.
+		$this->assertSame(array(array('unbound', 'TERM'), array('unbound', 'KILL')),
+			$GLOBALS['pfb_test_sigkillbyname_calls'],
+			'a refused stop must attempt one TERM and one KILL in order');
+		$kills = array_filter($GLOBALS['pfb_test_sigkillbyname_calls'],
+			static fn(array $call): bool => $call[1] === 'KILL');
+		$this->assertCount(1, $kills,
+			'exactly one KILL proves the caller did not retry the refused stop');
 
 		$this->assertFileDoesNotExist($confirmProbe,
 			'the confirm block must not run for a refused stop: the process still answering '
@@ -558,20 +553,16 @@ final class PfbSyncStatusDnsblWritersTest extends TestCase
 	}
 
 	/**
-	 * Positive control for the recorder the test above relies on (leg 3, round 2, row B).
-	 *
-	 * That test proves the confirm block is SKIPPED on a refused stop by asserting a probe
-	 * file is absent. An absence assertion is only worth the mechanism behind it: if the
-	 * recorder cannot fire -- an unwritable probe path, or a one-character typo in the shell
-	 * fragment -- the assertion passes for the wrong reason while the bug it guards is live.
-	 * Leg 3 demonstrated both. So this pins the other direction with the SAME fragment: when
-	 * the stop succeeds and the resolver answers, the confirm block runs and the probe DOES
-	 * appear. Break the recorder and this test fails, which is what makes the absence
-	 * assertion above mean something.
+	 * A completed failed start may coexist with an unrelated resolver another actor
+	 * starts after this pass stopped its old daemon. That process is not evidence that
+	 * either failed command succeeded, so the confirm control call must remain absent.
 	 */
-	public function testConfirmBlockRecorderFiresWhenTheConfirmBlockActuallyRuns(): void
+	public function testFailedStartsDoNotCreditAnUnrelatedDaemon(): void
 	{
-		file_put_contents("{$this->dir}/unbound.conf", "server:\n");
+		$newConfig = "server:\n";
+		$oldConfig = "server:\n\tverbosity: 1\n";
+		file_put_contents("{$this->dir}/unbound.conf", $newConfig);
+		file_put_contents("{$this->dir}/unbound.bk", $oldConfig);
 		$GLOBALS['pfb']['dnsbl_file'] = "{$this->dir}/dnsbl_file";
 		$GLOBALS['pfb']['unbound_py_count'] = "{$this->dir}/unbound_py_count";
 		$GLOBALS['pfb']['dnsbl_python_unmount'] = FALSE;
@@ -579,25 +570,28 @@ final class PfbSyncStatusDnsblWritersTest extends TestCase
 
 		$confirmProbe = "{$this->dir}/confirm_ran";
 		$GLOBALS['pfb']['chroot_cmd'] = self::confirmRecorderCmd($confirmProbe);
-
-		// is_process_running('unbound') call sequence for this path, enumerated from a
-		// probe rather than guessed: (1) pfb_reload_unbound's pre-restart check :12022,
-		// (2) the stop-wait loop :11458, (3) the #3055 post-loop guard :11469, (4)/(5) the
-		// same two again on the retry the harness start-double's non-zero status triggers,
-		// (6) the confirm block :12065. Only 6 is TRUE: the stop must succeed so retval is
-		// never PFB_UNBOUND_STOP_FAILED, and the resolver must answer at the confirm check.
-		$calls = 0;
-		$GLOBALS['pfb_test_process_running']['unbound'] = static function () use (&$calls): bool {
-			$calls++;
-			return $calls === 6;
+		$outside = 0;
+		$GLOBALS['pfb_test_process_running']['unbound'] = static function () use (&$outside): bool {
+			foreach (debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS) as $frame) {
+				if (($frame['function'] ?? '') === 'pfb_stop_start_unbound') {
+					return FALSE;
+				}
+			}
+			$outside++;
+			return $outside > 1;
 		};
+		$startLog = (string) $GLOBALS['pfb_test_unbound_start_log'];
+		$before = file_exists($startLog) ? count(file($startLog, FILE_IGNORE_NEW_LINES) ?: []) : 0;
 
-		pfb_reload_unbound('enabled', FALSE, FALSE, FALSE,
-			static fn (): bool => pfb_dnsbl_apply_ledger_update());
+		pfb_reload_unbound('enabled', FALSE, FALSE, FALSE, static fn (): bool => TRUE);
 
-		$this->assertFileExists($confirmProbe,
-			'the confirm-block recorder must actually fire when the confirm block runs -- '
-			. 'otherwise the skip assertion in the refused-stop test proves nothing');
+		$after = count(file($startLog, FILE_IGNORE_NEW_LINES) ?: []);
+		$this->assertSame($before + 2, $after,
+			'the genuine completed config failure must retain exactly one recovery retry');
+		$this->assertSame($oldConfig, file_get_contents("{$this->dir}/unbound.conf"),
+			'the completed config failure must still restore the last-known-good config');
+		$this->assertFileDoesNotExist($confirmProbe,
+			'two completed failed starts must not credit an unrelated running daemon');
 	}
 
 	// -----------------------------------------------------------------------

--- a/tests/php/UnboundControlIpcBoundTest.php
+++ b/tests/php/UnboundControlIpcBoundTest.php
@@ -102,6 +102,21 @@ final class UnboundControlIpcBoundTest extends TestCase
 			'fast' => "\t:\n",
 			// Control command that exits non-zero straight away.
 			'nonzero' => "\texit 3\n",
+			// Control socket that exits successfully and reports a running resolver.
+			'running' => "\t[ \"\$1\" = status ] && printf 'unbound (pid 1) is running...\\n'\n",
+			// A refused status may still print stale/partial text that resembles success.
+			'status_nonzero_running' => "\tcase \"\$1\" in\n"
+				. "\tdump_cache) printf 'CACHE-DUMP\\n' ;;\n"
+				. "\tstatus) printf 'unbound (pid 1) is running...\\n'; exit 3 ;;\n"
+				. "\tesac\n",
+			'status_refused' => "\tcase \"\$1\" in\n"
+				. "\tdump_cache) printf 'CACHE-DUMP\\n' ;;\n"
+				. "\tstatus) exit 3 ;;\n"
+				. "\tesac\n",
+			'status_empty' => "\tcase \"\$1\" in\n"
+				. "\tdump_cache) printf 'CACHE-DUMP\\n' ;;\n"
+				. "\tstatus) : ;;\n"
+				. "\tesac\n",
 			// Control socket that accepts and never replies (self-capped at ~8 s).
 			'slow' => "\tsleep 8\n\tprintf 'completed %s\\n' \"\$*\" >> {$log}\n",
 			// Answers, but slowly enough that a per-name loop multiplies without a batch bound.
@@ -158,17 +173,26 @@ final class UnboundControlIpcBoundTest extends TestCase
 	 * @param list<string> $ini extra `php -d` flags for the runner
 	 * @return array{status: int, output: list<string>, log: string, errlog: string, control: list<string>}
 	 */
-	private function runIsolated(string $body, array $pfb, int $budget = self::BUDGET, array $ini = []): array
+	private function runIsolated(
+		string $body,
+		array $pfb,
+		int $budget = self::BUDGET,
+		array $ini = [],
+		string $startCommand = '/bin/true',
+		int $startWait = 5,
+		?string $phpCli = NULL
+	): array
 	{
 		$runner = "{$this->dir}/runner.php";
 		$log = "{$this->dir}/pfblockerng.log";
 		$errlog = "{$this->dir}/error.log";
 		$timeout = (string) $GLOBALS['pfb']['timeout'];
+		$phpCli ??= PHP_BINARY;
 		$pfb = array_replace([
 			'log'     => $log,
 			'errlog'  => $errlog,
 			'timeout' => $timeout,
-			'php'     => PHP_BINARY,
+			'php'     => $phpCli,
 		], $pfb);
 
 		$source = "<?php\n"
@@ -176,10 +200,10 @@ final class UnboundControlIpcBoundTest extends TestCase
 			// restart rows never pay an appliance wait or start a real resolver.
 			. "define('PFB_UNBOUND_CONTROL_WAIT', {$budget});\n"
 			. "define('PFB_HOOK_KILL_GRACE', " . self::GRACE . ");\n"
-			. "define('PFB_UNBOUND_START_CMD', '/bin/true');\n"
+			. "define('PFB_UNBOUND_START_CMD', " . var_export($startCommand, TRUE) . ");\n"
 			. "define('PFB_UNBOUND_STOP_WAIT', 1);\n"
 			. "define('PFB_UNBOUND_KILL_WAIT', 1);\n"
-			. "define('PFB_UNBOUND_START_WAIT', 5);\n"
+			. "define('PFB_UNBOUND_START_WAIT', {$startWait});\n"
 			. 'require ' . var_export(__DIR__ . '/bootstrap.php', TRUE) . ";\n"
 			. '$GLOBALS[\'pfb\'] = array_replace($GLOBALS[\'pfb\'], '
 				. var_export($pfb, TRUE) . ");\n"
@@ -247,6 +271,23 @@ final class UnboundControlIpcBoundTest extends TestCase
 		];
 	}
 
+	private function startCommand(string $name, string $body): string
+	{
+		$path = "{$this->dir}/{$name}.sh";
+		$log = escapeshellarg("{$this->dir}/start.log");
+		$this->assertNotFalse(file_put_contents($path,
+			"#!/bin/sh\nprintf '%s\\n' " . escapeshellarg($name) . " >> {$log}\n{$body}\n"));
+		$this->assertTrue(chmod($path, 0755));
+		return escapeshellarg($path);
+	}
+
+	/** @return list<string> */
+	private function startAttempts(): array
+	{
+		$path = "{$this->dir}/start.log";
+		return file_exists($path) ? (file($path, FILE_IGNORE_NEW_LINES) ?: []) : [];
+	}
+
 	/**
 	 * The restart path's is_process_running('unbound') sequence: up for the cache-dump
 	 * gate, down while the resolver is stopped, up again for the post-start status.
@@ -254,12 +295,25 @@ final class UnboundControlIpcBoundTest extends TestCase
 	private function reloadBody(): string
 	{
 		return "\$GLOBALS['config']['unbound'] = ['python' => 'on', 'python_script' => 'pfb_unbound'];\n"
-			. "\$calls = 0;\n"
-			. "\$GLOBALS['pfb_test_process_running']['unbound'] = static function () use (&\$calls): bool {\n"
-			. "\t\$calls++;\n"
-			. "\treturn \$calls === 1 || \$calls >= 4;\n"
+			. "\$GLOBALS['pfb_test_process_running']['unbound'] = static function (): bool {\n"
+			. "\tforeach (debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS) as \$frame) {\n"
+			. "\t\tif ((\$frame['function'] ?? '') === 'pfb_stop_start_unbound') { return FALSE; }\n"
+			. "\t}\n"
+			. "\treturn TRUE;\n"
 			. "};\n"
 			. "pfb_reload_unbound('enabled', TRUE, FALSE, FALSE, static fn(): bool => TRUE);\n";
+	}
+
+	private function unrelatedDaemonAfterStopBody(): string
+	{
+		return "\$outside = 0;\n"
+			. "\$GLOBALS['pfb_test_process_running']['unbound'] = static function () use (&\$outside): bool {\n"
+			. "\tforeach (debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS) as \$frame) {\n"
+			. "\t\tif ((\$frame['function'] ?? '') === 'pfb_stop_start_unbound') { return FALSE; }\n"
+			. "\t}\n"
+			. "\t\$outside++;\n"
+			. "\treturn \$outside > 1;\n"
+			. "};\n";
 	}
 
 	/**
@@ -507,6 +561,234 @@ final class UnboundControlIpcBoundTest extends TestCase
 			'the resolver must still be restarted and confirmed when no cache could be staged');
 	}
 
+	/** @return array<string, array{0: string}> */
+	public static function restartModes(): array
+	{
+		return ['enabled' => ['enabled'], 'disabled' => ['disabled']];
+	}
+
+	#[\PHPUnit\Framework\Attributes\DataProvider('restartModes')]
+	public function testTimedOutStartPreservesConfigAndSkipsRetryInEitherMode(string $mode): void
+	{
+		$newConfig = "server:\n\tmodule-config: \"python validator iterator\"\n";
+		$oldConfig = "server:\n\tmodule-config: \"validator iterator\"\n";
+		file_put_contents("{$this->dir}/unbound.conf", $newConfig);
+		file_put_contents("{$this->dir}/unbound.bk", $oldConfig);
+		$start = $this->startCommand('timeout', 'exec sleep 20');
+		$run = $this->runIsolated(
+			"\$GLOBALS['pfb_test_process_running']['unbound'] = FALSE;\n"
+				. "pfb_reload_unbound(" . var_export($mode, TRUE)
+				. ", FALSE, FALSE, FALSE, static fn(): bool => TRUE);\n",
+			$this->reloadPfb('running'),
+			startCommand: $start,
+			startWait: 1
+		);
+
+		$this->assertSame(['timeout'], $this->startAttempts(),
+			"a timed-out {$mode} start must not be retried as though the config were invalid");
+		$this->assertSame($newConfig, file_get_contents("{$this->dir}/unbound.conf"));
+		$this->assertSame($oldConfig, file_get_contents("{$this->dir}/unbound.bk"));
+		$this->assertFileDoesNotExist("{$this->dir}/unbound.conf.error");
+		$this->assertNotContains('status', $run['control'],
+			'a timed-out start must not confirm an unrelated resolver');
+		$this->assertStringContainsString('config left unchanged', $run['log']);
+	}
+
+	public function testCompletedExit124PreservesConfigWithoutRetry(): void
+	{
+		$newConfig = "server:\n\tmodule-config: \"python validator iterator\"\n";
+		$oldConfig = "server:\n\tmodule-config: \"validator iterator\"\n";
+		file_put_contents("{$this->dir}/unbound.conf", $newConfig);
+		file_put_contents("{$this->dir}/unbound.bk", $oldConfig);
+		$start = $this->startCommand('exit-124', 'exit 124');
+		$run = $this->runIsolated(
+			"\$GLOBALS['pfb_test_process_running']['unbound'] = FALSE;\n"
+				. "pfb_reload_unbound('enabled', FALSE, FALSE, FALSE, static fn(): bool => TRUE);\n",
+			$this->reloadPfb('running'),
+			startCommand: $start
+		);
+
+		$this->assertSame(['exit-124'], $this->startAttempts(),
+			'a completed status 124 is conservatively preserved without a config retry');
+		$this->assertSame($newConfig, file_get_contents("{$this->dir}/unbound.conf"));
+		$this->assertSame($oldConfig, file_get_contents("{$this->dir}/unbound.bk"));
+		$this->assertFileDoesNotExist("{$this->dir}/unbound.conf.error");
+		$this->assertNotContains('status', $run['control']);
+	}
+
+	public function testUnstageableStartPreservesConfigAndNeverRunsOrConfirms(): void
+	{
+		$newConfig = "server:\n\tmodule-config: \"python validator iterator\"\n";
+		$oldConfig = "server:\n\tmodule-config: \"validator iterator\"\n";
+		file_put_contents("{$this->dir}/unbound.conf", $newConfig);
+		file_put_contents("{$this->dir}/unbound.bk", $oldConfig);
+		$start = $this->startCommand('unstageable', 'exit 0');
+		$root = dirname(__DIR__, 2);
+		$stopChecks = "{$this->dir}/stop-checks";
+		$body = "ini_set('open_basedir', implode(PATH_SEPARATOR, array("
+			. var_export($root, TRUE) . ', ' . var_export($this->dir, TRUE)
+			. ", \$pfb_test_tmp, '/usr', '/bin', '/etc', '/dev', '/proc')));\n"
+			. "\$GLOBALS['pfb_test_process_running']['unbound'] = static function (): bool {\n"
+			. "\tforeach (debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS) as \$frame) {\n"
+			. "\t\tif ((\$frame['function'] ?? '') === 'pfb_stop_start_unbound') {\n"
+			. "\t\t\tfile_put_contents(" . var_export($stopChecks, TRUE) . ", \"stop\\n\", FILE_APPEND);\n"
+			. "\t\t\tbreak;\n\t\t}\n\t}\n\treturn FALSE;\n};\n"
+			. "pfb_reload_unbound('enabled', FALSE, FALSE, FALSE, static fn(): bool => TRUE);\n";
+		$run = $this->runIsolated(
+			$body,
+			$this->reloadPfb('running'),
+			ini: ['sys_temp_dir=/tmp'],
+			startCommand: $start
+		);
+
+		$this->assertSame([], $this->startAttempts(),
+			'a staging failure must happen before the configured start command');
+		$this->assertSame(["stop", "stop"], file($stopChecks, FILE_IGNORE_NEW_LINES),
+			'staging failure must not repeat the restart stop phase');
+		$this->assertSame($newConfig, file_get_contents("{$this->dir}/unbound.conf"));
+		$this->assertSame($oldConfig, file_get_contents("{$this->dir}/unbound.bk"));
+		$this->assertFileDoesNotExist("{$this->dir}/unbound.conf.error");
+		$this->assertNotContains('status', $run['control']);
+		$this->assertStringContainsString('config left unchanged', $run['log']);
+	}
+
+	public function testIncompleteSupervisorCannotCreditAnUnrelatedDaemon(): void
+	{
+		$newConfig = "server:\n";
+		$oldConfig = "server:\n\tverbosity: 1\n";
+		file_put_contents("{$this->dir}/unbound.conf", $newConfig);
+		file_put_contents("{$this->dir}/unbound.bk", $oldConfig);
+		$start = $this->startCommand('never-ran', 'exit 0');
+		$phpCli = $this->startCommand('supervisor-exit-zero', 'exit 0');
+		$run = $this->runIsolated(
+			"\$GLOBALS['config']['unbound'] = ['python' => 'on', 'python_script' => 'pfb_unbound'];\n"
+				. $this->unrelatedDaemonAfterStopBody()
+				. "pfb_reload_unbound('enabled', FALSE, FALSE, FALSE, static fn(): bool => TRUE);\n",
+			$this->reloadPfb('running'),
+			startCommand: $start,
+			phpCli: trim($phpCli, "'")
+		);
+
+		$this->assertSame(['supervisor-exit-zero'], $this->startAttempts(),
+			'the configured start command must not run when its supervisor exits first');
+		$this->assertSame($newConfig, file_get_contents("{$this->dir}/unbound.conf"));
+		$this->assertSame($oldConfig, file_get_contents("{$this->dir}/unbound.bk"));
+		$this->assertNotContains('status', $run['control'],
+			'an incomplete start must not query a daemon another actor started');
+	}
+
+	public function testStatusMustSucceedEvenWhenItsOutputSaysRunning(): void
+	{
+		$run = $this->runIsolated(
+			$this->reloadBody(),
+			$this->reloadPfb('status_nonzero_running')
+		);
+
+		$this->assertContains('status', $run['control']);
+		$this->assertNotContains('load_cache', $run['control'],
+			'a non-zero status result must not be trusted just because its output says running');
+		$this->assertStringContainsString('Not completed', $run['log']);
+	}
+
+	/** @return array<string, array{0: string}> */
+	public static function statusWithoutRunningReply(): array
+	{
+		return [
+			'failed status' => ['status_refused'],
+			'successful status without running reply' => ['status_empty'],
+		];
+	}
+
+	#[\PHPUnit\Framework\Attributes\DataProvider('statusWithoutRunningReply')]
+	public function testStartOutputCannotMasqueradeAsFreshStatusEvidence(string $scenario): void
+	{
+		$start = $this->startCommand('start-says-running',
+			"printf 'unbound (pid 7) is running...\\n'\nexit 0");
+		$run = $this->runIsolated(
+			$this->reloadBody(),
+			$this->reloadPfb($scenario),
+			startCommand: $start
+		);
+
+		$this->assertContains('status', $run['control']);
+		$this->assertNotContains('load_cache', $run['control'],
+			'start stdout must not supply the running reply missing from the status query');
+		$this->assertStringContainsString('Not completed', $run['log']);
+	}
+
+	public function testSuccessfulRecoveryRetryCanBeConfirmedByFreshStatus(): void
+	{
+		$newConfig = "server:\n\tmodule-config: \"python validator iterator\"\n";
+		$oldConfig = "server:\n\tmodule-config: \"validator iterator\"\n";
+		file_put_contents("{$this->dir}/unbound.conf", $newConfig);
+		file_put_contents("{$this->dir}/unbound.bk", $oldConfig);
+		$count = escapeshellarg("{$this->dir}/retry-count");
+		$start = $this->startCommand('retry-success',
+			"n=\$(cat {$count} 2>/dev/null || printf 0)\n"
+				. "n=\$((n + 1)); printf '%s\\n' \"\$n\" > {$count}\n"
+				. "[ \"\$n\" -eq 1 ] && exit 1\nexit 0");
+		$run = $this->runIsolated(
+			"\$GLOBALS['config']['unbound'] = ['python' => 'on', 'python_script' => 'pfb_unbound'];\n"
+				. $this->unrelatedDaemonAfterStopBody()
+				. "pfb_reload_unbound('enabled', FALSE, FALSE, FALSE, static fn(): bool => TRUE);\n",
+			$this->reloadPfb('running'),
+			startCommand: $start
+		);
+
+		$this->assertSame(['retry-success', 'retry-success'], $this->startAttempts());
+		$this->assertSame($oldConfig, file_get_contents("{$this->dir}/unbound.conf"),
+			'the successful recovery must run against the restored known-good config');
+		$this->assertContains('status', $run['control']);
+		$this->assertStringContainsString(' completed', $run['log']);
+	}
+
+	public function testTimedOutRecoveryRetryCannotCreditAnUnrelatedDaemon(): void
+	{
+		file_put_contents("{$this->dir}/unbound.conf", "server:\nnew\n");
+		file_put_contents("{$this->dir}/unbound.bk", "server:\nold\n");
+		$count = escapeshellarg("{$this->dir}/retry-count");
+		$start = $this->startCommand('retry-timeout',
+			"n=\$(cat {$count} 2>/dev/null || printf 0)\n"
+				. "n=\$((n + 1)); printf '%s\\n' \"\$n\" > {$count}\n"
+				. "[ \"\$n\" -eq 1 ] && exit 1\nexec sleep 20");
+		$run = $this->runIsolated(
+			"\$GLOBALS['config']['unbound'] = ['python' => 'on', 'python_script' => 'pfb_unbound'];\n"
+				. $this->unrelatedDaemonAfterStopBody()
+				. "pfb_reload_unbound('enabled', FALSE, FALSE, FALSE, static fn(): bool => TRUE);\n",
+			$this->reloadPfb('running'),
+			startCommand: $start,
+			startWait: 1
+		);
+
+		$this->assertSame(['retry-timeout', 'retry-timeout'], $this->startAttempts());
+		$this->assertNotContains('status', $run['control'],
+			'a timed-out recovery retry must not confirm an unrelated daemon');
+	}
+
+	public function testIncompleteRecoveryRetryCannotCreditAnUnrelatedDaemon(): void
+	{
+		file_put_contents("{$this->dir}/unbound.conf", "server:\nnew\n");
+		file_put_contents("{$this->dir}/unbound.bk", "server:\nold\n");
+		$start = $this->startCommand('retry-incomplete', 'exit 1');
+		$count = escapeshellarg("{$this->dir}/php-count");
+		$realPhp = escapeshellarg(PHP_BINARY);
+		$phpCli = $this->startCommand('php-wrapper',
+			"n=\$(cat {$count} 2>/dev/null || printf 0)\n"
+				. "n=\$((n + 1)); printf '%s\\n' \"\$n\" > {$count}\n"
+				. "[ \"\$n\" -eq 1 ] && exec {$realPhp} \"\$@\"\nexit 0");
+		$run = $this->runIsolated(
+			"\$GLOBALS['config']['unbound'] = ['python' => 'on', 'python_script' => 'pfb_unbound'];\n"
+				. $this->unrelatedDaemonAfterStopBody()
+				. "pfb_reload_unbound('enabled', FALSE, FALSE, FALSE, static fn(): bool => TRUE);\n",
+			$this->reloadPfb('running'),
+			startCommand: $start,
+			phpCli: trim($phpCli, "'")
+		);
+
+		$this->assertSame(['php-wrapper', 'retry-incomplete', 'php-wrapper'], $this->startAttempts());
+		$this->assertNotContains('status', $run['control'],
+			'an incomplete recovery retry must not confirm an unrelated daemon');
+	}
 	/**
 	 * Scenario: an operator (or a harness) narrows the control budget below a second.
 	 *   Given a one-second and then a zero-second whole-batch budget, with a resolver

--- a/tests/php/UnboundRestartSeamTest.php
+++ b/tests/php/UnboundRestartSeamTest.php
@@ -11,10 +11,6 @@ use PHPUnit\Framework\TestCase;
  * PFB_UNBOUND_STOP_WAIT) that tests/php/bootstrap.php overrides before the package loads,
  * so a unit run starts no resolver on a developer box that HAS Unbound installed at the
  * shipped path, and no individual test has to defuse the appliance's 30-poll stop-wait.
- *
- * The shipped appliance values are pinned from source: the harness necessarily replaces
- * both constants for the whole process, so the only place their real values can be
- * asserted is the file that ships them.
  */
 #[CoversFunction('pfb_stop_start_unbound')]
 final class UnboundRestartSeamTest extends TestCase
@@ -46,8 +42,7 @@ final class UnboundRestartSeamTest extends TestCase
 			$GLOBALS['g']['varrun_path'] ?? NULL,
 		];
 
-		// varrun_path holds no unbound.pid, so the TERM half is skipped; the stop-wait
-		// loop, the KILL escalation and the daemon start are what this file exercises.
+		// Each row owns its pidfile and process state; no signal reaches a host daemon.
 		$GLOBALS['pfb'] = array_replace($GLOBALS['pfb'], [
 			'log'                  => "{$this->dir}/pfblockerng.log",
 			'errlog'               => "{$this->dir}/error.log",
@@ -72,8 +67,9 @@ final class UnboundRestartSeamTest extends TestCase
 		} else {
 			unset($GLOBALS['g']['varrun_path']);
 		}
-		unset($GLOBALS['pfb_test_process_running'], $GLOBALS['pfb_test_sigkillbyname_calls'],
-			$GLOBALS['pfb_test_sigkillbyname_effect']);
+		unset($GLOBALS['pfb_test_process_running'], $GLOBALS['pfb_test_valid_pids'],
+			$GLOBALS['pfb_test_sigkillbypid_calls'], $GLOBALS['pfb_test_sigkillbypid_effect'],
+			$GLOBALS['pfb_test_sigkillbyname_calls'], $GLOBALS['pfb_test_sigkillbyname_effect']);
 		rmdir_recursive($this->dir);
 	}
 
@@ -105,12 +101,15 @@ final class UnboundRestartSeamTest extends TestCase
 	 * default mode reaps the whole runner tree if production regresses to an
 	 * unbounded wait.
 	 *
+	 * @param list<string> $ini PHP INI settings applied only to the isolated runner
 	 * @return array{status: int, output: list<string>, payload: array<string, mixed>|null}
 	 */
 	private function runIsolatedStart(
 		string $startCommand,
 		int $budget = 5,
-		?string $phpCli = NULL
+		?string $phpCli = NULL,
+		array $ini = [],
+		string $prelude = ''
 	): array
 	{
 		$phpCli ??= PHP_BINARY;
@@ -133,6 +132,7 @@ final class UnboundRestartSeamTest extends TestCase
 			. "\$GLOBALS['pfb']['dnsbl_python_unmount'] = FALSE;\n"
 			. '$GLOBALS[\'g\'][\'varrun_path\'] = ' . var_export($this->dir, TRUE) . ";\n"
 			. "\$GLOBALS['pfb_test_process_running']['unbound'] = FALSE;\n"
+			. $prelude
 			. "\$final = pfb_stop_start_unbound('');\n"
 			. 'echo json_encode([\'final\' => $final, \'log\' => (string) @file_get_contents('
 			. var_export($log, TRUE) . '), \'errlog\' => (string) @file_get_contents('
@@ -140,9 +140,13 @@ final class UnboundRestartSeamTest extends TestCase
 
 		$output = [];
 		$status = 0;
+		$flags = '';
+		foreach ($ini as $flag) {
+			$flags .= ' -d ' . escapeshellarg($flag);
+		}
 		$cmd = 'TMPDIR=' . escapeshellarg($this->dir) . ' ' .
 			escapeshellarg($timeout) . ' -s TERM -k 2 ' . self::SALVAGE_SECONDS .
-			' ' . escapeshellarg(PHP_BINARY) . ' ' . escapeshellarg($runner) . ' 2>&1';
+			' ' . escapeshellarg(PHP_BINARY) . $flags . ' ' . escapeshellarg($runner) . ' 2>&1';
 		exec($cmd, $output, $status);
 
 		$payload = NULL;
@@ -193,6 +197,9 @@ final class UnboundRestartSeamTest extends TestCase
 		$this->assertSame(127, $final['retval'],
 			'the double must keep reporting command-not-found, the status an absent binary '
 			. "already produces off-appliance, so the caller's retry branch stays exercised");
+		$this->assertArrayHasKey('start_completed', $final);
+		$this->assertTrue($final['start_completed'],
+			'a completed command-not-found result must be distinguishable from a pre-start failure');
 		$this->assertNotEmpty($final['result'],
 			'the caller logs the start output on failure, so the double must produce one');
 	}
@@ -243,6 +250,9 @@ final class UnboundRestartSeamTest extends TestCase
 			'a stop that never completed must not reach the daemon start at all');
 		$this->assertSame(PFB_UNBOUND_STOP_FAILED, $final['retval'],
 			'the refusal must be reported to the caller as a failure, not a silent success');
+		$this->assertArrayHasKey('start_completed', $final);
+		$this->assertFalse($final['start_completed'],
+			'a refused stop must report that no start command completed');
 		// issue #3094: the whole point of the code is that a caller can tell "the daemon
 		// would not stop" from "the generated config is bad". Sharing -1 with the generic
 		// failure would put it straight back into the unbound.bk rollback path.
@@ -250,8 +260,9 @@ final class UnboundRestartSeamTest extends TestCase
 			'the stop-failure code must be distinguishable from a generic failure');
 		$this->assertNotEmpty($final['result'],
 			'the caller logs the result, so the refusal must carry a reason');
-		$this->assertSame(array(array('unbound', 'KILL')), $GLOBALS['pfb_test_sigkillbyname_calls'],
-			'the timeout must escalate TERM to KILL exactly once before giving up');
+		$this->assertSame(array(array('unbound', 'TERM'), array('unbound', 'KILL')),
+			$GLOBALS['pfb_test_sigkillbyname_calls'],
+			'the timeout must attempt TERM before escalating to KILL exactly once');
 		$this->assertStringContainsString('not starting a second instance',
 			(string) @file_get_contents($GLOBALS['pfb']['log']),
 			'the refusal must be loud in the log, not inferable only from a return value');
@@ -267,6 +278,7 @@ final class UnboundRestartSeamTest extends TestCase
 	{
 		$before = $this->doubleInvocations();
 		$GLOBALS['pfb_test_process_running']['unbound'] = TRUE;
+		$GLOBALS['pfb_test_sigkillbyname_calls'] = array();
 		$GLOBALS['pfb_test_sigkillbyname_effect'] = static function (string $name, string $sig): void {
 			if ($name === 'unbound' && $sig === 'KILL') {
 				$GLOBALS['pfb_test_process_running']['unbound'] = FALSE;
@@ -283,6 +295,90 @@ final class UnboundRestartSeamTest extends TestCase
 			'a daemon that KILL did clear must be restarted, not abandoned');
 		$this->assertSame(127, $final['retval'],
 			'the start must run through the harness double exactly as on the clean-stop path');
+		$this->assertArrayHasKey('start_completed', $final);
+		$this->assertTrue($final['start_completed'],
+			'the post-KILL start command must report its completed non-zero status');
+		$this->assertSame(array(array('unbound', 'TERM'), array('unbound', 'KILL')),
+			$GLOBALS['pfb_test_sigkillbyname_calls'],
+			'a missing pidfile must attempt name-based TERM before KILL');
+	}
+
+	public function testValidLivePidfileUsesPidTermOnly(): void
+	{
+		$pidfile = "{$this->dir}/unbound.pid";
+		file_put_contents($pidfile, "123\n");
+		$GLOBALS['pfb_test_valid_pids'] = [$pidfile => TRUE];
+		$GLOBALS['pfb_test_process_running']['unbound'] = TRUE;
+		$GLOBALS['pfb_test_sigkillbypid_calls'] = array();
+		$GLOBALS['pfb_test_sigkillbyname_calls'] = array();
+		$GLOBALS['pfb_test_sigkillbypid_effect'] = static function (string $file, string $sig): void {
+			if ($sig === 'TERM') {
+				$GLOBALS['pfb_test_process_running']['unbound'] = FALSE;
+			}
+		};
+
+		$final = pfb_stop_start_unbound('');
+
+		$this->assertSame(array(array($pidfile, 'TERM')), $GLOBALS['pfb_test_sigkillbypid_calls'],
+			'a valid live pidfile must target only that PID with TERM');
+		$this->assertSame(array(), $GLOBALS['pfb_test_sigkillbyname_calls'],
+			'a valid live pidfile must not fan TERM out by process name');
+		$this->assertArrayHasKey('start_completed', $final);
+		$this->assertTrue($final['start_completed']);
+	}
+
+	public function testMissingPidfileUsesNameTermAndStartsWhenDaemonStops(): void
+	{
+		$GLOBALS['pfb_test_process_running']['unbound'] = TRUE;
+		$GLOBALS['pfb_test_sigkillbyname_calls'] = array();
+		$GLOBALS['pfb_test_sigkillbyname_effect'] = static function (string $name, string $sig): void {
+			if ($name === 'unbound' && $sig === 'TERM') {
+				$GLOBALS['pfb_test_process_running']['unbound'] = FALSE;
+			}
+		};
+
+		$final = pfb_stop_start_unbound('');
+
+		$this->assertSame(array(array('unbound', 'TERM')), $GLOBALS['pfb_test_sigkillbyname_calls'],
+			'a live daemon without a pidfile must receive name-based TERM before any KILL');
+		$this->assertArrayHasKey('start_completed', $final);
+		$this->assertTrue($final['start_completed'],
+			'a daemon that exits on name-based TERM must proceed to one completed start');
+	}
+
+	public function testInvalidPidfileFallsBackToNameTerm(): void
+	{
+		$pidfile = "{$this->dir}/unbound.pid";
+		file_put_contents($pidfile, "not-a-pid\n");
+		$GLOBALS['pfb_test_valid_pids'] = [$pidfile => FALSE];
+		$GLOBALS['pfb_test_process_running']['unbound'] = TRUE;
+		$GLOBALS['pfb_test_sigkillbypid_calls'] = array();
+		$GLOBALS['pfb_test_sigkillbyname_calls'] = array();
+		$GLOBALS['pfb_test_sigkillbyname_effect'] = static function (string $name, string $sig): void {
+			if ($name === 'unbound' && $sig === 'TERM') {
+				$GLOBALS['pfb_test_process_running']['unbound'] = FALSE;
+			}
+		};
+
+		pfb_stop_start_unbound('');
+
+		$this->assertSame(array(), $GLOBALS['pfb_test_sigkillbypid_calls'],
+			'an invalid pidfile must never be trusted as a PID signal target');
+		$this->assertSame(array(array('unbound', 'TERM')), $GLOBALS['pfb_test_sigkillbyname_calls'],
+			'an invalid pidfile with a live daemon must fall back to name-based TERM');
+	}
+
+	public function testNoLiveDaemonSendsNoTermSignal(): void
+	{
+		$GLOBALS['pfb_test_process_running']['unbound'] = FALSE;
+		$GLOBALS['pfb_test_sigkillbypid_calls'] = array();
+		$GLOBALS['pfb_test_sigkillbyname_calls'] = array();
+
+		pfb_stop_start_unbound('');
+
+		$this->assertSame(array(), $GLOBALS['pfb_test_sigkillbypid_calls']);
+		$this->assertSame(array(), $GLOBALS['pfb_test_sigkillbyname_calls'],
+			'an absent daemon must not receive a name-based signal');
 	}
 	public function testDaemonizedStartSurvivesTheBoundedWrapper(): void
 	{
@@ -305,6 +401,9 @@ final class UnboundRestartSeamTest extends TestCase
 			$this->assertIsArray($run['payload'], 'the isolated start runner must return its JSON result');
 			$this->assertSame(0, $run['payload']['final']['retval'],
 				'a successfully daemonized start must remain a successful start');
+			$this->assertArrayHasKey('start_completed', $run['payload']['final']);
+			$this->assertTrue($run['payload']['final']['start_completed'],
+				'the successful daemon start must carry a validated completion record');
 			$this->assertTrue($this->pidIsAlive($pid),
 				'a successfully daemonized resolver must escape the supervised launcher group and survive');
 		} finally {
@@ -332,6 +431,8 @@ final class UnboundRestartSeamTest extends TestCase
 			'the process-group runner must complete inside its salvage cap: ' . implode("\n", $run['output']));
 		$this->assertIsArray($run['payload']);
 		$this->assertSame(0, $run['payload']['final']['retval']);
+		$this->assertArrayHasKey('start_completed', $run['payload']['final']);
+		$this->assertTrue($run['payload']['final']['start_completed']);
 		$this->assertMatchesRegularExpression('/^[1-9][0-9]*$/', $expected,
 			'RED issue #2882: the launcher must publish its group only after setpgid succeeds');
 		$this->assertSame($expected, $actual,
@@ -354,6 +455,8 @@ final class UnboundRestartSeamTest extends TestCase
 		$this->assertIsArray($run['payload']);
 		$this->assertSame(0, $run['payload']['final']['retval'],
 			'the configured CLI executable must run the supervisor and preserve child success');
+		$this->assertArrayHasKey('start_completed', $run['payload']['final']);
+		$this->assertTrue($run['payload']['final']['start_completed']);
 		$this->assertSame('-r', $argv[0] ?? NULL,
 			'RED issue #2882: the supervisor must invoke the configured CLI PHP, not PHP_BINARY/php-cgi');
 		$this->assertContains('--', $argv,
@@ -386,7 +489,10 @@ final class UnboundRestartSeamTest extends TestCase
 			. implode("\n", $run['output']));
 		$this->assertIsArray($run['payload'], 'the bounded start must return its JSON result');
 		$this->assertSame(124, $run['payload']['final']['retval'],
-			'an expired start must surface timeout(1) status 124 so retry/recovery still runs');
+			'an expired start must retain status 124 so callers preserve the valid configuration');
+		$this->assertArrayHasKey('start_completed', $run['payload']['final']);
+		$this->assertFalse($run['payload']['final']['start_completed'],
+			'a command killed at its deadline did not produce a valid completion record');
 		$this->assertStringContainsString('Unbound Resolver start TIMED OUT after 2s and was killed',
 			$run['payload']['log'], 'expiry must be explicit in the main log');
 		$this->assertStringContainsString('Unbound Resolver start TIMED OUT after 2s and was killed',
@@ -433,7 +539,10 @@ final class UnboundRestartSeamTest extends TestCase
 			'the process-tree expiry runner must complete inside its salvage cap: ' . implode("\n", $run['output']));
 		$this->assertIsArray($run['payload']);
 		$this->assertSame(124, $run['payload']['final']['retval'],
-			'the process-tree expiry must preserve the retry-triggering timeout status');
+			'the process-tree expiry must preserve the distinguished timeout status');
+		$this->assertArrayHasKey('start_completed', $run['payload']['final']);
+		$this->assertFalse($run['payload']['final']['start_completed'],
+			'an expired process tree did not produce a valid completion record');
 		$this->assertFalse($launcherAlive,
 			'the direct TERM-ignoring launcher must be absent after kill grace');
 		$this->assertFalse($helperAlive,
@@ -451,6 +560,9 @@ final class UnboundRestartSeamTest extends TestCase
 		$this->assertIsArray($run['payload']);
 		$this->assertSame(7, $run['payload']['final']['retval'],
 			'a quick non-zero start must retain its status for the existing retry branch');
+		$this->assertArrayHasKey('start_completed', $run['payload']['final']);
+		$this->assertTrue($run['payload']['final']['start_completed'],
+			'a quick non-zero command produced a valid completion record');
 		$this->assertSame(['start failed'], $run['payload']['final']['result'],
 			'a quick non-zero start must retain diagnostics for the existing recovery log');
 		$this->assertStringNotContainsString('TIMED OUT', $run['payload']['log'],
@@ -466,93 +578,76 @@ final class UnboundRestartSeamTest extends TestCase
 		$this->assertIsArray($run['payload']);
 		$this->assertSame(127, $run['payload']['final']['retval'],
 			'a start command that cannot launch must remain non-zero for retry/recovery');
+		$this->assertArrayHasKey('start_completed', $run['payload']['final']);
+		$this->assertTrue($run['payload']['final']['start_completed'],
+			'a shell-level command-not-found is still a completed start command');
 		$this->assertNotEmpty($run['payload']['final']['result'],
 			'the launch failure must retain timeout/shell diagnostics');
 	}
 
-
-	/**
-	 * The appliance keeps starting the shipped daemon against the shipped config, and
-	 * keeps both stop and start waits at 30 seconds -- asserted against the source
-	 * because the harness replaces those constants at load time in this process.
-	 */
-	public function testShippedDefaultsStillStartTheApplianceDaemon(): void
+	public function testCompletedExit124IsNotMisclassifiedAsWrapperExpiry(): void
 	{
-		$path = dirname(__DIR__, 2) . '/src/usr/local/pkg/pfblockerng/pfblockerng.inc';
-		$src = (string) @file_get_contents($path);
-		$this->assertNotSame('', $src, "could not read {$path}");
+		$script = $this->makeStartScript('exit-124.sh', 'exit 124');
 
-		// strpos() rather than assertStringContainsString(): the haystack is the whole
-		// 800 KB package file, and a failed containment assertion would dump all of it.
-		$this->assertNotFalse(strpos($src,
-			"define('PFB_UNBOUND_START_CMD', '/usr/local/sbin/unbound -c /var/unbound/unbound.conf 2>&1');"),
-			'the appliance must still start the shipped daemon against the shipped config');
-		$this->assertNotFalse(strpos($src, "define('PFB_UNBOUND_STOP_WAIT', 30);"),
-			'the appliance must still wait up to 30 seconds for the outgoing daemon');
-		$this->assertNotFalse(strpos($src, "define('PFB_UNBOUND_KILL_WAIT', 5);"),
-			'the KILL escalation must have its own finite five-second budget');
-		$this->assertNotFalse(strpos($src, "define('PFB_UNBOUND_STOP_FAILED', -2);"),
-			'the appliance must ship the distinct stop-failure code the callers branch on');
-		$this->assertNotFalse(strpos($src, "define('PFB_UNBOUND_START_WAIT', 30);"),
-			'the appliance start child must have an explicit finite 30-second budget');
-		$this->assertNotFalse(strpos($src, "define('PFB_UNBOUND_START_SETUP_WAIT', 5);"),
-			'the process-group setup barrier must have its own finite five-second budget');
+		$run = $this->runIsolatedStart(escapeshellarg($script));
 
-		$start = strpos($src, 'function pfb_stop_start_unbound(');
-		$this->assertNotFalse($start, 'pfb_stop_start_unbound() must still exist');
-		$end = strpos($src, "\n}\n", $start);
-		$this->assertNotFalse($end, 'could not find the end of pfb_stop_start_unbound()');
-		$body = substr($src, $start, $end - $start);
-		$this->assertStringContainsString('$start_ack_deadline = NULL;', $body,
-			'the start-ack deadline must have an explicit unarmed sentinel');
-		$this->assertStringContainsString('$deadline = NULL;', $body,
-			'the command deadline must have an explicit unarmed sentinel');
-		$this->assertStringContainsString('if ($start_ack_deadline === NULL) {', $body,
-			'the start-ack loop must fail closed before reading an unarmed deadline');
-		$this->assertStringContainsString('if ($deadline === NULL) {', $body,
-			'the command loop must fail closed before reading an unarmed deadline');
-		$release = strpos($body, '@touch($release)');
-		$acknowledged = strpos($body, 'file_exists($command_started)');
-		$deadline = strpos($body, '$deadline = hrtime(TRUE) + (PFB_UNBOUND_START_WAIT');
-		$this->assertNotFalse($release, 'the parent must explicitly release the verified process group');
-		$this->assertNotFalse($acknowledged, 'the child must acknowledge command start after release');
-		$this->assertNotFalse($deadline, 'the configured command deadline must be explicit');
-		$this->assertGreaterThan($acknowledged, $deadline,
-			'the start-command deadline must begin after the child start event, not during supervisor setup');
-
-		$this->assertStringContainsString(
-			"\$php_cli = (string) (\$pfb['php'] ?? (PHP_BINDIR . '/php'));",
-			$body,
-			'the appliance must select the canonical CLI executable without a version hardcode'
-		);
-		$this->assertStringNotContainsString('PHP_BINARY', $body,
-			'the web php-cgi SAPI binary must never launch the CLI-only -r supervisor');
-		$this->assertStringContainsString('PFB_UNBOUND_START_CMD', $body,
-			'the daemon start must run through the constant so a harness can neuter it');
-		$this->assertStringNotContainsString('/usr/local/sbin/unbound', $body,
-			'no branch may reach the daemon binary except through PFB_UNBOUND_START_CMD');
-		$this->assertStringContainsString('$i <= PFB_UNBOUND_STOP_WAIT;', $body,
-			'the stop-wait budget must come from the constant, not a literal');
-		$this->assertStringContainsString('$i <= PFB_UNBOUND_KILL_WAIT;', $body,
-			'the KILL-escalation budget must come from the constant, not a literal');
-		$stopLoop = strpos($body, '$i <= PFB_UNBOUND_STOP_WAIT;');
-		$refusal = strpos($body, 'not starting a ');
-		$start = strpos($body, 'PFB_UNBOUND_START_CMD,');
-		$this->assertNotFalse($refusal, 'the stop timeout must have an explicit refusal branch (#3055)');
-		$this->assertNotFalse($start, 'the daemon start must still be reachable');
-		$this->assertGreaterThan($stopLoop, $refusal,
-			'the refusal must be checked after the stop-wait loop, not inside it');
-		$this->assertLessThan($start, $refusal,
-			'the refusal must precede the daemon start, or the second instance is already launched');
-		$this->assertStringContainsString('posix_setpgid(0, 0)', $body,
-			'the start command must enter its own process group before the release barrier opens');
-		$this->assertStringContainsString('posix_kill(-$pid', $body,
-			'expiry must signal the whole launcher group, not only its direct process');
-		$this->assertStringContainsString('PFB_UNBOUND_START_WAIT', $body,
-			'the start wait must consume its configured finite budget');
-		$this->assertStringContainsString("0 => array('file', '/dev/null', 'r')", $body,
-			'the supervised launcher must read from /dev/null');
-		$this->assertStringContainsString("1 => array('file', \$outfile, 'a')", $body,
-			'a daemon must inherit a regular output file, never proc_open() pipes');
+		$this->assertSame(0, $run['status'],
+			'the exit-124 runner must complete inside its salvage cap: ' . implode("\n", $run['output']));
+		$this->assertIsArray($run['payload']);
+		$this->assertSame(124, $run['payload']['final']['retval']);
+		$this->assertArrayHasKey('start_completed', $run['payload']['final']);
+		$this->assertTrue($run['payload']['final']['start_completed'],
+			'a command that itself exits 124 still produced a valid completion record');
+		$this->assertStringNotContainsString('TIMED OUT', $run['payload']['log'],
+			'a completed command status 124 must not be mislabeled as wrapper expiry');
 	}
+
+	public function testSupervisorExitZeroWithoutDoneIsAnIncompleteFailure(): void
+	{
+		$startProbe = "{$this->dir}/start-ran";
+		$start = $this->makeStartScript('should-not-run.sh',
+			'touch ' . escapeshellarg($startProbe) . "\nexit 0");
+		$phpCli = $this->makeStartScript('zero-supervisor.sh', 'exit 0');
+
+		$run = $this->runIsolatedStart(escapeshellarg($start), phpCli: $phpCli);
+
+		$this->assertSame(0, $run['status'],
+			'the incomplete-supervisor runner must return inside its salvage cap: '
+			. implode("\n", $run['output']));
+		$this->assertIsArray($run['payload']);
+		$this->assertSame(-1, $run['payload']['final']['retval'],
+			'a supervisor exit without a valid done record must never look like start success');
+		$this->assertArrayHasKey('start_completed', $run['payload']['final']);
+		$this->assertFalse($run['payload']['final']['start_completed']);
+		$this->assertFileDoesNotExist($startProbe,
+			'the configured start command must not be credited when the supervisor never ran it');
+	}
+
+	public function testUnstageableOutputIsIncompleteAndNeverRunsStart(): void
+	{
+		$startProbe = "{$this->dir}/start-ran";
+		$start = $this->makeStartScript('unstageable-should-not-run.sh',
+			'touch ' . escapeshellarg($startProbe) . "\nexit 0");
+		$root = dirname(__DIR__, 2);
+		$prelude = "ini_set('open_basedir', implode(PATH_SEPARATOR, array("
+			. var_export($root, TRUE) . ', ' . var_export($this->dir, TRUE)
+			. ", \$pfb_test_tmp, '/usr', '/bin', '/etc', '/dev', '/proc')));\n";
+
+		$run = $this->runIsolatedStart(
+			escapeshellarg($start),
+			ini: ['sys_temp_dir=/tmp'],
+			prelude: $prelude
+		);
+
+		$this->assertSame(0, $run['status'],
+			'the staging-failure runner must return inside its salvage cap: ' . implode("\n", $run['output']));
+		$this->assertIsArray($run['payload']);
+		$this->assertSame(-1, $run['payload']['final']['retval']);
+		$this->assertArrayHasKey('start_completed', $run['payload']['final']);
+		$this->assertFalse($run['payload']['final']['start_completed']);
+		$this->assertFileDoesNotExist($startProbe,
+			'an output-staging failure must occur before the configured start command');
+	}
+
+
 }

--- a/tests/php/pfsense_doubles.php
+++ b/tests/php/pfsense_doubles.php
@@ -1158,6 +1158,19 @@ if (!function_exists('isvalidpid')) {
 	}
 }
 
+if (!function_exists('sigkillbypid')) {
+	// pfSense util.inc: signal the live PID named by a validated pidfile. Tests seed
+	// an optional effect and observe calls through the same pattern as sigkillbyname().
+	function sigkillbypid($pidfile, $sig) {
+		$GLOBALS['pfb_test_sigkillbypid_calls'][] = array($pidfile, $sig);
+		$effect = $GLOBALS['pfb_test_sigkillbypid_effect'] ?? NULL;
+		if (is_callable($effect)) {
+			$effect($pidfile, $sig);
+		}
+		return 0;
+	}
+}
+
 // --- ADR-61 Phase 3 doubles: pfb_dnsbl_converged() + pfb_reload_unbound() restart path ---
 
 if (!function_exists('is_process_running')) {


### PR DESCRIPTION
## Summary

Fixes #3100.

- Preserve the candidate configuration and backup on start timeout/status 124 and every incomplete start; do not quarantine or retry those outcomes.
- Add `start_completed` to distinguish a validated command completion from staging/setup/supervision failure. An incomplete apparent exit-zero becomes `-1`, so the unchanged installer cannot report success.
- Confirm only a successfully completed original or recovery start, using fresh output and a separate return value from the existing bounded `pfb_unbound_control_exec()` status helper.
- Attempt name-based TERM when the PID file is not valid and a resolver is live, before the existing bounded KILL/refusal path. Retain PID-specific TERM for a valid live PID.
- Preserve completed configuration-failure rollback/retry and shared ledger/cache cleanup. Remove incidental restart source-token tests and repair the permission-sensitive fallback fixture.

## Confirmation ownership

This takes the issue's explicitly permitted reachability option, not a PID-identity guarantee: the old resolver must be observed gone before starting, and failed/incomplete starts cannot reach confirmation. Only a completed exit-zero start may query fresh bounded status. The supervisor PID is not the daemon PID after daemonization. Concurrent external restarts after a successful command remain outside this guarantee; no new synchronization is claimed.

The three executable callers are the original reload, its recovery retry, and installation. Installation production is intentionally unchanged because the shared producer now makes incomplete apparent success nonzero.

## Executed verification

Final frozen test bytes were independently executed against the original production base and then the fix, under non-root isolation:

```text
RED:   Tests: 70, Assertions: 406, Failures: 28, Skipped: 0
GREEN: OK (70 tests, 477 assertions), Skipped: 0
```

Eight realistic source mutations were killed, with reuse mechanically bound to unchanged source/assertions after the final fixture correction. A ninth mutation omitting the shared ledger tail failed the retained exactly-once ledger assertion (`0` versus `1`). The condensed review independently reproduced the frozen RED/GREEN pair and killed a separate confirmation-guard mutation.

The final independent canonical run used the unchanged `scripts/agent/run-gates.sh --diff e7b41e92be65d150adb04a2c241254569f748ef6` runner through a native, fully mapped non-root namespace:

```text
All 14 selected gates: PASS
PHPUnit: 6622 tests, 41941 assertions, 0 failures, 0 errors
         30 warnings, 1 deprecation, 1 notice, 9 allowlisted skips
All 70 issue-specific cases executed and passed; none skipped.
Skip-set red canary failed as expected; the same-run native JUnit skip check passed.
```

Warnings and pre-existing platform/tool skips were not suppressed. Earlier failed runs remain recorded; their causes were discriminated rather than waived. The final environment preserves normal non-root ownership errors and signal defaults, keeps the host read-only, and isolates the default pending marker. No source workaround, passwd/host-owner change, or skip-list rewrite was introduced. Broader test-environment problems are tracked in #3103.

The signed candidate was rebased onto live `devel`; all six reviewed production/test blobs are byte-identical to the passing gate, and only the generated graph was refreshed for the newer base. Exact-head PR CI will provide the final integration verdict.

## Review disposition and limits

One condensed independent pass covered contract, correctness/hostile input, test honesty, and over-engineering. Its blocking undefined-counter assertion was corrected exactly as suggested, then verified under non-root execution and by the tail-omission mutation. Its optional additional status-124 confirmation fixture was not added: the same `retval === 0` condition is already independently mutation-proven with status 127, and there is no separate status-124 confirmation branch.

Verification is off-appliance: real supervised commands, failure/status fixtures, PID/signal doubles, and the unchanged installer result-consumption block. No live pfSense daemon or complete package-install smoke is claimed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Unbound stop and restart handling, including more reliable process detection and graceful termination.
  - Prevented incomplete or failed starts from being mistaken for successful resolver restarts.
  - Improved timeout and exit-failure reporting for DNSBL and resolver operations.
  - Added safer status verification before confirming that Unbound is running.
  - Preserved configuration and recovery behavior across restart failures and retries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->