### PR TITLE
tests: isolate host-dependent fixtures

### DIFF
--- a/tests/php/BootstrapSandboxTest.php
+++ b/tests/php/BootstrapSandboxTest.php
@@ -325,4 +325,105 @@ PHP;
 		$this->assertSame(0700, fileperms($outer) & 0777,
 			'ancestor search permission must be restored after the child exits');
 	}
+
+	public function testUnprivilegedHelperRejectsSymlinkedOwnedPathComponentsBeforeCallback(): void
+	{
+		if (!function_exists('posix_geteuid') || posix_geteuid() !== 0) {
+			$this->assertTrue(pfb_test_as_unprivileged(static fn (): bool => TRUE));
+			return;
+		}
+
+		$this->assertTrue(chmod($this->tmp, 0777));
+		$external = "{$this->tmp}/external";
+		$subdir = "{$external}/sub";
+		$fixture = "{$this->tmp}/fixture";
+		$this->assertTrue(mkdir($subdir, 0700, TRUE));
+		$this->assertTrue(mkdir($fixture, 0777));
+		$this->assertTrue(chmod($external, 0777));
+		$sentinel = "{$subdir}/sentinel";
+		$this->assertSame(4, file_put_contents($sentinel, 'safe'));
+		$this->assertTrue(chmod($sentinel, 0600));
+		$link = "{$fixture}/link";
+		$this->assertTrue(symlink($external, $link));
+		$owner = fileowner($sentinel);
+		$mode = fileperms($sentinel) & 07777;
+		$error = NULL;
+		$result = NULL;
+
+		try {
+			$result = pfb_test_as_unprivileged(
+				static fn (): int|false => file_put_contents("{$link}/sub/sentinel", 'changed'),
+				["{$link}/sub"]
+			);
+		} catch (RuntimeException $caught) {
+			$error = $caught;
+		}
+		clearstatcache(TRUE, $sentinel);
+		$contentAfter = file_get_contents($sentinel);
+		$ownerAfter = fileowner($sentinel);
+		$modeAfter = fileperms($sentinel) & 07777;
+		if ($contentAfter !== 'safe') {
+			file_put_contents($sentinel, 'safe');
+		}
+		if ($ownerAfter !== $owner) {
+			chown($sentinel, $owner);
+		}
+		if ($modeAfter !== $mode) {
+			chmod($sentinel, $mode);
+		}
+
+		$this->assertSame('safe', $contentAfter,
+			'an intermediate symlink must be rejected before the callback can change its target');
+		$this->assertSame($owner, $ownerAfter,
+			'an intermediate symlink must be rejected before its target is chowned');
+		$this->assertSame($mode, $modeAfter,
+			'an intermediate symlink must leave its target mode unchanged');
+		$this->assertNull($result);
+		$this->assertInstanceOf(RuntimeException::class, $error);
+		$this->assertStringContainsString('symlink', $error->getMessage());
+	}
+
+	public function testUnprivilegedHelperRejectsSymlinkedNestedTmpdirBeforeOwnershipMutation(): void
+	{
+		if (!function_exists('posix_geteuid') || posix_geteuid() !== 0) {
+			$this->assertTrue(pfb_test_as_unprivileged(static fn (): bool => TRUE));
+			return;
+		}
+
+		$external = "{$this->tmp}/external-tmp";
+		$nested = "{$this->tmp}/nested";
+		$link = "{$nested}/tmp";
+		$this->assertTrue(mkdir($external, 0700));
+		$this->assertTrue(mkdir($nested, 0755));
+		$this->assertTrue(symlink($external, $link));
+		$owner = fileowner($external);
+		$mode = fileperms($external) & 07777;
+		$bootstrap = var_export(self::ROOT . '/tests/php/bootstrap.php', TRUE);
+		$script = 'require ' . $bootstrap . ';'
+			. 'try { pfb_test_as_unprivileged(static fn (): bool => TRUE); }'
+			. 'catch (RuntimeException $error) { echo $error->getMessage(); }';
+		$command = 'TMPDIR=' . escapeshellarg($link) . ' '
+			. escapeshellarg($GLOBALS['pfb']['timeout']) . ' 10 '
+			. escapeshellarg(PHP_BINARY) . ' -r ' . escapeshellarg($script);
+		$output = [];
+		$status = 0;
+
+		exec($command . ' 2>&1', $output, $status);
+		clearstatcache(TRUE, $external);
+		$ownerAfter = fileowner($external);
+		$modeAfter = fileperms($external) & 07777;
+		if ($ownerAfter !== $owner) {
+			chown($external, $owner);
+		}
+		if ($modeAfter !== $mode) {
+			chmod($external, $mode);
+		}
+
+		$this->assertSame($owner, $ownerAfter,
+			'a symlinked TMPDIR must be rejected before its external target is chowned');
+		$this->assertSame($mode, $modeAfter,
+			'a symlinked TMPDIR must leave its external target mode unchanged');
+		$this->assertSame(0, $status, implode("\n", $output));
+		$this->assertStringContainsString('symlink', implode("\n", $output));
+	}
 }

--- a/tests/php/BootstrapSandboxTest.php
+++ b/tests/php/BootstrapSandboxTest.php
@@ -206,6 +206,38 @@ PHP;
 		];
 	}
 
+	public function testOutsideRootDiagnosticNamesTrustedRoot(): void
+	{
+		$root = "{$this->tmp}/trusted";
+		$this->assertTrue(mkdir($root, 0700));
+		$error = NULL;
+
+		try {
+			pfb_test_preflight_path($root, "{$this->tmp}/outside", 'owned-path');
+		} catch (RuntimeException $caught) {
+			$error = $caught;
+		}
+
+		$this->assertInstanceOf(RuntimeException::class, $error);
+		$this->assertStringEndsWith($root, $error->getMessage());
+	}
+
+	public function testDotDotDiagnosticNamesTrustedRoot(): void
+	{
+		$root = "{$this->tmp}/trusted";
+		$this->assertTrue(mkdir($root, 0700));
+		$error = NULL;
+
+		try {
+			pfb_test_preflight_path($root, "{$root}/../outside", 'owned-path');
+		} catch (RuntimeException $caught) {
+			$error = $caught;
+		}
+
+		$this->assertInstanceOf(RuntimeException::class, $error);
+		$this->assertStringEndsWith($root, $error->getMessage());
+	}
+
 	public function testUnprivilegedHelperRejectsSymlinksWithoutChangingTheirTargets(): void
 	{
 		if (!function_exists('posix_geteuid') || posix_geteuid() !== 0) {
@@ -267,6 +299,37 @@ PHP;
 			'every pre-existing fixture path must regain its original owner');
 	}
 
+	public function testUnprivilegedHelperRestoresOwnerWhenCallbackThrows(): void
+	{
+		if (!function_exists('posix_geteuid') || posix_geteuid() !== 0) {
+			$this->assertTrue(pfb_test_as_unprivileged(static fn (): bool => TRUE));
+			return;
+		}
+
+		$file = "{$this->tmp}/callback-owned";
+		$this->assertSame(1, file_put_contents($file, 'x'));
+		$owner = fileowner($file);
+		$error = NULL;
+
+		try {
+			pfb_test_as_unprivileged(static function (): never {
+				throw new LogicException('expected');
+			}, [$file]);
+		} catch (RuntimeException $caught) {
+			$error = $caught;
+		}
+		clearstatcache(TRUE, $file);
+		$ownerAfter = fileowner($file);
+		if ($ownerAfter !== $owner) {
+			chown($file, $owner);
+		}
+
+		$this->assertInstanceOf(RuntimeException::class, $error);
+		$this->assertStringContainsString('LogicException: expected', $error->getMessage());
+		$this->assertSame($owner, $ownerAfter,
+			'a callback exception must not leak prepared ownership');
+	}
+
 	public function testUnprivilegedHelperRestoresOwnersAfterPreparationFailure(): void
 	{
 		if (!function_exists('posix_geteuid') || posix_geteuid() !== 0) {
@@ -324,6 +387,46 @@ PHP;
 		clearstatcache(TRUE, $outer);
 		$this->assertSame(0700, fileperms($outer) & 0777,
 			'ancestor search permission must be restored after the child exits');
+	}
+
+	public function testUnprivilegedHelperMakesOwnedPathParentTraversableAndRestoresMode(): void
+	{
+		if (!function_exists('posix_geteuid') || posix_geteuid() !== 0) {
+			$this->assertTrue(pfb_test_as_unprivileged(static fn (): bool => TRUE));
+			return;
+		}
+
+		$parent = "{$this->tmp}/restrictive-parent";
+		$owned = "{$parent}/owned";
+		$this->assertTrue(mkdir($owned, 0777, TRUE));
+		$this->assertTrue(chmod($parent, 0700));
+		$marker = "{$owned}/marker";
+		$this->assertSame(2, file_put_contents($marker, 'ok'));
+		$mode = fileperms($parent) & 07777;
+		$result = NULL;
+		$error = NULL;
+
+		try {
+			$result = pfb_test_as_unprivileged(static function () use ($marker): string {
+				$value = @file_get_contents($marker);
+				if ($value === FALSE) {
+					throw new RuntimeException('owned-path parent is not traversable');
+				}
+				return $value;
+			}, [$owned]);
+		} catch (RuntimeException $caught) {
+			$error = $caught;
+		}
+		clearstatcache(TRUE, $parent);
+		$modeAfter = fileperms($parent) & 07777;
+		if ($modeAfter !== $mode) {
+			chmod($parent, $mode);
+		}
+
+		$this->assertSame($mode, $modeAfter,
+			'an owned-path parent must regain its original mode');
+		$this->assertNull($error, $error?->getMessage() ?? '');
+		$this->assertSame('ok', $result);
 	}
 
 	public function testUnprivilegedHelperRejectsSymlinkedOwnedPathComponentsBeforeCallback(): void

--- a/tests/php/BootstrapSandboxTest.php
+++ b/tests/php/BootstrapSandboxTest.php
@@ -205,4 +205,124 @@ PHP;
 			'legacy_root' => $legacyRoot,
 		];
 	}
+
+	public function testUnprivilegedHelperRejectsSymlinksWithoutChangingTheirTargets(): void
+	{
+		if (!function_exists('posix_geteuid') || posix_geteuid() !== 0) {
+			$this->assertTrue(pfb_test_as_unprivileged(static fn (): bool => TRUE));
+			return;
+		}
+
+		$external = "{$this->tmp}/external";
+		$fixture = "{$this->tmp}/fixture";
+		$this->assertTrue(mkdir($external, 0700));
+		$this->assertTrue(mkdir($fixture, 0700));
+		$sentinel = "{$external}/sentinel";
+		$this->assertSame(4, file_put_contents($sentinel, 'safe'));
+		$link = "{$fixture}/link";
+		$this->assertTrue(symlink($external, $link));
+		$owner = fileowner($sentinel);
+		$error = NULL;
+
+		try {
+			pfb_test_as_unprivileged(static fn (): bool => TRUE, [$link]);
+		} catch (RuntimeException $caught) {
+			$error = $caught;
+		}
+		clearstatcache(TRUE, $sentinel);
+		$ownerAfter = fileowner($sentinel);
+		if ($ownerAfter !== $owner) {
+			chown($sentinel, $owner);
+		}
+
+		$this->assertInstanceOf(RuntimeException::class, $error);
+		$this->assertStringContainsString('symlink', $error->getMessage());
+		$this->assertSame($owner, $ownerAfter,
+			'rejecting an owned-path symlink must not chown its external target');
+	}
+
+	public function testUnprivilegedHelperRestoresPreparedOwnersAfterCallback(): void
+	{
+		if (!function_exists('posix_geteuid') || posix_geteuid() !== 0) {
+			$this->assertTrue(pfb_test_as_unprivileged(static fn (): bool => TRUE));
+			return;
+		}
+
+		$fixture = "{$this->tmp}/owned";
+		$this->assertTrue(mkdir($fixture, 0700));
+		$file = "{$fixture}/value";
+		$this->assertSame(1, file_put_contents($file, 'x'));
+		$owners = [$fixture => fileowner($fixture), $file => fileowner($file)];
+
+		$this->assertTrue(pfb_test_as_unprivileged(static fn (): bool => TRUE, [$fixture]));
+		clearstatcache();
+		$ownersAfter = [$fixture => fileowner($fixture), $file => fileowner($file)];
+		foreach ($owners as $path => $owner) {
+			if ($ownersAfter[$path] !== $owner) {
+				chown($path, $owner);
+			}
+		}
+
+		$this->assertSame($owners, $ownersAfter,
+			'every pre-existing fixture path must regain its original owner');
+	}
+
+	public function testUnprivilegedHelperRestoresOwnersAfterPreparationFailure(): void
+	{
+		if (!function_exists('posix_geteuid') || posix_geteuid() !== 0) {
+			$this->assertTrue(pfb_test_as_unprivileged(static fn (): bool => TRUE));
+			return;
+		}
+
+		$file = "{$this->tmp}/prepared";
+		$this->assertSame(1, file_put_contents($file, 'x'));
+		$owner = fileowner($file);
+		$error = NULL;
+
+		try {
+			pfb_test_as_unprivileged(static fn (): bool => TRUE, [$file, "{$this->tmp}/missing"]);
+		} catch (RuntimeException $caught) {
+			$error = $caught;
+		}
+		clearstatcache(TRUE, $file);
+		$ownerAfter = fileowner($file);
+		if ($ownerAfter !== $owner) {
+			chown($file, $owner);
+		}
+
+		$this->assertInstanceOf(RuntimeException::class, $error);
+		$this->assertSame($owner, $ownerAfter,
+			'a later preparation failure must roll back earlier ownership changes');
+	}
+
+	public function testUnprivilegedHelperMakesNestedTmpdirTraversableOnlyForItsChild(): void
+	{
+		if (!function_exists('posix_geteuid') || posix_geteuid() !== 0) {
+			$this->assertTrue(pfb_test_as_unprivileged(static fn (): bool => TRUE));
+			return;
+		}
+
+		$outer = "{$this->tmp}/private";
+		$inner = "{$outer}/tmp";
+		$this->assertTrue(mkdir($inner, 0777, TRUE));
+		$this->assertTrue(chmod($outer, 0700));
+		$marker = "{$inner}/marker";
+		$this->assertSame(2, file_put_contents($marker, 'ok'));
+		$script = 'require ' . var_export(self::ROOT . '/tests/php/bootstrap.php', TRUE) . ';'
+			. '$marker=' . var_export($marker, TRUE) . ';'
+			. '$tmp=' . var_export($inner, TRUE) . ';'
+			. 'echo pfb_test_as_unprivileged(static fn (): string => (string) file_get_contents($marker), [$tmp]);';
+		$command = escapeshellarg($GLOBALS['pfb']['timeout']) . ' 10 '
+			. escapeshellarg(PHP_BINARY) . ' -r ' . escapeshellarg($script);
+		$output = [];
+		$status = 0;
+
+		exec('TMPDIR=' . escapeshellarg($inner) . ' ' . $command . ' 2>&1', $output, $status);
+
+		$this->assertSame(0, $status, implode("\n", $output));
+		$this->assertSame(['ok'], $output);
+		clearstatcache(TRUE, $outer);
+		$this->assertSame(0700, fileperms($outer) & 0777,
+			'ancestor search permission must be restored after the child exits');
+	}
 }

--- a/tests/php/CountLinesTest.php
+++ b/tests/php/CountLinesTest.php
@@ -110,14 +110,12 @@ final class CountLinesTest extends TestCase
 	{
 		// A file that EXISTS but cannot be opened must fail the same way a missing one does.
 		// Returning 0 here would read as "no lines" -- a count every caller would believe.
-		if (function_exists('posix_getuid') && posix_getuid() === 0) {
-			$this->markTestSkipped('root bypasses file permissions; cannot simulate an unreadable file');
-		}
 
 		file_put_contents($this->tmpFile, "a\nb\nc\n");
 		chmod($this->tmpFile, 0000);
 		try {
-			$this->assertNull(pfb_count_lines($this->tmpFile), 'an unreadable file must return NULL, never a count');
+			$this->assertNull(pfb_test_as_unprivileged(fn () => pfb_count_lines($this->tmpFile)),
+				'an unreadable file must return NULL, never a count');
 		} finally {
 			chmod($this->tmpFile, 0644);
 		}

--- a/tests/php/DnsblManifestMissingTest.php
+++ b/tests/php/DnsblManifestMissingTest.php
@@ -135,9 +135,6 @@ final class DnsblManifestMissingTest extends TestCase
 
 	public function testMarkerUnreadableReadsAsZero(): void
 	{
-		if (function_exists('posix_getuid') && posix_getuid() === 0) {
-			$this->markTestSkipped('root bypasses file permissions -- cannot simulate an unreadable file.');
-		}
 
 		$this->writeManifest();
 		$this->writeSentinel("5\n");
@@ -146,7 +143,7 @@ final class DnsblManifestMissingTest extends TestCase
 
 		try {
 			$this->assertFalse(
-				pfb_dnsbl_manifest_missing($this->makePfb()),
+				pfb_test_as_unprivileged(fn () => pfb_dnsbl_manifest_missing($this->makePfb()), [$this->dir]),
 				'an unreadable sentinel reads as generation 0, matching an absent applied (also 0) -- not missing'
 			);
 		} finally {

--- a/tests/php/DnsblManifestPublishFailureNoticeTest.php
+++ b/tests/php/DnsblManifestPublishFailureNoticeTest.php
@@ -23,9 +23,6 @@ final class DnsblManifestPublishFailureNoticeTest extends TestCase
 
 	protected function setUp(): void
 	{
-		if (function_exists('posix_getuid') && posix_getuid() === 0) {
-			$this->markTestSkipped('running as root -- a 0555 dir does not block tempnam()/fopen() for root');
-		}
 
 		$this->hadPfb = array_key_exists('pfb', $GLOBALS);
 		$this->originalPfb = $GLOBALS['pfb'] ?? [];
@@ -56,11 +53,7 @@ final class DnsblManifestPublishFailureNoticeTest extends TestCase
 
 	protected function tearDown(): void
 	{
-		// setUp() can skip BEFORE assigning the properties below, and PHPUnit still runs
-		// tearDown() after a skipped setUp. Reading an uninitialised typed property is a
-		// fatal Error, and because these fixtures share $GLOBALS it does not stop at this
-		// class: it leaves the globals dirty and every later test that reads them errors
-		// too. Bail out when setUp did not get far enough to create anything.
+		// A setup failure before the sandbox is assigned must not read an uninitialised property.
 		if (!isset($this->tmp)) {
 			return;
 		}
@@ -77,8 +70,12 @@ final class DnsblManifestPublishFailureNoticeTest extends TestCase
 
 	public function testPublishFailureIntoReadOnlyDirFiresANotice(): void
 	{
-		$this->assertFalse(pfb_unbound_python_sources(array()));
-
+		[$published, $notices] = pfb_test_as_unprivileged(function (): array {
+			$published = pfb_unbound_python_sources(array());
+			return [$published, $GLOBALS['pfb_test_file_notices']];
+		}, [$this->tmp]);
+		$GLOBALS['pfb_test_file_notices'] = $notices;
+		$this->assertFalse($published);
 		$this->assertCount(1, $GLOBALS['pfb_test_file_notices'], 'exactly one notice raised on publish failure');
 		$notice = $GLOBALS['pfb_test_file_notices'][0];
 		$this->assertSame('pfBlockerNG DNSBL', $notice['id']);

--- a/tests/php/DnsblManifestTickRecoveryTest.php
+++ b/tests/php/DnsblManifestTickRecoveryTest.php
@@ -38,6 +38,7 @@ final class DnsblManifestTickRecoveryTest extends TestCase
 		$this->stateDir = $this->dir . '/state';
 		mkdir($this->stateDir, 0755, TRUE);
 		$GLOBALS['pfb']['dbdir'] = $this->dir;
+		$GLOBALS['pfb']['pending_marker'] = $this->dir . '/pfb_pending_changes';
 		$GLOBALS['pfb']['schedule_state_dir'] = $this->stateDir;
 		$GLOBALS['pfb']['runlog'] = $this->dir . '/run.log';
 		$GLOBALS['pfb']['extraslog'] = $this->dir . '/extras.log';

--- a/tests/php/DownloadGeoipStagePublishTest.php
+++ b/tests/php/DownloadGeoipStagePublishTest.php
@@ -574,18 +574,18 @@ final class DownloadGeoipStagePublishTest extends TestCase
 	 */
 	public function testStagingThatEscapesTheShareRefusesBeforeExtracting(): void
 	{
-		if (function_exists('posix_getuid') && posix_getuid() === 0) {
-			$this->markTestSkipped('root bypasses the directory permissions this fixture relies on');
-		}
 		$before = $this->seedServedShare();
 		$this->assertTrue(chmod($this->share, 0555));
 		$seen = NULL;
 
-		$published = pfb_stage_publish_dir_merge($this->share, static function (string $staged) use (&$seen): int {
-			$seen = $staged;
-			file_put_contents("{$staged}/GeoLite2-Country.mmdb", "fresh-mmdb\n");
-			return 0;
-		});
+		[$published, $seen] = pfb_test_as_unprivileged(function () use (&$seen): array {
+			$published = pfb_stage_publish_dir_merge($this->share, static function (string $staged) use (&$seen): int {
+				$seen = $staged;
+				file_put_contents("{$staged}/GeoLite2-Country.mmdb", "fresh-mmdb\n");
+				return 0;
+			});
+			return [$published, $seen];
+		}, [$this->share]);
 
 		$this->assertTrue(chmod($this->share, 0755));
 		$this->assertFalse($published, 'staging outside the share must refuse the publication');

--- a/tests/php/DownloadSizeCeilingTest.php
+++ b/tests/php/DownloadSizeCeilingTest.php
@@ -109,12 +109,13 @@ final class DownloadSizeCeilingTest extends TestCase
 		$stderr = $this->dir . '/overflow.err';
 		$output = [];
 		$retval = 0;
-		exec(
-			'{ ' . pfb_extract_cmd('LC_ALL=C /bin/dd if=/dev/zero of=' . escapeshellarg($target) . ' bs=1024 count=1024',
-				$blocks) . '; } 2>' . escapeshellarg($stderr),
-			$output,
-			$retval
-		);
+		$command = '{ ' . pfb_extract_cmd(
+			'LC_ALL=C /bin/dd if=/dev/zero of=' . escapeshellarg($target) . ' bs=1024 count=1024',
+			$blocks
+		) . '; } 2>' . escapeshellarg($stderr);
+		$runner = 'if (!pcntl_signal(SIGXFSZ, SIG_DFL)) { exit(255); } '
+			. 'passthru(' . var_export($command, TRUE) . ', $status); exit($status);';
+		exec(escapeshellarg(PHP_BINARY) . ' -r ' . escapeshellarg($runner), $output, $retval);
 
 		if (PHP_OS_FAMILY === 'Darwin') {
 			if ($retval === 1) {

--- a/tests/php/FeedPassLockTest.php
+++ b/tests/php/FeedPassLockTest.php
@@ -456,9 +456,6 @@ final class FeedPassLockTest extends TestCase
 	// exit code.
 	public function testBeginFailsClosedWhenLockFileUnopenable(): void
 	{
-		if (function_exists('posix_getuid') && posix_getuid() === 0) {
-			$this->markTestSkipped('root bypasses directory permissions; cannot simulate an unwritable dbdir');
-		}
 
 		$denydir = "{$this->dbdir}/deny_begin";
 		mkdir($denydir, 0755, TRUE);
@@ -466,7 +463,7 @@ final class FeedPassLockTest extends TestCase
 		chmod($denydir, 0555);
 
 		try {
-			$this->assertFalse(pfb_feed_pass_begin('sync'),
+			$this->assertFalse(pfb_test_as_unprivileged(fn () => pfb_feed_pass_begin('sync'), [$denydir]),
 				'an unwritable dbdir must fail CLOSED -- begin() returns FALSE rather than running a pass with no mutual exclusion');
 		} finally {
 			chmod($denydir, 0755);

--- a/tests/php/HookEditorDeleteTest.php
+++ b/tests/php/HookEditorDeleteTest.php
@@ -105,16 +105,15 @@ final class HookEditorDeleteTest extends TestCase
 
 	public function testRefusesWhenTheHookDirectoryIsNotWritable(): void
 	{
-		// unlink() needs write+execute on the DIRECTORY, not on the file. Root
-		// bypasses file permissions entirely, so this cannot be simulated as root --
-		// the same guard the repo's other permission-denial tests use.
-		if (function_exists('posix_getuid') && posix_getuid() === 0) {
-			$this->markTestSkipped('root bypasses directory permissions; the denial cannot be simulated');
-		}
+		// unlink() needs write+execute on the directory, not on the file. The
+		// harness helper gives root runs the same effective permission boundary.
 		$path = $this->makeHook('hook_post_probe.sh');
 		chmod($this->dir, 0555);
 		try {
-			$this->assertFalse(pfb_hook_editor_delete('hook_post_probe.sh', 'post', $this->dir));
+			$this->assertFalse(pfb_test_as_unprivileged(
+				fn () => pfb_hook_editor_delete('hook_post_probe.sh', 'post', $this->dir),
+				[$this->dir]
+			));
 			$this->assertFileExists($path, 'a read-only hook directory must leave the hook in place');
 		} finally {
 			chmod($this->dir, 0755);

--- a/tests/php/IpRecomputeOrderChangeTest.php
+++ b/tests/php/IpRecomputeOrderChangeTest.php
@@ -128,15 +128,15 @@ final class IpRecomputeOrderChangeTest extends TestCase
 
 	public function testReturnsTrueWhenBaselineFileIsUnreadable(): void
 	{
-		if (function_exists('posix_getuid') && posix_getuid() === 0) {
-			$this->markTestSkipped('root bypasses file permissions; cannot simulate an unreadable baseline');
-		}
 		$this->writeBaseline(array('FeedA_v4'));
 		$this->assertFileExists($this->memberlist, 'before-state: the baseline file exists and is readable');
 
 		chmod($this->memberlist, 0000);
 
-		$got = pfb_ip_recompute_order_changed(array('FeedA_v4'), $this->snapdir, $this->memberlist);
+		$got = pfb_test_as_unprivileged(
+			fn () => pfb_ip_recompute_order_changed(array('FeedA_v4'), $this->snapdir, $this->memberlist),
+			[$this->root]
+		);
 
 		$this->assertTrue($got, 'an unreadable baseline is treated the same as a missing one -- fail-safe TRUE');
 	}
@@ -289,15 +289,15 @@ final class IpRecomputeOrderChangeTest extends TestCase
 
 	public function testWriteToReadOnlyTargetLogsFailure(): void
 	{
-		if (function_exists('posix_getuid') && posix_getuid() === 0) {
-			$this->markTestSkipped('root bypasses file permissions; cannot simulate a write-denied target');
-		}
 		file_put_contents($this->memberlist, 'stale');
 		chmod($this->memberlist, 0444);
 		$marker = "write failed for [ {$this->memberlist} ]";
 		$before = $this->countLogMarker($marker);
 
-		$got = pfb_ip_recompute_memberlist_write($this->memberlist, array('a'));
+		$got = pfb_test_as_unprivileged(
+			fn () => pfb_ip_recompute_memberlist_write($this->memberlist, array('a')),
+			[$this->root, $GLOBALS['pfb']['logdir']]
+		);
 
 		$this->assertFalse($got, 'a 0444 target must fail the write');
 		$this->assertSame($before + 1, $this->countLogMarker($marker), 'the failure must be logged');

--- a/tests/php/IpRecomputeSnapshotTest.php
+++ b/tests/php/IpRecomputeSnapshotTest.php
@@ -146,9 +146,6 @@ final class IpRecomputeSnapshotTest extends TestCase
 
 	public function testSeedSnapshotLogsAWarningWhenTheCopyFails(): void
 	{
-		if (function_exists('posix_getuid') && posix_getuid() === 0) {
-			$this->markTestSkipped('root bypasses directory permissions; cannot simulate an unwritable snapshot dir');
-		}
 
 		file_put_contents("{$this->denydir}/FeedF_v4.txt", "198.51.100.5\n");
 
@@ -162,7 +159,10 @@ final class IpRecomputeSnapshotTest extends TestCase
 
 		chmod($this->snapdir, 0555);
 		try {
-			$got = pfb_ip_recompute_seed_snapshot('FeedF_v4', $this->snapdir, $this->denydir);
+			$got = pfb_test_as_unprivileged(
+				fn () => pfb_ip_recompute_seed_snapshot('FeedF_v4', $this->snapdir, $this->denydir),
+				[$this->root]
+			);
 
 			$this->assertSame("{$this->snapdir}/FeedF_v4.snap", $got, 'the path contract is unchanged even when the seed copy fails');
 			$this->assertFileDoesNotExist($got);
@@ -229,14 +229,14 @@ final class IpRecomputeSnapshotTest extends TestCase
 
 	public function testWriteSnapshotAggcountIsZeroWhenSourceUnreadable(): void
 	{
-		if (function_exists('posix_getuid') && posix_getuid() === 0) {
-			$this->markTestSkipped('root bypasses file permissions; cannot simulate an unreadable source');
-		}
 		$src = "{$this->denydir}/FeedUnreadable_v4.txt";
 		file_put_contents($src, "198.51.100.1\n198.51.100.2\n");
 		chmod($src, 0000);
 		try {
-			pfb_ip_recompute_write_snapshot($src, 'FeedUnreadable_v4', $this->snapdir, $this->origdir);
+			pfb_test_as_unprivileged(
+				fn () => pfb_ip_recompute_write_snapshot($src, 'FeedUnreadable_v4', $this->snapdir, $this->origdir),
+				[$this->root]
+			);
 			$this->assertSame(
 				"0\n",
 				file_get_contents("{$this->origdir}/FeedUnreadable_v4.aggcount"),

--- a/tests/php/ListPreScriptStageTest.php
+++ b/tests/php/ListPreScriptStageTest.php
@@ -136,9 +136,6 @@ final class ListPreScriptStageTest extends TestCase
 
 	public function testCopyFailureFailsAndKeepsTheNormalizedPath(): void
 	{
-		if (function_exists('posix_getuid') && posix_getuid() === 0) {
-			$this->markTestSkipped('root bypasses directory permissions; cannot simulate an unwritable staging dir');
-		}
 
 		$norm = "{$this->tmp}/feed.norm";
 		file_put_contents($norm, "1.2.3.4\n");
@@ -148,8 +145,11 @@ final class ListPreScriptStageTest extends TestCase
 		$staged = "{$deniedDir}/feed.pre";
 		$script = $this->makeScript('ip_pre_unreached.sh', 'exit 0');
 
-		$result = pfb_list_pre_script_run($norm, $staged, $script, 'ip_pre_unreached.sh', 'MyFeed_v4',
-		    escapeshellarg($staged), '');
+		$result = pfb_test_as_unprivileged(
+			fn () => pfb_list_pre_script_run($norm, $staged, $script, 'ip_pre_unreached.sh', 'MyFeed_v4',
+				escapeshellarg($staged), ''),
+			[$this->tmp]
+		);
 
 		$this->assertFalse($result['ok'], 'a copy failure must fail the stage');
 		$this->assertSame($norm, $result['path'],

--- a/tests/php/LogAgeCutoffStreamTest.php
+++ b/tests/php/LogAgeCutoffStreamTest.php
@@ -184,14 +184,11 @@ final class LogAgeCutoffStreamTest extends TestCase
 	 * actually surfaces at the final rename($scratch, $temp) (destination dir
 	 * not writable). Still proves the same contract: FALSE returned, $temp
 	 * byte-for-byte untouched, and the now-orphaned-directory scratch file
-	 * cleaned up. Root bypasses directory permissions, so this cannot be
-	 * simulated there (mirrors testFailedCatNeverCorruptsLiveLogEvenWithAgeCutoffActive).
+	 * cleaned up. The harness helper gives root runs the same effective
+	 * permission boundary as an unprivileged runner.
 	 */
 	public function testStreamingHelperFailsAndLeavesTempUntouchedWhenDestinationDirReadOnly(): void
 	{
-		if (function_exists('posix_getuid') && posix_getuid() === 0) {
-			$this->markTestSkipped('root bypasses directory permissions; cannot simulate an unwritable scratch dir');
-		}
 
 		$this->seedMinimalConfig();
 		$this->ensureLogDir();
@@ -209,7 +206,10 @@ final class LogAgeCutoffStreamTest extends TestCase
 		$scratchBefore = glob(sys_get_temp_dir() . '/pfb_logtrim_*');
 
 		try {
-			$ok = pfb_log_age_trim_temp($temp, 30, 'log', TRUE);
+			$ok = pfb_test_as_unprivileged(
+				fn () => pfb_log_age_trim_temp($temp, 30, 'log', TRUE),
+				[$GLOBALS['pfb']['logdir']]
+			);
 
 			$this->assertFalse($ok, 'a read-only destination dir must make the streaming trim return FALSE');
 			clearstatcache(TRUE, $temp);

--- a/tests/php/LogMgmtAgeCutoffTest.php
+++ b/tests/php/LogMgmtAgeCutoffTest.php
@@ -816,15 +816,11 @@ final class LogMgmtAgeCutoffTest extends TestCase
 	 * "succeeded" into the temp file). Uses 'extraslog' to avoid stepping on
 	 * the shared 'log' path other tests in this suite use.
 	 *
-	 * Root bypasses file permissions (chmod is a no-op enforcement-wise for
-	 * root), so this test cannot simulate the denial there -- skipped, same
-	 * guard CLAUDE.md documents for the existing chmod-based PHPUnit tests.
+	 * The harness helper gives root runs the same effective permission boundary
+	 * as an unprivileged runner.
 	 */
 	public function testFailedCatNeverCorruptsLiveLogEvenWithAgeCutoffActive(): void
 	{
-		if (function_exists('posix_getuid') && posix_getuid() === 0) {
-			$this->markTestSkipped('root bypasses file permissions; cannot simulate a permission-denied write');
-		}
 
 		$this->seedMinimalConfig();
 		$this->setLogCaps('extraslog', '4', '10');
@@ -840,8 +836,8 @@ final class LogMgmtAgeCutoffTest extends TestCase
 		chmod($logPath, 0444);
 
 		try {
-			pfb_log_mgmt();
-
+			pfb_test_as_unprivileged(fn () => pfb_log_mgmt(),
+				[$GLOBALS['pfb']['logdir'], $GLOBALS['g']['tmp_path']]);
 			clearstatcache(TRUE, $logPath);
 			$this->assertSame($content, file_get_contents($logPath),
 				'a failed cat-over-the-live-log step must never blank/corrupt the original content'

--- a/tests/php/PfbDnsblConvergedTest.php
+++ b/tests/php/PfbDnsblConvergedTest.php
@@ -144,9 +144,6 @@ final class PfbDnsblConvergedTest extends TestCase
 
 	public function testUnboundConfExistsButUnreadable_returnsFalseInsteadOfCrashing(): void
 	{
-		if (function_exists('posix_getuid') && posix_getuid() === 0) {
-			$this->markTestSkipped('root bypasses file permissions -- cannot simulate an unreadable file.');
-		}
 
 		$this->writeSentinel(1);
 		$this->writeApplied(1);
@@ -157,7 +154,8 @@ final class PfbDnsblConvergedTest extends TestCase
 			// file_exists() sees the file (TOCTOU-style: present but unreadable), so
 			// file_get_contents() returns FALSE -- a bare strpos(FALSE, ...) call would
 			// TypeError in PHP 8+. Must degrade to FALSE, not throw.
-			$this->assertFalse(pfb_dnsbl_converged(), 'an existing-but-unreadable unbound.conf must read as not converged, never crash');
+			$this->assertFalse(pfb_test_as_unprivileged(fn () => pfb_dnsbl_converged(), [$this->dir]),
+				'an existing-but-unreadable unbound.conf must read as not converged, never crash');
 		} finally {
 			chmod("{$this->dir}/unbound.conf", 0644);
 		}
@@ -175,17 +173,16 @@ final class PfbDnsblConvergedTest extends TestCase
 
 	public function testMarkerGenerationUnreadableFile_returnsZeroInsteadOfCrashing(): void
 	{
-		if (function_exists('posix_getuid') && posix_getuid() === 0) {
-			$this->markTestSkipped('root bypasses file permissions -- cannot simulate an unreadable file.');
-		}
 
 		$path = "{$this->dir}/unreadable_marker";
 		file_put_contents($path, "5\n");
 		chmod($path, 0000);
 
 		try {
-			$this->assertSame(0, pfb_unbound_py_marker_generation($path),
-				'an existing-but-unreadable marker (file_get_contents() FALSE) must read as generation 0, never crash');
+			$this->assertSame(0, pfb_test_as_unprivileged(
+				fn () => pfb_unbound_py_marker_generation($path),
+				[$this->dir]
+			), 'an existing-but-unreadable marker (file_get_contents() FALSE) must read as generation 0, never crash');
 		} finally {
 			chmod($path, 0644);
 		}

--- a/tests/php/PfbFeedNormalizeTest.php
+++ b/tests/php/PfbFeedNormalizeTest.php
@@ -214,12 +214,9 @@ final class PfbFeedNormalizeTest extends TestCase
 
 	public function testUnwritableDirectoryFallsBackToParsingOrig(): void
 	{
-		if (function_exists('posix_getuid') && posix_getuid() === 0) {
-			$this->markTestSkipped('root bypasses file permissions; the unwritable-dir denial cannot be simulated');
-		}
 		$orig = $this->writeOrig("a.example.com\n");
 		chmod($this->dir, 0555);
-		$res = pfb_feed_normalize($orig, self::NO_CONVERTER);
+		$res = pfb_test_as_unprivileged(fn () => pfb_feed_normalize($orig, self::NO_CONVERTER), [$this->dir]);
 		$this->assertSame($orig, $res['path'], 'normalize failure must fall back to the raw .orig');
 		$this->assertFalse($res['normalized']);
 		$this->assertTrue($res['changed']);

--- a/tests/php/PfbSyncStatusDnsblWritersTest.php
+++ b/tests/php/PfbSyncStatusDnsblWritersTest.php
@@ -361,9 +361,6 @@ final class PfbSyncStatusDnsblWritersTest extends TestCase
 	 */
 	public function testRestartFallbackPathReachesTailWithConvergedState(): void
 	{
-		if (function_exists('posix_getuid') && posix_getuid() === 0) {
-			$this->markTestSkipped('root bypasses directory permissions -- cannot simulate the sentinel-flip failure.');
-		}
 
 		$writable = sys_get_temp_dir() . '/pfb_dnsbl_writable_' . getmypid() . '_' . uniqid();
 		mkdir($writable, 0777, TRUE);
@@ -397,10 +394,14 @@ final class PfbSyncStatusDnsblWritersTest extends TestCase
 
 		$ledger_calls = 0;
 		try {
-			pfb_reload_unbound('enabled', FALSE, FALSE, TRUE, static function () use (&$ledger_calls): bool {
-				$ledger_calls++;
-				return pfb_dnsbl_apply_ledger_update();
-			});
+			$ledger_calls = pfb_test_as_unprivileged(function (): int {
+				$ledger_calls = 0;
+				pfb_reload_unbound('enabled', FALSE, FALSE, TRUE, static function () use (&$ledger_calls): bool {
+					$ledger_calls++;
+					return pfb_dnsbl_apply_ledger_update();
+				});
+				return $ledger_calls;
+			}, [$this->dir, $writable]);
 		} finally {
 			chmod($this->dir, 0777);
 			foreach (glob("{$writable}/*") ?: [] as $file) {

--- a/tests/php/PfbSyncStatusLedgerTest.php
+++ b/tests/php/PfbSyncStatusLedgerTest.php
@@ -324,21 +324,20 @@ final class PfbSyncStatusLedgerTest extends TestCase
 
 	// -----------------------------------------------------------------------
 	// Unwritable ledger dir — chosen contract: silent no-op, never an uncaught
-	// exception. Root bypasses directory permissions entirely (a root run can't
-	// simulate the denial — CLAUDE.md "Running tests"), so this is skipped there,
-	// matching the repo's established chmod-0555 permission-test convention.
+	// exception. The harness helper gives root runs the same effective permission
+	// boundary as an unprivileged runner.
 	// -----------------------------------------------------------------------
 
 	public function testUnwritableLedgerDirFailsSafely(): void
 	{
-		if (function_exists('posix_getuid') && posix_getuid() === 0) {
-			$this->markTestSkipped('root bypasses directory permissions -- cannot simulate the denial.');
-		}
 
 		chmod($this->dir, 0555);
 
 		// Must not throw / must not emit an uncaught error up to the caller.
-		pfb_sync_status_open('ip', 'pfB_Example_v4', 'download', 'HTTP 404', $this->dir, self::clockAt(1000));
+		pfb_test_as_unprivileged(
+			fn () => pfb_sync_status_open('ip', 'pfB_Example_v4', 'download', 'HTTP 404', $this->dir, self::clockAt(1000)),
+			[$this->dir]
+		);
 
 		// The chosen contract is a silent no-op: nothing observable changed.
 		$this->assertFileDoesNotExist($this->dir . '/pfb_sync_status.json', 'an unwritable dir must not produce a ledger file');

--- a/tests/php/TickApplyReconcileCadenceTest.php
+++ b/tests/php/TickApplyReconcileCadenceTest.php
@@ -20,6 +20,8 @@ final class TickApplyReconcileCadenceTest extends TestCase
 		$this->originalConfig = $GLOBALS['config'] ?? [];
 		$GLOBALS['pfb'] = [
 			'dbdir' => $this->dir,
+			'pending_marker' => "{$this->dir}/pfb_pending_changes",
+			'schedule_state_dir' => $this->dir,
 			'aliasdir' => $this->dir,
 			'log' => "{$this->dir}/pfblockerng.log",
 			'errlog' => "{$this->dir}/error.log",

--- a/tests/php/TickApplyReconcileFailureTest.php
+++ b/tests/php/TickApplyReconcileFailureTest.php
@@ -23,6 +23,8 @@ final class TickApplyReconcileFailureTest extends TestCase
 		$this->originalG = $GLOBALS['g'] ?? [];
 		$GLOBALS['pfb'] = array_merge($GLOBALS['pfb'] ?? [], [
 			'dbdir' => $this->dir,
+			'pending_marker' => "{$this->dir}/pfb_pending_changes",
+			'schedule_state_dir' => $this->dir,
 			'log' => "{$this->dir}/pfblockerng.log",
 			'errlog' => "{$this->dir}/error.log",
 			'runlog' => "{$this->dir}/run.log",

--- a/tests/php/TickApplyReconciliationTest.php
+++ b/tests/php/TickApplyReconciliationTest.php
@@ -46,12 +46,14 @@ final class TickApplyReconciliationTest extends TestCase
 		$this->dir = sys_get_temp_dir() . '/pfb_tick_apply_reconciliation_' . getmypid() . '_' . uniqid();
 		mkdir($this->dir, 0755, TRUE);
 
-		foreach (['dbdir', 'aliasdir', 'dnsbldir', 'pfctl', 'php', 'log', 'errlog', 'runlog', 'extraslog',
-			  'dnsbl_file', 'dnsbl_python_unmount'] as $k) {
+		foreach (['dbdir', 'schedule_state_dir', 'aliasdir', 'dnsbldir', 'pfctl', 'php', 'log', 'errlog', 'runlog', 'extraslog',
+			  'dnsbl_file', 'dnsbl_python_unmount', 'pending_marker'] as $k) {
 			$this->saved[$k] = array_key_exists($k, $GLOBALS['pfb'] ?? []) ? $GLOBALS['pfb'][$k] : FALSE;
 		}
 
 		$GLOBALS['pfb']['dbdir']      = $this->dir;
+		$GLOBALS['pfb']['pending_marker'] = "{$this->dir}/pfb_pending_changes";
+		$GLOBALS['pfb']['schedule_state_dir'] = $this->dir;
 		$GLOBALS['pfb']['aliasdir']   = $this->dir;
 		$GLOBALS['pfb']['dnsbldir']   = $this->dir;
 		$GLOBALS['pfb']['log']        = "{$this->dir}/pfblockerng.log";
@@ -66,11 +68,12 @@ final class TickApplyReconciliationTest extends TestCase
 
 		$this->seedTickPrereqs();
 
-		// Keep the legacy fixed-job entries future-dated and neuter $pfb['php'] so
-		// this suite remains isolated to apply reconciliation.
+		// Keep the legacy compatibility entries and enabled DCC Extras entry
+		// future-dated, and neuter $pfb['php'], so this suite remains isolated
+		// to apply reconciliation.
 		$this->installPhpArgvRecorder();
 		$now = time();
-		foreach (['cron', 'dcc', 'bl'] as $jobKey) {
+		foreach (['cron', 'dcc', 'bl', 'extra:dcc'] as $jobKey) {
 			$this->seedFutureLedgerEntry($jobKey, $now);
 		}
 	}

--- a/tests/php/TickEntrypointTest.php
+++ b/tests/php/TickEntrypointTest.php
@@ -48,6 +48,8 @@ final class TickEntrypointTest extends TestCase
 	private mixed $originalDbdir = NULL;
 	private bool $hadStateDir = FALSE;
 	private mixed $originalStateDir = NULL;
+	private bool $hadPendingMarker = FALSE;
+	private mixed $originalPendingMarker = NULL;
 
 	/** Whether $GLOBALS['pfb']['runlog']/['extraslog'] were set before this test, and their values. */
 	private bool $hadRunlog = FALSE;
@@ -111,6 +113,8 @@ final class TickEntrypointTest extends TestCase
 		$this->originalDbdir = $GLOBALS['pfb']['dbdir'] ?? NULL;
 		$this->hadStateDir      = array_key_exists('schedule_state_dir', $GLOBALS['pfb'] ?? []);
 		$this->originalStateDir = $GLOBALS['pfb']['schedule_state_dir'] ?? NULL;
+		$this->hadPendingMarker      = array_key_exists('pending_marker', $GLOBALS['pfb'] ?? []);
+		$this->originalPendingMarker = $GLOBALS['pfb']['pending_marker'] ?? NULL;
 
 		$this->hadRunlog      = array_key_exists('runlog', $GLOBALS['pfb'] ?? []);
 		$this->originalRunlog = $GLOBALS['pfb']['runlog'] ?? NULL;
@@ -141,6 +145,7 @@ final class TickEntrypointTest extends TestCase
 		mkdir("{$this->dbdir}/state", 0755, TRUE);
 		$GLOBALS['pfb']['dbdir']     = $this->dbdir;
 		$GLOBALS['pfb']['schedule_state_dir'] = "{$this->dbdir}/state";
+		$GLOBALS['pfb']['pending_marker'] = "{$this->dbdir}/pfb_pending_changes";
 		$GLOBALS['pfb']['runlog']    = "{$this->dbdir}/pfblockerng_run.log";
 		$GLOBALS['pfb']['extraslog'] = "{$this->dbdir}/extras.log";
 		$GLOBALS['pfb']['logdir']    = $this->dbdir;
@@ -171,6 +176,11 @@ final class TickEntrypointTest extends TestCase
 			$GLOBALS['pfb']['schedule_state_dir'] = $this->originalStateDir;
 		} else {
 			unset($GLOBALS['pfb']['schedule_state_dir']);
+		}
+		if ($this->hadPendingMarker) {
+			$GLOBALS['pfb']['pending_marker'] = $this->originalPendingMarker;
+		} else {
+			unset($GLOBALS['pfb']['pending_marker']);
 		}
 		if ($this->hadRunlog) {
 			$GLOBALS['pfb']['runlog'] = $this->originalRunlog;

--- a/tests/php/TickExtrasOrderingTest.php
+++ b/tests/php/TickExtrasOrderingTest.php
@@ -22,6 +22,7 @@ final class TickExtrasOrderingTest extends TestCase
 		$this->dir = sys_get_temp_dir() . '/pfb_tick_extras_' . getmypid() . '_' . uniqid();
 		mkdir($this->dir . '/state', 0777, TRUE);
 		$GLOBALS['pfb']['dbdir'] = $this->dir;
+		$GLOBALS['pfb']['pending_marker'] = $this->dir . '/pfb_pending_changes';
 		$GLOBALS['pfb']['schedule_state_dir'] = $this->dir . '/state';
 		$GLOBALS['pfb']['runlog'] = $this->dir . '/run.log';
 		$GLOBALS['pfb']['extraslog'] = $this->dir . '/extras.log';

--- a/tests/php/TickFeedPassDeferralTest.php
+++ b/tests/php/TickFeedPassDeferralTest.php
@@ -41,6 +41,8 @@ final class TickFeedPassDeferralTest extends TestCase
 	private mixed $originalExtraslog = NULL;
 	private bool $hadStateDir = FALSE;
 	private mixed $originalStateDir = NULL;
+	private bool $hadPendingMarker = FALSE;
+	private mixed $originalPendingMarker = NULL;
 	private bool $hadPhp = FALSE;
 	private mixed $originalPhp = NULL;
 
@@ -59,6 +61,8 @@ final class TickFeedPassDeferralTest extends TestCase
 		$this->originalExtraslog = $GLOBALS['pfb']['extraslog'] ?? NULL;
 		$this->hadStateDir      = array_key_exists('schedule_state_dir', $GLOBALS['pfb'] ?? []);
 		$this->originalStateDir = $GLOBALS['pfb']['schedule_state_dir'] ?? NULL;
+		$this->hadPendingMarker      = array_key_exists('pending_marker', $GLOBALS['pfb'] ?? []);
+		$this->originalPendingMarker = $GLOBALS['pfb']['pending_marker'] ?? NULL;
 
 		$this->hadPhp      = array_key_exists('php', $GLOBALS['pfb'] ?? []);
 		$this->originalPhp = $GLOBALS['pfb']['php'] ?? NULL;
@@ -66,6 +70,7 @@ final class TickFeedPassDeferralTest extends TestCase
 		$this->dbdir = sys_get_temp_dir() . '/pfb_tick_feedpass_' . uniqid('', TRUE);
 		mkdir($this->dbdir, 0755, TRUE);
 		$GLOBALS['pfb']['dbdir']     = $this->dbdir;
+		$GLOBALS['pfb']['pending_marker'] = "{$this->dbdir}/pfb_pending_changes";
 		$GLOBALS['pfb']['runlog']    = "{$this->dbdir}/pfblockerng_run.log";
 		$GLOBALS['pfb']['extraslog'] = "{$this->dbdir}/extras.log";
 		$GLOBALS['pfb']['schedule_state_dir'] = "{$this->dbdir}/state";
@@ -106,6 +111,11 @@ final class TickFeedPassDeferralTest extends TestCase
 			$GLOBALS['pfb']['schedule_state_dir'] = $this->originalStateDir;
 		} else {
 			unset($GLOBALS['pfb']['schedule_state_dir']);
+		}
+		if ($this->hadPendingMarker) {
+			$GLOBALS['pfb']['pending_marker'] = $this->originalPendingMarker;
+		} else {
+			unset($GLOBALS['pfb']['pending_marker']);
 		}
 		if ($this->hadPhp) {
 			$GLOBALS['pfb']['php'] = $this->originalPhp;

--- a/tests/php/TickSafeSearchFailureTest.php
+++ b/tests/php/TickSafeSearchFailureTest.php
@@ -19,6 +19,8 @@ final class TickSafeSearchFailureTest extends TestCase
 		$this->originalConfig = $GLOBALS['config'] ?? [];
 		$GLOBALS['pfb'] = [
 			'dbdir'     => $this->dir,
+			'pending_marker' => "{$this->dir}/pfb_pending_changes",
+			'schedule_state_dir' => $this->dir,
 			'log'       => "{$this->dir}/pfblockerng.log",
 			'errlog'    => "{$this->dir}/error.log",
 			'runlog'    => "{$this->dir}/run.log",

--- a/tests/php/TickSafeSearchReservationTest.php
+++ b/tests/php/TickSafeSearchReservationTest.php
@@ -17,7 +17,11 @@ final class TickSafeSearchReservationTest extends TestCase
 		mkdir($this->dir, 0755, TRUE);
 		$this->originalPfb = $GLOBALS['pfb'] ?? [];
 		$this->originalConfig = $GLOBALS['config'] ?? [];
-		$GLOBALS['pfb'] = ['dbdir' => $this->dir];
+		$GLOBALS['pfb'] = [
+			'dbdir' => $this->dir,
+			'pending_marker' => "{$this->dir}/pfb_pending_changes",
+			'schedule_state_dir' => $this->dir,
+		];
 		$GLOBALS['config'] = [];
 
 		$gen = 'installedpackages/pfblockerng/config/0';

--- a/tests/php/TickScheduleRuntimeTest.php
+++ b/tests/php/TickScheduleRuntimeTest.php
@@ -24,6 +24,7 @@ final class TickScheduleRuntimeTest extends TestCase
 		$this->stateDir = $this->dir . '/state';
 		mkdir($this->stateDir, 0755, TRUE);
 		$GLOBALS['pfb']['dbdir'] = $this->dir;
+		$GLOBALS['pfb']['pending_marker'] = $this->dir . '/pfb_pending_changes';
 		$GLOBALS['pfb']['schedule_state_dir'] = $this->stateDir;
 		$GLOBALS['pfb']['runlog'] = $this->dir . '/run.log';
 		$GLOBALS['pfb']['extraslog'] = $this->dir . '/extras.log';

--- a/tests/php/Top1mDccDetectorTest.php
+++ b/tests/php/Top1mDccDetectorTest.php
@@ -428,9 +428,21 @@ PHP;
 			$old_hash = file_get_contents("{$base}.xxhash128");
 			file_put_contents("{$base}.source", $old_source);
 			pfb_validator_write("{$base}.orig", $old_etag, $old_lastmod);
+			$this->assertTrue(chmod($this->dir, 0777), 'fixture directory must remain writable while its hash is denied');
 			chmod("{$base}.xxhash128", 0444);
+			$root = function_exists('posix_geteuid') && posix_geteuid() === 0;
+			if ($root && !posix_seteuid(65534)) {
+				$this->fail('could not drop root privileges for the persistence-denial fixture');
+			}
+			try {
+				$result = $this->downloadTop1m($fixture['source'], $base, $active);
+			} finally {
+				if ($root && !posix_seteuid(0)) {
+					$this->fail('could not restore root privileges after the persistence-denial fixture');
+				}
+			}
 
-			$this->assertFalse($this->downloadTop1m($fixture['source'], $base, $active), "{$label}: persistence failure must fail");
+			$this->assertFalse($result, "{$label}: persistence failure must fail");
 			$this->assertSame("old active {$label}\n", file_get_contents($active), "{$label}: active rollback");
 			$this->assertSame($old_raw, file_get_contents("{$base}.orig"), "{$label}: raw rollback");
 			$this->assertSame($old_hash, file_get_contents("{$base}.xxhash128"), "{$label}: hash rollback");

--- a/tests/php/Top1mPreserveOnEmptyFeedTest.php
+++ b/tests/php/Top1mPreserveOnEmptyFeedTest.php
@@ -228,9 +228,6 @@ final class Top1mPreserveOnEmptyFeedTest extends TestCase
 	 */
 	public function testReadOnlyDbdirCausesRenameFailurePreservesPriorWhitelistAndWarns(): void
 	{
-		if (function_exists('posix_getuid') && posix_getuid() === 0) {
-			$this->markTestSkipped('running as root -- permission-based failure injection cannot be simulated');
-		}
 
 		// Given: a prior good whitelist, a valid+matching top-1m.csv, but a dbdir made
 		// read-only AFTER seeding both files.
@@ -241,7 +238,7 @@ final class Top1mPreserveOnEmptyFeedTest extends TestCase
 
 		try {
 			// When
-			pfblockerng_top1m();
+			pfb_test_as_unprivileged(fn () => pfblockerng_top1m(), [$this->dbdir]);
 		} finally {
 			// Restore write access up front so tearDown() can clean the sandbox.
 			@chmod($this->dbdir, 0777);

--- a/tests/php/Top1mSemanticMatrixTest.php
+++ b/tests/php/Top1mSemanticMatrixTest.php
@@ -205,15 +205,15 @@ final class Top1mSemanticMatrixTest extends TestCase
 
 	public function testCandidateRejectsUnreadableFile(): void
 	{
-		if (function_exists('posix_getuid') && posix_getuid() === 0) {
-			$this->markTestSkipped('root bypasses file permissions');
-		}
 		$provider = pfb_top1m_providers()['tranco'];
 		$path = "{$this->dir}/unreadable.csv";
 		$this->assertNotFalse(file_put_contents($path, "1,Example.COM\n"));
 		$this->assertTrue(chmod($path, 0000));
 		try {
-			$this->assertFalse(pfb_top1m_candidate_valid($path, $provider));
+			$this->assertFalse(pfb_test_as_unprivileged(
+				fn () => pfb_top1m_candidate_valid($path, $provider),
+				[$this->dir]
+			));
 		} finally {
 			chmod($path, 0600);
 		}

--- a/tests/php/V6CidrSubtractTest.php
+++ b/tests/php/V6CidrSubtractTest.php
@@ -610,9 +610,6 @@ final class V6CidrSubtractTest extends TestCase
 	 */
 	public function testFilePutContentsFailureUnlinksStrayTmpFile(): void
 	{
-		if (function_exists('posix_getuid') && posix_getuid() === 0) {
-			$this->markTestSkipped('running as root -- permission-based failure injection cannot be simulated');
-		}
 
 		$file     = $this->makeTempFile("2001:db8::/64\n");
 		$suppfile = $this->makeTempFile("2001:db8::5353/128\n");
@@ -623,7 +620,10 @@ final class V6CidrSubtractTest extends TestCase
 		$this->tmpfiles[] = $tmp;
 
 		try {
-			$ok = pfb_suppress_file_v6($file, $suppfile);
+			$ok = pfb_test_as_unprivileged(
+				fn () => pfb_suppress_file_v6($file, $suppfile),
+				[$file, $suppfile, $tmp]
+			);
 
 			$this->assertFalse($ok, 'a file_put_contents() failure on the tmp path must fail safe (FALSE)');
 			$this->assertFileDoesNotExist(

--- a/tests/php/bootstrap.php
+++ b/tests/php/bootstrap.php
@@ -145,7 +145,7 @@ function pfb_test_preflight_path(string $root, string $path, string $label): str
 	$path = rtrim($path, DIRECTORY_SEPARATOR) ?: DIRECTORY_SEPARATOR;
 	$prefix = $root === DIRECTORY_SEPARATOR ? $root : $root . DIRECTORY_SEPARATOR;
 	if ($path !== $root && !str_starts_with($path, $prefix)) {
-		throw new RuntimeException("refusing {$label} outside trusted temporary root {$path}");
+		throw new RuntimeException("refusing {$label} outside trusted temporary root {$root}");
 	}
 	$canonical = realpath($root);
 	if ($canonical === FALSE) {
@@ -156,7 +156,7 @@ function pfb_test_preflight_path(string $root, string $path, string $label): str
 			continue;
 		}
 		if ($component === '..') {
-			throw new RuntimeException("refusing {$label} outside trusted temporary root {$path}");
+			throw new RuntimeException("refusing {$label} outside trusted temporary root {$root}");
 		}
 		$canonical .= DIRECTORY_SEPARATOR . $component;
 		if (is_link($canonical)) {
@@ -181,9 +181,19 @@ function pfb_test_as_unprivileged(callable $callback, array $owned_paths = []): 
 	$tmp_owner = NULL;
 
 	foreach ($owned_paths as $path) {
-		pfb_test_preflight_path($tmp_path, $path, 'owned-path');
+		$canonical_path = pfb_test_preflight_path($tmp_path, $path, 'owned-path');
 		if (!file_exists($path)) {
 			throw new RuntimeException("could not prepare {$path} for an unprivileged fixture");
+		}
+		for ($directory = dirname($canonical_path); $canonical_path !== $tmp && $directory !== $tmp;
+		    $directory = dirname($directory)) {
+			$mode = fileperms($directory);
+			if ($mode === FALSE) {
+				throw new RuntimeException("could not inspect owned-path ancestor {$directory}");
+			}
+			if (($mode & 0001) === 0) {
+				$modes[$directory] = $mode & 07777;
+			}
 		}
 		$paths = [$path];
 		if (is_dir($path)) {

--- a/tests/php/bootstrap.php
+++ b/tests/php/bootstrap.php
@@ -139,6 +139,76 @@ function pfb_test_tar(): string
 	return $GLOBALS['pfb']['tar'] ?? '/usr/bin/tar';
 }
 
+function pfb_test_as_unprivileged(callable $callback, array $owned_paths = []): mixed
+{
+	if (!function_exists('posix_geteuid') || posix_geteuid() !== 0) {
+		return $callback();
+	}
+	$uid = 65534;
+	$tmp = sys_get_temp_dir();
+	$tmp_owner = NULL;
+	$tmp_mode = fileperms($tmp);
+	if ($tmp_mode !== FALSE && ($tmp_mode & 0001) === 0) {
+		$tmp_owner = fileowner($tmp);
+		if ($tmp_owner === FALSE || !chown($tmp, $uid)) {
+			throw new RuntimeException("could not make nested TMPDIR {$tmp} traversable by an unprivileged fixture");
+		}
+	}
+	foreach ($owned_paths as $path) {
+		$paths = [$path];
+		if (is_dir($path)) {
+			foreach (new RecursiveIteratorIterator(new RecursiveDirectoryIterator($path,
+				FilesystemIterator::SKIP_DOTS), RecursiveIteratorIterator::SELF_FIRST) as $entry) {
+				$paths[] = $entry->getPathname();
+			}
+		}
+		foreach ($paths as $owned_path) {
+			if (!chown($owned_path, $uid)) {
+				throw new RuntimeException("could not prepare {$owned_path} for an unprivileged fixture");
+			}
+		}
+	}
+
+	$sockets = stream_socket_pair(STREAM_PF_UNIX, STREAM_SOCK_STREAM, STREAM_IPPROTO_IP);
+	$pid = $sockets === FALSE ? -1 : pcntl_fork();
+	if ($pid === -1) {
+		if ($tmp_owner !== NULL) {
+			chown($tmp, $tmp_owner);
+		}
+		throw new RuntimeException('could not fork an unprivileged permission-denial fixture');
+	}
+	if ($pid === 0) {
+		fclose($sockets[0]);
+		try {
+			if (!posix_setgid($uid) || !posix_setuid($uid)) {
+				throw new RuntimeException('could not drop privileges in permission-denial fixture');
+			}
+			$payload = ['ok' => TRUE, 'value' => $callback()];
+		} catch (Throwable $error) {
+			$payload = ['ok' => FALSE, 'error' => get_class($error) . ': ' . $error->getMessage()];
+		}
+		fwrite($sockets[1], base64_encode(serialize($payload)) . "\n");
+		fclose($sockets[1]);
+		exit($payload['ok'] ? 0 : 1);
+	}
+
+	fclose($sockets[1]);
+	$encoded = fgets($sockets[0]);
+	fclose($sockets[0]);
+	pcntl_waitpid($pid, $status);
+	if ($tmp_owner !== NULL && !chown($tmp, $tmp_owner)) {
+		throw new RuntimeException("could not restore nested TMPDIR {$tmp} ownership");
+	}
+	$payload = is_string($encoded)
+		? unserialize(base64_decode(trim($encoded)), ['allowed_classes' => FALSE])
+		: NULL;
+	if (!pcntl_wifexited($status) || pcntl_wexitstatus($status) !== 0 || !is_array($payload)
+		|| ($payload['ok'] ?? FALSE) !== TRUE) {
+		throw new RuntimeException('unprivileged fixture failed: ' . ($payload['error'] ?? 'child exited unexpectedly'));
+	}
+	return $payload['value'];
+}
+
 $GLOBALS['pfb']['tar'] = pfb_resolve_archiver();
 
 // Snapshot the SHIPPED $pfb['mime_types'] allow-list exactly as the just-loaded

--- a/tests/php/bootstrap.php
+++ b/tests/php/bootstrap.php
@@ -146,37 +146,109 @@ function pfb_test_as_unprivileged(callable $callback, array $owned_paths = []): 
 	}
 	$uid = 65534;
 	$tmp = sys_get_temp_dir();
+	$owners = [];
+	$modes = [];
 	$tmp_owner = NULL;
-	$tmp_mode = fileperms($tmp);
-	if ($tmp_mode !== FALSE && ($tmp_mode & 0001) === 0) {
-		$tmp_owner = fileowner($tmp);
-		if ($tmp_owner === FALSE || !chown($tmp, $uid)) {
-			throw new RuntimeException("could not make nested TMPDIR {$tmp} traversable by an unprivileged fixture");
-		}
-	}
+
 	foreach ($owned_paths as $path) {
+		if (is_link($path)) {
+			throw new RuntimeException("refusing owned-path symlink {$path}");
+		}
+		if (!file_exists($path)) {
+			throw new RuntimeException("could not prepare {$path} for an unprivileged fixture");
+		}
 		$paths = [$path];
 		if (is_dir($path)) {
 			foreach (new RecursiveIteratorIterator(new RecursiveDirectoryIterator($path,
 				FilesystemIterator::SKIP_DOTS), RecursiveIteratorIterator::SELF_FIRST) as $entry) {
-				$paths[] = $entry->getPathname();
+				$owned_path = $entry->getPathname();
+				if ($entry->isLink()) {
+					throw new RuntimeException("refusing owned-path symlink {$owned_path}");
+				}
+				$paths[] = $owned_path;
 			}
 		}
 		foreach ($paths as $owned_path) {
+			$owner = fileowner($owned_path);
+			if ($owner === FALSE) {
+				throw new RuntimeException("could not inspect {$owned_path} for an unprivileged fixture");
+			}
+			$owners[$owned_path] = $owner;
+		}
+	}
+
+	for ($directory = $tmp; ; $directory = dirname($directory)) {
+		$mode = fileperms($directory);
+		if ($mode === FALSE) {
+			throw new RuntimeException("could not inspect nested TMPDIR ancestor {$directory}");
+		}
+		if (($mode & 0001) === 0) {
+			$modes[$directory] = $mode & 07777;
+		}
+		if ($directory === dirname($directory)) {
+			break;
+		}
+	}
+	if (isset($modes[$tmp])) {
+		$tmp_owner = fileowner($tmp);
+		if ($tmp_owner === FALSE) {
+			throw new RuntimeException("could not inspect nested TMPDIR {$tmp} ownership");
+		}
+	}
+
+	$restore = static function () use (&$owners, &$modes, $tmp, &$tmp_owner): void {
+		$restore_error = NULL;
+		foreach (array_reverse($owners, TRUE) as $path => $owner) {
+			if (is_link($path)) {
+				$restore_error ??= "refusing replacement symlink {$path} during ownership restore";
+				continue;
+			}
+			if (file_exists($path) && !chown($path, $owner)) {
+				$restore_error ??= "could not restore {$path} ownership";
+			}
+		}
+		if ($tmp_owner !== NULL && (!file_exists($tmp) || is_link($tmp) || !chown($tmp, $tmp_owner))) {
+			$restore_error ??= "could not safely restore nested TMPDIR {$tmp} ownership";
+		}
+		foreach (array_reverse($modes, TRUE) as $directory => $mode) {
+			if (!file_exists($directory) || is_link($directory) || !chmod($directory, $mode)) {
+				$restore_error ??= "could not safely restore nested TMPDIR ancestor {$directory} mode";
+			}
+		}
+		if ($restore_error !== NULL) {
+			throw new RuntimeException($restore_error);
+		}
+	};
+
+	$sockets = FALSE;
+	try {
+		foreach ($modes as $directory => $mode) {
+			if ($directory !== $tmp && !chmod($directory, $mode | 0001)) {
+				throw new RuntimeException("could not make nested TMPDIR ancestor {$directory} traversable");
+			}
+		}
+		if ($tmp_owner !== NULL && !chown($tmp, $uid)) {
+			throw new RuntimeException("could not make nested TMPDIR {$tmp} traversable by an unprivileged fixture");
+		}
+		foreach ($owners as $owned_path => $_owner) {
 			if (!chown($owned_path, $uid)) {
 				throw new RuntimeException("could not prepare {$owned_path} for an unprivileged fixture");
 			}
 		}
+		$sockets = stream_socket_pair(STREAM_PF_UNIX, STREAM_SOCK_STREAM, STREAM_IPPROTO_IP);
+		$pid = $sockets === FALSE ? -1 : pcntl_fork();
+		if ($pid === -1) {
+			throw new RuntimeException('could not fork an unprivileged permission-denial fixture');
+		}
+	} catch (Throwable $error) {
+		if (is_array($sockets)) {
+			fclose($sockets[0]);
+			fclose($sockets[1]);
+		}
+		$restore();
+		throw $error;
 	}
 
-	$sockets = stream_socket_pair(STREAM_PF_UNIX, STREAM_SOCK_STREAM, STREAM_IPPROTO_IP);
-	$pid = $sockets === FALSE ? -1 : pcntl_fork();
-	if ($pid === -1) {
-		if ($tmp_owner !== NULL) {
-			chown($tmp, $tmp_owner);
-		}
-		throw new RuntimeException('could not fork an unprivileged permission-denial fixture');
-	}
 	if ($pid === 0) {
 		fclose($sockets[0]);
 		try {
@@ -193,20 +265,30 @@ function pfb_test_as_unprivileged(callable $callback, array $owned_paths = []): 
 	}
 
 	fclose($sockets[1]);
-	$encoded = fgets($sockets[0]);
-	fclose($sockets[0]);
-	pcntl_waitpid($pid, $status);
-	if ($tmp_owner !== NULL && !chown($tmp, $tmp_owner)) {
-		throw new RuntimeException("could not restore nested TMPDIR {$tmp} ownership");
+	$waited = FALSE;
+	try {
+		$encoded = fgets($sockets[0]);
+		fclose($sockets[0]);
+		pcntl_waitpid($pid, $status);
+		$waited = TRUE;
+		$payload = is_string($encoded)
+			? unserialize(base64_decode(trim($encoded)), ['allowed_classes' => FALSE])
+			: NULL;
+		if (!pcntl_wifexited($status) || pcntl_wexitstatus($status) !== 0 || !is_array($payload)
+			|| ($payload['ok'] ?? FALSE) !== TRUE) {
+			throw new RuntimeException('unprivileged fixture failed: '
+				. ($payload['error'] ?? 'child exited unexpectedly'));
+		}
+		return $payload['value'];
+	} finally {
+		if (is_resource($sockets[0])) {
+			fclose($sockets[0]);
+		}
+		if (!$waited) {
+			pcntl_waitpid($pid, $status);
+		}
+		$restore();
 	}
-	$payload = is_string($encoded)
-		? unserialize(base64_decode(trim($encoded)), ['allowed_classes' => FALSE])
-		: NULL;
-	if (!pcntl_wifexited($status) || pcntl_wexitstatus($status) !== 0 || !is_array($payload)
-		|| ($payload['ok'] ?? FALSE) !== TRUE) {
-		throw new RuntimeException('unprivileged fixture failed: ' . ($payload['error'] ?? 'child exited unexpectedly'));
-	}
-	return $payload['value'];
 }
 
 $GLOBALS['pfb']['tar'] = pfb_resolve_archiver();

--- a/tests/php/bootstrap.php
+++ b/tests/php/bootstrap.php
@@ -139,21 +139,49 @@ function pfb_test_tar(): string
 	return $GLOBALS['pfb']['tar'] ?? '/usr/bin/tar';
 }
 
+function pfb_test_preflight_path(string $root, string $path, string $label): string
+{
+	$root = rtrim($root, DIRECTORY_SEPARATOR) ?: DIRECTORY_SEPARATOR;
+	$path = rtrim($path, DIRECTORY_SEPARATOR) ?: DIRECTORY_SEPARATOR;
+	$prefix = $root === DIRECTORY_SEPARATOR ? $root : $root . DIRECTORY_SEPARATOR;
+	if ($path !== $root && !str_starts_with($path, $prefix)) {
+		throw new RuntimeException("refusing {$label} outside trusted temporary root {$path}");
+	}
+	$canonical = realpath($root);
+	if ($canonical === FALSE) {
+		throw new RuntimeException("could not inspect trusted temporary root {$root}");
+	}
+	foreach (explode(DIRECTORY_SEPARATOR, ltrim(substr($path, strlen($root)), DIRECTORY_SEPARATOR)) as $component) {
+		if ($component === '' || $component === '.') {
+			continue;
+		}
+		if ($component === '..') {
+			throw new RuntimeException("refusing {$label} outside trusted temporary root {$path}");
+		}
+		$canonical .= DIRECTORY_SEPARATOR . $component;
+		if (is_link($canonical)) {
+			throw new RuntimeException("refusing {$label} symlink {$canonical}");
+		}
+	}
+	return $canonical;
+}
+
 function pfb_test_as_unprivileged(callable $callback, array $owned_paths = []): mixed
 {
 	if (!function_exists('posix_geteuid') || posix_geteuid() !== 0) {
 		return $callback();
 	}
 	$uid = 65534;
-	$tmp = sys_get_temp_dir();
+	$tmp_path = rtrim(sys_get_temp_dir(), DIRECTORY_SEPARATOR);
+	$tmp_prefix_end = strpos($tmp_path, DIRECTORY_SEPARATOR, 1);
+	$tmp_prefix = $tmp_prefix_end === FALSE ? $tmp_path : substr($tmp_path, 0, $tmp_prefix_end);
+	$tmp = pfb_test_preflight_path($tmp_prefix, $tmp_path, 'nested TMPDIR');
 	$owners = [];
 	$modes = [];
 	$tmp_owner = NULL;
 
 	foreach ($owned_paths as $path) {
-		if (is_link($path)) {
-			throw new RuntimeException("refusing owned-path symlink {$path}");
-		}
+		pfb_test_preflight_path($tmp_path, $path, 'owned-path');
 		if (!file_exists($path)) {
 			throw new RuntimeException("could not prepare {$path} for an unprivileged fixture");
 		}
@@ -196,11 +224,13 @@ function pfb_test_as_unprivileged(callable $callback, array $owned_paths = []): 
 		}
 	}
 
-	$restore = static function () use (&$owners, &$modes, $tmp, &$tmp_owner): void {
+	$restore = static function () use (&$owners, &$modes, $tmp, $tmp_path, &$tmp_owner): void {
 		$restore_error = NULL;
 		foreach (array_reverse($owners, TRUE) as $path => $owner) {
-			if (is_link($path)) {
-				$restore_error ??= "refusing replacement symlink {$path} during ownership restore";
+			try {
+				pfb_test_preflight_path($tmp_path, $path, 'replacement');
+			} catch (RuntimeException $error) {
+				$restore_error ??= $error->getMessage() . ' during ownership restore';
 				continue;
 			}
 			if (file_exists($path) && !chown($path, $owner)) {


### PR DESCRIPTION
## Summary

- isolate tick suites from the host pending-change marker and shared schedule state
- normalize inherited `SIGXFSZ` state in the extraction-ceiling child process
- make TOP1M and permission-denial fixtures deterministic when PHPUnit runs as root
- execute 22 formerly root-skipped permission assertions through one unprivileged harness helper
- make that root-side helper reject symlink escapes and restore fixture ownership and nested TMPDIR traversal state transactionally

## Verification

- archived-base focused matrix: 107 tests with 5 errors + 13 failures; branch: 107 tests, 2477 assertions, zero failures/errors
- archived-base root permission matrix: 326 tests, 1640 assertions, 24 skips with 22 unallowlisted root skips; branch caller matrix: 334 tests, 1768 assertions, 2 allowlisted skips
- review regressions: 4 failures before helper edit; 5 targeted tests, 29 assertions after; frozen test SHA-256 `825628c409f339530928c379011dffea659264400c845d55c606873cd7980222`
- full PHPUnit: 6712 tests, 42021 assertions, zero failures/errors; 8 allowlisted skips; JUnit skip gate passed
- `scripts/agent/run-gates.sh --diff 4aead67b75a927f2d15df277ebd338708cb95ecc`: `GATES: PASS`
- `sh scripts/agent/check-graph-fresh.sh`: fresh

Fixes #3103


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded coverage for permission-denied, unreadable-file, symlink, ownership, rollback, and filesystem boundary scenarios.
  - Permission-sensitive tests now run reliably even when the test suite executes with elevated privileges.
  - Improved test isolation by sandboxing temporary files, scheduling state, and pending-change markers.
  - Added safeguards to verify cleanup and restoration after simulated failures.
  - Enhanced platform-specific checks for extraction limits and persistence failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->