### PR TITLE
tests: capture and verify silent rsync timeout

### DIFF
--- a/tests/php/RsyncWallDeadlineTest.php
+++ b/tests/php/RsyncWallDeadlineTest.php
@@ -375,7 +375,12 @@ SH;
 		if ($real === NULL) {
 			$this->markTestSkipped('no real rsync binary available on this host');
 		}
-		$GLOBALS['pfb']['rsync_bin'] = $real;
+		$stderrPath = "{$this->workdir}/rsync.stderr";
+		$capture = "{$this->workdir}/rsync-capture.sh";
+		$this->assertNotFalse(file_put_contents($capture, "#!/bin/sh\nexec "
+			. escapeshellarg($real) . ' "$@" 2>' . escapeshellarg($stderrPath) . "\n"));
+		$this->assertTrue(chmod($capture, 0755));
+		$GLOBALS['pfb']['rsync_bin'] = $capture;
 
 		$errno  = 0;
 		$errstr = '';
@@ -395,6 +400,9 @@ SH;
 		$this->assertNotFalse(@stream_socket_accept($this->stallServer, 0),
 			"the site must reach the stalled peer through the injected rsync binary ({$real})");
 		$this->assertFalse($result->success, 'a silent peer must still fail finitely');
+		$stderr = (string) file_get_contents($stderrPath);
+		$this->assertMatchesRegularExpression('/\b(?:timeout|timed out)\b/i', $stderr,
+			"expected an I/O timeout from {$real}; stderr: {$stderr}; log: " . $this->logText());
 		$this->assertStringContainsString('RSYNC Failed (exit', $this->logText(),
 			'the silent peer must fail through rsync\'s own I/O timeout (rsync\'s exit), not '
 			. 'the wall deadline; log: ' . $this->logText());


### PR DESCRIPTION
## Summary

- Capture real rsync stderr only in the silent-peer fixture, using an executable `exec` wrapper at the existing binary injection seam.
- Require a timeout diagnostic in the captured stderr, in addition to the existing peer-connection, failed-transfer, and rsync-exit assertions.
- Keep passing PHPUnit runs quiet; assertion failures include the selected executable, captured stderr, and fixture log.

No production code, behavior deadline, or salvage cap changes. The other five fixture scenarios are unchanged. This does not claim to fix the separate unreproduced startup failures in #2992.

Fixes #3250.

## Verification

Host: Darwin arm64, PHP 8.5.10, PHPUnit 12.5.31.

- Before: isolated silent-peer method passed with 9 assertions while emitting `rsync(...): error: poll: timeout` on subprocess stderr.
- Before: a command-substitution mutant connected to the same peer, emitted `rsync: connection reset by peer`, and exited 23; the original test incorrectly passed.
- After: genuine silent-peer method passes with 12 assertions and empty subprocess stderr.
- After: entire fixture file passes with **6 tests, 56 assertions**, and empty subprocess stderr.
- Same strengthened test against the connected non-timeout-error mutant: **FAIL**, explicitly showing the connection-reset diagnostic and `RSYNC Failed (exit 23)`.
- Same strengthened test with production `--timeout=5` changed to `--timeout=0` in the isolated scratch archive: **FAIL**, captured stderr empty and fixture log reporting the outer `RSYNC transfer TIMED OUT` instead.
- Production restored in scratch: **PASS**, 1 test, 12 assertions. Strengthened test SHA-256 stayed `fde984bf5e00a935a34d9474792ed073241d00a7276ae0b0f1e97a8a02a92c66` throughout the after-change mutation/control runs.

Frozen production RED: **N/A — test maintenance**, per testing.md. No product behavior is changed; the mutation evidence proves the strengthened existing test rejects non-timeout outcomes. The non-timeout command substitute writes its stderr to the fixture capture destination; quietness is verified separately against the real unmodified command, not inferred from that substitute.

Full canonical gates and exact-head CI are required before landing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved coverage for rsync transfers involving silent peers.
  - Tests now verify that stalled transfers fail through rsync’s configured I/O timeout and report the expected timeout error.
  - Added validation of captured rsync error output to distinguish timeout handling from unrelated wall-clock deadline failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->