### PR TITLE
agent: provision receiving review skill

### DIFF
--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -19,6 +19,8 @@
     // documentation): its repeated "User"/"Assistant" headings and multiple
     // H1s are inherent to the format, so it is not linted.
     "**/TRANSCRIPT.md",
+    // Byte-faithful upstream skill; local reformatting would fork its content.
+    "scripts/agent/skills/receiving-code-review/SKILL.md",
     // Claude symlinks onto canonical repo-owned skills; lint each target once.
     ".claude/skills/**"
   ]

--- a/scripts/agent/setup-agent-tools.sh
+++ b/scripts/agent/setup-agent-tools.sh
@@ -177,6 +177,23 @@ setup_graphify_client() {
 	(cd "$HOME" && "$graphify_bin" "$1" install && "$graphify_bin" install --platform "$1")
 }
 
+install_receiving_code_review() {
+	source=$root/scripts/agent/skills/receiving-code-review
+	destination_parent=$HOME/.agents/skills
+	destination=$destination_parent/receiving-code-review
+	staged=$destination_parent/.receiving-code-review.new
+	[ -f "$source/SKILL.md" ] || fail "required vendored skill '$source/SKILL.md' is missing"
+	[ -f "$source/LICENSE" ] || fail "required vendored skill license '$source/LICENSE' is missing"
+	mkdir -p "$destination_parent"
+	rm -rf "$staged"
+	cp -R "$source" "$staged" || {
+		rm -rf "$staged"
+		return 1
+	}
+	rm -rf "$destination"
+	mv "$staged" "$destination"
+}
+
 configure_agents() {
 	# Run both Graphify update surfaces for every detected harness mapping so neither
 	# its integration nor its skill copy stays on the previous package release.
@@ -288,6 +305,7 @@ main() {
 	serena init
 	disable_serena_dashboard
 	configure_agents
+	install_receiving_code_review
 
 	sh "$init_tools" "$root"
 }

--- a/scripts/agent/setup-agent-tools.sh
+++ b/scripts/agent/setup-agent-tools.sh
@@ -182,16 +182,27 @@ install_receiving_code_review() {
 	destination_parent=$HOME/.agents/skills
 	destination=$destination_parent/receiving-code-review
 	staged=$destination_parent/.receiving-code-review.new
+	previous=$destination_parent/.receiving-code-review.old
+	mkdir -p "$destination_parent"
+	rm -rf "$staged" "$previous"
 	[ -f "$source/SKILL.md" ] || fail "required vendored skill '$source/SKILL.md' is missing"
 	[ -f "$source/LICENSE" ] || fail "required vendored skill license '$source/LICENSE' is missing"
-	mkdir -p "$destination_parent"
-	rm -rf "$staged"
 	cp -R "$source" "$staged" || {
 		rm -rf "$staged"
 		return 1
 	}
-	rm -rf "$destination"
-	mv "$staged" "$destination"
+	if [ -e "$destination" ]; then
+		mv "$destination" "$previous" || {
+			rm -rf "$staged"
+			return 1
+		}
+	fi
+	mv "$staged" "$destination" || {
+		rm -rf "$staged"
+		[ ! -e "$previous" ] || mv "$previous" "$destination"
+		return 1
+	}
+	rm -rf "$previous"
 }
 
 configure_agents() {

--- a/scripts/agent/skills/receiving-code-review/LICENSE
+++ b/scripts/agent/skills/receiving-code-review/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Jesse Vincent
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/scripts/agent/skills/receiving-code-review/SKILL.md
+++ b/scripts/agent/skills/receiving-code-review/SKILL.md
@@ -1,0 +1,205 @@
+---
+name: receiving-code-review
+description: Use when receiving code review feedback, before implementing suggestions, especially if feedback seems unclear or technically questionable - requires technical rigor and verification, not performative agreement or blind implementation
+---
+
+# Code Review Reception
+
+## Overview
+
+Code review requires technical evaluation, not emotional performance.
+
+**Core principle:** Verify before implementing. Ask before assuming. Technical correctness over social comfort.
+
+## The Response Pattern
+
+```
+WHEN receiving code review feedback:
+
+1. READ: Complete feedback without reacting
+2. UNDERSTAND: Restate requirement in own words (or ask)
+3. VERIFY: Check against codebase reality
+4. EVALUATE: Technically sound for THIS codebase?
+5. RESPOND: Technical acknowledgment or reasoned pushback
+6. IMPLEMENT: One item at a time, test each
+```
+
+## Forbidden Responses
+
+**NEVER:**
+- "You're absolutely right!" (explicit instruction-file violation)
+- "Great point!" / "Excellent feedback!" (performative)
+- "Let me implement that now" (before verification)
+
+**INSTEAD:**
+- Restate the technical requirement
+- Ask clarifying questions
+- Push back with technical reasoning if wrong
+- Just start working (actions > words)
+
+## Handling Unclear Feedback
+
+```
+IF any item is unclear:
+  STOP - do not implement anything yet
+  ASK for clarification on unclear items
+
+WHY: Items may be related. Partial understanding = wrong implementation.
+```
+
+**Example:**
+```
+your human partner: "Fix 1-6"
+You understand 1,2,3,6. Unclear on 4,5.
+
+❌ WRONG: Implement 1,2,3,6 now, ask about 4,5 later
+✅ RIGHT: "I understand items 1,2,3,6. Need clarification on 4 and 5 before proceeding."
+```
+
+## Source-Specific Handling
+
+### From your human partner
+- **Trusted** - implement after understanding
+- **Still ask** if scope unclear
+- **No performative agreement**
+- **Skip to action** or technical acknowledgment
+
+### From External Reviewers
+```
+BEFORE implementing:
+  1. Check: Technically correct for THIS codebase?
+  2. Check: Breaks existing functionality?
+  3. Check: Reason for current implementation?
+  4. Check: Works on all platforms/versions?
+  5. Check: Does reviewer understand full context?
+
+IF suggestion seems wrong:
+  Push back with technical reasoning
+
+IF can't easily verify:
+  Say so: "I can't verify this without [X]. Should I [investigate/ask/proceed]?"
+
+IF conflicts with your human partner's prior decisions:
+  Stop and discuss with your human partner first
+```
+
+**your human partner's rule:** "External feedback - be skeptical, but check carefully"
+
+## YAGNI Check for "Professional" Features
+
+```
+IF reviewer suggests "implementing properly":
+  grep codebase for actual usage
+
+  IF unused: "This endpoint isn't called. Remove it (YAGNI)?"
+  IF used: Then implement properly
+```
+
+**your human partner's rule:** "You and reviewer both report to me. If we don't need this feature, don't add it."
+
+## Implementation Order
+
+```
+FOR multi-item feedback:
+  1. Clarify anything unclear FIRST
+  2. Then implement in this order:
+     - Blocking issues (breaks, security)
+     - Simple fixes (typos, imports)
+     - Complex fixes (refactoring, logic)
+  3. Test each fix individually
+  4. Verify no regressions
+```
+
+## When To Push Back
+
+Push back when:
+- Suggestion breaks existing functionality
+- Reviewer lacks full context
+- Violates YAGNI (unused feature)
+- Technically incorrect for this stack
+- Legacy/compatibility reasons exist
+- Conflicts with your human partner's architectural decisions
+
+**How to push back:**
+- Use technical reasoning, not defensiveness
+- Ask specific questions
+- Reference working tests/code
+- Involve your human partner if architectural
+
+**If you're uncomfortable pushing back out loud:** Name that tension, then tell your partner about the issue you've seen. They'll appreciate your honesty.
+
+## Acknowledging Correct Feedback
+
+When feedback IS correct:
+```
+✅ "Fixed. [Brief description of what changed]"
+✅ "Good catch - [specific issue]. Fixed in [location]."
+✅ [Just fix it and show in the code]
+
+❌ "You're absolutely right!"
+❌ "Great point!"
+❌ "Thanks for catching that!"
+❌ "Thanks for [anything]"
+❌ ANY gratitude expression
+```
+
+**Why no thanks:** Actions speak. Just fix it. The code itself shows you heard the feedback.
+
+**If you catch yourself about to write "Thanks":** DELETE IT. State the fix instead.
+
+## Gracefully Correcting Your Pushback
+
+If you pushed back and were wrong:
+```
+✅ "You were right - I checked [X] and it does [Y]. Implementing now."
+✅ "Verified this and you're correct. My initial understanding was wrong because [reason]. Fixing."
+
+❌ Long apology
+❌ Defending why you pushed back
+❌ Over-explaining
+```
+
+State the correction factually and move on.
+
+## Common Mistakes
+
+| Mistake | Fix |
+|---------|-----|
+| Performative agreement | State requirement or just act |
+| Blind implementation | Verify against codebase first |
+| Batch without testing | One at a time, test each |
+| Assuming reviewer is right | Check if breaks things |
+| Avoiding pushback | Technical correctness > comfort |
+| Partial implementation | Clarify all items first |
+| Can't verify, proceed anyway | State limitation, ask for direction |
+
+## Real Examples
+
+**Performative Agreement (Bad):**
+```
+Reviewer: "Remove legacy code"
+❌ "You're absolutely right! Let me remove that..."
+```
+
+**Technical Verification (Good):**
+```
+Reviewer: "Remove legacy code"
+✅ "Checking... build target is 10.15+, this API needs 13+. Need legacy for backward compat. Current impl has wrong bundle ID - fix it or drop pre-13 support?"
+```
+
+**YAGNI (Good):**
+```
+Reviewer: "Implement proper metrics tracking with database, date filters, CSV export"
+✅ "Grepped codebase - nothing calls this endpoint. Remove it (YAGNI)? Or is there usage I'm missing?"
+```
+
+**Unclear Item (Good):**
+```
+your human partner: "Fix items 1-6"
+You understand 1,2,3,6. Unclear on 4,5.
+✅ "Understand 1,2,3,6. Need clarification on 4 and 5 before implementing."
+```
+
+## GitHub Thread Replies
+
+When replying to inline review comments on GitHub, reply in the comment thread (`gh api repos/{owner}/{repo}/pulls/{pr}/comments/{id}/replies`), not as a top-level PR comment.

--- a/tests/shell/agent_tools_setup_spec.sh
+++ b/tests/shell/agent_tools_setup_spec.sh
@@ -40,6 +40,10 @@ AGENTS_MARKER
 # repository policy marker
 preserve = true
 POLICY_MARKER
+    skill_source="$repository/scripts/agent/skills/receiving-code-review"
+    mkdir -p "$skill_source"
+    printf '%s\n' '# fixture receiving-code-review skill' > "$skill_source/SKILL.md"
+    printf '%s\n' 'fixture license' > "$skill_source/LICENSE"
     cp "$agent_marker" "$fixture/AGENTS.md.before"
     cp "$policy_marker" "$fixture/policy.before"
 
@@ -401,6 +405,68 @@ GROK
     The path "$home/.local/bin/semgrep" should be executable
     The path "$home/.local/bin/codegraph" should be executable
     The path "$home/.cargo/bin/wt" should be executable
+  End
+
+  It 'installs and refreshes the vendored review skill without disturbing sibling skills'
+    skill_destination="$home/.agents/skills/receiving-code-review"
+    mkdir -p "$skill_destination" "$home/.agents/skills/keep-me"
+    printf '%s\n' 'stale skill' > "$skill_destination/SKILL.md"
+    printf '%s\n' 'remove me' > "$skill_destination/stale-only"
+    printf '%s\n' 'preserved' > "$home/.agents/skills/keep-me/marker"
+    When run sh -c 'sh "$1" "$2" && sh "$1" "$2"' _ "$script_abs" "$repository"
+    The status should equal 0
+    Assert [ "$(cmp -s "$skill_source/SKILL.md" "$skill_destination/SKILL.md"; printf '%s' "$?")" -eq 0 ]
+    Assert [ "$(cmp -s "$skill_source/LICENSE" "$skill_destination/LICENSE"; printf '%s' "$?")" -eq 0 ]
+    The file "$skill_destination/stale-only" should not be exist
+    The contents of file "$home/.agents/skills/keep-me/marker" should equal 'preserved'
+  End
+
+  It 'keeps the installed review skill when the vendored skill file is missing'
+    skill_destination="$home/.agents/skills/receiving-code-review"
+    mkdir -p "$skill_destination"
+    printf '%s\n' 'installed skill' > "$skill_destination/SKILL.md"
+    rm "$skill_source/SKILL.md"
+    When run sh "$script_abs" "$repository"
+    The status should not equal 0
+    The stderr should include "required vendored skill '$skill_source/SKILL.md' is missing"
+    The contents of file "$skill_destination/SKILL.md" should equal 'installed skill'
+    The directory "$home/.agents/skills/.receiving-code-review.new" should not be exist
+  End
+
+  It 'keeps the installed review skill when the vendored license is missing'
+    skill_destination="$home/.agents/skills/receiving-code-review"
+    mkdir -p "$skill_destination"
+    printf '%s\n' 'installed skill' > "$skill_destination/SKILL.md"
+    rm "$skill_source/LICENSE"
+    When run sh "$script_abs" "$repository"
+    The status should not equal 0
+    The stderr should include "required vendored skill license '$skill_source/LICENSE' is missing"
+    The contents of file "$skill_destination/SKILL.md" should equal 'installed skill'
+    The directory "$home/.agents/skills/.receiving-code-review.new" should not be exist
+  End
+
+  It 'keeps the installed review skill and removes staging when its refresh copy fails'
+    skill_destination="$home/.agents/skills/receiving-code-review"
+    mkdir -p "$skill_destination" "$home/.agents/skills/keep-me"
+    printf '%s\n' 'installed skill' > "$skill_destination/SKILL.md"
+    printf '%s\n' 'installed license' > "$skill_destination/LICENSE"
+    printf '%s\n' 'preserved' > "$home/.agents/skills/keep-me/marker"
+    export DEBIAN_SKILL_SOURCE="$skill_source"
+    export DEBIAN_REAL_CP="$basebin/cp"
+    cat > "$activebin/cp" <<'FAIL_SKILL_COPY'
+#!/bin/sh
+if [ "$#" -eq 3 ] && [ "$1" = -R ] && [ "$2" = "$DEBIAN_SKILL_SOURCE" ]; then
+  exit 77
+fi
+exec "$DEBIAN_REAL_CP" "$@"
+FAIL_SKILL_COPY
+    chmod +x "$activebin/cp"
+    When run sh "$script_abs" "$repository"
+    The status should not equal 0
+    The contents of file "$skill_destination/SKILL.md" should equal 'installed skill'
+    The contents of file "$skill_destination/LICENSE" should equal 'installed license'
+    The directory "$home/.agents/skills/.receiving-code-review.new" should not be exist
+    The contents of file "$home/.agents/skills/keep-me/marker" should equal 'preserved'
   End
 
   It 'resolves every initial Linux tool from its configured destination immediately'

--- a/tests/shell/agent_tools_setup_spec.sh
+++ b/tests/shell/agent_tools_setup_spec.sh
@@ -425,6 +425,8 @@ GROK
     skill_destination="$home/.agents/skills/receiving-code-review"
     mkdir -p "$skill_destination"
     printf '%s\n' 'installed skill' > "$skill_destination/SKILL.md"
+    mkdir -p "$home/.agents/skills/.receiving-code-review.new"
+    printf '%s\n' 'stale stage' > "$home/.agents/skills/.receiving-code-review.new/marker"
     rm "$skill_source/SKILL.md"
     When run sh "$script_abs" "$repository"
     The status should not equal 0
@@ -437,6 +439,8 @@ GROK
     skill_destination="$home/.agents/skills/receiving-code-review"
     mkdir -p "$skill_destination"
     printf '%s\n' 'installed skill' > "$skill_destination/SKILL.md"
+    mkdir -p "$home/.agents/skills/.receiving-code-review.new"
+    printf '%s\n' 'stale stage' > "$home/.agents/skills/.receiving-code-review.new/marker"
     rm "$skill_source/LICENSE"
     When run sh "$script_abs" "$repository"
     The status should not equal 0
@@ -456,6 +460,8 @@ GROK
     cat > "$activebin/cp" <<'FAIL_SKILL_COPY'
 #!/bin/sh
 if [ "$#" -eq 3 ] && [ "$1" = -R ] && [ "$2" = "$DEBIAN_SKILL_SOURCE" ]; then
+  mkdir -p "$3"
+  printf '%s\n' partial > "$3/partial"
   exit 77
 fi
 exec "$DEBIAN_REAL_CP" "$@"
@@ -467,6 +473,30 @@ FAIL_SKILL_COPY
     The contents of file "$skill_destination/LICENSE" should equal 'installed license'
     The directory "$home/.agents/skills/.receiving-code-review.new" should not be exist
     The contents of file "$home/.agents/skills/keep-me/marker" should equal 'preserved'
+  End
+
+  It 'restores the installed review skill when publishing its refresh fails'
+    skill_destination="$home/.agents/skills/receiving-code-review"
+    mkdir -p "$skill_destination"
+    printf '%s\n' 'installed skill' > "$skill_destination/SKILL.md"
+    printf '%s\n' 'installed license' > "$skill_destination/LICENSE"
+    export DEBIAN_SKILL_STAGED="$home/.agents/skills/.receiving-code-review.new"
+    export DEBIAN_SKILL_DESTINATION="$skill_destination"
+    export DEBIAN_REAL_MV="$basebin/mv"
+    cat > "$activebin/mv" <<'FAIL_SKILL_PUBLISH'
+#!/bin/sh
+if [ "$#" -eq 2 ] && [ "$1" = "$DEBIAN_SKILL_STAGED" ] && [ "$2" = "$DEBIAN_SKILL_DESTINATION" ]; then
+  exit 77
+fi
+exec "$DEBIAN_REAL_MV" "$@"
+FAIL_SKILL_PUBLISH
+    chmod +x "$activebin/mv"
+    When run sh "$script_abs" "$repository"
+    The status should not equal 0
+    The contents of file "$skill_destination/SKILL.md" should equal 'installed skill'
+    The contents of file "$skill_destination/LICENSE" should equal 'installed license'
+    The directory "$home/.agents/skills/.receiving-code-review.new" should not be exist
+    The directory "$home/.agents/skills/.receiving-code-review.old" should not be exist
   End
 
   It 'resolves every initial Linux tool from its configured destination immediately'


### PR DESCRIPTION
## Summary

- Vendor the upstream MIT-licensed `receiving-code-review` skill as a byte-faithful provisioning asset.
- Refresh the managed global skill directory through `setup-agent-tools.sh` while preserving an existing install if validation, copying, or staged publication fails.
- Cover clean install, stale refresh, repeat execution, validation failures, partial-copy cleanup, publication rollback, and unrelated sibling preservation.

The corresponding `ai-harness-settings` snapshots remove the Superpowers OMP installation and retain this standalone skill for both machine profiles. The active OMP installation has been fully uninstalled; Claude, Codex, Copilot, and Grok had no Superpowers installation.

## Verification

| Frozen RED test | git hash-object | RED run tail |
| --- | --- | --- |
| `tests/shell/agent_tools_setup_spec.sh` | `b8a7e17c1e145a7a0935969852abc06141bea41c` | `FAILED publish rollback lost the installed skill on f1160e9a` |

- RED: the shipped test file above was re-executed against the prior PR head; its publication-failure example lost the installed skill and left staging behind.
- GREEN: `shellspec --shell dash tests/shell/agent_tools_setup_spec.sh` — 48 examples, 0 failures.
- Mutation probes: removing source guards, copy cleanup, or failure-safe publication each made the matching preservation assertion fail.
- `scripts/agent/run-gates.sh --diff origin/devel` — all gates pass after review fixes.
- Fresh OMP session: `receiving-code-review=yes`; `using-superpowers=no`.
- Condensed adversarial review: one test-honesty blocker found and fixed; all other changed files clean.
- Copilot and CodeRabbit findings: staged publication rollback, stale-stage cleanup, and partial-copy test honesty fixed in `59970ed3`.

Fixes #3252