### PR TITLE
agent: add curated standalone skill setup

### DIFF
--- a/.agents/context/repository-intelligence.md
+++ b/.agents/context/repository-intelligence.md
@@ -9,10 +9,11 @@ Load when: every agent session, from `AGENTS.md`.
   Graphify, and Worktrunk; configures only detected clients; disables Serena's web
   dashboard; and keeps Worktrunk worktrees outside the repository root.
 - Optionally add or refresh the project's curated third-party skills for every
-  supported agent with `sh scripts/agent/setup-agent-skills.sh`. The command is
-  additive: it leaves collaborators' other skills alone. Repository-owned skills
-  under `.agents/skills/` and the vendored `receiving-code-review` installer remain
-  authoritative.
+  supported agent with `sh scripts/agent/setup-agent-skills.sh`. The command
+  leaves other skill names alone and refuses to overwrite an existing selected
+  name unless the skills CLI records it as managed from the expected upstream.
+  Repository-owned skills under `.agents/skills/` and the vendored
+  `receiving-code-review` installer remain authoritative.
 - Every agent tool installs through one command that both installs on a fresh host
   and upgrades an outdated one — `uv tool install --upgrade <tool>`, `codegraph upgrade`,
   or the tool's own installer. A `>=` floor rides along only when a minimum release is

--- a/.agents/context/repository-intelligence.md
+++ b/.agents/context/repository-intelligence.md
@@ -8,6 +8,11 @@ Load when: every agent session, from `AGENTS.md`.
   never updates an installed one (#3106); installs or updates Serena, CodeGraph,
   Graphify, and Worktrunk; configures only detected clients; disables Serena's web
   dashboard; and keeps Worktrunk worktrees outside the repository root.
+- Optionally add or refresh the project's curated third-party skills for every
+  supported agent with `sh scripts/agent/setup-agent-skills.sh`. The command is
+  additive: it leaves collaborators' other skills alone. Repository-owned skills
+  under `.agents/skills/` and the vendored `receiving-code-review` installer remain
+  authoritative.
 - Every agent tool installs through one command that both installs on a fresh host
   and upgrades an outdated one — `uv tool install --upgrade <tool>`, `codegraph upgrade`,
   or the tool's own installer. A `>=` floor rides along only when a minimum release is

--- a/graphify-out/memory/query_20260909_231358_bfeac547_ai_collaborator_setup_skills_plugin_installation_s.md
+++ b/graphify-out/memory/query_20260909_231358_bfeac547_ai_collaborator_setup_skills_plugin_installation_s.md
@@ -1,0 +1,19 @@
+---
+type: "query"
+date: "2026-09-09T23:13:58.554666+00:00"
+question: "AI collaborator setup skills plugin installation scripts .agents skills-lock.json"
+contributor: "graphify"
+outcome: "dead_end"
+correction: "The setup surface is scripts/agent/setup-agent-tools.sh; repository policy forbids vendored third-party skills and skills-lock.json."
+---
+
+# Q: AI collaborator setup skills plugin installation scripts .agents skills-lock.json
+
+## Answer
+
+Query returned unrelated runtime symbols and did not locate configuration scripts.
+
+## Outcome
+
+- Signal: dead_end
+- Correction: The setup surface is scripts/agent/setup-agent-tools.sh; repository policy forbids vendored third-party skills and skills-lock.json.

--- a/graphify-out/memory/query_20260909_235941_5facafb7_scripts_check_coverage_pairing_py_coverage_pairing.md
+++ b/graphify-out/memory/query_20260909_235941_5facafb7_scripts_check_coverage_pairing_py_coverage_pairing.md
@@ -1,0 +1,23 @@
+---
+type: "query"
+date: "2026-09-09T23:59:41.945334+00:00"
+question: "scripts/check_coverage_pairing.py Coverage pairing workflow base SHA changed files scripts tests mapping"
+contributor: "graphify"
+outcome: "useful"
+source_nodes: ["scripts/check_coverage_pairing.py", ".github/workflows/test.yml"]
+---
+
+# Q: scripts/check_coverage_pairing.py Coverage pairing workflow base SHA changed files scripts tests mapping
+
+## Answer
+
+Coverage pairing treats scripts/ as release-plane behavior and validates PR-body Frozen RED evidence in CI; local uncommitted pairing only proved a tests/ path was present.
+
+## Outcome
+
+- Signal: useful
+
+## Source Nodes
+
+- scripts/check_coverage_pairing.py
+- .github/workflows/test.yml

--- a/scripts/agent/setup-agent-skills.sh
+++ b/scripts/agent/setup-agent-skills.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Add or refresh the curated third-party skills for every supported agent.
+# Add or refresh curated third-party skills without replacing differently sourced names.
 
 set -eu
 
@@ -8,68 +8,186 @@ command -v npx >/dev/null 2>&1 || {
 	exit 1
 }
 
-npx --yes skills add addyosmani/agent-skills --global \
-	--agent claude-code --agent codex --agent github-copilot --agent grok --agent pi --yes \
-	--skill api-and-interface-design \
-	--skill ci-cd-and-automation \
-	--skill code-review-and-quality \
-	--skill code-simplification \
-	--skill constraint-driven-development \
-	--skill context-engineering \
-	--skill debugging-and-error-recovery \
-	--skill deprecation-and-migration \
-	--skill doubt-driven-development \
-	--skill git-workflow-and-versioning \
-	--skill idea-refine \
-	--skill incremental-implementation \
-	--skill observability-and-instrumentation \
-	--skill performance-optimization \
-	--skill planning-and-task-breakdown \
-	--skill security-and-hardening \
-	--skill shipping-and-launch \
-	--skill source-driven-development \
-	--skill spec-driven-development \
-	--skill test-driven-development \
-	--skill using-agent-skills
+skill_root=${AGENT_SKILLS_HOME:-"${HOME}/.agents"}
+skill_lock="$skill_root/.skill-lock.json"
 
-npx --yes skills add mattpocock/skills --global \
-	--agent claude-code --agent codex --agent github-copilot --agent grok --agent pi --yes \
-	--skill code-review \
-	--skill codebase-design \
-	--skill diagnosing-bugs \
-	--skill domain-modeling \
-	--skill grill-me \
-	--skill grill-with-docs \
-	--skill handoff \
-	--skill implement \
-	--skill improve-codebase-architecture \
-	--skill prototype \
-	--skill research \
-	--skill resolving-merge-conflicts \
-	--skill tdd \
-	--skill teach \
-	--skill to-spec \
-	--skill to-tickets \
-	--skill triage \
-	--skill wait-what \
-	--skill wayfinder \
-	--skill writing-for-agents
+preflight_source() {
+	source=$1
+	shift
+	node -e '
+const fs = require("node:fs");
+const path = require("node:path");
+const [root, lockPath, source, ...skills] = process.argv.slice(1);
+const home = process.env.HOME;
+const agentRoots = [
+	path.join(process.env.CLAUDE_CONFIG_DIR || path.join(home, ".claude"), "skills"),
+	path.join(process.env.GROK_HOME || path.join(home, ".grok"), "skills"),
+	path.join(home, ".pi", "agent", "skills"),
+];
+let lock = { skills: {} };
+try {
+	lock = JSON.parse(fs.readFileSync(lockPath, "utf8"));
+} catch (error) {
+	if (error.code !== "ENOENT") throw error;
+}
+const exists = (candidate) => {
+	try {
+		fs.lstatSync(candidate);
+		return true;
+	} catch (error) {
+		if (error.code === "ENOENT") return false;
+		throw error;
+	}
+};
+const sameTree = (left, right) => {
+	const leftStat = fs.lstatSync(left);
+	const rightStat = fs.lstatSync(right);
+	if (leftStat.isSymbolicLink() || rightStat.isSymbolicLink()) {
+		return leftStat.isSymbolicLink() && rightStat.isSymbolicLink()
+			&& fs.readlinkSync(left) === fs.readlinkSync(right);
+	}
+	if (leftStat.isDirectory() || rightStat.isDirectory()) {
+		if (!leftStat.isDirectory() || !rightStat.isDirectory()) return false;
+		const leftNames = fs.readdirSync(left).sort();
+		const rightNames = fs.readdirSync(right).sort();
+		return leftNames.length === rightNames.length
+			&& leftNames.every((name, index) =>
+				name === rightNames[index] && sameTree(path.join(left, name), path.join(right, name)),
+			);
+	}
+	return leftStat.isFile() && rightStat.isFile()
+		&& fs.readFileSync(left).equals(fs.readFileSync(right));
+};
+const refuse = (skill) => {
+	console.error(
+		"setup-agent-skills.sh: refusing to overwrite " + skill + "; existing skill is not managed from " + source,
+	);
+	process.exitCode = 1;
+};
+for (const skill of skills) {
+	const canonical = path.join(root, "skills", skill);
+	const canonicalExists = exists(canonical);
+	if (canonicalExists && lock.skills?.[skill]?.source !== source) {
+		refuse(skill);
+		continue;
+	}
+	for (const agentRoot of agentRoots) {
+		const target = path.join(agentRoot, skill);
+		if (!exists(target)) continue;
+		try {
+			if (canonicalExists && (
+				fs.realpathSync(target) === fs.realpathSync(canonical) || sameTree(target, canonical)
+			)) continue;
+		} catch {}
+		refuse(skill);
+	}
+}
+' "$skill_root" "$skill_lock" "$source" "$@"
+}
 
-npx --yes skills add JuliusBrussee/caveman --global \
-	--agent claude-code --agent codex --agent github-copilot --agent grok --agent pi --yes \
-	--skill cavecrew \
-	--skill caveman \
-	--skill caveman-commit \
-	--skill caveman-compress \
-	--skill caveman-explore \
-	--skill caveman-review \
-	--skill investigate-first \
-	--skill migration \
-	--skill surgical-patch \
-	--skill verify-and-stop
+install_source() {
+	source=$1
+	shift
+	if output=$(npx --yes skills add "$source" --global \
+		--agent claude-code codex github-copilot grok pi --yes \
+		--skill "$@" 2>&1)
+	then
+		:
+	else
+		status=$?
+		if [ -n "$output" ]; then
+			printf '%s\n' "$output" >&2
+		fi
+		return "$status"
+	fi
+	case $output in
+		*'Failed to install '*)
+			printf '%s\n' "$output" >&2
+			printf '%s\n' 'setup-agent-skills.sh: skills reported an installation failure' >&2
+			return 1
+			;;
+	esac
+	if [ -n "$output" ]; then
+		printf '%s\n' "$output"
+	fi
+}
 
-npx --yes skills add DietrichGebert/ponytail --global \
-	--agent claude-code --agent codex --agent github-copilot --agent grok --agent pi --yes \
-	--skill ponytail \
-	--skill ponytail-audit \
-	--skill ponytail-review
+addy_skills() {
+	"$1" addyosmani/agent-skills \
+		api-and-interface-design \
+		ci-cd-and-automation \
+		code-review-and-quality \
+		code-simplification \
+		constraint-driven-development \
+		context-engineering \
+		debugging-and-error-recovery \
+		deprecation-and-migration \
+		doubt-driven-development \
+		git-workflow-and-versioning \
+		idea-refine \
+		incremental-implementation \
+		observability-and-instrumentation \
+		performance-optimization \
+		planning-and-task-breakdown \
+		security-and-hardening \
+		shipping-and-launch \
+		source-driven-development \
+		spec-driven-development \
+		test-driven-development \
+		using-agent-skills
+}
+
+matt_skills() {
+	"$1" mattpocock/skills \
+		code-review \
+		codebase-design \
+		diagnosing-bugs \
+		domain-modeling \
+		grill-me \
+		grill-with-docs \
+		handoff \
+		implement \
+		improve-codebase-architecture \
+		prototype \
+		research \
+		resolving-merge-conflicts \
+		tdd \
+		teach \
+		to-spec \
+		to-tickets \
+		triage \
+		wait-what \
+		wayfinder \
+		writing-for-agents
+}
+
+caveman_skills() {
+	"$1" JuliusBrussee/caveman \
+		cavecrew \
+		caveman \
+		caveman-commit \
+		caveman-compress \
+		caveman-explore \
+		caveman-review \
+		investigate-first \
+		migration \
+		surgical-patch \
+		verify-and-stop
+}
+
+ponytail_skills() {
+	"$1" DietrichGebert/ponytail \
+		ponytail \
+		ponytail-audit \
+		ponytail-review
+}
+
+addy_skills preflight_source
+matt_skills preflight_source
+caveman_skills preflight_source
+ponytail_skills preflight_source
+
+addy_skills install_source
+matt_skills install_source
+caveman_skills install_source
+ponytail_skills install_source

--- a/scripts/agent/setup-agent-skills.sh
+++ b/scripts/agent/setup-agent-skills.sh
@@ -1,0 +1,75 @@
+#!/bin/sh
+# Add or refresh the curated third-party skills for every supported agent.
+
+set -eu
+
+command -v npx >/dev/null 2>&1 || {
+	printf '%s\n' 'setup-agent-skills.sh: npx is required' >&2
+	exit 1
+}
+
+npx --yes skills add addyosmani/agent-skills --global \
+	--agent claude-code --agent codex --agent github-copilot --agent grok --agent pi --yes \
+	--skill api-and-interface-design \
+	--skill ci-cd-and-automation \
+	--skill code-review-and-quality \
+	--skill code-simplification \
+	--skill constraint-driven-development \
+	--skill context-engineering \
+	--skill debugging-and-error-recovery \
+	--skill deprecation-and-migration \
+	--skill doubt-driven-development \
+	--skill git-workflow-and-versioning \
+	--skill idea-refine \
+	--skill incremental-implementation \
+	--skill observability-and-instrumentation \
+	--skill performance-optimization \
+	--skill planning-and-task-breakdown \
+	--skill security-and-hardening \
+	--skill shipping-and-launch \
+	--skill source-driven-development \
+	--skill spec-driven-development \
+	--skill test-driven-development \
+	--skill using-agent-skills
+
+npx --yes skills add mattpocock/skills --global \
+	--agent claude-code --agent codex --agent github-copilot --agent grok --agent pi --yes \
+	--skill code-review \
+	--skill codebase-design \
+	--skill diagnosing-bugs \
+	--skill domain-modeling \
+	--skill grill-me \
+	--skill grill-with-docs \
+	--skill handoff \
+	--skill implement \
+	--skill improve-codebase-architecture \
+	--skill prototype \
+	--skill research \
+	--skill resolving-merge-conflicts \
+	--skill tdd \
+	--skill teach \
+	--skill to-spec \
+	--skill to-tickets \
+	--skill triage \
+	--skill wait-what \
+	--skill wayfinder \
+	--skill writing-for-agents
+
+npx --yes skills add JuliusBrussee/caveman --global \
+	--agent claude-code --agent codex --agent github-copilot --agent grok --agent pi --yes \
+	--skill cavecrew \
+	--skill caveman \
+	--skill caveman-commit \
+	--skill caveman-compress \
+	--skill caveman-explore \
+	--skill caveman-review \
+	--skill investigate-first \
+	--skill migration \
+	--skill surgical-patch \
+	--skill verify-and-stop
+
+npx --yes skills add DietrichGebert/ponytail --global \
+	--agent claude-code --agent codex --agent github-copilot --agent grok --agent pi --yes \
+	--skill ponytail \
+	--skill ponytail-audit \
+	--skill ponytail-review

--- a/tests/shell/agent_skills_setup_spec.sh
+++ b/tests/shell/agent_skills_setup_spec.sh
@@ -11,13 +11,22 @@ Describe 'setup-agent-skills.sh'
     bin="$fixture/bin"
     skill_log="$fixture/skills.log"
     mkdir -p "$bin"
+    home="$fixture/home"
+    mkdir -p "$home"
+    export HOME="$home"
+    export AGENT_SKILLS_HOME="$home/.agents"
     cat > "$bin/npx" <<'NPX'
 #!/bin/sh
 printf 'npx:%s\n' "$*" >> "$AGENT_SKILLS_LOG"
+if [ "${AGENT_SKILLS_NPX_PARTIAL_FAILURE:-0}" = 1 ]; then
+  printf '%s\n' 'Failed to install 1' >&2
+fi
 NPX
     chmod +x "$bin/npx"
     export AGENT_SKILLS_LOG="$skill_log"
-    PATH="$bin:/usr/bin:/bin"; export PATH
+    unset AGENT_SKILLS_NPX_PARTIAL_FAILURE
+    node_bin=$(dirname "$(command -v node)")
+    PATH="$bin:$node_bin:/usr/bin:/bin"; export PATH
   }
 
   cleanup() {
@@ -31,10 +40,49 @@ NPX
     When run sh "$script_abs"
     The status should equal 0
     The contents of file "$skill_log" should equal "$(printf '%s\n' \
-      'npx:--yes skills add addyosmani/agent-skills --global --agent claude-code --agent codex --agent github-copilot --agent grok --agent pi --yes --skill api-and-interface-design --skill ci-cd-and-automation --skill code-review-and-quality --skill code-simplification --skill constraint-driven-development --skill context-engineering --skill debugging-and-error-recovery --skill deprecation-and-migration --skill doubt-driven-development --skill git-workflow-and-versioning --skill idea-refine --skill incremental-implementation --skill observability-and-instrumentation --skill performance-optimization --skill planning-and-task-breakdown --skill security-and-hardening --skill shipping-and-launch --skill source-driven-development --skill spec-driven-development --skill test-driven-development --skill using-agent-skills' \
-      'npx:--yes skills add mattpocock/skills --global --agent claude-code --agent codex --agent github-copilot --agent grok --agent pi --yes --skill code-review --skill codebase-design --skill diagnosing-bugs --skill domain-modeling --skill grill-me --skill grill-with-docs --skill handoff --skill implement --skill improve-codebase-architecture --skill prototype --skill research --skill resolving-merge-conflicts --skill tdd --skill teach --skill to-spec --skill to-tickets --skill triage --skill wait-what --skill wayfinder --skill writing-for-agents' \
-      'npx:--yes skills add JuliusBrussee/caveman --global --agent claude-code --agent codex --agent github-copilot --agent grok --agent pi --yes --skill cavecrew --skill caveman --skill caveman-commit --skill caveman-compress --skill caveman-explore --skill caveman-review --skill investigate-first --skill migration --skill surgical-patch --skill verify-and-stop' \
-      'npx:--yes skills add DietrichGebert/ponytail --global --agent claude-code --agent codex --agent github-copilot --agent grok --agent pi --yes --skill ponytail --skill ponytail-audit --skill ponytail-review')"
+      'npx:--yes skills add addyosmani/agent-skills --global --agent claude-code codex github-copilot grok pi --yes --skill api-and-interface-design ci-cd-and-automation code-review-and-quality code-simplification constraint-driven-development context-engineering debugging-and-error-recovery deprecation-and-migration doubt-driven-development git-workflow-and-versioning idea-refine incremental-implementation observability-and-instrumentation performance-optimization planning-and-task-breakdown security-and-hardening shipping-and-launch source-driven-development spec-driven-development test-driven-development using-agent-skills' \
+      'npx:--yes skills add mattpocock/skills --global --agent claude-code codex github-copilot grok pi --yes --skill code-review codebase-design diagnosing-bugs domain-modeling grill-me grill-with-docs handoff implement improve-codebase-architecture prototype research resolving-merge-conflicts tdd teach to-spec to-tickets triage wait-what wayfinder writing-for-agents' \
+      'npx:--yes skills add JuliusBrussee/caveman --global --agent claude-code codex github-copilot grok pi --yes --skill cavecrew caveman caveman-commit caveman-compress caveman-explore caveman-review investigate-first migration surgical-patch verify-and-stop' \
+      'npx:--yes skills add DietrichGebert/ponytail --global --agent claude-code codex github-copilot grok pi --yes --skill ponytail ponytail-audit ponytail-review')"
+  End
+
+  It 'refuses to overwrite a selected skill from another source'
+    mkdir -p "$AGENT_SKILLS_HOME/skills/code-review"
+    printf '%s\n' 'collaborator custom skill' > "$AGENT_SKILLS_HOME/skills/code-review/SKILL.md"
+    When run sh "$script_abs"
+    The status should not equal 0
+    The stderr should include 'refusing to overwrite code-review'
+    The contents of file "$AGENT_SKILLS_HOME/skills/code-review/SKILL.md" should equal 'collaborator custom skill'
+    The file "$skill_log" should not be exist
+  End
+
+  It 'refuses to overwrite a selected agent-specific skill'
+    mkdir -p "$AGENT_SKILLS_HOME/skills/tdd" "$HOME/.claude/skills/tdd"
+    printf '%s\n' 'managed upstream skill' > "$AGENT_SKILLS_HOME/skills/tdd/SKILL.md"
+    printf '%s\n' '{"version":3,"skills":{"tdd":{"source":"mattpocock/skills"}}}' > "$AGENT_SKILLS_HOME/.skill-lock.json"
+    printf '%s\n' 'collaborator Claude skill' > "$HOME/.claude/skills/tdd/SKILL.md"
+    When run sh "$script_abs"
+    The status should not equal 0
+    The stderr should include 'refusing to overwrite tdd'
+    The contents of file "$HOME/.claude/skills/tdd/SKILL.md" should equal 'collaborator Claude skill'
+    The file "$skill_log" should not be exist
+  End
+
+  It 'refreshes an agent-specific copy managed from the expected source'
+    mkdir -p "$AGENT_SKILLS_HOME/skills/tdd" "$HOME/.claude/skills/tdd"
+    printf '%s\n' 'managed upstream skill' > "$AGENT_SKILLS_HOME/skills/tdd/SKILL.md"
+    printf '%s\n' 'managed upstream skill' > "$HOME/.claude/skills/tdd/SKILL.md"
+    printf '%s\n' '{"version":3,"skills":{"tdd":{"source":"mattpocock/skills"}}}' > "$AGENT_SKILLS_HOME/.skill-lock.json"
+    When run sh "$script_abs"
+    The status should equal 0
+    The contents of file "$skill_log" should include 'npx:--yes skills add mattpocock/skills'
+  End
+
+  It 'fails when the skills CLI reports a partial installation'
+    export AGENT_SKILLS_NPX_PARTIAL_FAILURE=1
+    When run sh "$script_abs"
+    The status should not equal 0
+    The stderr should include 'skills reported an installation failure'
   End
 
   It 'fails before installation when npx is unavailable'
@@ -42,6 +90,5 @@ NPX
     When run /usr/bin/env PATH="$fixture/empty" /bin/sh "$script_abs"
     The status should not equal 0
     The stderr should include 'npx is required'
-    The file "$skill_log" should not be exist
   End
 End

--- a/tests/shell/agent_skills_setup_spec.sh
+++ b/tests/shell/agent_skills_setup_spec.sh
@@ -1,0 +1,47 @@
+#shellcheck shell=sh
+# Curated third-party skills are installed additively for every supported agent.
+
+Describe 'setup-agent-skills.sh'
+  project_root="${SHELLSPEC_PROJECT_ROOT:-$PWD}"
+  script_abs="$project_root/scripts/agent/setup-agent-skills.sh"
+
+  setup() {
+    fixture=$(mktemp -d "${TMPDIR:-/tmp}/agent_skills_setup.XXXXXX") || return 1
+    fixture=$(cd "$fixture" && pwd -P) || return 1
+    bin="$fixture/bin"
+    skill_log="$fixture/skills.log"
+    mkdir -p "$bin"
+    cat > "$bin/npx" <<'NPX'
+#!/bin/sh
+printf 'npx:%s\n' "$*" >> "$AGENT_SKILLS_LOG"
+NPX
+    chmod +x "$bin/npx"
+    export AGENT_SKILLS_LOG="$skill_log"
+    PATH="$bin:/usr/bin:/bin"; export PATH
+  }
+
+  cleanup() {
+    rm -rf "$fixture"
+  }
+
+  BeforeEach 'setup'
+  AfterEach 'cleanup'
+
+  It 'installs only the curated skills for every project-supported agent'
+    When run sh "$script_abs"
+    The status should equal 0
+    The contents of file "$skill_log" should equal "$(printf '%s\n' \
+      'npx:--yes skills add addyosmani/agent-skills --global --agent claude-code --agent codex --agent github-copilot --agent grok --agent pi --yes --skill api-and-interface-design --skill ci-cd-and-automation --skill code-review-and-quality --skill code-simplification --skill constraint-driven-development --skill context-engineering --skill debugging-and-error-recovery --skill deprecation-and-migration --skill doubt-driven-development --skill git-workflow-and-versioning --skill idea-refine --skill incremental-implementation --skill observability-and-instrumentation --skill performance-optimization --skill planning-and-task-breakdown --skill security-and-hardening --skill shipping-and-launch --skill source-driven-development --skill spec-driven-development --skill test-driven-development --skill using-agent-skills' \
+      'npx:--yes skills add mattpocock/skills --global --agent claude-code --agent codex --agent github-copilot --agent grok --agent pi --yes --skill code-review --skill codebase-design --skill diagnosing-bugs --skill domain-modeling --skill grill-me --skill grill-with-docs --skill handoff --skill implement --skill improve-codebase-architecture --skill prototype --skill research --skill resolving-merge-conflicts --skill tdd --skill teach --skill to-spec --skill to-tickets --skill triage --skill wait-what --skill wayfinder --skill writing-for-agents' \
+      'npx:--yes skills add JuliusBrussee/caveman --global --agent claude-code --agent codex --agent github-copilot --agent grok --agent pi --yes --skill cavecrew --skill caveman --skill caveman-commit --skill caveman-compress --skill caveman-explore --skill caveman-review --skill investigate-first --skill migration --skill surgical-patch --skill verify-and-stop' \
+      'npx:--yes skills add DietrichGebert/ponytail --global --agent claude-code --agent codex --agent github-copilot --agent grok --agent pi --yes --skill ponytail --skill ponytail-audit --skill ponytail-review')"
+  End
+
+  It 'fails before installation when npx is unavailable'
+    mkdir -p "$fixture/empty"
+    When run /usr/bin/env PATH="$fixture/empty" /bin/sh "$script_abs"
+    The status should not equal 0
+    The stderr should include 'npx is required'
+    The file "$skill_log" should not be exist
+  End
+End


### PR DESCRIPTION
## Summary

- add an opt-in `npx skills` installer for the curated third-party skill set
- target Claude Code, Codex, GitHub Copilot, Grok, and Pi/OMP without removing collaborator-owned skills
- refuse selected-name collisions, including agent-specific overrides, while allowing unchanged managed copies to refresh
- fail when the upstream CLI reports per-agent installation failures with a zero exit status

## Verification

- initial missing-script RED: `2 examples, 2 failures` at test blob `f33fe8ff72510c2af91bfac9c3cd020c8216d777`
- final managed-copy regression RED/GREEN: `6 examples, 1 failure` → `6 examples, 0 failures`
- `shellcheck scripts/agent/setup-agent-skills.sh tests/shell/agent_skills_setup_spec.sh`
- `pytest -q tests/test_cross_agent_tooling.py` (21 passed)
- `sh scripts/agent/run-gates.sh` (pass)
- live installer smoke: 54 external skills installed from four upstream repositories

| Frozen RED test | git hash-object | RED run tail |
| --- | --- | --- |
| `tests/shell/agent_skills_setup_spec.sh` | `571c2d41a13f9206c8039a8e2d1c3908f66a9238` | `6 examples, 1 failure` |

Fixes #3255
