### PR TITLE
tests: reap channel installer process groups

### DIFF
--- a/tests/test_channel_install.py
+++ b/tests/test_channel_install.py
@@ -1701,7 +1701,9 @@ def test_pkg_output_is_streamed_while_pkg_still_runs() -> None:
             stderr=subprocess.STDOUT,
             text=True,
             bufsize=1,
+            start_new_session=True,
         )
+        pgid = os.getpgid(proc.pid)
         seen: list[str] = []
         stream = proc.stdout
         assert stream is not None
@@ -1715,12 +1717,7 @@ def test_pkg_output_is_streamed_while_pkg_still_runs() -> None:
             still_running = proc.poll() is None
         finally:
             sentinel.write_text("")
-            try:
-                proc.wait(timeout=60)
-            except subprocess.TimeoutExpired:
-                proc.kill()
-                proc.wait(timeout=30)
-            reader.join(timeout=10)
+            _finish_install_process(proc, pgid, reader, completion_timeout=60.0)
 
         output = "".join(seen)
         assert proc.returncode == 0, output
@@ -1785,6 +1782,77 @@ def _install_sh_pids(pgid: int) -> list[str]:
     return [line for line in found.stdout.split() if line]
 
 
+def _process_group_members(pgid: int) -> list[tuple[int, str]]:
+    """Return every PID and state in one process group."""
+    found = subprocess.run(
+        ["ps", "-eo", "pid=,pgid=,stat="],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    members: list[tuple[int, str]] = []
+    for line in found.stdout.splitlines():
+        fields = line.split()
+        if len(fields) == 3 and int(fields[1]) == pgid:
+            members.append((int(fields[0]), fields[2]))
+    return members
+
+
+def _wait_for_no_live_process_group_members(pgid: int, *, timeout: float = 10.0) -> None:
+    """Wait until a process group has no members capable of doing more work."""
+    deadline = time.monotonic() + timeout
+    while True:
+        live = [(pid, state) for pid, state in _process_group_members(pgid) if not state.startswith("Z")]
+        if not live:
+            return
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise RuntimeError(
+                "salvage cap expired / stuck or environment: "
+                f"expected no live process-group members for pgid={pgid}; actual={live}"
+            )
+        time.sleep(min(0.05, remaining))
+
+
+def _finish_install_process(
+    proc: subprocess.Popen[str],
+    pgid: int,
+    reader: threading.Thread,
+    *,
+    completion_timeout: float,
+) -> None:
+    """Bound normal completion, then stop and reap every owned process and reader."""
+    with contextlib.suppress(subprocess.TimeoutExpired):
+        proc.wait(timeout=completion_timeout)
+    with contextlib.suppress(ProcessLookupError):
+        os.killpg(pgid, signal.SIGKILL)
+
+    group_error: RuntimeError | None = None
+    try:
+        _wait_for_no_live_process_group_members(pgid)
+    except RuntimeError as exc:
+        group_error = exc
+
+    parent_timeout: subprocess.TimeoutExpired | None = None
+    try:
+        proc.wait(timeout=10)
+    except subprocess.TimeoutExpired as exc:
+        parent_timeout = exc
+
+    reader.join(timeout=10)
+    if reader.is_alive() and proc.stdout is not None:
+        proc.stdout.close()
+        reader.join(timeout=1)
+    if proc.stdout is not None and not proc.stdout.closed:
+        proc.stdout.close()
+    if reader.is_alive():
+        raise RuntimeError(f"Python output reader outlived installer cleanup for pgid={pgid}") from group_error
+    if group_error is not None:
+        raise group_error
+    if parent_timeout is not None:
+        raise RuntimeError(f"installer parent could not be reaped for pgid={pgid}") from parent_timeout
+
+
 def test_output_reader_does_not_outlive_the_run() -> None:
     """install.sh streams pkg's output from a background reader. A background reader is
     an untracked wait, so it has to die with its task -- not reparent to PID 1 and poll
@@ -1808,13 +1876,12 @@ def test_output_reader_does_not_outlive_the_run() -> None:
             start_new_session=True,
         )
         pgid = os.getpgid(proc.pid)
+        seen: list[str] = []
+        stream = proc.stdout
+        assert stream is not None
+        reader = threading.Thread(target=lambda: seen.extend(stream), daemon=True)
+        reader.start()
         try:
-            seen: list[str] = []
-            stream = proc.stdout
-            assert stream is not None
-            reader = threading.Thread(target=lambda: seen.extend(stream), daemon=True)
-            reader.start()
-
             deadline = time.monotonic() + 15.0
             while time.monotonic() < deadline and not any(_STREAM_MARKER in ln for ln in seen):
                 time.sleep(0.05)
@@ -1836,13 +1903,89 @@ def test_output_reader_does_not_outlive_the_run() -> None:
                 f"the output reader outlived install.sh (pids {survivors}); it must stop when its parent is gone"
             )
         finally:
-            sentinel.write_text("")
-            for pid in _install_sh_pids(pgid):
-                with contextlib.suppress(ProcessLookupError, ValueError):
-                    os.kill(int(pid), signal.SIGKILL)
-            with contextlib.suppress(ProcessLookupError):
-                os.kill(proc.pid, signal.SIGKILL)
-            proc.wait(timeout=30)
+            _finish_install_process(proc, pgid, reader, completion_timeout=0.0)
+
+
+def test_install_process_cleanup_runs_after_assertion_failure() -> None:
+    """Failure cleanup kills a real non-install.sh descendant without touching another group."""
+    ready = threading.Event()
+    seen: list[str] = []
+    proc = subprocess.Popen(
+        ["sh", "-c", "printf 'ready\\n'; while :; do sleep 1; done"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        start_new_session=True,
+    )
+    stream = proc.stdout
+    assert stream is not None
+
+    def read_output() -> None:
+        for line in stream:
+            seen.append(line)
+            if line == "ready\n":
+                ready.set()
+
+    reader = threading.Thread(target=read_output, daemon=True)
+    reader.start()
+    unrelated = subprocess.Popen(["sleep", "30"], start_new_session=True)
+    try:
+        with pytest.raises(AssertionError, match="forced body failure"):
+            try:
+                assert ready.wait(timeout=5), f"fixture broken: target emitted no readiness line; got {seen!r}"
+                assert reader.is_alive(), "fixture broken: Python output reader exited before cleanup"
+                assert _process_group_members(proc.pid), "fixture broken: target group was not live"
+                raise AssertionError("forced body failure")
+            finally:
+                _finish_install_process(proc, proc.pid, reader, completion_timeout=0.0)
+
+        assert not [member for member in _process_group_members(proc.pid) if not member[1].startswith("Z")], (
+            "target process group remained live after failure cleanup"
+        )
+        assert not reader.is_alive(), "Python output reader remained live after failure cleanup"
+        assert stream.closed, "Python output stream remained open after failure cleanup"
+        assert unrelated.poll() is None, "cleanup killed an unrelated process group"
+    finally:
+        with contextlib.suppress(ProcessLookupError):
+            os.killpg(unrelated.pid, signal.SIGKILL)
+        unrelated.wait(timeout=5)
+
+
+def test_process_group_wait_treats_zombie_as_finished_and_absent_as_finished() -> None:
+    """A zombie cannot write, and a fully absent target is already clean."""
+    proc = subprocess.Popen(["sh", "-c", "exit 0"], start_new_session=True)
+    try:
+        deadline = time.monotonic() + 5.0
+        members = _process_group_members(proc.pid)
+        while not any(state.startswith("Z") for _, state in members) and time.monotonic() < deadline:
+            time.sleep(0.05)
+            members = _process_group_members(proc.pid)
+        assert any(state.startswith("Z") for _, state in members), (
+            f"fixture broken: child never became a zombie; members={members}"
+        )
+
+        _wait_for_no_live_process_group_members(proc.pid, timeout=0.0)
+        proc.wait(timeout=5)
+        assert not _process_group_members(proc.pid)
+        _wait_for_no_live_process_group_members(proc.pid, timeout=0.0)
+    finally:
+        with contextlib.suppress(ProcessLookupError):
+            os.killpg(proc.pid, signal.SIGKILL)
+        proc.wait(timeout=5)
+
+
+def test_process_group_wait_reports_live_member_at_bound() -> None:
+    """The salvage deadline fails loudly while a real group member can still work."""
+    proc = subprocess.Popen(["sleep", "30"], start_new_session=True)
+    try:
+        with pytest.raises(RuntimeError, match="expected no live process-group members") as caught:
+            _wait_for_no_live_process_group_members(proc.pid, timeout=0.0)
+        assert f"pgid={proc.pid}" in str(caught.value)
+        assert str(proc.pid) in str(caught.value)
+    finally:
+        with contextlib.suppress(ProcessLookupError):
+            os.killpg(proc.pid, signal.SIGKILL)
+        proc.wait(timeout=5)
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/test_channel_install.py
+++ b/tests/test_channel_install.py
@@ -1840,10 +1840,7 @@ def _finish_install_process(
         parent_timeout = exc
 
     reader.join(timeout=10)
-    if reader.is_alive() and proc.stdout is not None:
-        proc.stdout.close()
-        reader.join(timeout=1)
-    if proc.stdout is not None and not proc.stdout.closed:
+    if not reader.is_alive() and proc.stdout is not None and not proc.stdout.closed:
         proc.stdout.close()
     if reader.is_alive():
         raise RuntimeError(f"Python output reader outlived installer cleanup for pgid={pgid}") from group_error
@@ -1911,7 +1908,7 @@ def test_install_process_cleanup_runs_after_assertion_failure() -> None:
     ready = threading.Event()
     seen: list[str] = []
     proc = subprocess.Popen(
-        ["sh", "-c", "printf 'ready\\n'; while :; do sleep 1; done"],
+        ["sh", "-c", "printf 'ready\\n'; while true; do sleep 1; done"],
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
         text=True,

--- a/tests/test_channel_install_teardown_failure_regression.py
+++ b/tests/test_channel_install_teardown_failure_regression.py
@@ -1,0 +1,99 @@
+"""Failure-path coverage for the issue #3054 regression harness."""
+
+from __future__ import annotations
+
+import contextlib
+import importlib
+import os
+import signal
+import subprocess
+import threading
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+regression: Any = importlib.import_module("tests.test_channel_install_teardown_regression")
+
+
+def test_regression_wrapper_cleans_captured_group_when_inner_test_raises(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A subprocess captured before an inner failure is still killed and reaped."""
+    spawned: list[subprocess.Popen[str]] = []
+
+    def fail_after_spawn() -> None:
+        proc = regression.channel_install.subprocess.Popen(
+            ["sleep", "30"],
+            stdout=subprocess.PIPE,
+            text=True,
+            start_new_session=True,
+        )
+        spawned.append(proc)
+        raise RuntimeError("forced inner failure")
+
+    monkeypatch.setattr(
+        regression.channel_install,
+        "test_output_reader_does_not_outlive_the_run",
+        fail_after_spawn,
+    )
+    try:
+        with pytest.raises(RuntimeError, match="forced inner failure"):
+            regression.test_output_reader_teardown_kills_surviving_pkg_descendant(monkeypatch, tmp_path)
+        assert len(spawned) == 1, f"fixture broken: expected one captured process, got {len(spawned)}"
+        survivors = regression._live_group_pids(spawned[0].pid)
+        assert not survivors, f"regression wrapper leaked a process after inner failure: {survivors}"
+    finally:
+        for proc in spawned:
+            with contextlib.suppress(ProcessLookupError):
+                os.killpg(proc.pid, signal.SIGKILL)
+            proc.wait(timeout=5)
+
+
+def test_install_process_cleanup_fails_boundedly_when_an_escaped_writer_blocks_reader() -> None:
+    """An unowned pipe writer yields a bounded teardown error, never a blocking close."""
+    read_fd, write_fd = os.pipe()
+    proc = subprocess.Popen(["sleep", "30"], start_new_session=True)
+    stream = os.fdopen(read_fd, encoding="utf-8")
+    proc.stdout = stream
+    escaped = subprocess.Popen(["sleep", "30"], stdout=write_fd, start_new_session=True)
+    os.close(write_fd)
+
+    reader_started = threading.Event()
+
+    def read_output() -> None:
+        reader_started.set()
+        list(stream)
+
+    reader = threading.Thread(target=read_output, daemon=True)
+    reader.start()
+    assert reader_started.wait(timeout=5), "fixture broken: Python output reader did not start"
+
+    finished = threading.Event()
+    errors: list[Exception] = []
+
+    def finish() -> None:
+        try:
+            regression.channel_install._finish_install_process(proc, proc.pid, reader, completion_timeout=0.0)
+        except RuntimeError as exc:
+            errors.append(exc)
+        finally:
+            finished.set()
+
+    cleanup = threading.Thread(target=finish, daemon=True)
+    cleanup.start()
+    try:
+        assert finished.wait(timeout=12), "cleanup blocked while closing a stream with a live reader"
+        assert len(errors) == 1, f"expected one bounded reader error, got {errors!r}"
+        assert "Python output reader outlived installer cleanup" in str(errors[0])
+    finally:
+        with contextlib.suppress(ProcessLookupError):
+            os.killpg(escaped.pid, signal.SIGKILL)
+        escaped.wait(timeout=5)
+        cleanup.join(timeout=5)
+        with contextlib.suppress(ProcessLookupError):
+            os.killpg(proc.pid, signal.SIGKILL)
+        proc.wait(timeout=5)
+        reader.join(timeout=5)
+        if not stream.closed:
+            stream.close()

--- a/tests/test_channel_install_teardown_regression.py
+++ b/tests/test_channel_install_teardown_regression.py
@@ -71,9 +71,11 @@ def test_output_reader_teardown_kills_surviving_pkg_descendant(monkeypatch: pyte
         survivors = _live_group_pids(pgid)
         assert not survivors, f"installer process-group members outlived test teardown: {survivors}"
     finally:
-        if pgid > 0:
+        for captured_proc in capture:
+            captured_pgid = captured_proc.pid
             with contextlib.suppress(ProcessLookupError):
-                os.killpg(pgid, signal.SIGKILL)
+                os.killpg(captured_pgid, signal.SIGKILL)
             deadline = time.monotonic() + 5.0
-            while _live_group_pids(pgid) and time.monotonic() < deadline:
+            while _live_group_pids(captured_pgid) and time.monotonic() < deadline:
                 time.sleep(0.05)
+            captured_proc.wait(timeout=5)

--- a/tests/test_channel_install_teardown_regression.py
+++ b/tests/test_channel_install_teardown_regression.py
@@ -1,0 +1,79 @@
+"""Regression coverage for channel-installer subprocess teardown (issue #3054)."""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import shlex
+import signal
+import subprocess
+import time
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from tests import test_channel_install as channel_install
+
+
+def _live_group_pids(pgid: int) -> list[int]:
+    result = subprocess.run(
+        ["ps", "-eo", "pid=,pgid=,stat="],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return [
+        int(fields[0])
+        for line in result.stdout.splitlines()
+        if len(fields := line.split()) == 3 and int(fields[1]) == pgid and not fields[2].startswith("Z")
+    ]
+
+
+def test_output_reader_teardown_kills_surviving_pkg_descendant(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """A real blocked pkg descendant cannot outlive the install test's temporary root."""
+    started = tmp_path / "descendant-started"
+    release = tmp_path / "descendant-release"
+    original_stub = channel_install._PKG_STUB
+    original_popen = subprocess.Popen
+    capture: list[subprocess.Popen[str]] = []
+
+    stream_start = '        /bin/echo "pfb-stream-marker-2644"\n'
+    stream_start_with_marker = f"        printf 'started\\n' > {shlex.quote(str(started))}\n" + stream_start
+    post_unblock = f"""    if [ -f {shlex.quote(str(started))} ]; then
+        while [ ! -f {shlex.quote(str(release))} ]; do
+            sleep 0.1
+        done
+    fi
+"""
+    monkeypatch.setattr(
+        channel_install,
+        "_PKG_STUB",
+        original_stub.replace(stream_start, stream_start_with_marker, 1).replace(
+            '    _repo=""\n', post_unblock + '    _repo=""\n', 1
+        ),
+    )
+
+    def capture_popen(*args: Any, **kwargs: Any) -> subprocess.Popen[str]:
+        proc = original_popen(*args, **kwargs)
+        if kwargs.get("start_new_session") is True:
+            capture.append(proc)
+        return proc
+
+    monkeypatch.setattr(channel_install.subprocess, "Popen", capture_popen)
+
+    pgid = -1
+    try:
+        channel_install.test_output_reader_does_not_outlive_the_run()
+        assert started.exists(), "fixture broken: the real pkg descendant never reached its blocking call"
+        assert len(capture) == 1, f"expected one isolated installer process, captured {len(capture)}"
+        pgid = capture[0].pid
+        survivors = _live_group_pids(pgid)
+        assert not survivors, f"installer process-group members outlived test teardown: {survivors}"
+    finally:
+        if pgid > 0:
+            with contextlib.suppress(ProcessLookupError):
+                os.killpg(pgid, signal.SIGKILL)
+            deadline = time.monotonic() + 5.0
+            while _live_group_pids(pgid) and time.monotonic() < deadline:
+                time.sleep(0.05)

--- a/tests/test_channel_install_teardown_regression.py
+++ b/tests/test_channel_install_teardown_regression.py
@@ -46,13 +46,11 @@ def test_output_reader_teardown_kills_surviving_pkg_descendant(monkeypatch: pyte
         done
     fi
 """
-    monkeypatch.setattr(
-        channel_install,
-        "_PKG_STUB",
-        original_stub.replace(stream_start, stream_start_with_marker, 1).replace(
-            '    _repo=""\n', post_unblock + '    _repo=""\n', 1
-        ),
-    )
+    marked_stub = original_stub.replace(stream_start, stream_start_with_marker, 1)
+    assert marked_stub != original_stub, "fixture broken: the stream-start anchor is gone from _PKG_STUB"
+    patched_stub = marked_stub.replace('    _repo=""\n', post_unblock + '    _repo=""\n', 1)
+    assert patched_stub != marked_stub, "fixture broken: the descendant-block anchor is gone from _PKG_STUB"
+    monkeypatch.setattr(channel_install, "_PKG_STUB", patched_stub)
 
     def capture_popen(*args: Any, **kwargs: Any) -> subprocess.Popen[str]:
         proc = original_popen(*args, **kwargs)


### PR DESCRIPTION
## Summary

- isolate both installer subprocess fixtures in their own process sessions
- terminate and poll the entire owned process group, treating zombies as completed work
- reap the installer parent and join/close the Python output reader before temporary-directory removal
- cover successful, timed-out, assertion-failure, absent-group, zombie, unrelated-group, and live-member-boundary teardown paths

## Evidence

- Root-cause probe: after killing the parent and waiting for all `install.sh` PIDs to disappear, a live fake-`pkg` process remained in the same process group and wrote its post-unblock marker; reaping the parent did not remove it.
- Frozen regression hash: `cbf1ac5fb63861f079e31e92c5a17c969eb245e3`
- RED on pre-fix source: `1 failed`; `installer process-group members outlived test teardown: [2163537, 2163568]`
- GREEN unchanged: `1 passed in 2.21s`
- Focused file: `101 passed in 16.11s`
- Repeated orphan and streaming cases: five independent invocations, each `2 passed`
- Shell-only teardown mutant: frozen regression failed with surviving PIDs `[2170583, 2170635]`; the test's own cleanup removed both.

Fixes #3054


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded subprocess streaming coverage for process-group isolation and reliable cleanup.
  - Added regression tests ensuring cleanup occurs after assertion failures and handles missing, zombie, or lingering processes.
  - Verified teardown reports bounded errors instead of blocking when output readers remain alive.
  - Added coverage confirming unrelated process groups are not affected during installer cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->