### PR TITLE
tests: share the deferral lock harness

### DIFF
--- a/tests/php/CronDeferralExitCodeTest.php
+++ b/tests/php/CronDeferralExitCodeTest.php
@@ -6,6 +6,7 @@ use PHPUnit\Framework\TestCase;
 
 require_once __DIR__ . '/../../src/usr/local/pkg/pfblockerng/pfblockerng_cron.inc';
 require_once __DIR__ . '/support/FailingFlockStream.php';
+require_once __DIR__ . '/DeferralLockHarnessTrait.php';
 
 /**
  * Issue #2591: pfblockerng_sync_cron() keeps its established bool while exposing
@@ -16,15 +17,13 @@ require_once __DIR__ . '/support/FailingFlockStream.php';
  */
 final class CronDeferralExitCodeTest extends TestCase
 {
+	use DeferralLockHarnessTrait;
+
 	private string $dbdir = '';
 	private bool $hadPfb = FALSE;
 	private array $originalPfb = [];
 	private bool $hadConfig = FALSE;
 	private mixed $originalConfig = NULL;
-
-	/** Raw fds simulating ANOTHER process holding a lock. */
-	private $feedLockFp = NULL;
-	private $dispatchLockFp = NULL;
 
 	protected function setUp(): void
 	{
@@ -46,27 +45,12 @@ final class CronDeferralExitCodeTest extends TestCase
 		]);
 		$GLOBALS['config'] = [];
 
-		// No inherited locks: a leaked handle would make a deferral row pass vacuously
-		// (the reentrancy short-circuit returns TRUE without ever reaching the guard).
-		unset($GLOBALS['pfb_schedule_dispatch_lock'], $GLOBALS['pfb_feed_pass_lock']);
+		$this->resetDeferralLocks();
 	}
 
 	protected function tearDown(): void
 	{
-		foreach ([$this->feedLockFp, $this->dispatchLockFp] as $fp) {
-			if (is_resource($fp)) {
-				@flock($fp, LOCK_UN);
-				@fclose($fp);
-			}
-		}
-		$this->feedLockFp = $this->dispatchLockFp = NULL;
-
-		pfb_feed_pass_release();
-		if (isset($GLOBALS['pfb_schedule_dispatch_lock']) && is_resource($GLOBALS['pfb_schedule_dispatch_lock'])) {
-			@flock($GLOBALS['pfb_schedule_dispatch_lock'], LOCK_UN);
-			@fclose($GLOBALS['pfb_schedule_dispatch_lock']);
-		}
-		unset($GLOBALS['pfb_schedule_dispatch_lock'], $GLOBALS['pfb_feed_pass_lock']);
+		$this->releaseDeferralLocks();
 
 		foreach (glob("{$this->dbdir}/*") ?: [] as $path) {
 			is_dir($path) ? @rmdir($path) : @unlink($path);
@@ -85,17 +69,9 @@ final class CronDeferralExitCodeTest extends TestCase
 		}
 	}
 
-	private function mainLog(): string
-	{
-		$log = $GLOBALS['pfb']['log'];
-		return is_file($log) ? (string) file_get_contents($log) : '';
-	}
-
 	public function testDispatcherLockPreservesScheduledTrueAndNamesLock(): void
 	{
-		$this->dispatchLockFp = fopen("{$this->dbdir}/pfb_schedule_dispatch.lock", 'c');
-		$this->assertIsResource($this->dispatchLockFp, 'test setup: could not open the dispatcher lock');
-		$this->assertTrue(flock($this->dispatchLockFp, LOCK_EX), 'test setup: could not hold the dispatcher lock');
+		$this->holdDispatcherLock();
 		$deferredBy = NULL;
 
 		$result = pfblockerng_sync_cron(FALSE, 'both', FALSE, FALSE, $deferredBy);
@@ -108,9 +84,7 @@ final class CronDeferralExitCodeTest extends TestCase
 
 	public function testFeedPassLockPreservesScheduledTrueAndNamesLock(): void
 	{
-		$this->feedLockFp = fopen("{$this->dbdir}/pfb_feed_pass.lock", 'c');
-		$this->assertIsResource($this->feedLockFp, 'test setup: could not open the feed-pass lock');
-		$this->assertTrue(flock($this->feedLockFp, LOCK_EX), 'test setup: could not hold the feed-pass lock');
+		$this->holdFeedPassLock();
 		$deferredBy = NULL;
 
 		$result = pfblockerng_sync_cron(FALSE, 'both', FALSE, FALSE, $deferredBy);
@@ -123,9 +97,7 @@ final class CronDeferralExitCodeTest extends TestCase
 
 	public function testForceCheckFeedPassDeferralPreservesFalseAndNamesLock(): void
 	{
-		$this->feedLockFp = fopen("{$this->dbdir}/pfb_feed_pass.lock", 'c');
-		$this->assertIsResource($this->feedLockFp, 'test setup: could not open the feed-pass lock');
-		$this->assertTrue(flock($this->feedLockFp, LOCK_EX), 'test setup: could not hold the feed-pass lock');
+		$this->holdFeedPassLock();
 		$deferredBy = NULL;
 
 		$result = pfblockerng_sync_cron(TRUE, 'both', FALSE, FALSE, $deferredBy);
@@ -138,9 +110,7 @@ final class CronDeferralExitCodeTest extends TestCase
 
 	public function testForceCheckDispatcherDeferralPreservesFalseAndNamesLock(): void
 	{
-		$this->dispatchLockFp = fopen("{$this->dbdir}/pfb_schedule_dispatch.lock", 'c');
-		$this->assertIsResource($this->dispatchLockFp, 'test setup: could not open the dispatcher lock');
-		$this->assertTrue(flock($this->dispatchLockFp, LOCK_EX), 'test setup: could not hold the dispatcher lock');
+		$this->holdDispatcherLock();
 		$deferredBy = NULL;
 
 		$result = pfblockerng_sync_cron(TRUE, 'both', FALSE, FALSE, $deferredBy);

--- a/tests/php/DeferralLockHarnessTrait.php
+++ b/tests/php/DeferralLockHarnessTrait.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Assert;
+
+/** Shared lock contention and log readers; consuming suites own paths and fixture lifecycle. */
+trait DeferralLockHarnessTrait
+{
+	/** @var array<int, resource> Raw holds simulate another process; never publish them in lock globals. */
+	private array $rawFps = [];
+
+	private function mainLog(): string
+	{
+		$log = $GLOBALS['pfb']['log'];
+		return is_file($log) ? (string) file_get_contents($log) : '';
+	}
+
+	private function syslogMessages(): string
+	{
+		return implode("\n", array_column($GLOBALS['pfb_test_logger_calls'] ?? [], 'message'));
+	}
+
+	private function holdDispatcherLock(): void
+	{
+		$fp = fopen("{$GLOBALS['pfb']['schedule_state_dir']}/pfb_schedule_dispatch.lock", 'c');
+		Assert::assertIsResource($fp, 'test setup: could not open the dispatcher lock');
+		$this->rawFps[] = $fp;
+		Assert::assertTrue(flock($fp, LOCK_EX), 'test setup: could not hold the dispatcher lock');
+	}
+
+	private function holdFeedPassLock(): void
+	{
+		$fp = fopen("{$GLOBALS['pfb']['dbdir']}/pfb_feed_pass.lock", 'c');
+		Assert::assertIsResource($fp, 'test setup: could not open the feed-pass lock');
+		$this->rawFps[] = $fp;
+		Assert::assertTrue(flock($fp, LOCK_EX), 'test setup: could not hold the feed-pass lock');
+	}
+
+	private function resetDeferralLocks(): void
+	{
+		// Inherited handles would bypass the guards through the reentrancy short-circuit.
+		unset($GLOBALS['pfb_schedule_dispatch_lock'], $GLOBALS['pfb_feed_pass_lock']);
+	}
+
+	private function releaseDeferralLocks(): void
+	{
+		foreach ($this->rawFps as $fp) {
+			if (is_resource($fp)) {
+				@flock($fp, LOCK_UN);
+				@fclose($fp);
+			}
+		}
+		$this->rawFps = [];
+		pfb_feed_pass_release();
+		pfb_schedule_dispatch_release();
+		$this->resetDeferralLocks();
+	}
+}

--- a/tests/php/ExtrasDispatcherDeferralLoggingTest.php
+++ b/tests/php/ExtrasDispatcherDeferralLoggingTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/support/FailingFlockStream.php';
+require_once __DIR__ . '/DeferralLockHarnessTrait.php';
 
 use PHPUnit\Framework\TestCase;
 
@@ -35,15 +36,14 @@ use PHPUnit\Framework\TestCase;
  */
 final class ExtrasDispatcherDeferralLoggingTest extends TestCase
 {
+	use DeferralLockHarnessTrait;
+
 	/** The syslog wording the sibling guards use, with this guard's label. */
 	private const NOTICE = 'Feed pass [ extras ] deferred - the scheduler dispatcher lock is unavailable.';
 
 	private string $dir = '';
 	private bool $hadPfb = FALSE;
 	private array $originalPfb = [];
-
-	/** Raw fds simulating ANOTHER process holding a lock -- closed in tearDown. */
-	private array $rawFps = [];
 
 	protected function setUp(): void
 	{
@@ -61,10 +61,7 @@ final class ExtrasDispatcherDeferralLoggingTest extends TestCase
 			'extraslog'          => "{$this->dir}/extras.log",
 		]);
 
-		// No inherited locks: a leaked handle makes pfb_schedule_dispatch_begin()
-		// short-circuit on its reentrancy check, so the guard under test is never
-		// reached and a deferral row would pass vacuously.
-		unset($GLOBALS['pfb_schedule_dispatch_lock'], $GLOBALS['pfb_feed_pass_lock']);
+		$this->resetDeferralLocks();
 
 		// Fresh syslog capture (pfsense_doubles.php logger() double).
 		$GLOBALS['pfb_test_logger_calls'] = [];
@@ -72,18 +69,7 @@ final class ExtrasDispatcherDeferralLoggingTest extends TestCase
 
 	protected function tearDown(): void
 	{
-		foreach ($this->rawFps as $fp) {
-			if (is_resource($fp)) {
-				@flock($fp, LOCK_UN);
-				@fclose($fp);
-			}
-		}
-		$this->rawFps = [];
-
-		// Never leave this process holding a lock across tests (self-encapsulation).
-		pfb_feed_pass_release();
-		pfb_schedule_dispatch_release();
-		unset($GLOBALS['pfb_schedule_dispatch_lock'], $GLOBALS['pfb_feed_pass_lock']);
+		$this->releaseDeferralLocks();
 		unset($GLOBALS['pfb_test_logger_calls']);
 
 		foreach (glob("{$this->dir}/*") ?: [] as $path) {
@@ -96,36 +82,6 @@ final class ExtrasDispatcherDeferralLoggingTest extends TestCase
 		} else {
 			unset($GLOBALS['pfb']);
 		}
-	}
-
-	private function mainLog(): string
-	{
-		$log = $GLOBALS['pfb']['log'];
-		return is_file($log) ? (string) file_get_contents($log) : '';
-	}
-
-	/** The syslog messages captured by the logger() double, one per line. */
-	private function syslogMessages(): string
-	{
-		return implode("\n", array_column($GLOBALS['pfb_test_logger_calls'] ?? [], 'message'));
-	}
-
-	/** ANOTHER process wedges the scheduler dispatcher lock. */
-	private function holdDispatcherLock(): void
-	{
-		$fp = fopen("{$this->dir}/pfb_schedule_dispatch.lock", 'c');
-		$this->assertIsResource($fp, 'test setup: could not open the dispatcher lock');
-		$this->rawFps[] = $fp;
-		$this->assertTrue(flock($fp, LOCK_EX), 'test setup: could not hold the dispatcher lock');
-	}
-
-	/** ANOTHER process wedges the feed-pass lock. */
-	private function holdFeedPassLock(): void
-	{
-		$fp = fopen("{$this->dir}/pfb_feed_pass.lock", 'c');
-		$this->assertIsResource($fp, 'test setup: could not open the feed-pass lock');
-		$this->rawFps[] = $fp;
-		$this->assertTrue(flock($fp, LOCK_EX), 'test setup: could not hold the feed-pass lock');
 	}
 
 	// -----------------------------------------------------------------------

--- a/tests/php/ListPreScriptStageTest.php
+++ b/tests/php/ListPreScriptStageTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 use PHPUnit\Framework\Attributes\CoversFunction;
 use PHPUnit\Framework\TestCase;
 
+require_once __DIR__ . '/DeferralLockHarnessTrait.php';
+
 /**
  * issue #1925: pfb_list_pre_script_run() stages a COPY of the normalized feed
  * for the per-feed pre-script — the script rewrites the copy in place; the
@@ -18,6 +20,8 @@ use PHPUnit\Framework\TestCase;
 #[CoversFunction('pfb_list_pre_script_run')]
 final class ListPreScriptStageTest extends TestCase
 {
+	use DeferralLockHarnessTrait;
+
 	private string $tmp;
 	/** @var array<string, mixed> */
 	private array $originalPfb;
@@ -57,11 +61,6 @@ final class ListPreScriptStageTest extends TestCase
 		file_put_contents($path, "#!/bin/sh\n{$body}\n");
 		chmod($path, 0755);
 		return $path;
-	}
-
-	private function mainLog(): string
-	{
-		return (string) @file_get_contents("{$this->tmp}/pfblockerng.log");
 	}
 
 	public function testSuccessfulRewriteStagesTheCopyAndLeavesTheSourceUntouched(): void

--- a/tests/php/SyncGuardLoggingTest.php
+++ b/tests/php/SyncGuardLoggingTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/SyncPrereqSeedTrait.php';
+require_once __DIR__ . '/DeferralLockHarnessTrait.php';
 
 use PHPUnit\Framework\TestCase;
 
@@ -32,6 +33,7 @@ use PHPUnit\Framework\TestCase;
 final class SyncGuardLoggingTest extends TestCase
 {
 	use SyncPrereqSeedTrait;
+	use DeferralLockHarnessTrait;
 
 	private const APPLY = __DIR__ . '/../../src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc';
 	private const EXTRA = __DIR__ . '/../../src/usr/local/pkg/pfblockerng/pfblockerng_extra.inc';
@@ -43,8 +45,6 @@ final class SyncGuardLoggingTest extends TestCase
 	// leak into a later test (CLAUDE.md: self-encapsulated, never order-dependent).
 	private bool $hadChrootPath = FALSE;
 	private mixed $originalChrootPath = NULL;
-	/** @var array<int, resource> */
-	private array $rawFps = [];
 
 	public static function setUpBeforeClass(): void
 	{
@@ -71,8 +71,7 @@ final class SyncGuardLoggingTest extends TestCase
 			'log'                => "{$this->dir}/pfblockerng.log",
 			'errlog'             => "{$this->dir}/error.log",
 		]);
-		// A previous test (or a reentrant caller) must not lend us its locks.
-		unset($GLOBALS['pfb_schedule_dispatch_lock'], $GLOBALS['pfb_feed_pass_lock']);
+		$this->resetDeferralLocks();
 
 		// Seed the config keys pfb_global() reads, so these rows do not add
 		// "Undefined array key" trigger listings to the suite's warning detail.
@@ -81,23 +80,7 @@ final class SyncGuardLoggingTest extends TestCase
 
 	protected function tearDown(): void
 	{
-		foreach ($this->rawFps as $fp) {
-			if (is_resource($fp)) {
-				@flock($fp, LOCK_UN);
-				@fclose($fp);
-			}
-		}
-		$this->rawFps = [];
-		// Release anything the function under test acquired before its guard fired.
-		if (isset($GLOBALS['pfb_feed_pass_lock']) && is_resource($GLOBALS['pfb_feed_pass_lock'])) {
-			@flock($GLOBALS['pfb_feed_pass_lock'], LOCK_UN);
-			@fclose($GLOBALS['pfb_feed_pass_lock']);
-		}
-		if (isset($GLOBALS['pfb_schedule_dispatch_lock']) && is_resource($GLOBALS['pfb_schedule_dispatch_lock'])) {
-			@flock($GLOBALS['pfb_schedule_dispatch_lock'], LOCK_UN);
-			@fclose($GLOBALS['pfb_schedule_dispatch_lock']);
-		}
-		unset($GLOBALS['pfb_schedule_dispatch_lock'], $GLOBALS['pfb_feed_pass_lock']);
+		$this->releaseDeferralLocks();
 
 		$paths = array_merge(
 			glob("{$this->dir}/db/*") ?: [],
@@ -127,18 +110,9 @@ final class SyncGuardLoggingTest extends TestCase
 		}
 	}
 
-	private function mainLog(): string
-	{
-		$log = $GLOBALS['pfb']['log'];
-		return is_file($log) ? (string) file_get_contents($log) : '';
-	}
-
 	public function testDispatchLockUnavailableLogsThePrecondition(): void
 	{
-		$holder = fopen("{$this->dir}/state/pfb_schedule_dispatch.lock", 'c');
-		$this->assertIsResource($holder, 'test setup: could not open the dispatch lock');
-		$this->rawFps[] = $holder;
-		$this->assertTrue(flock($holder, LOCK_EX), 'test setup: could not hold the dispatch lock');
+		$this->holdDispatcherLock();
 
 		$this->assertFalse(sync_package_pfblockerng('noupdates'),
 			'before-state: a held dispatcher lock must abort the sync');

--- a/tests/php/TriggerFunnelDeferralExitCodeTest.php
+++ b/tests/php/TriggerFunnelDeferralExitCodeTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/SyncPrereqSeedTrait.php';
+require_once __DIR__ . '/DeferralLockHarnessTrait.php';
 
 use PHPUnit\Framework\TestCase;
 
@@ -17,6 +18,7 @@ use PHPUnit\Framework\TestCase;
 final class TriggerFunnelDeferralExitCodeTest extends TestCase
 {
 	use SyncPrereqSeedTrait;
+	use DeferralLockHarnessTrait;
 
 	private string $dbdir = '';
 	private bool $hadPfb = FALSE;
@@ -25,10 +27,6 @@ final class TriggerFunnelDeferralExitCodeTest extends TestCase
 	private mixed $originalConfig = NULL;
 	private bool $hadChrootPath = FALSE;
 	private mixed $originalChrootPath = NULL;
-
-	/** Raw fds simulating ANOTHER process holding a lock. */
-	private $feedLockFp = NULL;
-	private $dispatchLockFp = NULL;
 
 	protected function setUp(): void
 	{
@@ -59,9 +57,7 @@ final class TriggerFunnelDeferralExitCodeTest extends TestCase
 		// so no row can go green through this early-return.
 		$GLOBALS['g']['pfblockerng_install'] = TRUE;
 
-		// No inherited locks: a leaked handle would make a deferral row pass
-		// vacuously (the reentrancy short-circuit never reaches the guard).
-		unset($GLOBALS['pfb_schedule_dispatch_lock'], $GLOBALS['pfb_feed_pass_lock']);
+		$this->resetDeferralLocks();
 
 		// Fresh syslog capture (pfsense_doubles.php logger() double).
 		$GLOBALS['pfb_test_logger_calls'] = [];
@@ -69,17 +65,7 @@ final class TriggerFunnelDeferralExitCodeTest extends TestCase
 
 	protected function tearDown(): void
 	{
-		foreach ([$this->feedLockFp, $this->dispatchLockFp] as $fp) {
-			if (is_resource($fp)) {
-				@flock($fp, LOCK_UN);
-				@fclose($fp);
-			}
-		}
-		$this->feedLockFp = $this->dispatchLockFp = NULL;
-
-		pfb_feed_pass_release();
-		pfb_schedule_dispatch_release();
-		unset($GLOBALS['pfb_schedule_dispatch_lock'], $GLOBALS['pfb_feed_pass_lock']);
+		$this->releaseDeferralLocks();
 		unset($GLOBALS['g']['pfblockerng_install']);
 		unset($GLOBALS['pfb_test_logger_calls']);
 
@@ -103,32 +89,6 @@ final class TriggerFunnelDeferralExitCodeTest extends TestCase
 		} else {
 			unset($GLOBALS['g']['unbound_chroot_path']);
 		}
-	}
-
-	private function mainLog(): string
-	{
-		$log = $GLOBALS['pfb']['log'];
-		return is_file($log) ? (string) file_get_contents($log) : '';
-	}
-
-	private function holdDispatcherLock(): void
-	{
-		$this->dispatchLockFp = fopen("{$this->dbdir}/pfb_schedule_dispatch.lock", 'c');
-		$this->assertIsResource($this->dispatchLockFp, 'test setup: could not open the dispatcher lock');
-		$this->assertTrue(flock($this->dispatchLockFp, LOCK_EX), 'test setup: could not hold the dispatcher lock');
-	}
-
-	private function holdFeedPassLock(): void
-	{
-		$this->feedLockFp = fopen("{$this->dbdir}/pfb_feed_pass.lock", 'c');
-		$this->assertIsResource($this->feedLockFp, 'test setup: could not open the feed-pass lock');
-		$this->assertTrue(flock($this->feedLockFp, LOCK_EX), 'test setup: could not hold the feed-pass lock');
-	}
-
-	/** The syslog messages captured by the logger() double, one per line. */
-	private function syslogMessages(): string
-	{
-		return implode("\n", array_column($GLOBALS['pfb_test_logger_calls'] ?? [], 'message'));
 	}
 
 	/**


### PR DESCRIPTION
Fixes #2827.

## Summary

Extract `DeferralLockHarnessTrait` and adopt it across all five named suites. The trait owns main-log/syslog readers, dispatcher/feed-pass contention helpers, raw-descriptor teardown, and lock-global reset. Each suite retains its existing temporary directories, configuration restoration, and syslog lifecycle; `ListPreScriptStageTest` uses only `mainLog()`.

Lock paths come from the existing fixture's `schedule_state_dir` and `dbdir`, preserving `SyncGuardLoggingTest`'s separate state/database directories. No production code or assertions changed.

## Verification

PHP 8.4.24 / PHPUnit 12.5.31, baseline `d924e8c40a201fb1268a7bc17aa1cb7646eb0a08` and extracted harness:

| Suite | Tests before/after | Assertions before/after |
| --- | --- | --- |
| `CronDeferralExitCodeTest` | 8 | 32 |
| `SyncGuardLoggingTest` | 3 | 10 |
| `TriggerFunnelDeferralExitCodeTest` | 6 | 32 |
| `ExtrasDispatcherDeferralLoggingTest` | 8 | 34 |
| `ListPreScriptStageTest` | 5 | 20 |

`vendor/bin/phpunit --no-coverage --filter 'CronDeferralExitCodeTest|SyncGuardLoggingTest|TriggerFunnelDeferralExitCodeTest|ExtrasDispatcherDeferralLoggingTest|ListPreScriptStageTest' --log-junit <report>`: **30 tests, 128 assertions, zero failures/errors/skips**, before and after. The same totals pass with `--order-by=reverse` and `--order-by=random --random-order-seed=2827`. Both baseline and refactor report the same 11 existing config-key warnings from `SyncGuardLoggingTest`.

**19 production mutations killed before and after with identical failing-test sets.** Each mutation ran singly in an isolated archive, passed `php -l`, failed a behavioral assertion (not a test error), then restored the production file. Covers the nine recorded Extras kills (main log, syslog, guard identity, priority, sink, prefix, leading newline, granted-path silence, FALSE return), both lock-identity results for Cron and Trigger, all three SyncGuard diagnostics, and the three ListPreScript failure diagnostics. The historical gettext-wrapper gap remains deliberately unclaimed. Detailed patches and failing-test IDs are attached in the audit comment.

## Frozen RED

N/A — pure test maintenance, per `.agents/policy/testing.md`. No production behavior change; no manufactured RED.

| File | Current git blob hash | Proof |
| --- | --- | --- |
| `tests/php/CronDeferralExitCodeTest.php` | `a2ec97c278fd77d6bc919885e900de9f9ebe8215` | N/A — test maintenance; shared fixtures only |
| `tests/php/SyncGuardLoggingTest.php` | `554aea492725e33625f47be57fbd6b4541363c8b` | N/A — test maintenance; shared fixtures only |
| `tests/php/TriggerFunnelDeferralExitCodeTest.php` | `f9b26e2787b26158618ab089a11df5de18b53934` | N/A — test maintenance; shared fixtures only |
| `tests/php/ExtrasDispatcherDeferralLoggingTest.php` | `b9b41a11098edf9e7a3bff27a84090aee1bdd9fe` | N/A — test maintenance; shared fixtures only |
| `tests/php/ListPreScriptStageTest.php` | `9cd2037eb70dbe6b627bb51622e0bc428a2cbd57` | N/A — test maintenance; shared fixtures only |
| `tests/php/DeferralLockHarnessTrait.php` | `8eb1ebce43fb29fe6314b09ea6ace82c74e4735f` | N/A — test maintenance; shared fixtures only |

No appliance/UI surface changes; live/UI verification is not applicable.

## Canonical gates

`sh scripts/agent/run-gates.sh --diff origin/devel`: **GATES: PASS**. Coverage pairing, generated-graph freshness, Composer vendor check, toggle registry, reentry bounds, syntax checks for all six PHP files, full PHPUnit, PHPStan, and PHPCS all passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added shared test utilities for managing lock contention, cleanup, and log inspection.
  * Updated deferral, dispatcher, synchronization, and trigger-related tests to use consistent lock lifecycle handling.
  * Preserved existing test behavior while reducing duplicated setup and teardown logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->