### PR TITLE
tests: share PID shim harness

### DIFF
--- a/tests/php/EditHooksPageWiringTest.php
+++ b/tests/php/EditHooksPageWiringTest.php
@@ -2,15 +2,21 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/PidShimHarnessTrait.php';
+
 use PHPUnit\Framework\TestCase;
 
 /** Runtime contracts for the privilege-gated Edit Hooks page. */
 final class EditHooksPageWiringTest extends TestCase
 {
+	use PidShimHarnessTrait;
+
 	private string $dir = '';
 
-	/** @var list<string> Stale shim paths planted by runDeniedPage(), swept after each test. */
-	private array $planted = [];
+	protected function pidShimPrefix(): string
+	{
+		return 'pfb_edit_hooks_shim_';
+	}
 
 	protected function setUp(): void
 	{
@@ -25,11 +31,7 @@ final class EditHooksPageWiringTest extends TestCase
 			@unlink($path);
 		}
 		@rmdir($this->dir);
-		foreach ($this->planted as $path) {
-			@unlink($path . '/guiconfig.inc');
-			@rmdir($path);
-		}
-		$this->planted = [];
+		$this->sweepPlantedShims();
 	}
 
 	private function makeHook(string $name, string $body = "#!/bin/sh\nexit 0\n"): string
@@ -106,32 +108,16 @@ final class EditHooksPageWiringTest extends TestCase
 		$this->assertSame([], array_diff($this->shimResidue($result['pid']), $this->planted));
 	}
 
-	/** @return list<string> Shim directories owned by child PID $pid, with or without a per-invocation suffix. */
-	private function shimResidue(int $pid): array
-	{
-		$prefix = sys_get_temp_dir() . '/pfb_edit_hooks_shim_' . $pid;
-		return array_merge(glob($prefix) ?: [], glob($prefix . '_*') ?: []);
-	}
-
 	/** @return array{status:int,stdout:string,stderr:string,pid:int} */
 	private function runDeniedPage(bool $plantStaleShim = FALSE): array
 	{
 		$root = var_export(dirname(__DIR__, 2), TRUE);
 		$page = var_export(dirname(__DIR__, 2) . '/src/usr/local/www/pfblockerng/pfblockerng_edit_hooks.php', TRUE);
+		$preamble = $this->pidShimPreamble('edit hooks include shim creation failed');
 		$script = <<<PHP
 stream_get_contents(STDIN);
 require {$root} . '/tests/php/bootstrap.php';
-\$shim = sys_get_temp_dir() . '/pfb_edit_hooks_shim_' . getmypid() . '_' . bin2hex(random_bytes(8));
-if (!mkdir(\$shim, 0700, TRUE)) {
-	fwrite(STDERR, "edit hooks include shim creation failed\\n");
-	exit(1);
-}
-register_shutdown_function(static function () use (\$shim): void {
-	@unlink(\$shim . '/guiconfig.inc');
-	@rmdir(\$shim);
-});
-file_put_contents(\$shim . '/guiconfig.inc', "<?php");
-set_include_path(\$shim . PATH_SEPARATOR . get_include_path());
+{$preamble}
 error_reporting(E_ERROR | E_PARSE);
 \$GLOBALS['pfb_test_allowed_pages'] = ['diag_command.php' => FALSE];
 register_shutdown_function(static function (): void { echo 'shutdown'; });
@@ -145,10 +131,7 @@ PHP;
 		if ($plantStaleShim) {
 			// The child blocks on STDIN until the pipe is closed below, so the
 			// plant always lands before it creates its own shim.
-			$residue = sys_get_temp_dir() . '/pfb_edit_hooks_shim_' . $pid;
-			$this->planted[] = $residue;
-			@mkdir($residue, 0777, TRUE);
-			$this->assertDirectoryExists($residue);
+			$this->plantStaleShim($pid);
 		}
 		fclose($pipes[0]);
 		$stdout = stream_get_contents($pipes[1]);

--- a/tests/php/LintEndpointWiringTest.php
+++ b/tests/php/LintEndpointWiringTest.php
@@ -2,23 +2,20 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/PidShimHarnessTrait.php';
+
 use PHPUnit\Framework\TestCase;
 
 final class LintEndpointWiringTest extends TestCase
 {
+	use PidShimHarnessTrait;
+
 	private const ROOT = __DIR__ . '/../..';
 	private const PAGE = self::ROOT . '/src/usr/local/www/pfblockerng/pfblockerng_lint.php';
 
-	/** @var list<string> Stale shim paths planted by request(), swept after each test. */
-	private array $planted = [];
-
-	protected function tearDown(): void
+	protected function pidShimPrefix(): string
 	{
-		foreach ($this->planted as $path) {
-			@unlink($path . '/guiconfig.inc');
-			@rmdir($path);
-		}
-		$this->planted = [];
+		return 'pfb_lint_shim_';
 	}
 
 	public function testRealPageRejectsWrongMethodBeforeDispatch(): void
@@ -98,35 +95,19 @@ final class LintEndpointWiringTest extends TestCase
 		$this->assertSame([], array_diff($this->shimResidue($result['pid']), $this->planted));
 	}
 
-	/** @return list<string> Shim directories owned by child PID $pid, with or without a per-invocation suffix. */
-	private function shimResidue(int $pid): array
-	{
-		$prefix = sys_get_temp_dir() . '/pfb_lint_shim_' . $pid;
-		return array_merge(glob($prefix) ?: [], glob($prefix . '_*') ?: []);
-	}
-
 	/** @param array<string,mixed> $post @param array<string,string> $server @param array<string,bool> $allowed @return array{body:array<string,mixed>,pid:int} */
 	private function request(array $post, array $server, array $allowed = [], bool $plantStaleShim = FALSE): array
 	{
 		$payload = json_encode(compact('post', 'server', 'allowed'), JSON_THROW_ON_ERROR);
 		$root = var_export(self::ROOT, TRUE);
 		$page = var_export(self::PAGE, TRUE);
+		$preamble = $this->pidShimPreamble('lint include shim creation failed');
 		$script = <<<PHP
 \$request = json_decode(stream_get_contents(STDIN), TRUE, 512, JSON_THROW_ON_ERROR);
 \$GLOBALS['pfb_test_allowed_pages'] = \$request['allowed'];
 \$_SERVER = \$request['server'];
 \$_POST = \$request['post'];
-\$shim = sys_get_temp_dir() . '/pfb_lint_shim_' . getmypid() . '_' . bin2hex(random_bytes(8));
-if (!mkdir(\$shim, 0700, TRUE)) {
-	fwrite(STDERR, "lint include shim creation failed\\n");
-	exit(1);
-}
-register_shutdown_function(static function () use (\$shim): void {
-	@unlink(\$shim . '/guiconfig.inc');
-	@rmdir(\$shim);
-});
-file_put_contents(\$shim . '/guiconfig.inc', "<?php");
-set_include_path(\$shim . PATH_SEPARATOR . get_include_path());
+{$preamble}
 require {$root} . '/tests/php/bootstrap.php';
 require {$page};
 PHP;
@@ -137,10 +118,7 @@ PHP;
 		if ($plantStaleShim) {
 			// The child blocks on STDIN until the pipe is closed below, so the
 			// plant always lands before it creates its own shim.
-			$residue = sys_get_temp_dir() . '/pfb_lint_shim_' . $pid;
-			$this->planted[] = $residue;
-			@mkdir($residue, 0777, TRUE);
-			$this->assertDirectoryExists($residue);
+			$this->plantStaleShim($pid);
 		}
 		fwrite($pipes[0], $payload);
 		fclose($pipes[0]);

--- a/tests/php/PidShimHarnessTrait.php
+++ b/tests/php/PidShimHarnessTrait.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+trait PidShimHarnessTrait
+{
+	/** @var list<string> Stale shim paths planted for recycled-PID tests. */
+	private array $planted = [];
+
+	abstract protected function pidShimPrefix(): string;
+
+	protected function tearDown(): void
+	{
+		$this->sweepPlantedShims();
+	}
+
+	protected function sweepPlantedShims(): void
+	{
+		foreach ($this->planted as $path) {
+			@unlink($path . '/guiconfig.inc');
+			@rmdir($path);
+		}
+		$this->planted = [];
+	}
+
+	private function pidShimPreamble(string $mkdirError): string
+	{
+		$prefix = var_export('/' . $this->pidShimPrefix(), TRUE);
+		$error = var_export($mkdirError . "\n", TRUE);
+
+		return <<<PHP
+\$shim = sys_get_temp_dir() . {$prefix} . getmypid() . '_' . bin2hex(random_bytes(8));
+if (!mkdir(\$shim, 0700, TRUE)) {
+	fwrite(STDERR, {$error});
+	exit(1);
+}
+register_shutdown_function(static function () use (\$shim): void {
+	@unlink(\$shim . '/guiconfig.inc');
+	@rmdir(\$shim);
+});
+file_put_contents(\$shim . '/guiconfig.inc', "<?php");
+set_include_path(\$shim . PATH_SEPARATOR . get_include_path());
+PHP;
+	}
+
+	private function plantStaleShim(int $pid): void
+	{
+		$residue = sys_get_temp_dir() . '/' . $this->pidShimPrefix() . $pid;
+		$this->planted[] = $residue;
+		@mkdir($residue, 0777, TRUE);
+		\PHPUnit\Framework\Assert::assertDirectoryExists($residue);
+	}
+
+	/** @return list<string> Shim directories owned by child PID $pid, with or without a per-invocation suffix. */
+	private function shimResidue(int $pid): array
+	{
+		$prefix = sys_get_temp_dir() . '/' . $this->pidShimPrefix() . $pid;
+		return array_merge(glob($prefix) ?: [], glob($prefix . '_*') ?: []);
+	}
+}

--- a/tests/php/WidgetGetTableArgOrderTest.php
+++ b/tests/php/WidgetGetTableArgOrderTest.php
@@ -2,23 +2,20 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/PidShimHarnessTrait.php';
+
 use PHPUnit\Framework\TestCase;
 
 final class WidgetGetTableArgOrderTest extends TestCase
 {
+	use PidShimHarnessTrait;
+
 	private const ROOT = __DIR__ . '/../..';
 	private const WIDGET = self::ROOT . '/src/usr/local/www/widgets/widgets/pfblockerng.widget.php';
 
-	/** @var list<string> Stale shim paths planted by runWidget(), swept after each test. */
-	private array $planted = [];
-
-	protected function tearDown(): void
+	protected function pidShimPrefix(): string
 	{
-		foreach ($this->planted as $path) {
-			@unlink($path . '/guiconfig.inc');
-			@rmdir($path);
-		}
-		$this->planted = [];
+		return 'pfb_widget_shim_';
 	}
 
 	public function testAjaxWidgetBranchExecutesTheShippedTableCall(): void
@@ -68,13 +65,6 @@ final class WidgetGetTableArgOrderTest extends TestCase
 		$this->assertSame([], array_diff($this->shimResidue($result['pid']), $this->planted));
 	}
 
-	/** @return list<string> Shim directories owned by child PID $pid, with or without a per-invocation suffix. */
-	private function shimResidue(int $pid): array
-	{
-		$prefix = sys_get_temp_dir() . '/pfb_widget_shim_' . $pid;
-		return array_merge(glob($prefix) ?: [], glob($prefix . '_*') ?: []);
-	}
-
 	/** @return array{status:int,stdout:string,stderr:string,pid:int} */
 	private function runWidget(array $get, array $post, bool $plantStaleShim = FALSE): array
 	{
@@ -82,6 +72,7 @@ final class WidgetGetTableArgOrderTest extends TestCase
 		$widget = var_export(self::WIDGET, TRUE);
 		$getCode = var_export($get, TRUE);
 		$postCode = var_export($post, TRUE);
+		$preamble = $this->pidShimPreamble('widget include shim creation failed');
 		$script = <<<PHP
 stream_get_contents(STDIN);
 \$GLOBALS['argv'] = ['widget'];
@@ -89,17 +80,7 @@ error_reporting(E_ERROR | E_PARSE);
 \$_GET = {$getCode};
 \$_POST = {$postCode};
 \$_SERVER = [];\$widgetname = 'pfblockerng';
-\$shim = sys_get_temp_dir() . '/pfb_widget_shim_' . getmypid() . '_' . bin2hex(random_bytes(8));
-if (!mkdir(\$shim, 0700, TRUE)) {
-	fwrite(STDERR, "widget include shim creation failed\\n");
-	exit(1);
-}
-register_shutdown_function(static function () use (\$shim): void {
-	@unlink(\$shim . '/guiconfig.inc');
-	@rmdir(\$shim);
-});
-file_put_contents(\$shim . '/guiconfig.inc', "<?php");
-set_include_path(\$shim . PATH_SEPARATOR . get_include_path());
+{$preamble}
 require {$root} . '/tests/php/bootstrap.php';
 require {$widget};
 echo 'after-include';
@@ -111,10 +92,7 @@ PHP;
 		if ($plantStaleShim) {
 			// The child blocks on STDIN until the pipe is closed below, so the
 			// plant always lands before it creates its own shim.
-			$residue = sys_get_temp_dir() . '/pfb_widget_shim_' . $pid;
-			$this->planted[] = $residue;
-			@mkdir($residue, 0777, TRUE);
-			$this->assertDirectoryExists($residue);
+			$this->plantStaleShim($pid);
 		}
 		fclose($pipes[0]);
 		$stdout = stream_get_contents($pipes[1]);

--- a/tests/php/WidgetPostAllowedTest.php
+++ b/tests/php/WidgetPostAllowedTest.php
@@ -2,24 +2,21 @@
 
 declare(strict_types=1);
 
+require_once __DIR__ . '/PidShimHarnessTrait.php';
+
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class WidgetPostAllowedTest extends TestCase
 {
+	use PidShimHarnessTrait;
+
 	private const ROOT = __DIR__ . '/../..';
 	private const WIDGET = self::ROOT . '/src/usr/local/www/widgets/widgets/pfblockerng.widget.php';
 
-	/** @var list<string> Stale shim paths planted by runWidget(), swept after each test. */
-	private array $planted = [];
-
-	protected function tearDown(): void
+	protected function pidShimPrefix(): string
 	{
-		foreach ($this->planted as $path) {
-			@unlink($path . '/guiconfig.inc');
-			@rmdir($path);
-		}
-		$this->planted = [];
+		return 'pfb_widget_shim_';
 	}
 
 	public static function setUpBeforeClass(): void
@@ -99,13 +96,6 @@ final class WidgetPostAllowedTest extends TestCase
 		$this->assertSame([], array_diff($this->shimResidue($result['pid']), $this->planted));
 	}
 
-	/** @return list<string> Shim directories owned by child PID $pid, with or without a per-invocation suffix. */
-	private function shimResidue(int $pid): array
-	{
-		$prefix = sys_get_temp_dir() . '/pfb_widget_shim_' . $pid;
-		return array_merge(glob($prefix) ?: [], glob($prefix . '_*') ?: []);
-	}
-
 	/** @return array{status:int,stdout:string,stderr:string,pid:int} */
 	private function runWidget(array $get, array $post, bool $plantStaleShim = FALSE): array
 	{
@@ -113,23 +103,14 @@ final class WidgetPostAllowedTest extends TestCase
 		$widget = var_export(self::WIDGET, TRUE);
 		$getCode = var_export($get, TRUE);
 		$postCode = var_export($post, TRUE);
+		$preamble = $this->pidShimPreamble('widget include shim creation failed');
 		$script = <<<PHP
 stream_get_contents(STDIN);
 \$_GET = {$getCode};
 \$_POST = {$postCode};
 \$_SERVER = [];
 \$widgetname = 'pfblockerng';
-\$shim = sys_get_temp_dir() . '/pfb_widget_shim_' . getmypid() . '_' . bin2hex(random_bytes(8));
-if (!mkdir(\$shim, 0700, TRUE)) {
-	fwrite(STDERR, "widget include shim creation failed\\n");
-	exit(1);
-}
-register_shutdown_function(static function () use (\$shim): void {
-	@unlink(\$shim . '/guiconfig.inc');
-	@rmdir(\$shim);
-});
-file_put_contents(\$shim . '/guiconfig.inc', "<?php");
-set_include_path(\$shim . PATH_SEPARATOR . get_include_path());
+{$preamble}
 require {$root} . '/tests/php/bootstrap.php';
 require {$widget};
 PHP;
@@ -140,10 +121,7 @@ PHP;
 		if ($plantStaleShim) {
 			// The child blocks on STDIN until the pipe is closed below, so the
 			// plant always lands before it creates its own shim.
-			$residue = sys_get_temp_dir() . '/pfb_widget_shim_' . $pid;
-			$this->planted[] = $residue;
-			@mkdir($residue, 0777, TRUE);
-			$this->assertDirectoryExists($residue);
+			$this->plantStaleShim($pid);
 		}
 		fclose($pipes[0]);
 		$stdout = stream_get_contents($pipes[1]);

--- a/tests/php/WidgetSubmitPostGuardTest.php
+++ b/tests/php/WidgetSubmitPostGuardTest.php
@@ -113,10 +113,9 @@ final class WidgetSubmitPostGuardTest extends TestCase
 		// classes instead glob sys_get_temp_dir() and filter by the child's PID from
 		// proc_get_status(); that works, but the glob sees every concurrent class's shims,
 		// so it needs a before/after snapshot and is still exposed to PID reuse. A private
-		// base needs neither. #2849 extracts these five sites into one trait and should
-		// take this shape, not the glob -- the exemplar deliberately diverges from its
-		// four copies until then. The mkdir guard, the random suffix and the shutdown
-		// hook are unchanged.
+		// base needs neither. #2849 now shares only the four full PID-keyed copies; this
+		// #2846 exemplar keeps its parent-owned base because its assertions observe cleanup
+		// across exit(0). The mkdir guard, the random suffix and the shutdown hook are unchanged.
 		//
 		// Recorded for the tearDown() sweep before it is created: every assertion between
 		// here and the cleanup below aborts the method and skips that cleanup, so a


### PR DESCRIPTION
## Summary

- extract the PID-keyed include-shim scaffolding shared by four endpoint/widget test classes into `PidShimHarnessTrait`
- keep each child script's statement ordering, prefix, and failure text under caller control
- retain explicit Edit Hooks fixture cleanup while sweeping the trait-owned stale shim state

## Verification

- baseline: `vendor/bin/phpunit tests/php/LintEndpointWiringTest.php tests/php/WidgetGetTableArgOrderTest.php tests/php/WidgetPostAllowedTest.php tests/php/EditHooksPageWiringTest.php` — `OK (47 tests, 226 assertions)`
- refactored: same command — `OK (47 tests, 226 assertions)`
- focused cleanup: four recycled-PID tests — `OK (4 tests, 27 assertions)`; no new lint/widget/Edit Hooks shim or fixture residue
- mutation: removing the shared random suffix failed one recycled-PID test in each adopter; restoring it passed each (`7`, `6`, `6`, and `8` assertions respectively)
- canonical gates: initial private scratch `TMPDIR` mode `0755` failed the same two privilege-drop tests on base and head; mode `01777` (matching system temp semantics) produced `14/14` gate passes on `eba95003deec27eb1f04e898c4d482e75606206b`
- independent four-lens review: approved; the one stale #2849 prediction was corrected without changing the distinct #2846 exemplar behavior

Fixes #2849
