### PR TITLE
pfblockerng: record post-script staging failures

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
@@ -584,6 +584,17 @@ function pfb_list_post_script_failure_record(int $exit_status, string $facility,
 	pfb_list_script_failure_record($facility, $item, $message, $ledger_dir, NULL, $state);
 }
 
+/** Stage a post-script copy, recording a script failure without a retry marker on failure. */
+function pfb_list_post_script_stage(string $source, string $staged, string $facility, string $item,
+    string $message, string $ledger_dir, array &$state): bool {
+	if (@copy($source, $staged)) {
+		return TRUE;
+	}
+	unlink_if_exists($staged);
+	pfb_list_script_failure_record($facility, $item, $message, $ledger_dir, NULL, $state);
+	return FALSE;
+}
+
 function pfb_list_script_failure_close(string $facility, string $item, string $ledger_dir, array $state): void {
 	if (empty($state['failed'])) {
 		pfb_sync_status_close($facility, $item, 'script', $ledger_dir);
@@ -2651,7 +2662,9 @@ function sync_package_pfblockerng($cron='', ?string &$deferred_by = NULL): bool 
 								// the IP loop, which discards post-script edits via restore).
 								if ($pfb_row_script_post && is_file("{$pfb_row_script_post}")) {
 									pfb_logger("\nExecuting post-script: {$list['script_post']}\n", 1);
-									if (@copy("{$file_dwn}.orig", "{$file_dwn}.post")) {
+									if (pfb_list_post_script_stage("{$file_dwn}.orig", "{$file_dwn}.post", 'dnsbl', $alias,
+									    "[ {$alias} - {$header} ] Post-script input staging unavailable",
+									    $pfb['dbdir'], state: $pfb_script_state)) {
 										$pfb_post_status = pfb_list_script_exec($pfb_row_script_post, $list['script_post'], 'post', $header,
 										    escapeshellarg("{$file_dwn}.post") . " dnsbl {$elog}");
 										unlink_if_exists("{$file_dwn}.post");
@@ -4076,23 +4089,30 @@ function sync_package_pfblockerng($cron='', ?string &$deferred_by = NULL): bool 
 							pfb_logger("\n", 1);
 
 							// IP v4/6 Advanced Tunable - (Post Script processing)
+							$pfb_post_staged = FALSE;
 							if ($pfb_script_post && is_file("{$pfb_script_post}")) {
 								pfb_logger("\nExecuting post-script: {$list['script_post']}\n", 1);
 								$file_org_esc = escapeshellarg("{$file_dwn}.orig");
-								@copy("{$file_dwn}.orig", "{$file_dwn}.orig.post"); // Save original file for restoration
-								$pfb_post_status = pfb_list_script_exec($pfb_script_post, $list['script_post'], 'post', $header,
-								    "{$file_org_esc} {$list['vtype']} {$elog}");
-								if ($pfb_post_status !== 0) {
-									// issue #1927: restore the download now so the empty-feed check
-									// below reads it, not the failed script's leftovers.
-									if (file_exists("{$file_dwn}.orig.post")) {
-										@rename("{$file_dwn}.orig.post", "{$file_dwn}.orig");
+								$pfb_post_staged = pfb_list_post_script_stage("{$file_dwn}.orig", "{$file_dwn}.orig.post", 'ip', $alias,
+								    "[ {$alias} - {$header} ] Post-script restore point unavailable",
+								    $pfb['dbdir'], state: $pfb_script_state);
+								if ($pfb_post_staged) {
+									$pfb_post_status = pfb_list_script_exec($pfb_script_post, $list['script_post'], 'post', $header,
+									    "{$file_org_esc} {$list['vtype']} {$elog}");
+									if ($pfb_post_status !== 0) {
+										// issue #1927: restore the download now so the empty-feed check
+										// below reads it, not the failed script's leftovers.
+										if (file_exists("{$file_dwn}.orig.post")) {
+											@rename("{$file_dwn}.orig.post", "{$file_dwn}.orig");
+										}
 									}
+									// issue #2059: 'script' stage, never 'download' -- the feed refreshed.
+									pfb_list_post_script_failure_record($pfb_post_status, 'ip', $alias,
+									    "[ {$alias} - {$header} ] Post-script FAIL - feed updated, side effects incomplete",
+									    $pfb['dbdir'], $pfb_script_state);
+								} else {
+									pfb_logger("\n[ {$header} ] post-script '{$list['script_post']}' could not stage its restore point; skipping\n", 2);
 								}
-								// issue #2059: 'script' stage, never 'download' -- the feed refreshed.
-								pfb_list_post_script_failure_record($pfb_post_status, 'ip', $alias,
-								    "[ {$alias} - {$header} ] Post-script FAIL - feed updated, side effects incomplete",
-								    $pfb['dbdir'], $pfb_script_state);
 							}
 
 							// Check to see if list actually failed download or has no IPs listed.
@@ -4197,7 +4217,7 @@ function sync_package_pfblockerng($cron='', ?string &$deferred_by = NULL): bool 
 							}
 
 							// Restore Original Downloaded file after Post Script function
-							if (file_exists("{$file_dwn}.orig.post")) {
+							if ($pfb_post_staged && file_exists("{$file_dwn}.orig.post")) {
 								@rename("{$file_dwn}.orig.post", "{$file_dwn}.orig");
 							}
 						}

--- a/tests/php/ListScriptFailureLedgerWiringTest.php
+++ b/tests/php/ListScriptFailureLedgerWiringTest.php
@@ -29,10 +29,7 @@ final class ListScriptFailureLedgerWiringTest extends TestCase
 
 	protected function tearDown(): void
 	{
-		foreach (glob("{$this->dir}/*") ?: [] as $file) {
-			@unlink($file);
-		}
-		@rmdir($this->dir);
+		rmdir_recursive($this->dir);
 	}
 
 	private function applyScope(string $source, string $start, string $end): string
@@ -250,6 +247,50 @@ final class ListScriptFailureLedgerWiringTest extends TestCase
 		$this->assertStringContainsString('Post-script FAIL', $open[0]['message']);
 	}
 
+	public function testFailedPostScriptStagingOpensAnEntryThatSurvivesTheAliasClose(): void
+	{
+		$source = "{$this->dir}/feed.orig";
+		$staged = "{$this->dir}/feed.post";
+		file_put_contents($source, "served\n");
+		$this->assertTrue(mkdir($staged, 0700));
+		$state = ['failed' => FALSE];
+
+		$this->assertFalse(pfb_list_post_script_stage(
+			$source, $staged, 'dnsbl', 'DNSBL_Example',
+			'[ DNSBL_Example - feed ] Post-script FAIL - input staging unavailable',
+			$this->dir, $state
+		));
+		$this->assertSame("served\n", file_get_contents($source),
+			'a staging failure must leave the served input byte-identical');
+		$this->assertTrue($state['failed'],
+			'the failed state must stop the alias close from clearing the entry');
+
+		pfb_list_script_failure_close('dnsbl', 'DNSBL_Example', $this->dir, $state);
+		$open = pfb_sync_status_list_open($this->dir, 'dnsbl');
+		$this->assertCount(1, $open);
+		$this->assertSame('script', $open[0]['stage']);
+		$this->assertStringContainsString('input staging unavailable', $open[0]['message']);
+	}
+
+	public function testSuccessfulPostScriptStagingCopiesInputWithoutRecordingAFailure(): void
+	{
+		$source = "{$this->dir}/feed.orig";
+		$staged = "{$this->dir}/feed.post";
+		file_put_contents($source, "served\n");
+		$state = ['failed' => FALSE];
+
+		$this->assertTrue(pfb_list_post_script_stage(
+			$source, $staged, 'ip', 'pfB_Example_v4',
+			'this message must never reach the ledger', $this->dir, $state
+		));
+
+		$this->assertSame("served\n", file_get_contents($source));
+		$this->assertSame("served\n", file_get_contents($staged));
+		$this->assertFalse($state['failed']);
+		$this->assertSame([], pfb_sync_status_list_open($this->dir, 'ip'),
+			'a successful staging copy must not create a false script failure');
+	}
+
 	/**
 	 * The other side of the same branch, and the reason
 	 * pfb_list_post_script_failure_record() owns the exit-status test (rationale
@@ -407,5 +448,41 @@ final class ListScriptFailureLedgerWiringTest extends TestCase
 			$this->assertSame(0, substr_count($mutantScope, $needle),
 				"a {$needle} relocation after its post-script branch must fail the scope pin");
 		}
+	}
+
+	public function testEachFamilyStagesPostScriptInputBeforeExecution(): void
+	{
+		$source      = php_strip_whitespace(self::APPLY);
+		$dnsbl_start = 'if ($pfb_row_script_post && is_file("{$pfb_row_script_post}")) {';
+		$dnsbl_end   = 'if (isset($csvline)) {';
+		$ip_start    = 'if ($pfb_script_post && is_file("{$pfb_script_post}")) {';
+		$ip_end      = '$file_chk = pfb_ip_script_probe_staged(';
+		$dnsbl_post  = $this->applyScope($source, $dnsbl_start, $dnsbl_end);
+		$ip_post     = $this->applyScope($source, $ip_start, $ip_end);
+
+		$dnsbl_stage = 'if (pfb_list_post_script_stage("{$file_dwn}.orig", "{$file_dwn}.post", \'dnsbl\', $alias,';
+		$ip_stage    = '$pfb_post_staged = pfb_list_post_script_stage("{$file_dwn}.orig", "{$file_dwn}.orig.post", \'ip\', $alias,';
+		$this->assertSame(1, substr_count($dnsbl_post, $dnsbl_stage),
+			'the DNSBL loop must stage its throwaway input through the failure-recording seam');
+		$this->assertSame(1, substr_count($ip_post, $ip_stage),
+			'the IP loop must stage its restore point through the failure-recording seam');
+		$this->assertSame(2, substr_count($source, 'pfb_list_post_script_stage("{$file_dwn}.orig",'),
+			'only the DNSBL input and IP restore-point copies use the post-script staging seam');
+
+		$this->assertLessThan(
+			strpos($dnsbl_post, '$pfb_post_status = pfb_list_script_exec('),
+			strpos($dnsbl_post, $dnsbl_stage),
+			'the DNSBL staging guard must precede script execution'
+		);
+		$this->assertSame(1, substr_count($ip_post, 'if ($pfb_post_staged) {'),
+			'the IP script must run only after its restore point was staged');
+		$this->assertLessThan(
+			strpos($ip_post, '$pfb_post_status = pfb_list_script_exec('),
+			strpos($ip_post, 'if ($pfb_post_staged) {'),
+			'the IP staging guard must precede script execution'
+		);
+		$this->assertSame(1,
+			substr_count($source, 'if ($pfb_post_staged && file_exists("{$file_dwn}.orig.post")) {'),
+			'a failed restore-point copy must not make a stale path eligible for restoration');
 	}
 }

--- a/tests/php/fixtures/function_inventory.json
+++ b/tests/php/fixtures/function_inventory.json
@@ -7679,6 +7679,61 @@
             }
         ]
     },
+    "pfb_list_post_script_stage": {
+        "returnsRef": false,
+        "returnType": "bool",
+        "params": [
+            {
+                "name": "source",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "staged",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "facility",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "item",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "message",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "ledger_dir",
+                "byRef": false,
+                "variadic": false,
+                "type": "string",
+                "default": null
+            },
+            {
+                "name": "state",
+                "byRef": true,
+                "variadic": false,
+                "type": "array",
+                "default": null
+            }
+        ]
+    },
     "pfb_list_pre_script_run": {
         "returnsRef": false,
         "returnType": "array",


### PR DESCRIPTION
Fixes #2848

## What was wrong

The DNSBL post-script branch logged a failed input copy but left the script-failure state clean. The group-end close therefore removed any existing `stage='script'` entry and reported the pass as successful. The IP branch ignored failure of its `.orig.post` restore-point copy, ran the script against `.orig` anyway, and could not restore the original bytes if that script failed.

## Decision and fix

Post-script staging failures now use the existing script failure ledger contract without adding a retry marker or a new ledger stage. A shared two-caller staging helper copies the input and, on failure, removes any partial stage, marks the alias state failed, and opens the existing `stage='script'` row.

- DNSBL runs the post-script only after its throwaway `.post` copy succeeds.
- IP runs the post-script only after its `.orig.post` restore point succeeds. The late restore also requires that this pass created the restore point, so a stale path is never restored after a failed copy.
- Successful staging, zero/non-zero script exit handling, post-script side effects, and the existing no-retry-marker behavior are unchanged.

## Diagnosis

Two hypotheses were tested before production changes:

1. The DNSBL log-only arm never marks script failure state, so the group close clears the ledger entry; the unchecked IP copy also permits the script to mutate `.orig` without a usable restore point.
2. Another existing mechanism marks the staging failure or prevents unsafe IP execution.

A PHP probe used real files, an existing directory as the copy destination to force `copy()` failure even under root, and the production ledger/runner functions:

```text
$ php /var/tmp/agents/issue-2848/staging_probe.php
DNSBL copy=false state_before_close=false open_before_close=1
DNSBL open_after_close=0
IP restore_copy=false script_status=3 source=mutated
```

This confirmed hypothesis 1 and refuted hypothesis 2.

## Test-first proof

Frozen regression file:

```text
$ git hash-object tests/php/ListScriptFailureLedgerWiringTest.php
41d684cb1b8b30e2c45c67d54497cc80a1b150d9
```

Before production changes:

```text
$ vendor/bin/phpunit --no-coverage tests/php/ListScriptFailureLedgerWiringTest.php
............EE.......F  22 / 22 (100%)
2 errors: Call to undefined function pfb_list_post_script_stage()
1 failure: the DNSBL loop must stage its throwaway input through the failure-recording seam
Tests: 22, Assertions: 117, Errors: 2, Failures: 1.
```

After production changes, with the test file byte-identical:

```text
$ vendor/bin/phpunit --no-coverage tests/php/ListScriptFailureLedgerWiringTest.php
......................  22 / 22 (100%)
OK (22 tests, 134 assertions)

$ git hash-object tests/php/ListScriptFailureLedgerWiringTest.php
41d684cb1b8b30e2c45c67d54497cc80a1b150d9
```

The behavioral rows use a genuine failed copy, assert the source bytes remain unchanged, verify that the ledger entry survives the alias close, and verify that successful staging copies bytes without recording a failure. Route coverage pins both post-script call sites, the IP execution guard, and the stale-restore guard.

Private-scratch mutations were all killed:

| Mutation | Failure |
| --- | --- |
| Remove the staging failure recorder | failed state remained false |
| Treat a failed copy as success | expected false, received true |
| Run the IP script without `$pfb_post_staged` | IP execution-guard assertion failed |
| Restore `.orig.post` without `$pfb_post_staged` | stale-restore assertion failed |

## Verification

Focused neighboring contracts:

```text
$ vendor/bin/phpunit --no-coverage tests/php/ListScriptFailureLedgerWiringTest.php tests/php/PfbListScriptFailureRecordTest.php tests/php/ListScriptExitStatusTest.php tests/php/ListPreScriptStageTest.php tests/php/ListScriptTransformRerunWiringTest.php tests/php/PfbListUserScriptActiveTest.php tests/php/FunctionInventoryParityTest.php
................................................................. 65 / 65 (100%)
OK (65 tests, 302 assertions)
```

Canonical gates on commit `bbd9956ae1dbc943c45c96f45689bc2520069def`:

```text
GATE PASS: python3 scripts/check_coverage_pairing.py --name-status-z
GATE PASS: sh scripts/agent/check-graph-fresh.sh
GATE PASS: uv run --locked python scripts/check_composer_vendor.py
GATE PASS: uv run --locked python scripts/check_toggle_registry.py --self-test && uv run --locked python scripts/check_toggle_registry.py
GATE PASS: uv run --locked python scripts/check_reentry_bounds.py --self-test && uv run --locked python scripts/check_reentry_bounds.py
GATE PASS: php -l src/usr/local/pkg/pfblockerng/pfblockerng_apply.inc
GATE PASS: php -l tests/php/ListScriptFailureLedgerWiringTest.php
GATE PASS: vendor/bin/phpunit
GATE PASS: composer phpstan
GATE PASS: composer phpcs -- --standard=phpcs.xml.dist src/
GATES: PASS
```

The branch was then rebased onto current `origin/devel`; no upstream commit touched the production or test files above. The graph artifact was regenerated and the resulting signed head is `a07e64dd`.
