### PR TITLE
fix: isolate webassets reproducibility build

### DIFF
--- a/.agents/policy/coderabbit-misses.md
+++ b/.agents/policy/coderabbit-misses.md
@@ -15,6 +15,7 @@ narrative could otherwise park. `scripts/check_context_budget.py` enforces both
 caps, the shape, and this file's 12,288-byte policy budget; the recorded SHAs
 and their order are pinned by `tests/test_context_budget.py`.
 
+- `78a498db9`  fix: isolate webassets reproducibility build  (#3266) — asked twice, two quota notices; condensed review and Copilot approval resolved.
 - `e1aa16c16`  tests: share PID shim harness  (#3264) — asked twice, two quota notices (51 then 58 min); four legs + Copilot approval resolved; rebase CI PASS.
 - `2dce4766b`  gui: point apply guidance at the Update tab's Run Now, not retired Force actions  (#3241) — asked twice, two quota notices; findings of the finished pre-delta review resolved.
 - `01e9baa22`  perf: avoid Python DNS-label charset scans  (#3235) — two quota notices; condensed review and Copilot findings resolved.

--- a/scripts/check_webassets_vendor.py
+++ b/scripts/check_webassets_vendor.py
@@ -15,8 +15,8 @@ thing that may write that vendor tree.
 This mirrors ``scripts/check_composer_vendor.py``'s role for the PHP vendor/
 tree, but the drift can only be proven by actually rebuilding (there's no
 single upstream file to hash-compare -- the bundle is esbuild's own output) --
-so this checker re-runs the build script and diffs its output, rather than
-comparing lockfile metadata.
+so this checker copies the build inputs to a temporary directory, re-runs the
+build script there, and diffs its output against the committed tree.
 
 Exit status: 0 = the vendor tree matches its pinned source, 1 = it has
 drifted (regenerate with ``scripts/build-webassets.sh`` and commit the
@@ -25,8 +25,10 @@ result), 2 = the build itself failed to run.
 
 from __future__ import annotations
 
+import shutil
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 
 VENDOR_DIR = "src/usr/local/www/pfblockerng/vendor/codemirror"
@@ -43,15 +45,32 @@ def main(argv: list[str]) -> int:
         print("usage: check_webassets_vendor.py", file=sys.stderr)
         return 2
     root = _repo_root()
-    build = subprocess.run(["sh", str(root / "scripts" / "build-webassets.sh")], cwd=root)
-    if build.returncode != 0:
-        print(f"build-webassets.sh failed (exit {build.returncode})", file=sys.stderr)
-        return 2
-    diff = subprocess.run(["git", "diff", "--exit-code", "--", VENDOR_DIR], cwd=root)
-    if diff.returncode != 0:
-        print(f"vendor tree drifted from its pinned source -- {REMEDIATION}", file=sys.stderr)
-        return 1
-    return 0
+    with tempfile.TemporaryDirectory(prefix="pfb-webassets-") as temp:
+        build_root = Path(temp)
+        try:
+            (build_root / "scripts").mkdir()
+            shutil.copy2(root / "scripts" / "build-webassets.sh", build_root / "scripts")
+            shutil.copytree(
+                root / "tools" / "webassets",
+                build_root / "tools" / "webassets",
+                ignore=shutil.ignore_patterns("node_modules"),
+            )
+        except (OSError, shutil.Error) as error:
+            print(f"build-webassets.sh failed to run: {error}", file=sys.stderr)
+            return 2
+        build = subprocess.run(["sh", str(build_root / "scripts" / "build-webassets.sh")], cwd=build_root)
+        if build.returncode != 0:
+            print(f"build-webassets.sh failed (exit {build.returncode})", file=sys.stderr)
+            return 2
+        diff = subprocess.run(
+            ["git", "diff", "--no-index", "--exit-code", "--", root / VENDOR_DIR, build_root / VENDOR_DIR]
+        )
+        if diff.returncode == 0:
+            diff = subprocess.run(["git", "diff", "--exit-code", "--", VENDOR_DIR], cwd=root)
+        if diff.returncode != 0:
+            print(f"vendor tree drifted from its pinned source -- {REMEDIATION}", file=sys.stderr)
+            return 1
+        return 0
 
 
 if __name__ == "__main__":

--- a/tests/test_check_webassets_vendor.py
+++ b/tests/test_check_webassets_vendor.py
@@ -36,6 +36,118 @@ EXPECTED_FILES = (
 )
 
 
+def _checker_fixture(tmp_path: Path, mode: str) -> tuple[Path, str]:
+    root = tmp_path / mode
+    vendor = root / "src/usr/local/www/pfblockerng/vendor/codemirror"
+    tools = root / "tools/webassets"
+    scripts = root / "scripts"
+    vendor.mkdir(parents=True)
+    tools.mkdir(parents=True)
+    scripts.mkdir()
+    (vendor / "bundle.js").write_text("committed\n", encoding="utf-8")
+    if mode == "missing":
+        (vendor / "stale.js").write_text("committed stale\n", encoding="utf-8")
+    (tools / "generated.txt").write_text("committed source\n", encoding="utf-8")
+    (tools / "mode").write_text(mode, encoding="utf-8")
+    (scripts / "build-webassets.sh").write_text(
+        """#!/bin/sh
+set -eu
+root="$(CDPATH='' cd "$(dirname "$0")/.." && pwd)"
+vendor="$root/src/usr/local/www/pfblockerng/vendor/codemirror"
+mode="$(cat "$root/tools/webassets/mode")"
+rm -rf "$vendor"
+mkdir -p "$vendor"
+printf 'committed\\n' > "$vendor/bundle.js"
+printf 'generated\\n' > "$root/tools/webassets/generated.txt"
+case "$mode" in
+    changed) printf 'rebuilt\\n' > "$vendor/bundle.js" ;;
+    extra) printf 'unexpected\\n' > "$vendor/extra.js" ;;
+    failure) printf 'partial\\n' > "$vendor/bundle.js"; exit 9 ;;
+esac
+""",
+        encoding="utf-8",
+    )
+    subprocess.run(["git", "init", "-q"], cwd=root, check=True)
+    subprocess.run(["git", "add", "."], cwd=root, check=True)
+    status = subprocess.run(
+        ["git", "status", "--porcelain"], cwd=root, check=True, capture_output=True, text=True
+    ).stdout
+    return root, status
+
+
+@pytest.mark.parametrize("mode", ("same", "changed", "missing", "extra"))
+def test_checker_compares_rebuilt_tree_without_modifying_checkout(tmp_path: Path, mode: str) -> None:
+    root, status_before = _checker_fixture(tmp_path, mode)
+
+    result = subprocess.run([sys.executable, str(SCRIPT)], cwd=root, capture_output=True, text=True)
+
+    expected_status = 0 if mode == "same" else 1
+    assert result.returncode == expected_status, result.stdout + result.stderr
+    if expected_status == 1:
+        assert "vendor tree drifted from its pinned source" in result.stderr
+        assert "sh scripts/build-webassets.sh, then commit the result" in result.stderr
+    status_after = subprocess.run(
+        ["git", "status", "--porcelain"], cwd=root, check=True, capture_output=True, text=True
+    ).stdout
+    assert status_after == status_before, (
+        f"checker modified its checkout for {mode=}\nbefore:\n{status_before}\nafter:\n{status_after}"
+    )
+
+
+def test_checker_rejects_dirty_vendor_tree_that_matches_rebuild(tmp_path: Path) -> None:
+    root, _ = _checker_fixture(tmp_path, "changed")
+    vendor_file = root / "src/usr/local/www/pfblockerng/vendor/codemirror/bundle.js"
+    vendor_file.write_text("rebuilt\n", encoding="utf-8")
+    status_before = subprocess.run(
+        ["git", "status", "--porcelain"], cwd=root, check=True, capture_output=True, text=True
+    ).stdout
+
+    result = subprocess.run([sys.executable, str(SCRIPT)], cwd=root, capture_output=True, text=True)
+
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert "vendor tree drifted from its pinned source" in result.stderr
+    status_after = subprocess.run(
+        ["git", "status", "--porcelain"], cwd=root, check=True, capture_output=True, text=True
+    ).stdout
+    assert status_after == status_before, (
+        f"checker modified the already-dirty checkout\nbefore:\n{status_before}\nafter:\n{status_after}"
+    )
+
+
+def test_checker_missing_build_input_returns_two_without_modifying_checkout(tmp_path: Path) -> None:
+    root, _ = _checker_fixture(tmp_path, "same")
+    shutil.rmtree(root / "tools/webassets")
+    status_before = subprocess.run(
+        ["git", "status", "--porcelain"], cwd=root, check=True, capture_output=True, text=True
+    ).stdout
+
+    result = subprocess.run([sys.executable, str(SCRIPT)], cwd=root, capture_output=True, text=True)
+
+    assert result.returncode == 2, result.stdout + result.stderr
+    assert "build-webassets.sh failed to run" in result.stderr
+    status_after = subprocess.run(
+        ["git", "status", "--porcelain"], cwd=root, check=True, capture_output=True, text=True
+    ).stdout
+    assert status_after == status_before, (
+        f"checker modified checkout with missing build input\nbefore:\n{status_before}\nafter:\n{status_after}"
+    )
+
+
+def test_checker_build_failure_does_not_modify_checkout(tmp_path: Path) -> None:
+    root, status_before = _checker_fixture(tmp_path, "failure")
+
+    result = subprocess.run([sys.executable, str(SCRIPT)], cwd=root, capture_output=True, text=True)
+
+    assert result.returncode == 2, result.stdout + result.stderr
+    assert "build-webassets.sh failed (exit 9)" in result.stderr
+    status_after = subprocess.run(
+        ["git", "status", "--porcelain"], cwd=root, check=True, capture_output=True, text=True
+    ).stdout
+    assert status_after == status_before, (
+        f"checker modified its checkout on build failure\nbefore:\n{status_before}\nafter:\n{status_after}"
+    )
+
+
 def _manifest_entries() -> dict[str, str]:
     assert MANIFEST.is_file(), f"missing manifest: {MANIFEST}"
     entries: dict[str, str] = {}


### PR DESCRIPTION
## Summary

- rebuild the CodeMirror vendor bundle from copied inputs in a temporary directory
- compare the complete rebuilt directory without writing generated files into the checkout
- preserve Git-index drift detection and the documented 0/1/2 exit statuses
- cover identical, changed, missing, extra, already-dirty, and build-failure outcomes

## Evidence

- Diagnosis: isolated `strace` showed the previous checker opening all four tracked vendor outputs with `O_TRUNC`; this confirmed the checker itself caused the mutation.
- Frozen regression blob: `2a0fda91afeaf2e7d00d016bb3eaaba8dfaef26d`
  - original checker: **5 failed** (checkout mutation and invisible extra output)
  - pre-review isolated checker: **2 failed** (dirty-index false clean and missing-input traceback)
  - final checker, unchanged test blob: **7 passed**

| Frozen RED test | `git hash-object` | RED run tail |
| --- | --- | --- |
| `tests/test_check_webassets_vendor.py` | `2a0fda91afeaf2e7d00d016bb3eaaba8dfaef26d` | `FAILED: 5 original-checker regressions; FAILED: 2 pre-review-checker regressions` |

- Focused module: `uv run pytest -q tests/test_check_webassets_vendor.py` → **16 passed**, including the real pinned `npm ci`/Lezer/esbuild rebuild; `git status --porcelain` was identical before and after.
- Canonical local gate: `sh scripts/agent/run-gates.sh --diff origin/devel` → **PASS**: coverage pairing, graph freshness, pytest, ruff check, ruff format, and mypy.
- Signed commit: `f02d5ae71f5a32f307a85f86d65e7b1f157fa2ff` (`git log --show-signature` reports a good ECDSA signature).

## Review

One condensed independent adversarial pass covered contract conformance, correctness/hostile inputs, test honesty, and over-engineering. Its three findings were applied: preserve index-baseline semantics, convert input-copy failures to exit 2, and format the test file. Post-resolution scratch probes approved checker blob `1fcf89819f7358d27bf1e79144719895c63c5e33`; no findings remain.

Fixes #2825
