### PR TITLE
agent: refresh Graphify skill after upgrade

### DIFF
--- a/scripts/agent/ensure-graphify.sh
+++ b/scripts/agent/ensure-graphify.sh
@@ -55,8 +55,14 @@ main() {
 
 	uv tool install --upgrade "$graphify_spec" 1>&2 ||
 		fail 'Graphify installation failed'
-	graphify_bin=$(resolve_graphify_launcher) ||
+	graphify_uv_bin=$(uv tool dir --bin 2>/dev/null) ||
+		fail 'cannot resolve uv tool executable directory'
+	graphify_bin=$(absolutize_graphify_launcher "$graphify_uv_bin/graphify") ||
 		fail 'cannot resolve the installed Graphify launcher'
+	[ -x "$graphify_bin" ] ||
+		fail "installed Graphify launcher '$graphify_bin' is not executable"
+	"$graphify_bin" install --platform agents 1>&2 ||
+		fail 'Graphify skill installation failed'
 	printf '%s\n' "$graphify_bin"
 }
 

--- a/tests/shell/agent_graphify_merge_driver_spec.sh
+++ b/tests/shell/agent_graphify_merge_driver_spec.sh
@@ -39,14 +39,16 @@ case "$*" in
   *) exit 9 ;;
 esac
 UV
-    # A tripwire, never a collaborator: the real `graphify hook install` writes
-    # post-commit and post-checkout into `git rev-parse --git-path hooks` (which
-    # honours core.hooksPath), and the driver is registered by the helper itself
-    # (issue #3139). Any call is logged, drops the hooks the way the CLI would,
-    # and fails.
+    # `ensure-graphify.sh` must refresh the generic agents skill through the
+    # resolved pinned launcher. Any other Graphify call remains a tripwire:
+    # `graphify hook install` would recreate retired repository hooks.
     cat > "$stubdir/graphify" <<'GRAPHIFY'
 #!/bin/sh
 printf '%s\t%s\n' "$PWD" "$*" >> "$GRAPHIFY_LOG"
+if [ "$*" = 'install --platform agents' ]; then
+  [ "${GRAPHIFY_SKILL_FAIL:-0}" = 0 ] || exit 92
+  exit 0
+fi
 hooks_dir=$(git rev-parse --git-path hooks) && mkdir -p "$hooks_dir" && # git-env-scrub-guard: the stub mimics the real CLI, which resolves the hooks dir of the tree under test
   true > "$hooks_dir/post-commit" && true > "$hooks_dir/post-checkout"
 exit 91
@@ -64,7 +66,7 @@ exec "$REAL_GIT" "$@"
 GIT
     chmod +x "$gitstub/git"
     chmod +x "$stubdir/uv" "$stubdir/graphify"
-    export UV_LOG="$uv_log" GRAPHIFY_LOG="$graphify_log"
+    export UV_LOG="$uv_log" GRAPHIFY_LOG="$graphify_log" UV_TOOL_BIN_FIXTURE="$stubdir"
     PATH="$stubdir:$PATH"
     export PATH
   }
@@ -77,9 +79,23 @@ GIT
     When run sh "$script_abs" "$repo"
     The status should equal 0
     The contents of file "$uv_log" should include 'tool install --upgrade graphifyy[leiden] @ git+https://github.com/pfBlockerNG/graphify@'
-    The file "$graphify_log" should not be exist
+    The contents of file "$graphify_log" should include 'install --platform agents'
     The value "$(git_fixture -C "$repo" config --get merge.graphify.name)" should equal 'graphify graph.json union merge'
     The value "$(git_fixture -C "$repo" config --get merge.graphify.driver)" should equal "\"$stubdir/graphify\" merge-driver %O %A %B"
+  End
+
+  It 'uses the uv-owned launcher even when another Graphify executable shadows it on PATH'
+    uv_tool_bin="$fixture/uv-tool-bin"
+    mkdir -p "$uv_tool_bin"
+    cp "$stubdir/graphify" "$uv_tool_bin/graphify"
+    cat > "$stubdir/graphify" <<'SHADOW'
+#!/bin/sh
+exit 93
+SHADOW
+    chmod +x "$stubdir/graphify"
+    When run env UV_TOOL_BIN_FIXTURE="$uv_tool_bin" sh "$script_abs" "$repo"
+    The status should equal 0
+    The value "$(git_fixture -C "$repo" config --get merge.graphify.driver)" should equal "\"$uv_tool_bin/graphify\" merge-driver %O %A %B"
   End
 
   It 'leaves .githooks/post-commit and .githooks/post-checkout absent: registration never runs `graphify hook install` (issue #3139)'
@@ -89,8 +105,15 @@ GIT
     The status should equal 0
     The path "$repo/.githooks/post-commit" should not be exist
     The path "$repo/.githooks/post-checkout" should not be exist
-    The file "$graphify_log" should not be exist
+    The contents of file "$graphify_log" should include 'install --platform agents'
     The value "$(git_fixture -C "$repo" config --get merge.graphify.driver)" should equal "\"$stubdir/graphify\" merge-driver %O %A %B"
+  End
+
+  It 'fails before merge-driver registration when the pinned launcher cannot refresh the agents skill'
+    When run env GRAPHIFY_SKILL_FAIL=1 sh "$script_abs" "$repo"
+    The status should equal 1
+    The stderr should include 'Graphify skill installation failed'
+    The value "$(git_fixture -C "$repo" config --get merge.graphify.driver)" should equal ''
   End
 
   Context 'registration failures'


### PR DESCRIPTION
## Summary

- keep the existing Graphify package pin unchanged
- after installing or upgrading the package, refresh its generic agents skill through the exact uv-owned launcher
- propagate installer failure before registering the merge driver

This replaces the previous scope-expanded branch. No Graphify generator changes or package upgrade are required.

## Verification

- unchanged regression on original bootstrap: **8 examples, 4 failures**
- same regression with fix: **8 examples, 0 failures**
- actual CLI under isolated HOME and uv tool directories: fresh skill installation and replacement of stale SKILL.md/reference both passed with the original pinned package
- shared skill bytes match the original packaged artifacts
- focused tooling pytest: **21 passed**
- lock check, POSIX syntax, and ShellCheck passed

| Frozen RED test | `git hash-object` | RED run tail |
| --- | --- | --- |
| `tests/shell/agent_graphify_merge_driver_spec.sh` | `ffb91c18a81eca1f17b6792cd0d9fbc79d3698e0` | `8 examples, 4 failures` |

Related: andrebrait/ai-harness-settings#2

Fixes #3267


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Agent setup now reliably locates and uses the installed Graphify launcher.
  - Graphify agent skills are installed before merge-driver registration proceeds.
  - Setup now stops safely when skill installation fails, preventing incomplete configuration.

- **Tests**
  - Added coverage for launcher selection, skill installation, and failure handling.
  - Improved validation that unsupported Graphify commands do not create hooks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->