### PR TITLE
Fix reviewer quota sentinel handling

### DIFF
--- a/.agents/policy/coderabbit-misses.md
+++ b/.agents/policy/coderabbit-misses.md
@@ -15,6 +15,7 @@ narrative could otherwise park. `scripts/check_context_budget.py` enforces both
 caps, the shape, and this file's 12,288-byte policy budget; the recorded SHAs
 and their order are pinned by `tests/test_context_budget.py`.
 
+- `019e16e01`  test: pin singular reviewer quota units  (#3269) — asked twice, two quota notices; condensed review and Copilot finding resolved.
 - `31201726f`  pfblockerng: record post-script staging failures  (#3265) — asked twice, two quota notices; condensed review and Copilot findings resolved.
 - `78a498db9`  fix: isolate webassets reproducibility build  (#3266) — asked twice, two quota notices; condensed review and Copilot approval resolved.
 - `e1aa16c16`  tests: share PID shim harness  (#3264) — asked twice, two quota notices (51 then 58 min); four legs + Copilot approval resolved; rebase CI PASS.

--- a/.agents/policy/coderabbit-misses.md
+++ b/.agents/policy/coderabbit-misses.md
@@ -55,20 +55,20 @@ and their order are pinned by `tests/test_context_budget.py`.
 - `888ed710`  www/wizards: put the step-2 callouts in rows  (#2916) — never asked; the hourly slot went to #2917 and test-only PRs were skipped. Five legs, rounds 3-4 each blocking. CI green.
 - `edeb3865`  www/wizards: stop advertising a retired sinkhole VIP range  (#2912) — asked 14:53Z, rate-limited 59 min, not retried. Four legs, mutation table re-run. CI green.
 - `64623d72`  widgets: pair the jQuery-set backgrounds so the scanner sees them  (#2891) — never asked, same slot call. Four legs; helper defects split to #2866/#2892. CI green.
-- `07b4894e`  pfblockerng: name the schedule-cache failure instead of asking for a bug report  (#2887) — one quota notice (999 min), no review; 4 legs over three rounds, two blockers fixed.
-- `a12bae30`  test: repair the UI coverage the DNSBL/IP tab reorganisation broke  (#2885) — one quota notice (999 min), no review; 4 legs over two rounds, one blocker fixed; live-VM gate green.
+- `07b4894e`  pfblockerng: name the schedule-cache failure instead of asking for a bug report  (#2887) — one quota notice (4 min), no review; 4 legs over three rounds, two blockers fixed.
+- `a12bae30`  test: repair the UI coverage the DNSBL/IP tab reorganisation broke  (#2885) — one quota notice (31 min), no review; 4 legs over two rounds, one blocker fixed; live-VM gate green.
 - `ee6c4efe`  pfblockerng: serialize Alerts mutations  (#2883) — two quota notices, no review; 4 legs + verifier PASS; live-VM gate green.
 - `e3cc14df`  pfblockerng: close the script stage when an alias is removed  (#2847) — two quota notices, no review.
 - `e7d66d89`  tests: stop the lint endpoint shim leaking a PID-keyed temp dir  (#2835) — two quota notices (10 min, then 59 min), no review; 8 leg passes over two rounds.
 - `d41cabc1`  extras: name the lost dispatcher lock in the Extras guard  (#2826) — two quota notices, no review; 6 leg rounds + verifier PASS.
 - `38a2332c`  download: drop a refused ingest's promoted validators  (#2831) — one quota notice, no review.
 - `85bb57e3`  download: sanity-scan an archive's extracted payload  (#2819) — two quota notices, no review; 4 legs + verifier PASS.
-- `76b4ecc9`  download: stream the XLSX shared-strings part past the run tmpdir  (#2816) — one quota notice (999 min), no review; 4 legs over two rounds, three blockers fixed.
+- `76b4ecc9`  download: stream the XLSX shared-strings part past the run tmpdir  (#2816) — one quota notice (33 min), no review; 4 legs over two rounds, three blockers fixed.
 - `309b1902`  download: refuse an XLSX extraction that finds no address  (#2806) — two quota notices, no review; 4 legs over two rounds + verifier PASS.
 - `3aa51d4d`  pfblockerng: stage the two direct-write GeoIP extractions  (#2782) — finished review at `aa696272` applied, then rebased; this SHA unreviewed.
-- `4fa68d01`  tests: align the worktree-intelligence pin with the tracked root graph  (#2790) — one quota notice (999 min), no review; 4 legs, one blocking hole fixed.
+- `4fa68d01`  tests: align the worktree-intelligence pin with the tracked root graph  (#2790) — one quota notice (19 min), no review; 4 legs, one blocking hole fixed.
 - `3aab75a1`  install-pkg.sh: fail closed when pkg POST-INSTALL fails  (#2775) — one quota notice, no review; substitute review plus a correctness/test-honesty round.
-- `624e9a75`  install.sh: document fetch-to-file not fetch|sh  (#2756) — two quota notices, no review; 4 legs, one blocking defect fixed.
+- `624e9a75`  install.sh: document fetch-to-file not fetch|sh  (#2756) — two quota notices (59 then 52 min), no review; 4 legs, one blocking defect fixed.
 - `f9a7e158`  pfblockerng: unlink leftover Blacklist orig/hash sidecars  (#2740) — finished review at `aa6567dc` resolved, then rebased twice; this SHA unreviewed.
 - `8bb7d925`  pfblockerng: fail closed on bzip2/zip Blacklist bodies  (#2742) — never asked, never engaged; 4 legs over two rounds.
 - `dc1debe1`  ci: add scripted refresh for artifact-action majors  (#2741) — never asked, never engaged; 4 legs, two blockers discharged.

--- a/.agents/policy/coderabbit.md
+++ b/.agents/policy/coderabbit.md
@@ -73,6 +73,10 @@ Composes with [`landing.md`](landing.md) (triage, leg review, merge gate),
      nudge — a nudge inside a live window refreshes the countdown.
      Otherwise post one more `@coderabbitai review` and re-arm. A second
      quota notice ends it: record the miss, do not loop.
+   - **Exit 1 with a quota/Snyk classification diagnostic** is not a verdict:
+     do not guess a wait, re-ask, or record a miss. Read the reported state;
+     update the matcher when a real duration exists, otherwise report the
+     unclassifiable notice/error and stop.
    - **NOACK / NOTPRESENT / TIMEOUT** → re-ask **once** with a fresh
      window. Still silent → CodeRabbit is unavailable; the legs
      carry the review step. Never a second silent-nudge.

--- a/scripts/agent/wait-reviewer.sh
+++ b/scripts/agent/wait-reviewer.sh
@@ -18,8 +18,8 @@
 # Handle matching is case-insensitive and ANCHORED, so `--handle copilot` matches
 # copilot-pull-request-reviewer[bot] and `coderabbitai` matches coderabbitai[bot], but a
 # login that merely CONTAINS the handle does not count.
-# `--handle snyk` reads the head-SHA commit status/check-runs instead of comments; a
-# non-terminal error exits nonzero rather than inventing a quota duration.
+# `--handle snyk` reads the head-SHA commit status/check-runs instead of comments;
+# an unclassifiable Snyk state exits nonzero rather than inventing a quota duration.
 # Login match is ANCHORED: == handle, == handle[bot], or startswith(handle-).
 # A wall-clock deadline (max-iter x interval + 300 s slack; PFB_WAIT_DEADLINE overrides)
 # bounds the wait even when individual gh calls stall.
@@ -44,7 +44,7 @@ usage() {
 classify() {
 	if [ "$handle" = "snyk" ]; then
 		if printf '%s' "$sinfo" | grep -Eqi 'limit reached|^(error|action_required|timed_out|cancelled|stale)'; then
-			printf 'wait-reviewer.sh: non-terminal Snyk state has no authoritative duration\n' >&2
+			printf 'wait-reviewer.sh: unclassifiable Snyk state has no authoritative duration\n' >&2
 			return 1
 		fi
 		if printf '%s' "$sinfo" | grep -Eqi '^(success|failure|neutral|completed)'; then

--- a/scripts/agent/wait-reviewer.sh
+++ b/scripts/agent/wait-reviewer.sh
@@ -18,13 +18,14 @@
 # Handle matching is case-insensitive and ANCHORED, so `--handle copilot` matches
 # copilot-pull-request-reviewer[bot] and `coderabbitai` matches coderabbitai[bot], but a
 # login that merely CONTAINS the handle does not count.
-# `--handle snyk` reads the head-SHA commit status/check-runs instead of comments (Snyk
-# posts no review comments); its `error` state reports QUOTA, never a clean pass.
+# `--handle snyk` reads the head-SHA commit status/check-runs instead of comments; a
+# non-terminal error exits nonzero rather than inventing a quota duration.
 # Login match is ANCHORED: == handle, == handle[bot], or startswith(handle-).
 # A wall-clock deadline (max-iter x interval + 300 s slack; PFB_WAIT_DEADLINE overrides)
 # bounds the wait even when individual gh calls stall.
-# Exit codes: see agent_env.sh (0 verdict, 1 GH-ERROR after 3 failed polls, 2 usage,
-# 3 gh unavailable -> MCP fallback, 4 TOOL-MISSING).
+# Exit codes: see agent_env.sh (0 verdict, 1 GH-ERROR after 3 failed polls or an
+# unclassifiable quota/error state, 2 usage, 3 gh unavailable -> MCP fallback,
+# 4 TOOL-MISSING).
 # Self-terminating by construction (CLAUDE.md "No orphaned waits" #1): iteration cap AND
 # wall-clock deadline; run it in the background and read the verdict.
 
@@ -43,8 +44,8 @@ usage() {
 classify() {
 	if [ "$handle" = "snyk" ]; then
 		if printf '%s' "$sinfo" | grep -Eqi 'limit reached|^(error|action_required|timed_out|cancelled|stale)'; then
-			printf 'QUOTA 999'
-			return 0
+			printf 'wait-reviewer.sh: non-terminal Snyk state has no authoritative duration\n' >&2
+			return 1
 		fi
 		if printf '%s' "$sinfo" | grep -Eqi '^(success|failure|neutral|completed)'; then
 			printf 'FINISHED'
@@ -61,19 +62,27 @@ classify() {
 		return 0
 	fi
 	if printf '%s' "$issuec" | grep -Eqi 'run out of usage credits|review limit reached|rate limited by coderabbit|reached your .*review (rate )?limit'; then
-		# issue #2837: the colon is optional ("available in 40 minutes"), and the
-		# window must name exactly ONE numeric component -- a compound window
-		# ("1 hour 30 minutes") falls back rather than resuming on one of its parts.
-		win=$(printf '%s' "$issuec" | grep -oEi 'available in:?[^.]{0,48}' | head -1)
-		mins=''
-		if [ "$(printf '%s' "$win" | grep -oE '[0-9]+' | wc -l | tr -d ' ')" = '1' ] &&
-		   printf '%s' "$win" | grep -qEi '[0-9]+ *(minute|hour)'; then
-			mins=$(printf '%s' "$win" | grep -oE '[0-9]+' | head -1)
-			if printf '%s' "$win" | grep -qEi '[0-9]+ *hour'; then
-				mins=$(( mins * 60 ))
-			fi
+		# issue #2837: the colon is optional ("available in 40 minutes").
+		# Accept one complete duration line; partial and compound values are errors.
+		win=$(printf '%s\n' "$issuec" | grep -i 'available in' | head -1 | tr '[:upper:]' '[:lower:]')
+		quota_re='^.*available in:?[[:space:]]*[*]*([0-9]+)[[:space:]]+(minutes?|hours?)[.]?[*]*[[:space:]]*$'
+		if ! printf '%s' "$win" | grep -Eq "$quota_re"; then
+			printf 'wait-reviewer.sh: quota notice has no parseable duration\n' >&2
+			return 1
 		fi
-		printf 'QUOTA %s' "${mins:-999}"
+		parsed=$(printf '%s' "$win" | sed -E "s/$quota_re/\1 \2/")
+		quantity=${parsed%% *}
+		unit=${parsed#* }
+		quantity=$(printf '%s' "$quantity" | sed 's/^0*//')
+		[ -n "$quantity" ] || quantity=0
+		# Seven normalized digits keep an hours conversion inside POSIX's
+		# minimum 32-bit signed arithmetic range.
+		case "$quantity" in
+			????????*) printf 'wait-reviewer.sh: quota notice has no parseable duration\n' >&2; return 1 ;;
+		esac
+		mins=$quantity
+		case "$unit" in hours|hour) mins=$((quantity * 60)) ;; esac
+		printf 'QUOTA %s' "$mins"
 		return 0
 	fi
 	if printf '%s' "$issuec" | grep -qi 'review skipped' &&
@@ -227,6 +236,10 @@ main() {
 		ghfail=0
 		[ -n "${inline_any}${review_any}${issuec_any}$(printf '%s' "$sinfo" | tr -dc '[:lower:]')" ] && seen=1
 		v=$(classify)
+		classify_status=$?
+		if [ "$classify_status" -ne 0 ]; then
+			exit "$classify_status"
+		fi
 		if [ -n "$v" ]; then
 			printf '%s\n' "$issuec" | head -c 3000
 			printf '\n%s\n' "$v"

--- a/tests/fixtures/reviewer/coderabbit-quota-6.md
+++ b/tests/fixtures/reviewer/coderabbit-quota-6.md
@@ -1,0 +1,80 @@
+<!-- This is an auto-generated comment: summarize by coderabbit.ai -->
+<!-- This is an auto-generated comment: rate limited by coderabbit.ai -->
+
+> [!WARNING]
+> ## Review limit reached
+> 
+> **Next included review available in 6 minutes.**
+> 
+> <details>
+> <summary>View limit details</summary>
+> 
+> **Limit details:** You’ve used the included review currently available.
+> 
+> You've used all free OSS reviews for now. Wait for the free limit to reset to keep reviewing this public repository.
+> 
+> [Learn how review limits work](https://docs.coderabbit.ai/management/plans#rate-limits).
+> 
+> **Review configuration:**
+> 
+> <details>
+> <summary>⚙️ Run configuration</summary>
+> 
+> **Configuration used**: Path: .coderabbit.yaml
+> 
+> **Review profile**: CHILL
+> 
+> **Plan**: Pro Plus
+> 
+> **Run ID**: `1edd33b0-f2da-47be-87c4-b95cf2559db0`
+> 
+> </details>
+> 
+> <details>
+> <summary>📥 Commits</summary>
+> 
+> Reviewing files that changed from the base of the PR and between c113f2d5e0ca25b20d0dbc33e568aadb30a0c26e and 3490c6f042c3d11b86a0ae2e2a267a455b55cf7b.
+> 
+> </details>
+> 
+> <details>
+> <summary>⛔ Files ignored due to path filters (1)</summary>
+> 
+> * `.agents/context/repository-intelligence.md` is excluded by `!**/*.md`, `!.agents/**`
+> 
+> </details>
+> 
+> <details>
+> <summary>📒 Files selected for processing (4)</summary>
+> 
+> * `graphify-out/graph.json`
+> * `sgconfig.yml`
+> * `tests/skip-allowlist.txt`
+> * `tests/test_cross_agent_tooling.py`
+> 
+> </details>
+> 
+> </details>
+
+<!-- end of auto-generated comment: rate limited by coderabbit.ai -->
+
+<!-- tips_start -->
+
+---
+
+Thanks for using [CodeRabbit](https://coderabbit.ai?utm_source=oss&utm_medium=github&utm_campaign=pfBlockerNG/pfBlockerNG&utm_content=2809)! It's free for OSS, and your support helps us grow. If you like it, consider giving us a shout-out.
+
+<details>
+<summary>❤️ Share</summary>
+
+- [X](https://twitter.com/intent/tweet?text=I%20just%20used%20%40coderabbitai%20for%20my%20code%20review%2C%20and%20it%27s%20fantastic%21%20It%27s%20free%20for%20OSS%20and%20offers%20a%20free%20trial%20for%20the%20proprietary%20code.%20Check%20it%20out%3A&url=https%3A//coderabbit.ai)
+- [Mastodon](https://mastodon.social/share?text=I%20just%20used%20%40coderabbitai%20for%20my%20code%20review%2C%20and%20it%27s%20fantastic%21%20It%27s%20free%20for%20OSS%20and%20offers%20a%20free%20trial%20for%20the%20proprietary%20code.%20Check%20it%20out%3A%20https%3A%2F%2Fcoderabbit.ai)
+- [Reddit](https://www.reddit.com/submit?title=Great%20tool%20for%20code%20review%20-%20CodeRabbit&text=I%20just%20used%20CodeRabbit%20for%20my%20code%20review%2C%20and%20it%27s%20fantastic%21%20It%27s%20free%20for%20OSS%20and%20offers%20a%20free%20trial%20for%20proprietary%20code.%20Check%20it%20out%3A%20https%3A//coderabbit.ai)
+- [LinkedIn](https://www.linkedin.com/sharing/share-offsite/?url=https%3A%2F%2Fcoderabbit.ai&mini=true&title=Great%20tool%20for%20code%20review%20-%20CodeRabbit&summary=I%20just%20used%20CodeRabbit%20for%20my%20code%20review%2C%20and%20it%27s%20fantastic%21%20It%27s%20free%20for%20OSS%20and%20offers%20a%20free%20trial%20for%20proprietary%20code)
+
+</details>
+
+
+<sub>Comment `@coderabbitai help` to get the list of available commands.</sub>
+
+<!-- tips_end -->

--- a/tests/shell/agent_wait_reviewer_fixture_spec.sh
+++ b/tests/shell/agent_wait_reviewer_fixture_spec.sh
@@ -15,4 +15,19 @@ Describe 'wait-reviewer.sh historical quota fixture'
     When call classify
     The output should equal 'QUOTA 6'
   End
+
+  Parameters
+    '1 minute' 'QUOTA 1'
+    '1 hour' 'QUOTA 60'
+  End
+  It "accepts the singular duration $1"
+    handle='coderabbitai'
+    mode='finished'
+    inline=''
+    review=''
+    issuec="Review limit reached. Next included review available in $1."
+    sinfo=''
+    When call classify
+    The output should equal "$2"
+  End
 End

--- a/tests/shell/agent_wait_reviewer_fixture_spec.sh
+++ b/tests/shell/agent_wait_reviewer_fixture_spec.sh
@@ -1,0 +1,18 @@
+#shellcheck shell=sh
+# PR #2809's original 2026-08-28T04:40:41Z CodeRabbit quota body.
+
+Describe 'wait-reviewer.sh historical quota fixture'
+  AGENT_SOURCE_ONLY=1
+  Include scripts/agent/wait-reviewer.sh
+
+  It 'reports the notice-stated six-minute window'
+    handle='coderabbitai'
+    mode='finished'
+    inline=''
+    review=''
+    issuec=$(cat tests/fixtures/reviewer/coderabbit-quota-6.md)
+    sinfo=''
+    When call classify
+    The output should equal 'QUOTA 6'
+  End
+End

--- a/tests/shell/agent_wait_reviewer_spec.sh
+++ b/tests/shell/agent_wait_reviewer_spec.sh
@@ -45,12 +45,12 @@ Describe 'wait-reviewer.sh classify()'
     The output should equal 'QUOTA 120'
   End
 
-  It 'reports QUOTA with the stated minutes when the notice carries no colon'
+  It 'reports QUOTA 6 for the exact duration wording from PR 2809'
     issuec='> ## Review limit reached
 >
-> **Next included review available in 40 minutes.**'
+> **Next included review available in 6 minutes.**'
     When call classify
-    The output should equal 'QUOTA 40'
+    The output should equal 'QUOTA 6'
   End
 
   It 'converts a colonless hours-denominated resume time to minutes'
@@ -61,28 +61,36 @@ Describe 'wait-reviewer.sh classify()'
     The output should equal 'QUOTA 120'
   End
 
-  It 'falls back rather than reading a multi-unit window as its first number'
+  It 'fails rather than reading a multi-unit window as its first number'
     issuec='Review limit reached. Next included review available in 1 day 30 minutes.'
     When call classify
-    The output should equal 'QUOTA 999'
+    The status should equal 1
+    The output should equal ''
+    The stderr should include 'no parseable duration'
   End
 
-  It 'falls back when the window names an hour and a minute component'
+  It 'fails when the window names an hour and a minute component'
     issuec='Review limit reached. Next included review available in 1 hour 30 minutes.'
     When call classify
-    The output should equal 'QUOTA 999'
+    The status should equal 1
+    The output should equal ''
+    The stderr should include 'no parseable duration'
   End
 
-  It 'falls back when the window names its components in the other order'
+  It 'fails when the window names its components in the other order'
     issuec='Review limit reached. Next included review available in 40 minutes and 2 hours.'
     When call classify
-    The output should equal 'QUOTA 999'
+    The status should equal 1
+    The output should equal ''
+    The stderr should include 'no parseable duration'
   End
 
-  It 'reports QUOTA 999 when the resume time is unparsable'
+  It 'fails when a usage-credit notice carries no resume time'
     issuec='You have run out of usage credits.'
     When call classify
-    The output should equal 'QUOTA 999'
+    The status should equal 1
+    The output should equal ''
+    The stderr should include 'no parseable duration'
   End
 
   It 'reports QUOTA on the PR-review-limit phrasing (no "rate" in the notice)'
@@ -91,23 +99,107 @@ Describe 'wait-reviewer.sh classify()'
     The output should equal 'QUOTA 46'
   End
 
-  It 'reports QUOTA on the rate-limited-by-coderabbit phrasing'
+  It 'fails when the rate-limit notice carries no resume time'
     issuec='This PR is rate limited by CodeRabbit.'
     When call classify
-    The output should equal 'QUOTA 999'
+    The status should equal 1
+    The output should equal ''
+    The stderr should include 'no parseable duration'
+  End
+
+  It 'fails when the duration value is empty'
+    issuec='Review limit reached. Next included review available in .'
+    When call classify
+    The status should equal 1
+    The output should equal ''
+    The stderr should include 'no parseable duration'
+  End
+
+  It 'fails when the duration number is absent'
+    issuec='Review limit reached. Next included review available in minutes.'
+    When call classify
+    The status should equal 1
+    The output should equal ''
+    The stderr should include 'no parseable duration'
+  End
+
+  It 'fails rather than accepting the numeric substring of a negative duration'
+    issuec='Review limit reached. Next included review available in -6 minutes.'
+    When call classify
+    The status should equal 1
+    The output should equal ''
+    The stderr should include 'no parseable duration'
+  End
+
+  It 'fails rather than accepting part of a decimal duration'
+    issuec='Review limit reached. Next included review available in 1.5 hours.'
+    When call classify
+    The status should equal 1
+    The output should equal ''
+    The stderr should include 'no parseable duration'
+  End
+
+  It 'fails rather than accepting a mixed-unit duration'
+    issuec='Review limit reached. Next included review available in 6 minutes and 2 hours.'
+    When call classify
+    The status should equal 1
+    The output should equal ''
+    The stderr should include 'no parseable duration'
+  End
+
+  It 'fails before shell arithmetic can overflow'
+    issuec='Review limit reached. Next included review available in 999999999999999999999 hours.'
+    When call classify
+    The status should equal 1
+    The output should equal ''
+    The stderr should include 'no parseable duration'
+  End
+
+  It 'normalizes leading zeroes without octal arithmetic'
+    issuec='Review limit reached. Next included review available in 0006 minutes.'
+    When call classify
+    The output should equal 'QUOTA 6'
+  End
+
+  It 'accepts Markdown and surrounding whitespace around one duration'
+    issuec='> ## Review limit reached
+>
+> **Next included review available in:   **0002 hours.**   '
+    When call classify
+    The output should equal 'QUOTA 120'
+  End
+
+  It 'ignores unrelated numbers outside the duration line'
+    issuec='Review limit reached.
+Run ID: 123456789
+**Next included review available in 6 minutes.**
+Plan allows 1 review per hour.'
+    When call classify
+    The output should equal 'QUOTA 6'
+  End
+
+  It 'fails rather than accepting a duration prefix'
+    issuec='Review limit reached. Next included review available in 6 minutes remaining.'
+    When call classify
+    The status should equal 1
+    The output should equal ''
+    The stderr should include 'no parseable duration'
   End
 
   Parameters
+    error
     action_required
     timed_out
     cancelled
     stale
   End
-  It "reports QUOTA for the non-verdict Snyk state $1"
+  It "fails for the non-verdict Snyk state $1 without inventing a wait"
     handle='snyk'
     sinfo="$1 scan did not complete"
     When call classify
-    The output should equal 'QUOTA 999'
+    The status should equal 1
+    The output should equal ''
+    The stderr should include 'no authoritative duration'
   End
 
   It 'reports DECLINE on a review-skipped-for-base-branch notice'
@@ -162,12 +254,6 @@ Describe 'wait-reviewer.sh classify()'
     The output should equal ''
   End
 
-  It 'reports QUOTA 999 for a Snyk error status (a skipped scan is never a clean pass)'
-    handle='snyk'
-    sinfo='error Code test limit reached'
-    When call classify
-    The output should equal 'QUOTA 999'
-  End
 
   It 'reports FINISHED for a terminal Snyk verdict'
     handle='snyk'
@@ -342,6 +428,26 @@ STUB
     echo 'Actionable comments posted: 1' > "$GH_STUB_ISSUE_SINCE"
     When run sh "$script" --repo o/r --pr 1 --handle coderabbitai --until finished --since x --interval 0 --max-iter 3
     The output should include 'FINISHED'
+  End
+
+  It 'prints QUOTA 6 as the final CLI verdict for the PR 2809 wording'
+    export GH_STUB_ISSUE_SINCE="$stubdir/issue.txt"
+    cat > "$GH_STUB_ISSUE_SINCE" <<'NOTICE'
+> ## Review limit reached
+>
+> **Next included review available in 6 minutes.**
+NOTICE
+    When run sh "$script" --repo o/r --pr 1 --handle coderabbitai --until finished --since x --interval 0 --max-iter 1
+    The line 5 of output should equal 'QUOTA 6'
+  End
+
+  It 'propagates an unparsable quota notice as a nonzero CLI result'
+    export GH_STUB_ISSUE_SINCE="$stubdir/issue.txt"
+    echo 'This PR is rate limited by CodeRabbit.' > "$GH_STUB_ISSUE_SINCE"
+    When run sh "$script" --repo o/r --pr 1 --handle coderabbitai --until finished --since x --interval 0 --max-iter 1
+    The status should equal 1
+    The output should not include 'QUOTA 999'
+    The stderr should include 'no parseable duration'
   End
 
   It 'honours the wall-clock deadline even when content would be found (No-orphaned-waits #1)'


### PR DESCRIPTION
Fixes #2814.

## Summary

- parse CodeRabbit quota durations strictly and preserve the exact notice-stated wait instead of inventing `QUOTA 999`
- fail with a diagnostic when quota or terminal-error states have no authoritative duration, and propagate that failure through the CLI
- preserve the earlier colonless-duration fix and content-first review verdict ordering
- add the exact recoverable original six-minute PR #2809 notice as a regression fixture
- correct the five historical 999-minute ledger records while preserving their genuinely unreviewed SHAs and append public corrections to the affected PRs

## Test-first proof

The behavior spec was frozen at blob `6d6bf0af4cc7458cace81b8be05db92629cd9d1d` before the production edit.

- RED: `shellspec --shell "$(command -v dash)" tests/shell/agent_wait_reviewer_spec.sh` — 108 examples, 19 failures
- GREEN with the same test blob — 108 examples, 0 failures
- final focused suite, including exact historical fixture and review-added singular-unit coverage — 111 examples, 0 failures

The suite rejects malformed, missing, compound, negative, decimal, prefixed, and oversized durations; exercises singular/plural hours and minutes, Markdown, whitespace, leading zeroes, unrelated numbers, CLI status propagation, and Snyk error states. Six production mutants were killed. The condensed reviewer then found that a plural-only regex mutant survived; parameterized singular minute/hour assertions now kill it with 2 failures.

## Review and gate

- one condensed adversarial reviewer pass covered contract, correctness/hostile input, test honesty, and over-engineering: 0 blockers; F1 test gap applied, F2 generated-metadata note skipped as informational
- public pre-fix finding audit: https://github.com/pfBlockerNG/pfBlockerNG/issues/2814#issuecomment-5617982050
- independent verifier reproduced frozen RED 108/19 → GREEN 109/0
- final F1 delta gate on `019e16e0188326ff5fcfe4073b7eeeae970767de`: focused 111/0; plural-only mutant 111/2; all nine canonical mapped gates passed
- both commits are signed and the final candidate passed `git verify-commit`

## Historical audit

GitHub comment/review surfaces and edit histories confirmed the actual notices:

- #2887: 4 minutes
- #2885: 31 minutes
- #2816: 33 minutes
- #2790: 19 minutes
- #2756: 59 minutes, then 52 minutes after the quota comment was edited

All five recorded SHAs genuinely lacked a finished CodeRabbit review. Public append-only correction comments were added to each affected PR; #2756 has a follow-up after its earlier edit revision was recovered.

For #2809, GitHub GraphQL retained the exact original creation revision containing `Next included review available in 6 minutes.` The issue reports observing a 9,381-byte payload, while GitHub's retained creation-revision diff is 3,248 bytes and the text fixture adds one final LF; the fixture uses the exact retrievable original revision rather than reconstructing or padding it.


## Frozen RED evidence

| Frozen RED test | git hash-object | RED run tail |
|---|---|---|
| `tests/shell/agent_wait_reviewer_spec.sh` | `6d6bf0af4cc7458cace81b8be05db92629cd9d1d` | `108 examples, 19 failures` |
| `tests/shell/agent_wait_reviewer_fixture_spec.sh` | `0d8713738ed6412e2738dbe37aad693c266f5f80` | `N/A — post-freeze preservation coverage; parent already parsed singular and exact six-minute wording correctly via #2837` |
