### PR TITLE
tests: isolate each temporary fixture invocation

### DIFF
--- a/tests/php/DownloadExtractionExitCodeTest.php
+++ b/tests/php/DownloadExtractionExitCodeTest.php
@@ -459,9 +459,15 @@ final class DownloadExtractionExitCodeTest extends TestCase
 	public function testBlacklistTarFinalizeTreatsDirectoryOnlyTreeAsEmpty(): void
 	{
 		$this->assertTrue(function_exists('pfb_blacklist_tar_finalize_staged'));
-		$staged = sys_get_temp_dir() . '/pfb2764_' . (string) getmypid();
-		@mkdir($staged, 0700, TRUE);
-		@mkdir($staged . '/feed_cat', 0700);
+		$staged = sys_get_temp_dir() . '/pfb2764_' . getmypid() . '_' . bin2hex(random_bytes(8));
+		$this->assertTrue(mkdir($staged, 0700, TRUE), "could not create the test staging dir {$staged}");
+		$ownerPid = getmypid();
+		register_shutdown_function(static function () use ($staged, $ownerPid): void {
+			if (getmypid() === $ownerPid) {
+				rmdir_recursive($staged);
+			}
+		});
+		$this->assertTrue(mkdir($staged . '/feed_cat', 0700), "could not create the test feed_cat dir {$staged}/feed_cat");
 		try {
 			$this->assertSame(
 				pfb_download_initial_retval(),

--- a/tests/php/DownloadGeoipStagePublishTest.php
+++ b/tests/php/DownloadGeoipStagePublishTest.php
@@ -38,7 +38,21 @@ final class DownloadGeoipStagePublishTest extends TestCase
 		// Shell-clean on purpose: a fixture path carrying metacharacters would make
 		// every failure ambiguous. The escaping the generated staged target needs is
 		// pinned by its own case below.
-		$this->dir = sys_get_temp_dir() . '/pfb_geoip_stage_' . getmypid();
+		$this->dir = sys_get_temp_dir() . '/pfb_geoip_stage_' . getmypid() . '_' . bin2hex(random_bytes(8));
+		$this->assertTrue(mkdir($this->dir, 0755, TRUE));
+		$dir = $this->dir;
+		$ownerPid = getmypid();
+		register_shutdown_function(static function () use ($dir, $ownerPid): void {
+			// pcntl_fork() inherits shutdown callbacks; only the process that created this tree owns it.
+			if (getmypid() === $ownerPid) {
+				// A fixture deliberately drops write permission on the share; restore it so
+				// process exit can still remove the tree whatever the test did to it.
+				if (is_dir($dir) && !is_link($dir)) {
+					exec('/bin/chmod -R u+rwx ' . escapeshellarg($dir) . ' 2>/dev/null');
+				}
+				rmdir_recursive($dir);
+			}
+		});
 		$this->share = "{$this->dir}/GeoIP";
 		$this->build = "{$this->dir}/build";
 		$this->assertTrue(mkdir("{$this->share}/cc", 0755, TRUE));

--- a/tests/php/DownloadStagePublishDirTest.php
+++ b/tests/php/DownloadStagePublishDirTest.php
@@ -26,8 +26,16 @@ final class DownloadStagePublishDirTest extends TestCase
 
 	protected function setUp(): void
 	{
-		$this->dir = sys_get_temp_dir() . '/pfb stagedir; ' . getmypid() . " 'fixture'";
+		$this->dir = sys_get_temp_dir() . '/pfb stagedir; ' . getmypid() . '_' . bin2hex(random_bytes(8)) . " 'fixture'";
 		$this->assertTrue(mkdir($this->dir, 0700, TRUE));
+		$dir = $this->dir;
+		$ownerPid = getmypid();
+		register_shutdown_function(static function () use ($dir, $ownerPid): void {
+			// pcntl_fork() inherits shutdown callbacks; only the process that created this tree owns it.
+			if (getmypid() === $ownerPid) {
+				rmdir_recursive($dir);
+			}
+		});
 	}
 
 	protected function tearDown(): void

--- a/tests/php/DownloadStagePublishTest.php
+++ b/tests/php/DownloadStagePublishTest.php
@@ -21,8 +21,16 @@ final class DownloadStagePublishTest extends TestCase
 
 	protected function setUp(): void
 	{
-		$this->dir = sys_get_temp_dir() . '/pfb stage; ' . getmypid() . " 'fixture'";
+		$this->dir = sys_get_temp_dir() . '/pfb stage; ' . getmypid() . '_' . bin2hex(random_bytes(8)) . " 'fixture'";
 		$this->assertTrue(mkdir($this->dir, 0700, TRUE));
+		$dir = $this->dir;
+		$ownerPid = getmypid();
+		register_shutdown_function(static function () use ($dir, $ownerPid): void {
+			// pcntl_fork() inherits shutdown callbacks; only the process that created this tree owns it.
+			if (getmypid() === $ownerPid) {
+				rmdir_recursive($dir);
+			}
+		});
 	}
 
 	protected function tearDown(): void

--- a/tests/php/FixtureInlineLifecycleTest.php
+++ b/tests/php/FixtureInlineLifecycleTest.php
@@ -1,0 +1,312 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/** Local fixture creation must neither adopt stale roots nor outlive its process. */
+final class FixtureInlineLifecycleTest extends TestCase
+{
+	private const ROOT = __DIR__ . '/../..';
+
+	/** @var list<string> observation base directories to sweep, recorded before creation */
+	private array $bases = [];
+
+	protected function tearDown(): void
+	{
+		foreach ($this->bases as $base) {
+			rmdir_recursive($base);
+		}
+		$this->bases = [];
+		parent::tearDown();
+	}
+
+	private function newObservationBase(): string
+	{
+		$base = sys_get_temp_dir() . '/pfb_inline_lifecycle_' . getmypid() . '_' . bin2hex(random_bytes(8));
+		$this->bases[] = $base;
+		if (!mkdir($base, 0700, TRUE)) {
+			throw new RuntimeException("observation base directory creation failed: {$base}");
+		}
+		return (string) realpath($base);
+	}
+
+	/** @return array{status:int,stdout:string,stderr:string} */
+	private function runChildScript(string $script, string $base): array
+	{
+		$descriptors = [1 => ['pipe', 'w'], 2 => ['pipe', 'w']];
+		$process = proc_open([PHP_BINARY, '-d', 'sys_temp_dir=' . $base, '-r', $script], $descriptors, $pipes);
+		$this->assertIsResource($process, 'failed to spawn the child PHP process');
+		$stdout = (string) stream_get_contents($pipes[1]);
+		$stderr = (string) stream_get_contents($pipes[2]);
+		fclose($pipes[1]);
+		fclose($pipes[2]);
+		$status = proc_close($process);
+		return ['status' => $status, 'stdout' => $stdout, 'stderr' => $stderr];
+	}
+
+	/** @return array<string, mixed> */
+	private function decodeMarkedResult(string $namingSite, array $result, string $marker): array
+	{
+		$this->assertSame(
+			0, $result['status'],
+			"{$namingSite}: child process exited nonzero -- stderr: {$result['stderr']}"
+		);
+		$pos = strrpos($result['stdout'], $marker);
+		$this->assertIsInt($pos, "{$namingSite}: child produced no {$marker} payload; stdout: {$result['stdout']}");
+		$decoded = json_decode(substr($result['stdout'], $pos + strlen($marker)), TRUE, 512, JSON_THROW_ON_ERROR);
+		$this->assertIsArray($decoded, "{$namingSite}: expected a decoded array payload from {$marker}");
+		return $decoded;
+	}
+
+	/** @param list<string> $extraPreCreateSubpaths @return array<string,mixed> */
+	private function runCollisionProbe(
+		string $namingSite,
+		string $class,
+		string $method,
+		string $markerSubpath,
+		array $extraPreCreateSubpaths
+	): array {
+		$base = $this->newObservationBase();
+		$repoRoot = var_export(realpath(self::ROOT), TRUE);
+		$classCode = var_export($class, TRUE);
+		$methodCode = var_export($method, TRUE);
+		$markerSubpathCode = var_export($markerSubpath, TRUE);
+		$extraCode = var_export($extraPreCreateSubpaths, TRUE);
+		$prefixCode = var_export('/' . $namingSite, TRUE);
+		$script = <<<PHP
+\$pid = getmypid();
+\$fixtureRoot = sys_get_temp_dir() . {$prefixCode} . \$pid;
+if (!mkdir(\$fixtureRoot, 0755, TRUE)) {
+	throw new RuntimeException('cannot plant stale fixture root');
+}
+foreach ({$extraCode} as \$extraSub) {
+	if (!mkdir(\$fixtureRoot . \$extraSub, 0755, TRUE)) {
+		throw new RuntimeException('cannot plant stale fixture child');
+	}
+}
+\$markerDir = \$fixtureRoot . {$markerSubpathCode};
+if (!is_dir(\$markerDir) && !mkdir(\$markerDir, 0755, TRUE)) {
+	throw new RuntimeException('cannot plant stale marker directory');
+}
+\$markerFile = \$markerDir . '/stale-marker.txt';
+\$markerContent = 'stale-from-prior-pid-' . \$pid . "\\n";
+if (file_put_contents(\$markerFile, \$markerContent) !== strlen(\$markerContent)) {
+	throw new RuntimeException('cannot plant stale marker');
+}
+
+require {$repoRoot} . '/vendor/autoload.php';
+require {$repoRoot} . '/tests/php/bootstrap.php';
+require {$repoRoot} . '/tests/php/' . {$classCode} . '.php';
+
+\$class = {$classCode};
+\$method = {$methodCode};
+\$object = new \$class(\$method);
+\$class::setUpBeforeClass();
+(new ReflectionMethod(\$class, 'setUp'))->invoke(\$object);
+
+\$events = [];
+set_error_handler(static function (int \$severity, string \$message) use (&\$events): bool {
+	\$events[] = ['unsuppressed' => (error_reporting() & \$severity) !== 0, 'message' => \$message];
+	return TRUE;
+});
+\$error = NULL;
+try {
+	\$object->{\$method}();
+} catch (Throwable \$e) {
+	\$error = get_class(\$e) . ': ' . \$e->getMessage();
+}
+restore_error_handler();
+(new ReflectionMethod(\$class, 'tearDown'))->invoke(\$object);
+
+\$markerStillExists = file_exists(\$markerFile);
+\$markerByteIdentical = \$markerStillExists ? (file_get_contents(\$markerFile) === \$markerContent) : FALSE;
+echo "\\n__PFB_COLLISION_RESULT__" . json_encode(compact('events', 'error', 'markerFile', 'markerContent', 'markerStillExists', 'markerByteIdentical'));
+PHP;
+		$result = $this->runChildScript($script, $base);
+		$payload = $this->decodeMarkedResult($namingSite, $result, '__PFB_COLLISION_RESULT__');
+		$this->assertStringStartsWith($base . '/', $payload['markerFile']);
+		$this->assertFileExists($payload['markerFile'], 'fixture shutdown erased a stale root');
+		$this->assertSame($payload['markerContent'], file_get_contents($payload['markerFile']));
+		return $payload;
+	}
+
+	/** @return array<string,mixed> */
+	private function runCreationRefusalProbe(string $namingSite, string $class, string $method): array
+	{
+		$base = $this->newObservationBase();
+		$repoRoot = var_export(realpath(self::ROOT), TRUE);
+		$classCode = var_export($class, TRUE);
+		$methodCode = var_export($method, TRUE);
+		$script = <<<PHP
+require {$repoRoot} . '/vendor/autoload.php';
+require {$repoRoot} . '/tests/php/bootstrap.php';
+require {$repoRoot} . '/tests/php/' . {$classCode} . '.php';
+
+\$class = {$classCode};
+\$method = {$methodCode};
+\$object = new \$class(\$method);
+\$class::setUpBeforeClass();
+(new ReflectionMethod(\$class, 'setUp'))->invoke(\$object);
+
+\$events = [];
+set_error_handler(static function (int \$severity, string \$message) use (&\$events): bool {
+	\$events[] = ['unsuppressed' => (error_reporting() & \$severity) !== 0, 'message' => \$message];
+	return TRUE;
+});
+
+ini_set('open_basedir', {$repoRoot});
+
+\$error = NULL;
+try {
+	(new ReflectionMethod(\$class, \$method))->invoke(\$object);
+} catch (Throwable \$e) {
+	\$error = get_class(\$e) . ': ' . \$e->getMessage();
+}
+
+echo "\\n__PFB_REFUSAL_RESULT__" . json_encode(compact('events', 'error'));
+PHP;
+		$result = $this->runChildScript($script, $base);
+		// The restriction also blocks bootstrap cleanup; parent teardown owns that residue.
+		return $this->decodeMarkedResult($namingSite, $result, '__PFB_REFUSAL_RESULT__');
+	}
+
+	/** @return array<string,array{string,string,string,string,list<string>}> */
+	public static function inlineFixtureRows(): array
+	{
+		return [
+			'blacklist finalize' => [
+				'pfb2764_', 'DownloadExtractionExitCodeTest', 'testBlacklistTarFinalizeTreatsDirectoryOnlyTreeAsEmpty',
+				'', ['/feed_cat'],
+			],
+			'exact prefetch' => [
+				'pfb_833_exact_', 'IpPrefetchTest', 'test_single_file_folder_exact_match_resolves_correctly_per_row_and_batched',
+				'', [],
+			],
+			'CIDR prefetch' => [
+				'pfb_833_cidr_', 'IpPrefetchTest', 'test_single_file_folder_cidr_only_coverage_resolves_correctly_per_row_and_batched',
+				'', [],
+			],
+			'miss prefetch' => [
+				'pfb_831_', 'IpPrefetchTest', 'test_single_file_folder_miss_row_is_correctly_seeded_after_the_833_fix',
+				'/cc', [],
+			],
+			'ET prefetch' => [
+				'pfb_832_et_', 'IpPrefetchTest', 'test_et_header_still_listed_ip_is_found_by_the_real_validate_exec',
+				'', [],
+			],
+			'hook scripts' => [
+				'pfb_hook_test_', 'PfbHookScriptsTest', 'testEnumerationExcludesSymlinksEscapingTheDirAndIncludesContainedAlias',
+				'', [],
+			],
+		];
+	}
+
+	#[DataProvider('inlineFixtureRows')]
+	public function testStalePidRootIsNotAdopted(
+		string $prefix, string $class, string $method, string $markerSubpath, array $extraPreCreateSubpaths
+	): void {
+		$payload = $this->runCollisionProbe($prefix, $class, $method, $markerSubpath, $extraPreCreateSubpaths);
+		$this->assertSame([], $payload['events'], "{$prefix} emitted fixture warnings: " . json_encode($payload['events']));
+		$this->assertNull($payload['error'], "{$prefix} public test failed: " . ($payload['error'] ?? ''));
+		$this->assertTrue($payload['markerStillExists'], "{$prefix} erased the stale marker");
+		$this->assertTrue($payload['markerByteIdentical'], "{$prefix} changed the stale marker");
+	}
+
+	#[DataProvider('inlineFixtureRows')]
+	public function testCreationStopsAtFirstUnsuppressedMkdirFailure(
+		string $prefix, string $class, string $method, string $markerSubpath, array $extraPreCreateSubpaths
+	): void {
+		$payload = $this->runCreationRefusalProbe($prefix, $class, $method);
+		$this->assertCount(1, $payload['events'], "{$prefix} continued after failed creation: " . json_encode($payload['events']));
+		$this->assertStringStartsWith('mkdir():', $payload['events'][0]['message']);
+		$this->assertTrue($payload['events'][0]['unsuppressed'], "{$prefix} suppressed directory creation failure");
+		$this->assertNotNull($payload['error'], "{$prefix} ignored failed directory creation");
+	}
+
+	public function testHookBuilderAllocationsAreIsolatedAndRemovedAtExit(): void
+	{
+		$base = $this->newObservationBase();
+		$repoRoot = var_export(realpath(self::ROOT), TRUE);
+		$script = <<<PHP
+require {$repoRoot} . '/vendor/autoload.php';
+require {$repoRoot} . '/tests/php/bootstrap.php';
+require {$repoRoot} . '/tests/php/PfbHookScriptsTest.php';
+
+\$make = new ReflectionMethod('PfbHookScriptsTest', 'makeSymlinkFixture');
+\$first = \$make->invoke(NULL);
+\$second = \$make->invoke(NULL);
+
+\$inspect = static function (array \$fixture): array {
+	\$dir = \$fixture['dir'];
+	\$realDir = realpath(\$dir);
+	\$realFile = realpath(\$dir . '/hook_pre_real.sh');
+	\$aliasReal = realpath(\$dir . '/hook_pre_alias.sh');
+	\$escapeReal = realpath(\$dir . '/hook_pre_escape.sh');
+	\$todirReal = realpath(\$dir . '/hook_pre_todir.sh');
+	return [
+		'directoryExists' => is_dir(\$dir),
+		'realFileIsPlainFile' => is_file(\$dir . '/hook_pre_real.sh') && !is_link(\$dir . '/hook_pre_real.sh'),
+		'aliasIsLink' => is_link(\$dir . '/hook_pre_alias.sh'),
+		'aliasResolvesInsideToRealFile' => (\$aliasReal !== FALSE && \$aliasReal === \$realFile),
+		'escapeIsLink' => is_link(\$dir . '/hook_pre_escape.sh'),
+		'escapeResolvesOutsideDir' => (\$escapeReal !== FALSE && \$realDir !== FALSE
+			&& strncmp(\$escapeReal, \$realDir, strlen(\$realDir)) !== 0),
+		'todirIsLinkToSameDir' => (is_link(\$dir . '/hook_pre_todir.sh') && is_dir(\$dir . '/hook_pre_todir.sh')
+			&& \$todirReal !== FALSE && \$todirReal === \$realDir),
+		'dangleIsLink' => is_link(\$dir . '/hook_pre_dangle.sh'),
+		'dangleUnresolvable' => (realpath(\$dir . '/hook_pre_dangle.sh') === FALSE),
+		'outsideIsExecutableFile' => (is_file(\$fixture['outside']) && is_executable(\$fixture['outside'])),
+	];
+};
+
+\$firstInspection = \$inspect(\$first);
+\$secondInspection = \$inspect(\$second);
+
+echo "\\n__PFB_HOOK_RESULT__" . json_encode(compact('first', 'second', 'firstInspection', 'secondInspection'));
+// No explicit fixture cleanup: the owning process must remove both allocations.
+PHP;
+		$result = $this->runChildScript($script, $base);
+		$payload = $this->decodeMarkedResult('pfb_hook_test_ builder', $result, '__PFB_HOOK_RESULT__');
+		$first = $payload['first'];
+		$second = $payload['second'];
+
+		$this->assertNotSame(
+			$first['dir'], $second['dir'],
+			'two hook fixture allocations shared the same directory'
+		);
+
+		foreach (['first' => $payload['firstInspection'], 'second' => $payload['secondInspection']] as $label => $inspection) {
+			$this->assertTrue($inspection['directoryExists'], "{$label} hook directory was never created");
+			$this->assertTrue($inspection['realFileIsPlainFile'], "pfb_hook_test_ {$label}: hook_pre_real.sh must be a plain file");
+			$this->assertTrue($inspection['aliasIsLink'], "pfb_hook_test_ {$label}: hook_pre_alias.sh must be a symlink");
+			$this->assertTrue(
+				$inspection['aliasResolvesInsideToRealFile'],
+				"pfb_hook_test_ {$label}: the contained alias must resolve to the real file inside the dir"
+			);
+			$this->assertTrue($inspection['escapeIsLink'], "pfb_hook_test_ {$label}: hook_pre_escape.sh must be a symlink");
+			$this->assertTrue(
+				$inspection['escapeResolvesOutsideDir'],
+				"pfb_hook_test_ {$label}: the escaping symlink must resolve outside the dir"
+			);
+			$this->assertTrue(
+				$inspection['todirIsLinkToSameDir'],
+				"pfb_hook_test_ {$label}: hook_pre_todir.sh must be a self-referential symlink to the dir"
+			);
+			$this->assertTrue($inspection['dangleIsLink'], "pfb_hook_test_ {$label}: hook_pre_dangle.sh must be a symlink");
+			$this->assertTrue($inspection['dangleUnresolvable'], "pfb_hook_test_ {$label}: the dangling symlink must not resolve");
+			$this->assertTrue(
+				$inspection['outsideIsExecutableFile'],
+				"pfb_hook_test_ {$label}: the outside script must exist and remain executable"
+			);
+		}
+
+		foreach ([$first, $second] as $fixture) {
+			$this->assertStringStartsWith($base . '/', $fixture['dir']);
+			$this->assertStringStartsWith($base . '/', $fixture['outside']);
+			$this->assertDirectoryDoesNotExist($fixture['dir'], 'hook directory survived process exit');
+			$this->assertFileDoesNotExist($fixture['outside'], 'outside hook script survived process exit');
+		}
+	}
+}

--- a/tests/php/FixtureInlineLifecycleTest.php
+++ b/tests/php/FixtureInlineLifecycleTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
+require_once __DIR__ . '/support/ProcessRunner.php';
+
 /** Local fixture creation must neither adopt stale roots nor outlive its process. */
 final class FixtureInlineLifecycleTest extends TestCase
 {
@@ -35,15 +37,8 @@ final class FixtureInlineLifecycleTest extends TestCase
 	/** @return array{status:int,stdout:string,stderr:string} */
 	private function runChildScript(string $script, string $base): array
 	{
-		$descriptors = [1 => ['pipe', 'w'], 2 => ['pipe', 'w']];
-		$process = proc_open([PHP_BINARY, '-d', 'sys_temp_dir=' . $base, '-r', $script], $descriptors, $pipes);
-		$this->assertIsResource($process, 'failed to spawn the child PHP process');
-		$stdout = (string) stream_get_contents($pipes[1]);
-		$stderr = (string) stream_get_contents($pipes[2]);
-		fclose($pipes[1]);
-		fclose($pipes[2]);
-		$status = proc_close($process);
-		return ['status' => $status, 'stdout' => $stdout, 'stderr' => $stderr];
+		$result = pfb_test_run_process([PHP_BINARY, '-d', 'sys_temp_dir=' . $base, '-r', $script]);
+		return ['status' => $result['exit'], 'stdout' => $result['stdout'], 'stderr' => $result['stderr']];
 	}
 
 	/** @return array<string, mixed> */

--- a/tests/php/FixtureLifecycleProcessTest.php
+++ b/tests/php/FixtureLifecycleProcessTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/support/ProcessRunner.php';
+
+final class FixtureLifecycleProcessTest extends TestCase
+{
+	/** @return array<string,array{string}> */
+	public static function fixtureClasses(): array
+	{
+		return [
+			'inline fixtures' => ['FixtureInlineLifecycleTest'],
+			'setup fixtures' => ['FixtureSetupLifecycleTest'],
+		];
+	}
+
+	/** @return array<string,mixed> */
+	private function runProbe(string $class, string $script): array
+	{
+		$root = var_export(dirname(__DIR__, 2), TRUE);
+		$classLiteral = var_export($class, TRUE);
+		$scriptLiteral = var_export($script, TRUE);
+		$probe = <<<PHP
+require {$root} . '/vendor/autoload.php';
+\$class = {$classLiteral};
+require {$root} . '/tests/php/' . \$class . '.php';
+\$object = new \$class('testProbe');
+try {
+	if (\$class === 'FixtureInlineLifecycleTest') {
+		\$method = new ReflectionMethod(\$class, 'runChildScript');
+		\$result = \$method->invoke(\$object, {$scriptLiteral}, sys_get_temp_dir());
+		\$result['stderrBytes'] = strlen(\$result['stderr']);
+		unset(\$result['stderr']);
+	} else {
+		\$method = new ReflectionMethod(\$class, 'runChild');
+		\$result = \$method->invoke(\$object, sys_get_temp_dir(), {$scriptLiteral});
+	}
+} catch (RuntimeException \$error) {
+	\$result = ['timeout' => str_starts_with(\$error->getMessage(), 'STUCK/ENVIRONMENT: process exceeded hard deadline:')];
+}
+echo json_encode(\$result);
+PHP;
+		// The outer watchdog reaps the whole probe group if its inner deadline regresses.
+		$result = pfb_test_run_process([
+			(string) $GLOBALS['pfb']['timeout'], '-s', 'TERM', '-k', '5', '30',
+			PHP_BINARY, '-r', $probe,
+		], 40.0);
+		$this->assertSame(0, $result['exit'], "STUCK/ENVIRONMENT: fixture probe did not complete:\n{$result['stdout']}{$result['stderr']}");
+		return json_decode($result['stdout'], TRUE, 512, JSON_THROW_ON_ERROR);
+	}
+
+	#[DataProvider('fixtureClasses')]
+	public function testChildCanFinishAfterFillingItsStderrPipe(string $class): void
+	{
+		$result = $this->runProbe($class, 'fwrite(STDERR, str_repeat("x", 1048576)); echo json_encode(["complete" => TRUE]);');
+		$expected = $class === 'FixtureInlineLifecycleTest'
+			? ['status' => 0, 'stdout' => '{"complete":true}', 'stderrBytes' => 1048576]
+			: ['complete' => TRUE];
+		$this->assertSame($expected, $result);
+	}
+
+	#[DataProvider('fixtureClasses')]
+	public function testStalledChildReportsItsOwnDeadlineBeforeTheOuterWatchdog(string $class): void
+	{
+		$result = $this->runProbe($class, 'sleep(60); echo json_encode(["complete" => TRUE]);');
+		$this->assertSame(['timeout' => TRUE], $result);
+	}
+}

--- a/tests/php/FixtureSetupLifecycleTest.php
+++ b/tests/php/FixtureSetupLifecycleTest.php
@@ -1,0 +1,326 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/** Fixture allocations stay isolated across setup calls and expire with their owning process. */
+final class FixtureSetupLifecycleTest extends TestCase
+{
+	private const ROOT = __DIR__ . '/../..';
+
+	/** @var list<string> parent-owned observation roots to sweep in tearDown() */
+	private array $observationRoots = [];
+
+	protected function tearDown(): void
+	{
+		foreach ($this->observationRoots as $root) {
+			// The GeoIP fixture can leave a read-only share behind on failure.
+			exec('/bin/chmod -R u+rwx ' . escapeshellarg($root) . ' 2>/dev/null');
+			rmdir_recursive($root);
+		}
+		$this->observationRoots = [];
+		parent::tearDown();
+	}
+
+	/** @return array<string,array{0:string,1:string,2:list<string>,3:bool}> */
+	public static function setupFixtureRows(): array
+	{
+		return [
+			'DownloadGeoipStagePublishTest' => [
+				'DownloadGeoipStagePublishTest', 'testTheExtractionFlagGateTracksWhetherTheHostTarIsLibarchive',
+				['dir'], FALSE,
+			],
+			'DownloadStagePublishTest' => [
+				'DownloadStagePublishTest', 'testSuccessfulExtractionPublishesTheStagedContent',
+				['dir'], FALSE,
+			],
+			'DownloadStagePublishDirTest' => [
+				'DownloadStagePublishDirTest', 'testSuccessfulExtractionPublishesTheStagedDirectory',
+				['dir'], FALSE,
+			],
+			'GeoipOrigTrailingNewlineWiringTest' => [
+				'GeoipOrigTrailingNewlineWiringTest', 'testPublicationPipelineOrdersMirrorBeforeConsumer',
+				['dir'], TRUE,
+			],
+			'GeoipPackageGenerationTest' => [
+				'GeoipPackageGenerationTest', 'testPackageUmbrellaGeneratesContinentAndReputationPagesAcrossStateTransitions',
+				['tmp'], FALSE,
+			],
+			'GunzipTrailingNewlineWiringTest' => [
+				'GunzipTrailingNewlineWiringTest', 'testGunzipPipelineTerminatesBeforeEtConsumer',
+				['dir'], TRUE,
+			],
+			'PfbResolveListScriptTest' => [
+				'PfbResolveListScriptTest', 'testContainedFileResolvesToPrimaryDir',
+				['dir1', 'dir2'], FALSE,
+			],
+			'PrivPageMatchesTest' => [
+				'PrivPageMatchesTest', 'testNoDuplicateMatchEntries',
+				['wwwRoot'], FALSE,
+			],
+		];
+	}
+
+	/** @return string a fresh parent-owned directory the child's sys_temp_dir points at */
+	private function newObservationRoot(string $label): string
+	{
+		$root = sys_get_temp_dir() . '/pfb_fixture_setup_obs_' . $label . '_' . getmypid() . '_' . bin2hex(random_bytes(8));
+		if (!mkdir($root, 0700, TRUE)) {
+			throw new RuntimeException("observation root creation failed: {$root}");
+		}
+		$this->observationRoots[] = $root;
+		return (string) realpath($root);
+	}
+
+	/** @return array<string,mixed> */
+	private function runChild(string $observationRoot, string $script): array
+	{
+		$descriptors = [1 => ['pipe', 'w'], 2 => ['pipe', 'w']];
+		$process = proc_open(
+			[PHP_BINARY, '-d', "sys_temp_dir={$observationRoot}", '-r', $script],
+			$descriptors,
+			$pipes
+		);
+		$this->assertIsResource($process);
+		$stdout = (string) stream_get_contents($pipes[1]);
+		$stderr = (string) stream_get_contents($pipes[2]);
+		fclose($pipes[1]);
+		fclose($pipes[2]);
+		$status = proc_close($process);
+		$this->assertSame(0, $status, "child process exited {$status}, stderr: {$stderr}");
+		$decoded = json_decode(trim($stdout), TRUE);
+		$this->assertIsArray($decoded, "child stdout was not JSON: {$stdout}\nstderr: {$stderr}");
+		return $decoded;
+	}
+
+	private function beforeClassLine(string $class, bool $needsSetUpBeforeClass): string
+	{
+		return $needsSetUpBeforeClass ? "{$class}::setUpBeforeClass();" : '';
+	}
+
+	/** Observe marker contents before process shutdown removes the allocations. */
+	private function buildRepeatScript(string $class, string $ctorMethod, array $props, bool $needsSetUpBeforeClass): string
+	{
+		$root = var_export(realpath(self::ROOT), TRUE);
+		$ctorLit = var_export($ctorMethod, TRUE);
+		$propsLit = var_export($props, TRUE);
+		$before = $this->beforeClassLine($class, $needsSetUpBeforeClass);
+
+		return <<<PHP
+require {$root} . '/vendor/autoload.php';
+require {$root} . '/tests/php/bootstrap.php';
+require {$root} . '/tests/php/{$class}.php';
+{$before}
+\$warnings = [];
+set_error_handler(static function (int \$severity, string \$message) use (&\$warnings): bool {
+	\$warnings[] = \$message;
+	return TRUE;
+});
+\$props = {$propsLit};
+\$object = new {$class}({$ctorLit});
+\$setup = new ReflectionMethod({$class}::class, 'setUp');
+\$setup->invoke(\$object);
+\$first = [];
+\$markers = [];
+\$firstExists = [];
+foreach (\$props as \$p) {
+	\$path = (new ReflectionProperty({$class}::class, \$p))->getValue(\$object);
+	\$first[\$p] = \$path;
+	\$firstExists[\$p] = is_dir(\$path);
+	\$marker = \$path . '/pfb_setup_repeat_marker';
+	file_put_contents(\$marker, 'first-allocation:' . \$p);
+	\$markers[\$p] = \$marker;
+}
+\$secondThrew = FALSE;
+\$secondThrowClass = NULL;
+try {
+	\$setup->invoke(\$object);
+} catch (Throwable \$e) {
+	\$secondThrew = TRUE;
+	\$secondThrowClass = get_class(\$e);
+}
+\$second = [];
+\$secondExists = [];
+\$markerContents = [];
+foreach (\$props as \$p) {
+	\$second[\$p] = (new ReflectionProperty({$class}::class, \$p))->getValue(\$object);
+	\$secondExists[\$p] = is_dir(\$second[\$p]);
+	\$markerContents[\$p] = file_get_contents(\$markers[\$p]);
+}
+echo json_encode(compact('first', 'second', 'firstExists', 'secondExists', 'markerContents', 'secondThrew', 'secondThrowClass', 'warnings'));
+PHP;
+	}
+
+	#[DataProvider('setupFixtureRows')]
+	public function testRepeatedSetupOnTheSameObjectProducesDisjointAllocations(
+		string $class, string $ctorMethod, array $props, bool $needsSetUpBeforeClass
+	): void {
+		$root = $this->newObservationRoot('repeat_' . $class);
+		$result = $this->runChild($root, $this->buildRepeatScript($class, $ctorMethod, $props, $needsSetUpBeforeClass));
+
+		foreach ($props as $p) {
+			$this->assertArrayHasKey($p, $result['first'], "{$class}::\${$p} missing from the first allocation's report");
+			$this->assertArrayHasKey($p, $result['second'], "{$class}::\${$p} missing from the second allocation's report");
+			$this->assertStringStartsWith("{$root}/", $result['first'][$p],
+				"{$class}::\${$p} was allocated outside the observed root -- the window this test watches saw nothing");
+			$this->assertStringStartsWith("{$root}/", $result['second'][$p],
+				"{$class} second allocation escaped the observed root");
+
+			$this->assertTrue($result['firstExists'][$p], "{$class} first fixture was never created");
+			$this->assertTrue($result['secondExists'][$p], "{$class} second fixture was never created");
+			$this->assertNotSame(
+				$result['first'][$p], $result['second'][$p],
+				"{$class}::\${$p} reused the first allocation's path"
+			);
+		}
+
+		$this->assertFalse($result['secondThrew'], "{$class} repeated setup failed");
+		$this->assertSame([], $result['warnings'], "{$class} repeated setup emitted warnings");
+		foreach ($props as $p) {
+			$this->assertSame('first-allocation:' . $p, $result['markerContents'][$p],
+				"{$class} second setup changed the first allocation");
+			$this->assertDirectoryDoesNotExist($result['first'][$p], "{$class} first allocation survived shutdown");
+			$this->assertDirectoryDoesNotExist($result['second'][$p], "{$class} second allocation survived shutdown");
+		}
+	}
+
+	/** One allocation isolates exit cleanup from a repeated-setup collision. */
+	private function buildExitScript(string $class, string $ctorMethod, array $props, bool $needsSetUpBeforeClass): string
+	{
+		$root = var_export(realpath(self::ROOT), TRUE);
+		$ctorLit = var_export($ctorMethod, TRUE);
+		$propsLit = var_export($props, TRUE);
+		$before = $this->beforeClassLine($class, $needsSetUpBeforeClass);
+
+		return <<<PHP
+require {$root} . '/vendor/autoload.php';
+require {$root} . '/tests/php/bootstrap.php';
+require {$root} . '/tests/php/{$class}.php';
+{$before}
+set_error_handler(static function (int \$severity, string \$message): bool { return TRUE; });
+\$props = {$propsLit};
+\$object = new {$class}({$ctorLit});
+(new ReflectionMethod({$class}::class, 'setUp'))->invoke(\$object);
+\$paths = [];
+\$exists = [];
+foreach (\$props as \$p) {
+	\$paths[\$p] = (new ReflectionProperty({$class}::class, \$p))->getValue(\$object);
+	\$exists[\$p] = is_dir(\$paths[\$p]);
+}
+echo json_encode(compact('paths', 'exists'));
+PHP;
+	}
+
+	#[DataProvider('setupFixtureRows')]
+	public function testProcessEndingAfterSetupWithoutTeardownLeavesNoResidue(
+		string $class, string $ctorMethod, array $props, bool $needsSetUpBeforeClass
+	): void {
+		$root = $this->newObservationRoot('exit_' . $class);
+		$result = $this->runChild($root, $this->buildExitScript($class, $ctorMethod, $props, $needsSetUpBeforeClass));
+
+		foreach ($props as $p) {
+			$path = $result['paths'][$p];
+			$this->assertTrue($result['exists'][$p], "{$class} fixture was never created");
+			$this->assertStringStartsWith("{$root}/", $path,
+				"{$class}::\${$p} was allocated outside the observed root -- the window this test watches saw nothing");
+			$this->assertDirectoryDoesNotExist($path,
+				"{$class}::\${$p} ({$path}) survived process exit without tearDown() running -- " .
+				'no shutdown fallback removed it');
+		}
+	}
+
+	/** Exercise the read-only share shape used by the GeoIP permission fixture. */
+	private function buildGeoipReadOnlyShareExitScript(string $ctorMethod): string
+	{
+		$class = 'DownloadGeoipStagePublishTest';
+		$root = var_export(realpath(self::ROOT), TRUE);
+		$ctorLit = var_export($ctorMethod, TRUE);
+
+		return <<<PHP
+require {$root} . '/vendor/autoload.php';
+require {$root} . '/tests/php/bootstrap.php';
+require {$root} . '/tests/php/{$class}.php';
+set_error_handler(static function (int \$severity, string \$message): bool { return TRUE; });
+\$object = new {$class}({$ctorLit});
+\$object->assertTrue(TRUE);
+\$result = pfb_test_as_unprivileged(static function () use (\$object): array {
+(new ReflectionMethod({$class}::class, 'setUp'))->invoke(\$object);
+\$dir = (new ReflectionProperty({$class}::class, 'dir'))->getValue(\$object);
+\$share = (new ReflectionProperty({$class}::class, 'share'))->getValue(\$object);
+file_put_contents(\$share . '/leftover.txt', 'stale-share-content');
+chmod(\$share, 0555);
+\$exists = is_dir(\$dir) && file_get_contents(\$share . '/leftover.txt') === 'stale-share-content';
+	return compact('dir', 'share', 'exists');
+});
+echo json_encode(\$result);
+PHP;
+	}
+
+	public function testProcessExitRemovesAReadOnlyGeoipShareWithoutTeardown(): void
+	{
+		$root = $this->newObservationRoot('exit_readonly_share_DownloadGeoipStagePublishTest');
+		$result = $this->runChild(
+			$root,
+			$this->buildGeoipReadOnlyShareExitScript('testTheExtractionFlagGateTracksWhetherTheHostTarIsLibarchive')
+		);
+
+		$this->assertTrue($result['exists'], 'the read-only fixture was never populated');
+		$this->assertStringStartsWith("{$root}/", $result['dir'],
+			'DownloadGeoipStagePublishTest::$dir was allocated outside the observed root');
+		$this->assertStringStartsWith($result['dir'] . '/', $result['share'],
+			'DownloadGeoipStagePublishTest::$share must sit inside $dir for this test to watch it');
+		$this->assertDirectoryDoesNotExist($result['dir'], 'the read-only GeoIP fixture survived shutdown');
+	}
+
+	/**
+	 * Restrict writes after loading the real fixture; mkdir fails without injected exceptions.
+	 * The parent reaps the bootstrap sandbox too, since the restriction blocks its cleanup.
+	 */
+	private function buildCreationRefusalScript(string $class, string $ctorMethod, bool $needsSetUpBeforeClass): string
+	{
+		$root = var_export(realpath(self::ROOT), TRUE);
+		$ctorLit = var_export($ctorMethod, TRUE);
+		$before = $this->beforeClassLine($class, $needsSetUpBeforeClass);
+
+		return <<<PHP
+require {$root} . '/vendor/autoload.php';
+require {$root} . '/tests/php/bootstrap.php';
+require {$root} . '/tests/php/{$class}.php';
+{$before}
+\$object = new {$class}({$ctorLit});
+\$events = [];
+set_error_handler(static function (int \$severity, string \$message) use (&\$events): bool {
+	\$events[] = ['unsuppressed' => (error_reporting() & \$severity) !== 0, 'message' => \$message];
+	return TRUE;
+});
+ini_set('open_basedir', {$root});
+try {
+	(new ReflectionMethod({$class}::class, 'setUp'))->invoke(\$object);
+	\$error = NULL;
+} catch (Throwable \$e) {
+	\$error = get_class(\$e) . ': ' . \$e->getMessage();
+}
+echo json_encode(compact('events', 'error'));
+PHP;
+	}
+
+	#[DataProvider('setupFixtureRows')]
+	public function testSetupStopsAtTheFirstMkdirFailureUnderARestrictedFilesystem(
+		string $class, string $ctorMethod, array $props, bool $needsSetUpBeforeClass
+	): void {
+		$root = $this->newObservationRoot('creation_refusal_' . $class);
+		$result = $this->runChild($root, $this->buildCreationRefusalScript($class, $ctorMethod, $needsSetUpBeforeClass));
+
+		$this->assertCount(1, $result['events'], "{$class} continued after failed directory creation");
+		$this->assertStringStartsWith('mkdir():', $result['events'][0]['message']);
+
+		$this->assertTrue($result['events'][0]['unsuppressed'],
+			"{$class} suppressed the mkdir failure's severity bit");
+
+		$this->assertNotNull($result['error'],
+			"{$class}::setUp() returned normally after its first mkdir() failed instead of raising or propagating " .
+			'an error that stops construction before any later write');
+	}
+}

--- a/tests/php/FixtureSetupLifecycleTest.php
+++ b/tests/php/FixtureSetupLifecycleTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
+require_once __DIR__ . '/support/ProcessRunner.php';
+
 /** Fixture allocations stay isolated across setup calls and expire with their owning process. */
 final class FixtureSetupLifecycleTest extends TestCase
 {
@@ -77,18 +79,10 @@ final class FixtureSetupLifecycleTest extends TestCase
 	/** @return array<string,mixed> */
 	private function runChild(string $observationRoot, string $script): array
 	{
-		$descriptors = [1 => ['pipe', 'w'], 2 => ['pipe', 'w']];
-		$process = proc_open(
-			[PHP_BINARY, '-d', "sys_temp_dir={$observationRoot}", '-r', $script],
-			$descriptors,
-			$pipes
-		);
-		$this->assertIsResource($process);
-		$stdout = (string) stream_get_contents($pipes[1]);
-		$stderr = (string) stream_get_contents($pipes[2]);
-		fclose($pipes[1]);
-		fclose($pipes[2]);
-		$status = proc_close($process);
+		$result = pfb_test_run_process([PHP_BINARY, '-d', "sys_temp_dir={$observationRoot}", '-r', $script]);
+		$stdout = $result['stdout'];
+		$stderr = $result['stderr'];
+		$status = $result['exit'];
 		$this->assertSame(0, $status, "child process exited {$status}, stderr: {$stderr}");
 		$decoded = json_decode(trim($stdout), TRUE);
 		$this->assertIsArray($decoded, "child stdout was not JSON: {$stdout}\nstderr: {$stderr}");

--- a/tests/php/GeoipOrigTrailingNewlineWiringTest.php
+++ b/tests/php/GeoipOrigTrailingNewlineWiringTest.php
@@ -17,8 +17,16 @@ final class GeoipOrigTrailingNewlineWiringTest extends TestCase
 
 	protected function setUp(): void
 	{
-		$this->dir = sys_get_temp_dir() . '/pfb geoip; ' . getmypid() . " 'fixture'";
+		$this->dir = sys_get_temp_dir() . '/pfb geoip; ' . getmypid() . '_' . bin2hex(random_bytes(8)) . " 'fixture'";
 		$this->assertTrue(mkdir($this->dir, 0700, TRUE));
+		$dir = $this->dir;
+		$ownerPid = getmypid();
+		register_shutdown_function(static function () use ($dir, $ownerPid): void {
+			// pcntl_fork() inherits shutdown callbacks; only the process that created this tree owns it.
+			if (getmypid() === $ownerPid) {
+				rmdir_recursive($dir);
+			}
+		});
 	}
 
 	protected function tearDown(): void

--- a/tests/php/GeoipPackageGenerationTest.php
+++ b/tests/php/GeoipPackageGenerationTest.php
@@ -22,11 +22,19 @@ final class GeoipPackageGenerationTest extends TestCase
 		$this->hadPfb = array_key_exists('pfb', $GLOBALS);
 		$this->originalPfb = $GLOBALS['pfb'] ?? NULL;
 
-		$this->tmp = sys_get_temp_dir() . '/pfb_geoip_package_' . getmypid();
+		$this->tmp = sys_get_temp_dir() . '/pfb_geoip_package_' . getmypid() . '_' . bin2hex(random_bytes(8));
+		$this->assertTrue(mkdir($this->tmp, 0777, TRUE), "geoip package root directory creation failed: {$this->tmp}");
+		$tmp = $this->tmp;
+		$ownerPid = getmypid();
+		register_shutdown_function(static function () use ($tmp, $ownerPid): void {
+			if (getmypid() === $ownerPid) {
+				rmdir_recursive($tmp);
+			}
+		});
 		$this->ccdir = "{$this->tmp}/cc";
 		$this->output = "{$this->tmp}/www";
-		@mkdir($this->ccdir, 0777, TRUE);
-		@mkdir($this->output, 0777, TRUE);
+		$this->assertTrue(mkdir($this->ccdir, 0777, TRUE), "geoip package cc directory creation failed: {$this->ccdir}");
+		$this->assertTrue(mkdir($this->output, 0777, TRUE), "geoip package www directory creation failed: {$this->output}");
 
 		$GLOBALS['pfb']['ccdir'] = $this->ccdir;
 		$GLOBALS['pfb']['ccdir_tmp'] = "{$this->tmp}/cc-tmp";

--- a/tests/php/GunzipTrailingNewlineWiringTest.php
+++ b/tests/php/GunzipTrailingNewlineWiringTest.php
@@ -17,8 +17,15 @@ final class GunzipTrailingNewlineWiringTest extends TestCase
 
 	protected function setUp(): void
 	{
-		$this->dir = sys_get_temp_dir() . '/pfb gunzip; ' . getmypid() . " 'fixture'";
-		$this->assertTrue(mkdir($this->dir, 0700, TRUE));
+		$this->dir = sys_get_temp_dir() . '/pfb gunzip; ' . getmypid() . '_' . bin2hex(random_bytes(8)) . " 'fixture'";
+		$this->assertTrue(mkdir($this->dir, 0700, TRUE), "gunzip fixture directory creation failed: {$this->dir}");
+		$dir = $this->dir;
+		$ownerPid = getmypid();
+		register_shutdown_function(static function () use ($dir, $ownerPid): void {
+			if (getmypid() === $ownerPid) {
+				rmdir_recursive($dir);
+			}
+		});
 	}
 
 	protected function tearDown(): void

--- a/tests/php/IpPrefetchTest.php
+++ b/tests/php/IpPrefetchTest.php
@@ -645,8 +645,14 @@ final class IpPrefetchTest extends TestCase
 	 */
 	public function test_single_file_folder_exact_match_resolves_correctly_per_row_and_batched(): void
 	{
-		$tmp = sys_get_temp_dir() . '/pfb_833_exact_' . getmypid();
-		mkdir($tmp, 0777, true);
+		$tmp = sys_get_temp_dir() . '/pfb_833_exact_' . getmypid() . '_' . bin2hex(random_bytes(8));
+		$this->assertTrue(mkdir($tmp, 0777, true), "could not create the test fixture dir {$tmp}");
+		$ownerPid = getmypid();
+		register_shutdown_function(static function () use ($tmp, $ownerPid): void {
+			if (getmypid() === $ownerPid) {
+				rmdir_recursive($tmp);
+			}
+		});
 		file_put_contents("{$tmp}/LoneFeed.txt", "192.0.2.201\n");
 		$folder = "{$tmp}/*.txt";
 
@@ -690,8 +696,14 @@ final class IpPrefetchTest extends TestCase
 	 */
 	public function test_single_file_folder_cidr_only_coverage_resolves_correctly_per_row_and_batched(): void
 	{
-		$tmp = sys_get_temp_dir() . '/pfb_833_cidr_' . getmypid();
-		mkdir($tmp, 0777, true);
+		$tmp = sys_get_temp_dir() . '/pfb_833_cidr_' . getmypid() . '_' . bin2hex(random_bytes(8));
+		$this->assertTrue(mkdir($tmp, 0777, true), "could not create the test fixture dir {$tmp}");
+		$ownerPid = getmypid();
+		register_shutdown_function(static function () use ($tmp, $ownerPid): void {
+			if (getmypid() === $ownerPid) {
+				rmdir_recursive($tmp);
+			}
+		});
 		file_put_contents("{$tmp}/LoneCidrFeed.txt", "192.0.2.0/24\n");
 		$folder = "{$tmp}/*.txt";
 
@@ -1133,8 +1145,15 @@ final class IpPrefetchTest extends TestCase
 	public function test_single_file_folder_miss_row_is_correctly_seeded_after_the_833_fix(): void
 	{
 		// Given: a GeoIP cc dir holding exactly ONE feed file that contains the host.
-		$tmp = sys_get_temp_dir() . '/pfb_831_' . getmypid();
-		mkdir("{$tmp}/cc", 0777, true);
+		$tmp = sys_get_temp_dir() . '/pfb_831_' . getmypid() . '_' . bin2hex(random_bytes(8));
+		$this->assertTrue(mkdir($tmp, 0777, true), "could not create the test fixture root {$tmp}");
+		$ownerPid = getmypid();
+		register_shutdown_function(static function () use ($tmp, $ownerPid): void {
+			if (getmypid() === $ownerPid) {
+				rmdir_recursive($tmp);
+			}
+		});
+		$this->assertTrue(mkdir("{$tmp}/cc", 0777, true), "could not create the test fixture cc dir {$tmp}/cc");
 		file_put_contents("{$tmp}/cc/LoneFeed.txt", "192.0.2.201\n");
 		$GLOBALS['pfb']['ccdir'] = "{$tmp}/cc";
 
@@ -1239,8 +1258,14 @@ final class IpPrefetchTest extends TestCase
 	 */
 	public function test_et_header_still_listed_ip_is_found_by_the_real_validate_exec(): void
 	{
-		$tmp = sys_get_temp_dir() . '/pfb_832_et_' . getmypid();
-		mkdir($tmp, 0777, true);
+		$tmp = sys_get_temp_dir() . '/pfb_832_et_' . getmypid() . '_' . bin2hex(random_bytes(8));
+		$this->assertTrue(mkdir($tmp, 0777, true), "could not create the test fixture dir {$tmp}");
+		$ownerPid = getmypid();
+		register_shutdown_function(static function () use ($tmp, $ownerPid): void {
+			if (getmypid() === $ownerPid) {
+				rmdir_recursive($tmp);
+			}
+		});
 		file_put_contents("{$tmp}/IQRiskFeed.txt", "192.0.2.201\n");
 		$savedEtdir = $GLOBALS['pfb']['etdir'];
 		$GLOBALS['pfb']['etdir'] = $tmp;

--- a/tests/php/PfbHookScriptsTest.php
+++ b/tests/php/PfbHookScriptsTest.php
@@ -136,10 +136,21 @@ final class PfbHookScriptsTest extends TestCase
 	 */
 	private static function makeSymlinkFixture(): array
 	{
-		$tmp    = sys_get_temp_dir() . '/pfb_hook_test_' . getmypid();
-		mkdir($tmp, 0755, TRUE);
+		$tmp = sys_get_temp_dir() . '/pfb_hook_test_' . getmypid() . '_' . bin2hex(random_bytes(8));
+		self::assertTrue(mkdir($tmp, 0755, TRUE), "could not create the test hook dir {$tmp}");
+		$ownerPid = getmypid();
+		register_shutdown_function(static function () use ($tmp, $ownerPid): void {
+			if (getmypid() === $ownerPid) {
+				rmdir_recursive($tmp);
+			}
+		});
 
 		$outside = self::makeOutsideScript();
+		register_shutdown_function(static function () use ($outside, $ownerPid): void {
+			if (getmypid() === $ownerPid) {
+				@unlink($outside);
+			}
+		});
 
 		// Plain real file
 		file_put_contents("{$tmp}/hook_pre_real.sh", "#!/bin/sh\n");

--- a/tests/php/PfbResolveListScriptTest.php
+++ b/tests/php/PfbResolveListScriptTest.php
@@ -28,11 +28,18 @@ final class PfbResolveListScriptTest extends TestCase
 
 	protected function setUp(): void
 	{
-		$base = sys_get_temp_dir() . '/pfb_rls_' . getmypid();
+		$base = sys_get_temp_dir() . '/pfb_rls_' . getmypid() . '_' . bin2hex(random_bytes(8));
 		$this->dir1 = "{$base}_1";
 		$this->dir2 = "{$base}_2";
-		mkdir($this->dir1, 0755, TRUE);
-		mkdir($this->dir2, 0755, TRUE);
+		$ownerPid = getmypid();
+		foreach ([$this->dir1, $this->dir2] as $dir) {
+			$this->assertTrue(mkdir($dir, 0755, TRUE), "resolve list script directory creation failed: {$dir}");
+			register_shutdown_function(static function () use ($dir, $ownerPid): void {
+				if (getmypid() === $ownerPid) {
+					rmdir_recursive($dir);
+				}
+			});
+		}
 	}
 
 	protected function tearDown(): void

--- a/tests/php/PrivPageMatchesTest.php
+++ b/tests/php/PrivPageMatchesTest.php
@@ -57,9 +57,16 @@ final class PrivPageMatchesTest extends TestCase
 		// cmp_page_matches() realpath()s the requested file under www_path and 403s
 		// if it does not exist. Recreate just the files the cases below request so
 		// the gate behaves exactly as on the appliance.
-		$wwwRoot = sys_get_temp_dir() . '/pfb_priv_www_' . getmypid();
-		@mkdir($wwwRoot . '/pfblockerng', 0777, true);
-		@mkdir($wwwRoot . '/widgets/widgets', 0777, true);
+		$wwwRoot = sys_get_temp_dir() . '/pfb_priv_www_' . getmypid() . '_' . bin2hex(random_bytes(8));
+		$this->assertTrue(mkdir($wwwRoot, 0777, true), "priv www root directory creation failed: {$wwwRoot}");
+		$ownerPid = getmypid();
+		register_shutdown_function(static function () use ($wwwRoot, $ownerPid): void {
+			if (getmypid() === $ownerPid) {
+				rmdir_recursive($wwwRoot);
+			}
+		});
+		$this->assertTrue(mkdir($wwwRoot . '/pfblockerng', 0777, true), "priv www pfblockerng directory creation failed: {$wwwRoot}/pfblockerng");
+		$this->assertTrue(mkdir($wwwRoot . '/widgets/widgets', 0777, true), "priv www widgets directory creation failed: {$wwwRoot}/widgets/widgets");
 		// Canonicalise: on macOS sys_get_temp_dir() is under /var, a symlink to
 		// /private/var, so realpath()d file paths would not share this prefix and
 		// the www_path strip below would fail. The appliance's /usr/local/www has


### PR DESCRIPTION
## Summary

Fixes #2845.

- Give all fourteen fixture naming sites in the eleven enumerated test files an eight-byte random suffix beside the PID (fifteen physical roots because the resolver creates a pair).
- Check directory creation without suppression and capture each created root plus its owning PID for process-end cleanup. Preserve ordinary teardown/finally paths, hostile filename punctuation, hook symlink shapes and macOS realpath handling. The GeoIP fallback restores its deliberately read-only permissions.
- Add behavioral subprocess regressions for repeated allocations, stale-PID isolation, process-end residue, read-only cleanup and first/root creation refusal. No production files or shared fixture helper changed.

## Original fixture change: test-first evidence

Before the accepted subprocess review correction below, the same two test files were executed before any of the eleven fixture edits and remained byte-identical through the original GREEN and independent mutation gate:

```sh
vendor/bin/phpunit tests/php/FixtureSetupLifecycleTest.php tests/php/FixtureInlineLifecycleTest.php
```

```text
RED:   Tests: 38, Assertions: 263, Failures: 33.
GREEN: OK (38 tests, 391 assertions)
```

Frozen Git blob hashes:

- `FixtureSetupLifecycleTest.php`: `4867b883e4355648e8952f2ed6304c90023f4d6d`
- `FixtureInlineLifecycleTest.php`: `92dad58ab268e5065c23f875d7fe6fcee2ff6dc2`

The independent gate replayed RED/GREEN, exercised all affected fixtures (`OK (195 tests, 1418 assertions)`), and recorded 70 intended behavioral mutation kills; two invalid attempts were excluded. Canonical and current-head validation are recorded in the PR audit rather than inferred across a rebase. Full retained evidence: `/var/tmp/agents/issue-2845/independent-gate/` and `/var/tmp/agents/issue-2845/landing/`.

## Accepted subprocess review correction

Copilot later identified two unbounded subprocess helpers in the new regressions. Commit `e9cf7a77ca8b18626c72bb551d8674031a18e760` makes both reuse the existing `pfb_test_run_process` nonblocking drains, hard deadline and termination. No product or original eleven fixture body changed. A separate `FixtureLifecycleProcessTest.php` was frozen before these helper edits: RED `4 tests, 4 assertions, 4 failures`; after the fix the three lifecycle files pass `42 tests, 361 assertions`. The new regression blob remains `501d167ccd4ad5273fb1b8b829c1f906f603257a`. The two original files now have updated helper-containing blobs, so their original frozen proof is historical, not a claim of current byte identity. The full correction and independent/current-CI evidence are in the PR audit.

## Scope and proof limits

The inline extraction and four prefetch methods already use `finally`, and the hook callers already protect their ordinary bodies. Their existing ordinary-failure cleanup is not credited as newly fixed; the added shutdown ownership is a distinct process-end fallback. The suite exercises process exit, not SIGKILL or host failure.

Creation-refusal regressions exercise the first/root boundary. Six newly checked child-directory calls are source-reviewed, not independently refusal-tested: GeoIP package `cc` and `www`, extraction `feed_cat`, prefetch `pfb_831_`'s `cc`, and privilege fixtures `pfblockerng` and `widgets/widgets`. The resolver's second-root creation-refusal ordering is likewise source-reviewed; both roots' shutdown callbacks were independently mutation-killed. The condensed review's surviving child-mkdir suppression mutant is disclosed, not counted as a kill.

Linux/PHP 8.4.24/PHPUnit 12.5.31 evidence only; no FreeBSD, macOS or live-appliance runtime claim. No host OS mutation or gate bypass.

The issue discussion retains implementation deviations: initial own-target edits in the primary checkout were restored and reapplied in the dedicated worktree, with independent eleven-path integrity checks clean. Author-only scratch probes/syntax checks were not canonical evidence; the rejected early RED harness was corrected before the authoritative frozen RED.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved test fixture isolation by using unique temporary directories, reducing collisions during repeated or parallel test runs.
  - Added reliable automatic cleanup when test processes exit, including handling of read-only fixture content.
  - Expanded coverage for fixture lifecycle behavior, including repeated setup, process termination, stale directories, symlink fixtures, and filesystem permission failures.
  - Improved diagnostics by ensuring directory creation failures are reported clearly instead of being silently suppressed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->