### PR TITLE
agent: pin Graphify 0.9.58 fork

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ package = false
 [dependency-groups]
 # Agent and developer CLI tools. Single source of truth for versions/pins.
 tools = [
-    "graphifyy[leiden] @ git+https://github.com/pfBlockerNG/graphify@6bda5d6a4bc0d18d83573bd3ade5769c918ddf6a",
+    "graphifyy[leiden] @ git+https://github.com/pfBlockerNG/graphify@a54c51260d97aaed3bb078ad7cfbf64a048b398f",
     "serena-agent",
     "ast-grep-cli",
     "semgrep",

--- a/uv.lock
+++ b/uv.lock
@@ -525,8 +525,8 @@ wheels = [
 
 [[package]]
 name = "graphifyy"
-version = "0.9.57"
-source = { git = "https://github.com/pfBlockerNG/graphify?rev=6bda5d6a4bc0d18d83573bd3ade5769c918ddf6a#6bda5d6a4bc0d18d83573bd3ade5769c918ddf6a" }
+version = "0.9.58"
+source = { git = "https://github.com/pfBlockerNG/graphify?rev=a54c51260d97aaed3bb078ad7cfbf64a048b398f#a54c51260d97aaed3bb078ad7cfbf64a048b398f" }
 dependencies = [
     { name = "networkx" },
     { name = "numpy" },
@@ -1375,7 +1375,7 @@ smoke = [
 ]
 tools = [
     { name = "ast-grep-cli" },
-    { name = "graphifyy", extras = ["leiden"], git = "https://github.com/pfBlockerNG/graphify?rev=6bda5d6a4bc0d18d83573bd3ade5769c918ddf6a" },
+    { name = "graphifyy", extras = ["leiden"], git = "https://github.com/pfBlockerNG/graphify?rev=a54c51260d97aaed3bb078ad7cfbf64a048b398f" },
     { name = "semgrep" },
     { name = "serena-agent" },
 ]


### PR DESCRIPTION
## Summary

Update the maintained Graphify fork to upstream v0.9.58 and pin its immutable commit `a54c51260d97aaed3bb078ad7cfbf64a048b398f`. Preserve project language overrides, target-suffix validation, and interpreter-gated Leiden packaging. Refresh the tracked root graph. No unrelated dependency changes.

## Verification

- Existing fork tests: 49 passed before replay; 50 passed after replay, including upstream's new all-extra union test.
- Range-diff preserves the language override and suffix-validation patches byte-for-byte. The packaging conflict retains both native Leiden and upstream psycopg[binary].
- Consumer tests: 21 pytest cases and 8 ShellSpec examples passed before and after the upgrade.
- Both lock checks pass; only Graphify package version and provenance change in the consumer lock.
- Installed package reports 0.9.58 at the exact pinned SHA; native Leiden imports successfully.
- Root graph freshness and canonical gates pass.
- Independent condensed four-lens review found no blocking findings.

This replays existing upstream and fork changes; no new parser behavior or pin-text tests were authored.

Fixes #3271

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated internal tooling configuration.
  - No user-facing features, behavior, or configuration changes are included in this update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->