### PR TITLE
test: neuter the remaining unbound-mount, pkg-bin, and chroot_cmd boundaries

### DIFF
--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -3288,11 +3288,7 @@ function pfb_maxmind_credential_notice(string $maxmind_key, string $maxmind_acco
 }
 
 
-// issue #2839 row 3: pfb_global() (re)computes the chroot_cmd command below on every
-// call, so a bootstrap-time array default alone cannot survive a later pfb_global()
-// refresh -- unlike PFB_UNBOUND_START_CMD, this was never a fixed value to begin with.
-// Guarding just the binary-invocation prefix, the same idiom as PFB_PKG_BIN, means
-// every pfb_global() call derives the harness-safe command again, not only the first.
+// Keep the harness override effective across repeated pfb_global() calls.
 if (!defined('PFB_UNBOUND_CONTROL_BIN')) {
 	define('PFB_UNBOUND_CONTROL_BIN', '/usr/sbin/chroot -u unbound -g unbound / /usr/local/sbin/unbound-control');
 }
@@ -11642,10 +11638,7 @@ if (!defined('PFB_UNBOUND_CONTROL_WAIT')) {
 	define('PFB_UNBOUND_CONTROL_WAIT', 30);
 }
 
-// issue #2839 row 1: same overridable idiom as PFB_UNBOUND_START_CMD above -- an
-// installed host has this literal path on disk, and its top level exec()s
-// mount_nullfs/umount four times with no seam to intercept (tests/php/bootstrap.php
-// points this at a harmless double).
+// The installed include executes mounts at load time; unit tests must replace it.
 if (!defined('PFB_UNBOUND_INCLUDE_FILE')) {
 	define('PFB_UNBOUND_INCLUDE_FILE', '/var/unbound/pfb_unbound_include.inc');
 }

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -5734,7 +5734,9 @@ function pfb_should_notify(?string $installed, ?string $latest, ?string $last_no
  * 'pfblockerng' or one of the per-channel 'pfblockerng-<channel>' catalogues), which is
  * now the authoritative channel signal AND the repo latest is read from.
  */
-define('PFB_PKG_BIN', '/usr/local/sbin/pkg');
+if (!defined('PFB_PKG_BIN')) {
+	define('PFB_PKG_BIN', '/usr/local/sbin/pkg');
+}
 
 if (!defined('PFB_REPO_GENERATE_HOOK')) {
 	define('PFB_REPO_GENERATE_HOOK', '/usr/local/etc/rc.d/pfblockerng_repo_generate.sh');
@@ -11631,6 +11633,14 @@ if (!defined('PFB_UNBOUND_CONTROL_WAIT')) {
 	define('PFB_UNBOUND_CONTROL_WAIT', 30);
 }
 
+// issue #2839 row 1: same overridable idiom as PFB_UNBOUND_START_CMD above -- an
+// installed host has this literal path on disk, and its top level exec()s
+// mount_nullfs/umount four times with no seam to intercept (tests/php/bootstrap.php
+// points this at a harmless double).
+if (!defined('PFB_UNBOUND_INCLUDE_FILE')) {
+	define('PFB_UNBOUND_INCLUDE_FILE', '/var/unbound/pfb_unbound_include.inc');
+}
+
 // Function to Start Unbound
 function pfb_stop_start_unbound($type) {
 	global $g, $pfb;
@@ -11687,10 +11697,10 @@ function pfb_stop_start_unbound($type) {
 	}
 
 	// Add/Remove additional python mounts
-	if (file_exists('/var/unbound/pfb_unbound_include.inc')) {
+	if (file_exists(PFB_UNBOUND_INCLUDE_FILE)) {
 		$g['pfblockerng_include_verbose'] = TRUE;
 		pfb_logger("\nAdditional mounts{$type}:", 1);
-		require_once('/var/unbound/pfb_unbound_include.inc');
+		require_once(PFB_UNBOUND_INCLUDE_FILE);
 		unset($g['pfblockerng_include_verbose']);
 	}
 

--- a/src/usr/local/pkg/pfblockerng/pfblockerng.inc
+++ b/src/usr/local/pkg/pfblockerng/pfblockerng.inc
@@ -3288,6 +3288,15 @@ function pfb_maxmind_credential_notice(string $maxmind_key, string $maxmind_acco
 }
 
 
+// issue #2839 row 3: pfb_global() (re)computes the chroot_cmd command below on every
+// call, so a bootstrap-time array default alone cannot survive a later pfb_global()
+// refresh -- unlike PFB_UNBOUND_START_CMD, this was never a fixed value to begin with.
+// Guarding just the binary-invocation prefix, the same idiom as PFB_PKG_BIN, means
+// every pfb_global() call derives the harness-safe command again, not only the first.
+if (!defined('PFB_UNBOUND_CONTROL_BIN')) {
+	define('PFB_UNBOUND_CONTROL_BIN', '/usr/sbin/chroot -u unbound -g unbound / /usr/local/sbin/unbound-control');
+}
+
 // [ $pfb ] pfBlockerNG global array. This needs to be called to get the updated settings.
 function pfb_global() {
 	global $g, $pfb;
@@ -3421,7 +3430,7 @@ function pfb_global() {
 	$pfb['extdns'] = pfb_filter($pfb['config_global']['pfbextdns'], PFB_FILTER_IPV4, 'pfb_global', '8.8.8.8');
 
 	// Unbound chroot cmd
-	$pfb['chroot_cmd'] = "/usr/sbin/chroot -u unbound -g unbound / /usr/local/sbin/unbound-control -c {$g['unbound_chroot_path']}/unbound.conf";
+	$pfb['chroot_cmd'] = PFB_UNBOUND_CONTROL_BIN . " -c {$g['unbound_chroot_path']}/unbound.conf";
 
 	// Define SQLite3 parameters
 	$pfb['sqlite_timeout']	= 100000;

--- a/tests/php/ChrootCmdBootstrapDefaultTest.php
+++ b/tests/php/ChrootCmdBootstrapDefaultTest.php
@@ -12,14 +12,11 @@ use PHPUnit\Framework\TestCase;
  * after whatever verb followed it -- harmless only because that happens to fail too. On an
  * installed host pfb_global() sets it to the REAL chroot(8)+unbound-control invocation with
  * no test involvement at all, which is why six existing suites each have to defuse it
- * themselves before touching it. tests/php/bootstrap.php now seeds an inert recorder
- * default, the same idiom PFB_UNBOUND_START_CMD established for the daemon-start boundary,
- * so a caller that never sets its own override still never reaches the shipped command.
- *
- * Run in an isolated process, never the shared suite process: many other test files call
- * pfb_global() directly, which unconditionally overwrites $pfb['chroot_cmd'] with the real
- * appliance command, so only a fresh process proves the value bootstrap.php itself seeds
- * rather than whatever a same-process neighbour left behind.
+ * themselves before touching it. pfb_global() RECOMPUTES the command on every call (it is
+ * not a one-time load-time value like PFB_UNBOUND_START_CMD), so tests/php/bootstrap.php
+ * guards the binary-invocation prefix itself (PFB_UNBOUND_CONTROL_BIN) rather than only the
+ * array default: a harness override then survives every later pfb_global() refresh, not
+ * only the first one, the same idiom PFB_PKG_BIN established for the package-query boundary.
  */
 #[CoversFunction('pfb_unbound_control_exec')]
 final class ChrootCmdBootstrapDefaultTest extends TestCase
@@ -85,5 +82,45 @@ final class ChrootCmdBootstrapDefaultTest extends TestCase
 		$this->assertSame(0, $payload['retval'], 'the bootstrap default recorder must answer successfully');
 		$this->assertStringContainsString('status', $payload['recorder_log'],
 			'the control verb must actually reach the bootstrap default recorder');
+	}
+
+	/**
+	 * Given a fresh process that requires bootstrap.php, then calls pfb_global() (the
+	 *   function every one of the six existing chroot_cmd-overriding suites, and dozens
+	 *   of unrelated suites, call to refresh $pfb) with the minimum config it needs,
+	 * When it reads $pfb['chroot_cmd'] afterward,
+	 * Then the value pfb_global() just recomputed is still the harness recorder, never
+	 *   the real chroot(8)+unbound-control invocation the shipped code composes.
+	 */
+	public function testChrootCmdSurvivesAPfbGlobalRefreshAfterInitialization(): void
+	{
+		$runner = "{$this->dir}/pfb_global_runner.php";
+		$out = "{$this->dir}/pfb_global_out.json";
+		file_put_contents($runner, "<?php\n"
+			. 'require ' . var_export(__DIR__ . '/bootstrap.php', TRUE) . ";\n"
+			. 'require ' . var_export(__DIR__ . '/SyncPrereqSeedTrait.php', TRUE) . ";\n"
+			. "\$seeder = new class { use SyncPrereqSeedTrait; public function seed(): void { \$this->seedSyncPrereqs(); } };\n"
+			. "\$seeder->seed();\n"
+			. "\$before = \$GLOBALS['pfb']['chroot_cmd'] ?? NULL;\n"
+			. "pfb_global();\n"
+			. "\$after = \$GLOBALS['pfb']['chroot_cmd'] ?? NULL;\n"
+			. 'file_put_contents(' . var_export($out, TRUE)
+			. ", json_encode(['before' => \$before, 'after' => \$after]));\n");
+
+		$output = [];
+		$status = 0;
+		$timeout = (string) ($GLOBALS['pfb']['timeout'] ?? '/usr/bin/timeout');
+		exec(escapeshellarg($timeout) . ' -s TERM -k 2 ' . self::SALVAGE_SECONDS . ' ' .
+			escapeshellarg(PHP_BINARY) . ' ' . escapeshellarg($runner) . ' 2>&1', $output, $status);
+		$this->assertSame(0, $status, 'the isolated runner must exit cleanly: ' . implode("\n", $output));
+
+		$payload = json_decode((string) file_get_contents($out), TRUE);
+		$this->assertIsArray($payload, 'the isolated runner must publish its JSON result');
+		$this->assertNotNull($payload['before'], 'the bootstrap default must be set before pfb_global() ever runs');
+		$this->assertNotNull($payload['after'], 'pfb_global() must still publish a chroot_cmd');
+		$this->assertStringNotContainsString('/usr/local/sbin/unbound-control', $payload['after'],
+			'pfb_global() must never revert an untouched caller to the real appliance command');
+		$this->assertStringContainsString('chroot-cmd-double', $payload['after'],
+			'pfb_global() must recompute the command from the SAME overridden binary, not a stale one');
 	}
 }

--- a/tests/php/ChrootCmdBootstrapDefaultTest.php
+++ b/tests/php/ChrootCmdBootstrapDefaultTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * issue #2839 row 3 -- $pfb['chroot_cmd'] is the unbound-control command prefix consumed
+ * by pfb_unbound_control_exec() and every sibling call site. Off-appliance it defaulted to
+ * unset, so a caller reached without a test-supplied override just named a bogus command
+ * after whatever verb followed it -- harmless only because that happens to fail too. On an
+ * installed host pfb_global() sets it to the REAL chroot(8)+unbound-control invocation with
+ * no test involvement at all, which is why six existing suites each have to defuse it
+ * themselves before touching it. tests/php/bootstrap.php now seeds an inert recorder
+ * default, the same idiom PFB_UNBOUND_START_CMD established for the daemon-start boundary,
+ * so a caller that never sets its own override still never reaches the shipped command.
+ *
+ * Run in an isolated process, never the shared suite process: many other test files call
+ * pfb_global() directly, which unconditionally overwrites $pfb['chroot_cmd'] with the real
+ * appliance command, so only a fresh process proves the value bootstrap.php itself seeds
+ * rather than whatever a same-process neighbour left behind.
+ */
+#[CoversFunction('pfb_unbound_control_exec')]
+final class ChrootCmdBootstrapDefaultTest extends TestCase
+{
+	private const SALVAGE_SECONDS = 10;
+
+	private string $dir = '';
+
+	protected function setUp(): void
+	{
+		$dir = tempnam(sys_get_temp_dir(), 'pfbchroot');
+		$this->assertNotFalse($dir);
+		$this->assertTrue(unlink($dir) && mkdir($dir, 0700));
+		$this->dir = $dir;
+	}
+
+	protected function tearDown(): void
+	{
+		if ($this->dir !== '' && is_dir($this->dir)) {
+			rmdir_recursive($this->dir);
+		}
+		$this->dir = '';
+	}
+
+	/**
+	 * Given a fresh process that requires ONLY bootstrap.php -- no test sets its own
+	 *   chroot_cmd, exactly like a caller that forgot to,
+	 * When it runs the shared unbound-control seam directly,
+	 * Then the bootstrap default recorder -- never the unset '(unset)' string and never
+	 *   the real appliance chroot+unbound-control invocation -- receives the command.
+	 */
+	public function testControlCallerReachesTheBootstrapDefaultRecorderUntouched(): void
+	{
+		$runner = "{$this->dir}/runner.php";
+		$out = "{$this->dir}/out.json";
+		file_put_contents($runner, "<?php\n"
+			. 'require ' . var_export(__DIR__ . '/bootstrap.php', TRUE) . ";\n"
+			. "\$before = \$GLOBALS['pfb']['chroot_cmd'] ?? NULL;\n"
+			. "\$result = [];\n"
+			. "\$retval = pfb_unbound_control_exec(\"{\$before} status 2>&1 < /dev/null\", 'status', \$result);\n"
+			. "\$recorderLog = \$GLOBALS['pfb_test_chroot_cmd_log'] ?? '';\n"
+			. 'file_put_contents(' . var_export($out, TRUE) . ", json_encode([\n"
+			. "\t'chroot_cmd' => \$before,\n"
+			. "\t'retval' => \$retval,\n"
+			. "\t'recorder_log' => \$recorderLog === '' ? '' : (string) @file_get_contents(\$recorderLog),\n"
+			. "]));\n");
+
+		$output = [];
+		$status = 0;
+		$timeout = (string) ($GLOBALS['pfb']['timeout'] ?? '/usr/bin/timeout');
+		exec(escapeshellarg($timeout) . ' -s TERM -k 2 ' . self::SALVAGE_SECONDS . ' ' .
+			escapeshellarg(PHP_BINARY) . ' ' . escapeshellarg($runner) . ' 2>&1', $output, $status);
+		$this->assertSame(0, $status, 'the isolated runner must exit cleanly: ' . implode("\n", $output));
+
+		$payload = json_decode((string) file_get_contents($out), TRUE);
+		$this->assertIsArray($payload, 'the isolated runner must publish its JSON result');
+		$this->assertNotNull($payload['chroot_cmd'],
+			'the harness must default chroot_cmd before any test runs -- an untouched caller '
+			. 'must never see the appliance-off "(unset)" gap');
+		$this->assertNotSame('', $payload['chroot_cmd']);
+		$this->assertStringNotContainsString('/usr/local/sbin/unbound-control', $payload['chroot_cmd'],
+			'the untouched default must never be the real appliance chroot+unbound-control invocation');
+		$this->assertSame(0, $payload['retval'], 'the bootstrap default recorder must answer successfully');
+		$this->assertStringContainsString('status', $payload['recorder_log'],
+			'the control verb must actually reach the bootstrap default recorder');
+	}
+}

--- a/tests/php/PkgCaHookDelegateTest.php
+++ b/tests/php/PkgCaHookDelegateTest.php
@@ -91,4 +91,65 @@ final class PkgCaHookDelegateTest extends TestCase
 		$this->assertSame(['ok'], $out);
 		$this->assertSame(0, $ret);
 	}
+
+	/**
+	 * issue #2839 row 2: PFB_PKG_BIN was the file's one unguarded constant, so a harness
+	 * could not point it away from the real appliance binary at all -- on a box that
+	 * actually has pfBlockerNG installed, every pfb_pkg_*() query in a phpunit run would
+	 * shell out to the real pkg(8).
+	 */
+	public function testPfbPkgBinIsOverriddenAwayFromTheShippedApplianceBinary(): void
+	{
+		$this->assertTrue(defined('PFB_PKG_BIN'));
+		$this->assertNotSame('/usr/local/sbin/pkg', PFB_PKG_BIN,
+			'the harness must override the shipped default with a harmless recorder, exactly '
+			. 'like the daemon-start and mount-include boundaries');
+		$this->assertTrue(is_executable(PFB_PKG_BIN),
+			'the override must actually be runnable so pfb_pkg_*() consumers keep working');
+	}
+
+	/**
+	 * Scenario: a real public pkg consumer must run through the overridden binary, never
+	 * the real one, and its query-parsing behaviour must be unaffected by the seam.
+	 *   Given PFB_PKG_BIN overridden (in an isolated process -- it is a constant) to a
+	 *     double that answers the '%n' glob query with a real-shaped package name,
+	 *   When pfb_pkg_installed_name() runs,
+	 *   Then it returns that name (query parsing preserved) and the double -- never
+	 *     /usr/local/sbin/pkg -- is what recorded receiving the query.
+	 */
+	public function testPkgInstalledNameParsesTheOverriddenBinarysOutputNotTheRealPkg(): void
+	{
+		$runner = "{$this->root}/pkg_bin_runner.php";
+		$log = "{$this->root}/pkg-bin.log";
+		$double = "{$this->root}/pkg-bin-double";
+		file_put_contents($double, "#!/bin/sh\n"
+			. 'printf \'%s\n\' "$*" >> ' . escapeshellarg($log) . "\n"
+			. "printf 'pfSense-pkg-pfBlockerNG-devel\\n'\n"
+			. "exit 0\n");
+		chmod($double, 0o755);
+		file_put_contents($runner, "<?php\n"
+			. "define('PFB_PKG_BIN', " . var_export($double, TRUE) . ");\n"
+			. 'require ' . var_export(__DIR__ . '/bootstrap.php', TRUE) . ";\n"
+			. "echo pfb_pkg_installed_name(), \"\\n\";\n");
+
+		$output = [];
+		$status = 0;
+		exec(escapeshellarg(PHP_BINARY) . ' ' . escapeshellarg($runner) . ' 2>&1', $output, $status);
+
+		try {
+			$this->assertSame(0, $status,
+				'the isolated runner must exit cleanly: ' . implode("\n", $output));
+			$this->assertSame('pfSense-pkg-pfBlockerNG-devel', trim((string) end($output)),
+				'the consumer must still parse a real-shaped query answer correctly through the override');
+			$this->assertStringContainsString(
+				'query -g %n pfSense-pkg-pfBlockerNG*',
+				(string) @file_get_contents($log),
+				'the overridden double, never the real /usr/local/sbin/pkg, must receive the query'
+			);
+		} finally {
+			@unlink($runner);
+			@unlink($log);
+			@unlink($double);
+		}
+	}
 }

--- a/tests/php/PkgCaHookDelegateTest.php
+++ b/tests/php/PkgCaHookDelegateTest.php
@@ -92,12 +92,7 @@ final class PkgCaHookDelegateTest extends TestCase
 		$this->assertSame(0, $ret);
 	}
 
-	/**
-	 * issue #2839 row 2: PFB_PKG_BIN was the file's one unguarded constant, so a harness
-	 * could not point it away from the real appliance binary at all -- on a box that
-	 * actually has pfBlockerNG installed, every pfb_pkg_*() query in a phpunit run would
-	 * shell out to the real pkg(8).
-	 */
+	// Package queries must use a runnable double even on hosts with pkg(8) installed.
 	public function testPfbPkgBinIsOverriddenAwayFromTheShippedApplianceBinary(): void
 	{
 		$this->assertTrue(defined('PFB_PKG_BIN'));
@@ -129,7 +124,14 @@ final class PkgCaHookDelegateTest extends TestCase
 		chmod($double, 0o755);
 		file_put_contents($runner, "<?php\n"
 			. "define('PFB_PKG_BIN', " . var_export($double, TRUE) . ");\n"
+			. "set_error_handler(static function (int \$severity, string \$message): bool {\n"
+			. "\tif (str_starts_with(\$message, 'Constant PFB_') && str_ends_with(\$message, 'already defined')) {\n"
+			. "\t\tthrow new ErrorException(\$message, 0, \$severity);\n"
+			. "\t}\n"
+			. "\treturn FALSE;\n"
+			. "});\n"
 			. 'require ' . var_export(__DIR__ . '/bootstrap.php', TRUE) . ";\n"
+			. "restore_error_handler();\n"
 			. "echo pfb_pkg_installed_name(), \"\\n\";\n");
 
 		$output = [];

--- a/tests/php/PkgCaHookDelegateTest.php
+++ b/tests/php/PkgCaHookDelegateTest.php
@@ -112,7 +112,7 @@ final class PkgCaHookDelegateTest extends TestCase
 	 *   Then it returns that name (query parsing preserved) and the double -- never
 	 *     /usr/local/sbin/pkg -- is what recorded receiving the query.
 	 */
-	public function testPkgInstalledNameParsesTheOverriddenBinarysOutputNotTheRealPkg(): void
+	public function testPkgInstalledNameParsesTheOverriddenBinaryOutputNotTheRealPkg(): void
 	{
 		$runner = "{$this->root}/pkg_bin_runner.php";
 		$log = "{$this->root}/pkg-bin.log";

--- a/tests/php/SoftwareFailedCheckStateTest.php
+++ b/tests/php/SoftwareFailedCheckStateTest.php
@@ -221,6 +221,10 @@ final class SoftwareFailedCheckStateTest extends TestCase
 
 		$this->assertSame('', $latest, 'no pkg binary here, so no version can be read');
 		$this->assertFalse($readOk, 'and the caller is TOLD the attempt failed, not just handed an empty string');
+		$binLog = $GLOBALS['pfb_test_pkg_bin_log'] ?? '';
+		$this->assertStringContainsString('update -f -r',
+			$binLog === '' ? '' : (string) @file_get_contents($binLog),
+			'the untouched default double, never a real pkg(8), must be what actually received the query');
 	}
 
 	/**

--- a/tests/php/SoftwareFailedCheckStateTest.php
+++ b/tests/php/SoftwareFailedCheckStateTest.php
@@ -208,19 +208,14 @@ final class SoftwareFailedCheckStateTest extends TestCase
 	 * with no pkg(8) to run, both calls exit non-zero and the attempt is a recorded FAILURE
 	 * rather than an indistinguishable empty string.
 	 *
-	 * This drives the real shellout, so it asserts a fixed outcome only where that shellout
-	 * cannot succeed. On a host that carries the port binary the result depends on that
-	 * host's repository configuration, which is not this case's subject: it skips there
-	 * rather than reporting a red for an environment difference.
+	 * This drives the real shellout, so it depends on PFB_PKG_BIN never being a real,
+	 * answering `pkg` binary. issue #2839 row 2 made that host-independent: the harness
+	 * unconditionally overrides PFB_PKG_BIN with a double that fails closed exactly like
+	 * the appliance's absence this replaces, so the assertion below no longer needs
+	 * (and no longer skips on) a bare-metal host that happens to carry a real pkg(8).
 	 */
 	public function testPkgLatestReportsAFailedAttemptToItsCaller(): void
 	{
-		if (is_executable(PFB_PKG_BIN)) {
-			$this->markTestSkipped(
-				'host carries ' . PFB_PKG_BIN . ' — the live read outcome is then repository state, not this rule'
-			);
-		}
-
 		$readOk = NULL;
 		$latest = pfb_pkg_latest(self::NAME, self::REPO, $readOk);
 

--- a/tests/php/UnboundRestartSeamTest.php
+++ b/tests/php/UnboundRestartSeamTest.php
@@ -212,6 +212,26 @@ final class UnboundRestartSeamTest extends TestCase
 	}
 
 	/**
+	 * Scenario: an untouched caller (no per-test override at all) must still reach the
+	 * harness's default double, never the shipped /var/unbound path -- the same
+	 * "no individual test has to remember to defuse it" guarantee row 2/3's untouched-
+	 * caller proofs give the pkg-bin and chroot_cmd boundaries.
+	 */
+	public function testMountIncludeDefaultDoubleRunsForAnUntouchedCaller(): void
+	{
+		$this->assertNotSame('/var/unbound/pfb_unbound_include.inc', PFB_UNBOUND_INCLUDE_FILE,
+			'the harness must default this constant away from the shipped path before any test runs');
+		$GLOBALS['pfb_test_process_running']['unbound'] = FALSE;
+
+		pfb_stop_start_unbound('');
+
+		$this->assertStringContainsString('included',
+			(string) @file_get_contents($GLOBALS['pfb_test_unbound_include_log'] ?? ''),
+			'the untouched default double must actually execute -- proving the seam is live '
+			. 'by default, not only when a test explicitly overrides it');
+	}
+
+	/**
 	 * Scenario: the stop-wait must not cost a test the appliance's full budget.
 	 *   Given a process-running double that never reports the daemon gone,
 	 *   When pfb_stop_start_unbound() waits for it to terminate,

--- a/tests/php/UnboundRestartSeamTest.php
+++ b/tests/php/UnboundRestartSeamTest.php
@@ -143,7 +143,8 @@ final class UnboundRestartSeamTest extends TestCase
 			. "\$final = pfb_stop_start_unbound('');\n"
 			. 'echo json_encode([\'final\' => $final, \'log\' => (string) @file_get_contents('
 			. var_export($log, TRUE) . '), \'errlog\' => (string) @file_get_contents('
-			. var_export($errlog, TRUE) . ")]), \"\\n\";\n");
+			. var_export($errlog, TRUE) . '), \'mount_include_log\' => (string) @file_get_contents('
+			. '$GLOBALS[\'pfb_test_unbound_include_log\'] ?? \'\')]), "\\n";' . "\n");
 
 		$output = [];
 		$status = 0;
@@ -221,14 +222,18 @@ final class UnboundRestartSeamTest extends TestCase
 	{
 		$this->assertNotSame('/var/unbound/pfb_unbound_include.inc', PFB_UNBOUND_INCLUDE_FILE,
 			'the harness must default this constant away from the shipped path before any test runs');
-		$GLOBALS['pfb_test_process_running']['unbound'] = FALSE;
 
-		pfb_stop_start_unbound('');
+		// Isolated, never the shared suite process: require_once() only executes the
+		// double ONCE per process, so a shared-process log could already carry an
+		// earlier test's "included" line even if THIS call never reached the seam.
+		$run = $this->runIsolatedStart('true');
 
-		$this->assertStringContainsString('included',
-			(string) @file_get_contents($GLOBALS['pfb_test_unbound_include_log'] ?? ''),
-			'the untouched default double must actually execute -- proving the seam is live '
-			. 'by default, not only when a test explicitly overrides it');
+		$this->assertSame(0, $run['status'],
+			'the isolated runner must exit cleanly: ' . implode("\n", $run['output']));
+		$this->assertIsArray($run['payload'], 'the isolated start runner must return its JSON result');
+		$this->assertStringContainsString('included', $run['payload']['mount_include_log'] ?? '',
+			'the untouched default double must actually execute in THIS call -- proving the '
+			. 'seam is live by default, not only when a test explicitly overrides it');
 	}
 
 	/**

--- a/tests/php/UnboundRestartSeamTest.php
+++ b/tests/php/UnboundRestartSeamTest.php
@@ -109,7 +109,8 @@ final class UnboundRestartSeamTest extends TestCase
 		int $budget = 5,
 		?string $phpCli = NULL,
 		array $ini = [],
-		string $prelude = ''
+		string $prelude = '',
+		?string $includeFile = NULL
 	): array
 	{
 		$phpCli ??= PHP_BINARY;
@@ -119,11 +120,17 @@ final class UnboundRestartSeamTest extends TestCase
 		$errlog = "{$this->dir}/isolated_{$id}.err";
 		$timeout = (string) $GLOBALS['pfb']['timeout'];
 		$bootstrap = __DIR__ . '/bootstrap.php';
+		// issue #2839 row 1: PFB_UNBOUND_INCLUDE_FILE, like PFB_UNBOUND_START_CMD above,
+		// must be defined BEFORE bootstrap.php loads production code -- it is a constant,
+		// fixed at first define() for the whole process.
+		$includeDefine = $includeFile === NULL ? ''
+			: "define('PFB_UNBOUND_INCLUDE_FILE', " . var_export($includeFile, TRUE) . ");\n";
 		file_put_contents($runner, "<?php\n"
 			. "define('PFB_UNBOUND_START_CMD', " . var_export($startCommand, TRUE) . ");\n"
 			. "define('PFB_UNBOUND_STOP_WAIT', 1);\n"
 			. "define('PFB_UNBOUND_START_WAIT', " . var_export($budget, TRUE) . ");\n"
 			. "define('PFB_HOOK_KILL_GRACE', 1);\n"
+			. $includeDefine
 			. 'require ' . var_export($bootstrap, TRUE) . ";\n"
 			. '$GLOBALS[\'pfb\'][\'timeout\'] = ' . var_export($timeout, TRUE) . ";\n"
 			. '$GLOBALS[\'pfb\'][\'php\'] = ' . var_export($phpCli, TRUE) . ";\n"
@@ -647,6 +654,49 @@ final class UnboundRestartSeamTest extends TestCase
 		$this->assertFalse($run['payload']['final']['start_completed']);
 		$this->assertFileDoesNotExist($startProbe,
 			'an output-staging failure must occur before the configured start command');
+	}
+
+	/**
+	 * Scenario (issue #2839 row 1): the mount-include boundary must be overridable exactly
+	 * like the daemon-start boundary above.
+	 *   Given the harness points PFB_UNBOUND_INCLUDE_FILE at a double with none of the real
+	 *     file's mount_nullfs/umount exec()s,
+	 *   When pfb_stop_start_unbound() reaches its mount-include step,
+	 *   Then the double actually runs -- proving the seam is live, not dormant only because
+	 *     the shipped /var/unbound path happens to be absent off-appliance.
+	 */
+	public function testMountIncludeRunsTheOverriddenFileNotTheShippedPath(): void
+	{
+		$this->assertTrue(defined('PFB_UNBOUND_INCLUDE_FILE'),
+			'the mount-include boundary must be an overridable constant, not a hardcoded literal path');
+		$marker = "{$this->dir}/mount_include_ran";
+		$include = "{$this->dir}/mount-include-double.inc";
+		file_put_contents($include, '<?php touch(' . var_export($marker, TRUE) . ");\n");
+
+		$run = $this->runIsolatedStart('true', includeFile: $include);
+
+		$this->assertSame(0, $run['status'],
+			'the isolated runner must exit cleanly: ' . implode("\n", $run['output']));
+		$this->assertFileExists($marker,
+			'the overridden include must actually execute -- proving the seam is live, '
+			. 'with none of the shipped file\'s exec()s involved');
+	}
+
+	/**
+	 * Scenario: an absent include (today's off-appliance default) must remain a valid,
+	 * silent no-op -- the new seam must not turn "file does not exist" into a failure.
+	 */
+	public function testAbsentMountIncludeRemainsValid(): void
+	{
+		$missing = "{$this->dir}/does-not-exist.inc";
+
+		$run = $this->runIsolatedStart('true', includeFile: $missing);
+
+		$this->assertSame(0, $run['status'],
+			'the isolated runner must exit cleanly: ' . implode("\n", $run['output']));
+		$this->assertIsArray($run['payload'], 'the isolated start runner must return its JSON result');
+		$this->assertTrue($run['payload']['final']['start_completed'] ?? FALSE,
+			'an absent mount-include file must not stop the resolver start from completing');
 	}
 
 

--- a/tests/php/bootstrap.php
+++ b/tests/php/bootstrap.php
@@ -88,10 +88,7 @@ if (!defined('PFB_UNBOUND_START_WAIT')) {
 }
 unset($pfb_test_unbound_start_cmd);
 
-// 4c. issue #2839 row 1: neuter the mount-include boundary the same way as the daemon
-//     start above. On a box that has pfBlockerNG actually installed, this literal path
-//     exists and its top level exec()s mount_nullfs/umount four times with no seam to
-//     intercept -- point the constant at a double that only records it ran.
+// 4c. Replace the mount-executing include even on hosts with pfBlockerNG installed.
 $GLOBALS['pfb_test_unbound_include_log'] = "{$pfb_test_tmp}/unbound_include.log";
 $pfb_test_unbound_include_file = "{$pfb_test_tmp}/pfb-unbound-include-double.inc";
 file_put_contents($pfb_test_unbound_include_file, '<?php file_put_contents('
@@ -101,10 +98,7 @@ if (!defined('PFB_UNBOUND_INCLUDE_FILE')) {
 }
 unset($pfb_test_unbound_include_file);
 
-// 4d. issue #2839 row 2: PFB_PKG_BIN feeds every pfb_pkg_*() read-only query's exec(). On
-//     a box that has pfBlockerNG installed, the shipped default is a REAL executable;
-//     point it at a double that fails closed -- matching the off-appliance absence this
-//     replaces -- and records what it was asked to run.
+// 4d. Record package commands and preserve the missing-package failure result.
 $GLOBALS['pfb_test_pkg_bin_log'] = "{$pfb_test_tmp}/pkg_bin.log";
 $pfb_test_pkg_bin = "{$pfb_test_tmp}/pkg-bin-double";
 file_put_contents($pfb_test_pkg_bin, "#!/bin/sh\n"
@@ -116,14 +110,7 @@ if (!defined('PFB_PKG_BIN')) {
 }
 unset($pfb_test_pkg_bin);
 
-// 4e. issue #2839 row 3: $pfb['chroot_cmd'] is the unbound-control command prefix; off-
-//     appliance it defaults to unset (a caller that forgets to set it just names a bogus
-//     command), but pfb_global() RECOMPUTES it on every call from PFB_UNBOUND_CONTROL_BIN
-//     -- guard that constant, not just the array key, or a later pfb_global() refresh
-//     (dozens of test files call it) would revert to the real appliance chroot+unbound-
-//     control invocation even after this default is set. A test wanting specific command
-//     expectations keeps overriding $GLOBALS['pfb']['chroot_cmd'] itself, exactly as six
-//     existing suites do; none of them also calls pfb_global(), so nothing here changes.
+// 4e. Override both the initial prefix and the source pfb_global() uses to rebuild it.
 $GLOBALS['pfb_test_chroot_cmd_log'] = "{$pfb_test_tmp}/chroot_cmd.log";
 $pfb_test_chroot_cmd = "{$pfb_test_tmp}/chroot-cmd-double";
 file_put_contents($pfb_test_chroot_cmd, "#!/bin/sh\n"

--- a/tests/php/bootstrap.php
+++ b/tests/php/bootstrap.php
@@ -118,16 +118,21 @@ unset($pfb_test_pkg_bin);
 
 // 4e. issue #2839 row 3: $pfb['chroot_cmd'] is the unbound-control command prefix; off-
 //     appliance it defaults to unset (a caller that forgets to set it just names a bogus
-//     command), but pfb_global() sets it to the REAL chroot+unbound-control invocation on
-//     an installed host with no test involvement. Default it the same way as the
-//     daemon-start double above; a test wanting specific command expectations keeps
-//     overriding $GLOBALS['pfb']['chroot_cmd'] itself, exactly as six existing suites do.
+//     command), but pfb_global() RECOMPUTES it on every call from PFB_UNBOUND_CONTROL_BIN
+//     -- guard that constant, not just the array key, or a later pfb_global() refresh
+//     (dozens of test files call it) would revert to the real appliance chroot+unbound-
+//     control invocation even after this default is set. A test wanting specific command
+//     expectations keeps overriding $GLOBALS['pfb']['chroot_cmd'] itself, exactly as six
+//     existing suites do; none of them also calls pfb_global(), so nothing here changes.
 $GLOBALS['pfb_test_chroot_cmd_log'] = "{$pfb_test_tmp}/chroot_cmd.log";
 $pfb_test_chroot_cmd = "{$pfb_test_tmp}/chroot-cmd-double";
 file_put_contents($pfb_test_chroot_cmd, "#!/bin/sh\n"
 	. 'printf \'%s\n\' "$*" >> ' . escapeshellarg($GLOBALS['pfb_test_chroot_cmd_log']) . "\n"
 	. "exit 0\n");
 chmod($pfb_test_chroot_cmd, 0755);
+if (!defined('PFB_UNBOUND_CONTROL_BIN')) {
+	define('PFB_UNBOUND_CONTROL_BIN', $pfb_test_chroot_cmd);
+}
 $GLOBALS['pfb']['chroot_cmd'] = $pfb_test_chroot_cmd;
 unset($pfb_test_chroot_cmd);
 

--- a/tests/php/bootstrap.php
+++ b/tests/php/bootstrap.php
@@ -88,6 +88,49 @@ if (!defined('PFB_UNBOUND_START_WAIT')) {
 }
 unset($pfb_test_unbound_start_cmd);
 
+// 4c. issue #2839 row 1: neuter the mount-include boundary the same way as the daemon
+//     start above. On a box that has pfBlockerNG actually installed, this literal path
+//     exists and its top level exec()s mount_nullfs/umount four times with no seam to
+//     intercept -- point the constant at a double that only records it ran.
+$GLOBALS['pfb_test_unbound_include_log'] = "{$pfb_test_tmp}/unbound_include.log";
+$pfb_test_unbound_include_file = "{$pfb_test_tmp}/pfb-unbound-include-double.inc";
+file_put_contents($pfb_test_unbound_include_file, '<?php file_put_contents('
+	. var_export($GLOBALS['pfb_test_unbound_include_log'], TRUE) . ", \"included\\n\", FILE_APPEND);\n");
+if (!defined('PFB_UNBOUND_INCLUDE_FILE')) {
+	define('PFB_UNBOUND_INCLUDE_FILE', $pfb_test_unbound_include_file);
+}
+unset($pfb_test_unbound_include_file);
+
+// 4d. issue #2839 row 2: PFB_PKG_BIN feeds every pfb_pkg_*() read-only query's exec(). On
+//     a box that has pfBlockerNG installed, the shipped default is a REAL executable;
+//     point it at a double that fails closed -- matching the off-appliance absence this
+//     replaces -- and records what it was asked to run.
+$GLOBALS['pfb_test_pkg_bin_log'] = "{$pfb_test_tmp}/pkg_bin.log";
+$pfb_test_pkg_bin = "{$pfb_test_tmp}/pkg-bin-double";
+file_put_contents($pfb_test_pkg_bin, "#!/bin/sh\n"
+	. 'printf \'%s\n\' "$*" >> ' . escapeshellarg($GLOBALS['pfb_test_pkg_bin_log']) . "\n"
+	. "exit 1\n");
+chmod($pfb_test_pkg_bin, 0755);
+if (!defined('PFB_PKG_BIN')) {
+	define('PFB_PKG_BIN', $pfb_test_pkg_bin);
+}
+unset($pfb_test_pkg_bin);
+
+// 4e. issue #2839 row 3: $pfb['chroot_cmd'] is the unbound-control command prefix; off-
+//     appliance it defaults to unset (a caller that forgets to set it just names a bogus
+//     command), but pfb_global() sets it to the REAL chroot+unbound-control invocation on
+//     an installed host with no test involvement. Default it the same way as the
+//     daemon-start double above; a test wanting specific command expectations keeps
+//     overriding $GLOBALS['pfb']['chroot_cmd'] itself, exactly as six existing suites do.
+$GLOBALS['pfb_test_chroot_cmd_log'] = "{$pfb_test_tmp}/chroot_cmd.log";
+$pfb_test_chroot_cmd = "{$pfb_test_tmp}/chroot-cmd-double";
+file_put_contents($pfb_test_chroot_cmd, "#!/bin/sh\n"
+	. 'printf \'%s\n\' "$*" >> ' . escapeshellarg($GLOBALS['pfb_test_chroot_cmd_log']) . "\n"
+	. "exit 0\n");
+chmod($pfb_test_chroot_cmd, 0755);
+$GLOBALS['pfb']['chroot_cmd'] = $pfb_test_chroot_cmd;
+unset($pfb_test_chroot_cmd);
+
 // 2 + load. Define the production functions by including the real source.
 // pfblockerng.inc is legacy code that emits some load-time E_DEPRECATED/E_WARNING
 // notices (e.g. an optional-before-required parameter, a switch `continue`) that

--- a/tests/skip-allowlist.txt
+++ b/tests/skip-allowlist.txt
@@ -93,5 +93,3 @@ smoke:tests.smoke.test_nightly_install::test_install_from_live_nightly_url  # SM
 smoke:tests.smoke.test_repo_install::test_install_from_live_pages_url  # SMOKE_REPO_LIVE_URL is dispatch-only; the schedule never passes it (issue #2389)
 smoke:tests.smoke.test_repo_install::test_live_nightly_downgrade_requires_selected_semantic_repo  # needs both live URLs; the schedule passes neither (issue #2389)
 
-# phpunit -- only on a host that carries the pkg(8) port binary (a FreeBSD/pfSense dev box).
-phpunit:SoftwareFailedCheckStateTest::testPkgLatestReportsAFailedAttemptToItsCaller  # drives the real pkg shellout; its outcome is host repository state where /usr/local/sbin/pkg exists


### PR DESCRIPTION
Fixes #2839.

## Summary

Seal the three unit-harness execution boundaries identified beside the Unbound start seam:

- Add guarded `PFB_UNBOUND_INCLUDE_FILE`, used by both `file_exists()` and `require_once()`. The bootstrap selects a harmless recording include instead of the installed mount script.
- Guard `PFB_PKG_BIN` and select an inert, fail-closed package recorder in the bootstrap. Existing public consumers retain their query behavior, and overriding the constant no longer triggers a duplicate-definition warning.
- Give `$pfb['chroot_cmd']` an inert bootstrap default. A guarded `PFB_UNBOUND_CONTROL_BIN` also preserves that safety when `pfb_global()` rebuilds the command. Tests that supply their own command still work.

Appliance defaults remain unchanged. No service supervision or mount behavior is otherwise changed.

## Regression coverage

- Include override, untouched bootstrap include, and absent include, using isolated child processes where `require_once()` state matters.
- Package query parsing through a custom executable and failed-refresh behavior through the untouched bootstrap recorder. Remove the obsolete host-dependent skip and its allowlist entry.
- Control command execution through the bootstrap recorder and preservation after `pfb_global()` initialization.
- Duplicate-definition detection around the isolated bootstrap load. Independent removal of each production constant guard now fails the same test, despite the bootstrap's legacy warning suppression.

The original three-row reproductions ran red before the initial production/bootstrap edits and green with unchanged test hashes. Subsequent test maintenance and review fixes were verified with isolated regression mutations. Independent review re-executed the affected paths, including the six existing custom-control test suites. Detailed commands, findings, and resolutions are in the review comments.

## Verification

- `sh scripts/agent/run-gates.sh --diff 7aff20fa775ec1d3374608b7c96b2ec991f7b389`: all 15 selected gates passed, including pytest, PHPUnit, both skip checks, PHPStan, PHPCS, graph freshness, and policy checks.
- Independent condensed review: contract, correctness/hostile inputs, test honesty, and over-engineering; all findings resolved.
- Copilot and CodeRabbit reviews requested; their findings and final-head CI are tracked in the PR comments.

Verification is off-appliance. No live pfSense boot or mount execution is claimed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration options to override the Unbound control command and include-file location.
  * Improved flexibility for environments using custom command paths or alternate Unbound configurations.

* **Bug Fixes**
  * Ensured custom command and include-file settings remain effective throughout operations.
  * Missing Unbound include files are now handled safely without interrupting processing.

* **Tests**
  * Expanded automated coverage for custom command paths, include files, package checks, and failed update handling.
  * Removed a test exception that depended on the host system’s package configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->