### PR TITLE
tools: pin reviewed Graphify 0.9.59 fork

### DIFF
--- a/.agents/policy/coderabbit-misses.md
+++ b/.agents/policy/coderabbit-misses.md
@@ -1,8 +1,6 @@
 # CodeRabbit missed reviews
 
-Append-only, newest first. One line per merged SHA whose only CodeRabbit
-engagement was a quota notice (or none) and that never got a later finished
-review of that SHA.
+Append-only, newest first. One line per merged SHA without a finished CodeRabbit review.
 
 Format, one line of at most 200 bytes: ``- `SHA`  title  (#PR) — one clause``.
 Two spaces separate the fields; the em-dash clause is optional. The clause is a
@@ -15,6 +13,7 @@ narrative could otherwise park. `scripts/check_context_budget.py` enforces both
 caps, the shape, and this file's 12,288-byte policy budget; the recorded SHAs
 and their order are pinned by `tests/test_context_budget.py`.
 
+- `a59563e5c`  Graphify 0.9.59 overrides  (#10) — pfBlockerNG/graphify#10; silent twice.
 - `ea8d3c43a`  Graphify rollback  (#9) — pfBlockerNG/graphify#9; silent twice.
 - `66285ab5c`  Shared Graphify skill  (#2) — andrebrait/ai-harness-settings#2; quota.
 - `c6f52993a`  test: pin singular reviewer quota units  (#3269) — asked twice, two quota notices (2 then 59 min after retry); condensed review and Copilot finding resolved.

--- a/graphify-out/memory/query_20260912_180327_2c7a6549_graphify_fork_installation_commit_pin_and_upgrade.md
+++ b/graphify-out/memory/query_20260912_180327_2c7a6549_graphify_fork_installation_commit_pin_and_upgrade.md
@@ -1,0 +1,19 @@
+---
+type: "query"
+date: "2026-09-12T18:03:27.596189+00:00"
+question: "Graphify fork installation commit pin and upgrade integration"
+contributor: "graphify"
+outcome: "dead_end"
+correction: "Use pyproject.toml, uv.lock, scripts/agent/ensure-graphify.sh and GitHub commit ancestry for installation and pin provenance."
+---
+
+# Q: Graphify fork installation commit pin and upgrade integration
+
+## Answer
+
+The semantic query did not locate the installer pin. pyproject.toml and uv.lock own the pfBlockerNG fork commit; scripts/agent/ensure-graphify.sh installs that specification. GitHub compare confirms upstream PR 3075 head 1ad08a9 is two commits ahead of v0.9.59.
+
+## Outcome
+
+- Signal: dead_end
+- Correction: Use pyproject.toml, uv.lock, scripts/agent/ensure-graphify.sh and GitHub commit ancestry for installation and pin provenance.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ package = false
 [dependency-groups]
 # Agent and developer CLI tools. Single source of truth for versions/pins.
 tools = [
-    "graphifyy[leiden] @ git+https://github.com/pfBlockerNG/graphify@481574300794093d44ea40d5371db0ef058b21fa",
+    "graphifyy[leiden] @ git+https://github.com/pfBlockerNG/graphify@a59563e5c0f63d6a71eaf7df6c4c97ae30564098",
     "serena-agent",
     "ast-grep-cli",
     "semgrep",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ package = false
 [dependency-groups]
 # Agent and developer CLI tools. Single source of truth for versions/pins.
 tools = [
-    "graphifyy[leiden] @ git+https://github.com/pfBlockerNG/graphify@a54c51260d97aaed3bb078ad7cfbf64a048b398f",
+    "graphifyy[leiden] @ git+https://github.com/pfBlockerNG/graphify@481574300794093d44ea40d5371db0ef058b21fa",
     "serena-agent",
     "ast-grep-cli",
     "semgrep",

--- a/uv.lock
+++ b/uv.lock
@@ -525,8 +525,8 @@ wheels = [
 
 [[package]]
 name = "graphifyy"
-version = "0.9.58"
-source = { git = "https://github.com/pfBlockerNG/graphify?rev=a54c51260d97aaed3bb078ad7cfbf64a048b398f#a54c51260d97aaed3bb078ad7cfbf64a048b398f" }
+version = "0.9.59"
+source = { git = "https://github.com/pfBlockerNG/graphify?rev=481574300794093d44ea40d5371db0ef058b21fa#481574300794093d44ea40d5371db0ef058b21fa" }
 dependencies = [
     { name = "networkx" },
     { name = "numpy" },
@@ -1375,7 +1375,7 @@ smoke = [
 ]
 tools = [
     { name = "ast-grep-cli" },
-    { name = "graphifyy", extras = ["leiden"], git = "https://github.com/pfBlockerNG/graphify?rev=a54c51260d97aaed3bb078ad7cfbf64a048b398f" },
+    { name = "graphifyy", extras = ["leiden"], git = "https://github.com/pfBlockerNG/graphify?rev=481574300794093d44ea40d5371db0ef058b21fa" },
     { name = "semgrep" },
     { name = "serena-agent" },
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -526,7 +526,7 @@ wheels = [
 [[package]]
 name = "graphifyy"
 version = "0.9.59"
-source = { git = "https://github.com/pfBlockerNG/graphify?rev=481574300794093d44ea40d5371db0ef058b21fa#481574300794093d44ea40d5371db0ef058b21fa" }
+source = { git = "https://github.com/pfBlockerNG/graphify?rev=a59563e5c0f63d6a71eaf7df6c4c97ae30564098#a59563e5c0f63d6a71eaf7df6c4c97ae30564098" }
 dependencies = [
     { name = "networkx" },
     { name = "numpy" },
@@ -1375,7 +1375,7 @@ smoke = [
 ]
 tools = [
     { name = "ast-grep-cli" },
-    { name = "graphifyy", extras = ["leiden"], git = "https://github.com/pfBlockerNG/graphify?rev=481574300794093d44ea40d5371db0ef058b21fa" },
+    { name = "graphifyy", extras = ["leiden"], git = "https://github.com/pfBlockerNG/graphify?rev=a59563e5c0f63d6a71eaf7df6c4c97ae30564098" },
     { name = "semgrep" },
     { name = "serena-agent" },
 ]


### PR DESCRIPTION
## Summary

- Pin `graphifyy[leiden]` to the reviewed fork commit `a59563e5c0f63d6a71eaf7df6c4c97ae30564098` (Graphify 0.9.59).
- Update the lockfile without changing transitive package versions.
- Refresh the tracked graph with the pinned tool; the graph retains all previous nodes and adds four nodes for the required query record.
- Record the CodeRabbit miss on the fork PR. The ledger header was shortened to remain within its unchanged byte budget; prior entries are untouched.

The source changes landed in [pfBlockerNG/graphify#10](https://github.com/pfBlockerNG/graphify/pull/10). Signed tag [v0.9.59-pfb.1](https://github.com/pfBlockerNG/graphify/tree/v0.9.59-pfb.1) resolves to the pinned commit. This includes upstream `1ad08a9` on 0.9.59, the retained fork patches, and the validated review corrections. [The upstream author has been invited to adopt the fixes](https://github.com/Graphify-Labs/graphify/pull/3075#issuecomment-5648887338).

## Verification

- Consumer Graphify checks: **4 passed**.
- Context-budget tests: **160 passed, 2 skipped**.
- Canonical coverage-pairing, graph-freshness and Markdown gates: **PASS**.
- Pre-commit and exact-tip pre-push gates: **PASS**.
- Installed CLI provenance matches the pin; native Leiden verified on Python 3.13.5.
- Fork full suite: **5,720 passed, 14 existing skips**; focused regressions: **124 passed**.
- Exact fork-head CI passed on Python 3.10/3.12 plus the skill-generation and security jobs. Copilot findings were fixed; CodeRabbit did not respond to either permitted request.

No appliance or production package code changes in this repository.

Fixes #3275.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a development dependency to a newer pinned version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->